### PR TITLE
Fix generated SDK errors to use pointer receivers

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,6 @@
 * Update SDK's `go-jmespath` dependency to latest tagged version `0.3.0` ([#3205](https://github.com/aws/aws-sdk-go/pull/3205))
 
 ### SDK Bugs
+* Fix generated SDK errors to use pointer receivers
+  * Fixes the generated SDK API errors to use pointer function receivers instead of value. This fixes potential confusion writing code and not casting to the correct type. The SDK will always return the API error as a pointer, not value.
+  * Code that did type assertions from the operation's returned error to the value type would never be satisfied. Leading to errors being missed. Changing the function receiver to a pointer prevents this error. Highlighting it in code bases.

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -904,12 +904,12 @@ func newErrorExceptionEvent(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExceptionEvent) Code() string {
+func (s *ExceptionEvent) Code() string {
 	return "ExceptionEvent"
 }
 
 // Message returns the exception's message.
-func (s ExceptionEvent) Message() string {
+func (s *ExceptionEvent) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -917,21 +917,21 @@ func (s ExceptionEvent) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExceptionEvent) OrigErr() error {
+func (s *ExceptionEvent) OrigErr() error {
 	return nil
 }
 
-func (s ExceptionEvent) Error() string {
+func (s *ExceptionEvent) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExceptionEvent) StatusCode() int {
+func (s *ExceptionEvent) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExceptionEvent) RequestID() string {
+func (s *ExceptionEvent) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -986,12 +986,12 @@ func newErrorExceptionEvent2(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExceptionEvent2) Code() string {
+func (s *ExceptionEvent2) Code() string {
 	return "ExceptionEvent2"
 }
 
 // Message returns the exception's message.
-func (s ExceptionEvent2) Message() string {
+func (s *ExceptionEvent2) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -999,21 +999,21 @@ func (s ExceptionEvent2) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExceptionEvent2) OrigErr() error {
+func (s *ExceptionEvent2) OrigErr() error {
 	return nil
 }
 
-func (s ExceptionEvent2) Error() string {
+func (s *ExceptionEvent2) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExceptionEvent2) StatusCode() int {
+func (s *ExceptionEvent2) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExceptionEvent2) RequestID() string {
+func (s *ExceptionEvent2) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -904,12 +904,12 @@ func newErrorExceptionEvent(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExceptionEvent) Code() string {
+func (s *ExceptionEvent) Code() string {
 	return "ExceptionEvent"
 }
 
 // Message returns the exception's message.
-func (s ExceptionEvent) Message() string {
+func (s *ExceptionEvent) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -917,21 +917,21 @@ func (s ExceptionEvent) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExceptionEvent) OrigErr() error {
+func (s *ExceptionEvent) OrigErr() error {
 	return nil
 }
 
-func (s ExceptionEvent) Error() string {
+func (s *ExceptionEvent) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExceptionEvent) StatusCode() int {
+func (s *ExceptionEvent) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExceptionEvent) RequestID() string {
+func (s *ExceptionEvent) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -986,12 +986,12 @@ func newErrorExceptionEvent2(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExceptionEvent2) Code() string {
+func (s *ExceptionEvent2) Code() string {
 	return "ExceptionEvent2"
 }
 
 // Message returns the exception's message.
-func (s ExceptionEvent2) Message() string {
+func (s *ExceptionEvent2) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -999,21 +999,21 @@ func (s ExceptionEvent2) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExceptionEvent2) OrigErr() error {
+func (s *ExceptionEvent2) OrigErr() error {
 	return nil
 }
 
-func (s ExceptionEvent2) Error() string {
+func (s *ExceptionEvent2) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExceptionEvent2) StatusCode() int {
+func (s *ExceptionEvent2) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExceptionEvent2) RequestID() string {
+func (s *ExceptionEvent2) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -1017,12 +1017,12 @@ func newErrorExceptionEvent(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExceptionEvent) Code() string {
+func (s *ExceptionEvent) Code() string {
 	return "ExceptionEvent"
 }
 
 // Message returns the exception's message.
-func (s ExceptionEvent) Message() string {
+func (s *ExceptionEvent) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1030,21 +1030,21 @@ func (s ExceptionEvent) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExceptionEvent) OrigErr() error {
+func (s *ExceptionEvent) OrigErr() error {
 	return nil
 }
 
-func (s ExceptionEvent) Error() string {
+func (s *ExceptionEvent) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExceptionEvent) StatusCode() int {
+func (s *ExceptionEvent) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExceptionEvent) RequestID() string {
+func (s *ExceptionEvent) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1099,12 +1099,12 @@ func newErrorExceptionEvent2(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExceptionEvent2) Code() string {
+func (s *ExceptionEvent2) Code() string {
 	return "ExceptionEvent2"
 }
 
 // Message returns the exception's message.
-func (s ExceptionEvent2) Message() string {
+func (s *ExceptionEvent2) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1112,21 +1112,21 @@ func (s ExceptionEvent2) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExceptionEvent2) OrigErr() error {
+func (s *ExceptionEvent2) OrigErr() error {
 	return nil
 }
 
-func (s ExceptionEvent2) Error() string {
+func (s *ExceptionEvent2) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExceptionEvent2) StatusCode() int {
+func (s *ExceptionEvent2) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExceptionEvent2) RequestID() string {
+func (s *ExceptionEvent2) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -814,12 +814,12 @@ func newError{{ $.ShapeName }}(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s {{ $.ShapeName }}) Code() string {
+func (s *{{ $.ShapeName }}) Code() string {
 	return "{{ $.ErrorName }}"
 }
 
 // Message returns the exception's message.
-func (s {{ $.ShapeName }}) Message() string {
+func (s *{{ $.ShapeName }}) Message() string {
 	{{- if index $.MemberRefs "Message_" }}
 		if s.Message_ != nil {
 			return *s.Message_
@@ -829,11 +829,11 @@ func (s {{ $.ShapeName }}) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s {{ $.ShapeName }}) OrigErr() error {
+func (s *{{ $.ShapeName }}) OrigErr() error {
 	return nil
 }
 
-func (s {{ $.ShapeName }}) Error() string {
+func (s *{{ $.ShapeName }}) Error() string {
 	{{- if or (and (eq (len $.MemberRefs) 1) (not (index $.MemberRefs "Message_"))) (gt (len $.MemberRefs) 1) }}
 		return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 	{{- else }}
@@ -842,12 +842,12 @@ func (s {{ $.ShapeName }}) Error() string {
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s {{ $.ShapeName }}) StatusCode() int {
+func (s *{{ $.ShapeName }}) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s {{ $.ShapeName }}) RequestID() string {
+func (s *{{ $.ShapeName }}) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 `))

--- a/service/accessanalyzer/api.go
+++ b/service/accessanalyzer/api.go
@@ -1923,12 +1923,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1936,21 +1936,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2291,12 +2291,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2304,21 +2304,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3449,12 +3449,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3462,21 +3462,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3975,12 +3975,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3988,21 +3988,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4041,12 +4041,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4054,21 +4054,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4272,12 +4272,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4285,21 +4285,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4610,12 +4610,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4623,21 +4623,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/acm/api.go
+++ b/service/acm/api.go
@@ -2554,12 +2554,12 @@ func newErrorInvalidArgsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgsException) Code() string {
+func (s *InvalidArgsException) Code() string {
 	return "InvalidArgsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgsException) Message() string {
+func (s *InvalidArgsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2567,21 +2567,21 @@ func (s InvalidArgsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgsException) OrigErr() error {
+func (s *InvalidArgsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgsException) Error() string {
+func (s *InvalidArgsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgsException) StatusCode() int {
+func (s *InvalidArgsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgsException) RequestID() string {
+func (s *InvalidArgsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2610,12 +2610,12 @@ func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArnException) Code() string {
+func (s *InvalidArnException) Code() string {
 	return "InvalidArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArnException) Message() string {
+func (s *InvalidArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2623,21 +2623,21 @@ func (s InvalidArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArnException) OrigErr() error {
+func (s *InvalidArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArnException) Error() string {
+func (s *InvalidArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArnException) StatusCode() int {
+func (s *InvalidArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArnException) RequestID() string {
+func (s *InvalidArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2666,12 +2666,12 @@ func newErrorInvalidDomainValidationOptionsException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s InvalidDomainValidationOptionsException) Code() string {
+func (s *InvalidDomainValidationOptionsException) Code() string {
 	return "InvalidDomainValidationOptionsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDomainValidationOptionsException) Message() string {
+func (s *InvalidDomainValidationOptionsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2679,21 +2679,21 @@ func (s InvalidDomainValidationOptionsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDomainValidationOptionsException) OrigErr() error {
+func (s *InvalidDomainValidationOptionsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDomainValidationOptionsException) Error() string {
+func (s *InvalidDomainValidationOptionsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDomainValidationOptionsException) StatusCode() int {
+func (s *InvalidDomainValidationOptionsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDomainValidationOptionsException) RequestID() string {
+func (s *InvalidDomainValidationOptionsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2722,12 +2722,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2735,21 +2735,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2778,12 +2778,12 @@ func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidStateException) Code() string {
+func (s *InvalidStateException) Code() string {
 	return "InvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateException) Message() string {
+func (s *InvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2791,21 +2791,21 @@ func (s InvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateException) OrigErr() error {
+func (s *InvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateException) Error() string {
+func (s *InvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateException) StatusCode() int {
+func (s *InvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateException) RequestID() string {
+func (s *InvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2835,12 +2835,12 @@ func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagException) Code() string {
+func (s *InvalidTagException) Code() string {
 	return "InvalidTagException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagException) Message() string {
+func (s *InvalidTagException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2848,21 +2848,21 @@ func (s InvalidTagException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagException) OrigErr() error {
+func (s *InvalidTagException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagException) Error() string {
+func (s *InvalidTagException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagException) StatusCode() int {
+func (s *InvalidTagException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagException) RequestID() string {
+func (s *InvalidTagException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2916,12 +2916,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2929,21 +2929,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3574,12 +3574,12 @@ func newErrorRequestInProgressException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestInProgressException) Code() string {
+func (s *RequestInProgressException) Code() string {
 	return "RequestInProgressException"
 }
 
 // Message returns the exception's message.
-func (s RequestInProgressException) Message() string {
+func (s *RequestInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3587,21 +3587,21 @@ func (s RequestInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestInProgressException) OrigErr() error {
+func (s *RequestInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s RequestInProgressException) Error() string {
+func (s *RequestInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestInProgressException) StatusCode() int {
+func (s *RequestInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestInProgressException) RequestID() string {
+func (s *RequestInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3742,12 +3742,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3755,21 +3755,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3799,12 +3799,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3812,21 +3812,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3957,12 +3957,12 @@ func newErrorTagPolicyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagPolicyException) Code() string {
+func (s *TagPolicyException) Code() string {
 	return "TagPolicyException"
 }
 
 // Message returns the exception's message.
-func (s TagPolicyException) Message() string {
+func (s *TagPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3970,21 +3970,21 @@ func (s TagPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagPolicyException) OrigErr() error {
+func (s *TagPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s TagPolicyException) Error() string {
+func (s *TagPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagPolicyException) StatusCode() int {
+func (s *TagPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagPolicyException) RequestID() string {
+func (s *TagPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4013,12 +4013,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4026,21 +4026,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/acmpca/api.go
+++ b/service/acmpca/api.go
@@ -2602,12 +2602,12 @@ func newErrorCertificateMismatchException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CertificateMismatchException) Code() string {
+func (s *CertificateMismatchException) Code() string {
 	return "CertificateMismatchException"
 }
 
 // Message returns the exception's message.
-func (s CertificateMismatchException) Message() string {
+func (s *CertificateMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2615,21 +2615,21 @@ func (s CertificateMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CertificateMismatchException) OrigErr() error {
+func (s *CertificateMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s CertificateMismatchException) Error() string {
+func (s *CertificateMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CertificateMismatchException) StatusCode() int {
+func (s *CertificateMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CertificateMismatchException) RequestID() string {
+func (s *CertificateMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2658,12 +2658,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2671,21 +2671,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3871,12 +3871,12 @@ func newErrorInvalidArgsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgsException) Code() string {
+func (s *InvalidArgsException) Code() string {
 	return "InvalidArgsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgsException) Message() string {
+func (s *InvalidArgsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3884,21 +3884,21 @@ func (s InvalidArgsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgsException) OrigErr() error {
+func (s *InvalidArgsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgsException) Error() string {
+func (s *InvalidArgsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgsException) StatusCode() int {
+func (s *InvalidArgsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgsException) RequestID() string {
+func (s *InvalidArgsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3927,12 +3927,12 @@ func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArnException) Code() string {
+func (s *InvalidArnException) Code() string {
 	return "InvalidArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArnException) Message() string {
+func (s *InvalidArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3940,21 +3940,21 @@ func (s InvalidArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArnException) OrigErr() error {
+func (s *InvalidArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArnException) Error() string {
+func (s *InvalidArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArnException) StatusCode() int {
+func (s *InvalidArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArnException) RequestID() string {
+func (s *InvalidArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3984,12 +3984,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3997,21 +3997,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4041,12 +4041,12 @@ func newErrorInvalidPolicyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPolicyException) Code() string {
+func (s *InvalidPolicyException) Code() string {
 	return "InvalidPolicyException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPolicyException) Message() string {
+func (s *InvalidPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4054,21 +4054,21 @@ func (s InvalidPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPolicyException) OrigErr() error {
+func (s *InvalidPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPolicyException) Error() string {
+func (s *InvalidPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPolicyException) StatusCode() int {
+func (s *InvalidPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPolicyException) RequestID() string {
+func (s *InvalidPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4097,12 +4097,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4110,21 +4110,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4154,12 +4154,12 @@ func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidStateException) Code() string {
+func (s *InvalidStateException) Code() string {
 	return "InvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateException) Message() string {
+func (s *InvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4167,21 +4167,21 @@ func (s InvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateException) OrigErr() error {
+func (s *InvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateException) Error() string {
+func (s *InvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateException) StatusCode() int {
+func (s *InvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateException) RequestID() string {
+func (s *InvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4211,12 +4211,12 @@ func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagException) Code() string {
+func (s *InvalidTagException) Code() string {
 	return "InvalidTagException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagException) Message() string {
+func (s *InvalidTagException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4224,21 +4224,21 @@ func (s InvalidTagException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagException) OrigErr() error {
+func (s *InvalidTagException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagException) Error() string {
+func (s *InvalidTagException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagException) StatusCode() int {
+func (s *InvalidTagException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagException) RequestID() string {
+func (s *InvalidTagException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4451,12 +4451,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4464,21 +4464,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4807,12 +4807,12 @@ func newErrorMalformedCSRException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MalformedCSRException) Code() string {
+func (s *MalformedCSRException) Code() string {
 	return "MalformedCSRException"
 }
 
 // Message returns the exception's message.
-func (s MalformedCSRException) Message() string {
+func (s *MalformedCSRException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4820,21 +4820,21 @@ func (s MalformedCSRException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MalformedCSRException) OrigErr() error {
+func (s *MalformedCSRException) OrigErr() error {
 	return nil
 }
 
-func (s MalformedCSRException) Error() string {
+func (s *MalformedCSRException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MalformedCSRException) StatusCode() int {
+func (s *MalformedCSRException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MalformedCSRException) RequestID() string {
+func (s *MalformedCSRException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4863,12 +4863,12 @@ func newErrorMalformedCertificateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MalformedCertificateException) Code() string {
+func (s *MalformedCertificateException) Code() string {
 	return "MalformedCertificateException"
 }
 
 // Message returns the exception's message.
-func (s MalformedCertificateException) Message() string {
+func (s *MalformedCertificateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4876,21 +4876,21 @@ func (s MalformedCertificateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MalformedCertificateException) OrigErr() error {
+func (s *MalformedCertificateException) OrigErr() error {
 	return nil
 }
 
-func (s MalformedCertificateException) Error() string {
+func (s *MalformedCertificateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MalformedCertificateException) StatusCode() int {
+func (s *MalformedCertificateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MalformedCertificateException) RequestID() string {
+func (s *MalformedCertificateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4995,12 +4995,12 @@ func newErrorPermissionAlreadyExistsException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s PermissionAlreadyExistsException) Code() string {
+func (s *PermissionAlreadyExistsException) Code() string {
 	return "PermissionAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s PermissionAlreadyExistsException) Message() string {
+func (s *PermissionAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5008,21 +5008,21 @@ func (s PermissionAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PermissionAlreadyExistsException) OrigErr() error {
+func (s *PermissionAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s PermissionAlreadyExistsException) Error() string {
+func (s *PermissionAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PermissionAlreadyExistsException) StatusCode() int {
+func (s *PermissionAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PermissionAlreadyExistsException) RequestID() string {
+func (s *PermissionAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5051,12 +5051,12 @@ func newErrorRequestAlreadyProcessedException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s RequestAlreadyProcessedException) Code() string {
+func (s *RequestAlreadyProcessedException) Code() string {
 	return "RequestAlreadyProcessedException"
 }
 
 // Message returns the exception's message.
-func (s RequestAlreadyProcessedException) Message() string {
+func (s *RequestAlreadyProcessedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5064,21 +5064,21 @@ func (s RequestAlreadyProcessedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestAlreadyProcessedException) OrigErr() error {
+func (s *RequestAlreadyProcessedException) OrigErr() error {
 	return nil
 }
 
-func (s RequestAlreadyProcessedException) Error() string {
+func (s *RequestAlreadyProcessedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestAlreadyProcessedException) StatusCode() int {
+func (s *RequestAlreadyProcessedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestAlreadyProcessedException) RequestID() string {
+func (s *RequestAlreadyProcessedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5107,12 +5107,12 @@ func newErrorRequestFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestFailedException) Code() string {
+func (s *RequestFailedException) Code() string {
 	return "RequestFailedException"
 }
 
 // Message returns the exception's message.
-func (s RequestFailedException) Message() string {
+func (s *RequestFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5120,21 +5120,21 @@ func (s RequestFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestFailedException) OrigErr() error {
+func (s *RequestFailedException) OrigErr() error {
 	return nil
 }
 
-func (s RequestFailedException) Error() string {
+func (s *RequestFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestFailedException) StatusCode() int {
+func (s *RequestFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestFailedException) RequestID() string {
+func (s *RequestFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5163,12 +5163,12 @@ func newErrorRequestInProgressException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestInProgressException) Code() string {
+func (s *RequestInProgressException) Code() string {
 	return "RequestInProgressException"
 }
 
 // Message returns the exception's message.
-func (s RequestInProgressException) Message() string {
+func (s *RequestInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5176,21 +5176,21 @@ func (s RequestInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestInProgressException) OrigErr() error {
+func (s *RequestInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s RequestInProgressException) Error() string {
+func (s *RequestInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestInProgressException) StatusCode() int {
+func (s *RequestInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestInProgressException) RequestID() string {
+func (s *RequestInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5220,12 +5220,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5233,21 +5233,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5616,12 +5616,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5629,21 +5629,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/alexaforbusiness/api.go
+++ b/service/alexaforbusiness/api.go
@@ -8748,12 +8748,12 @@ func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyExistsException) Code() string {
+func (s *AlreadyExistsException) Code() string {
 	return "AlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyExistsException) Message() string {
+func (s *AlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8761,21 +8761,21 @@ func (s AlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyExistsException) OrigErr() error {
+func (s *AlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyExistsException) Error() string {
+func (s *AlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyExistsException) StatusCode() int {
+func (s *AlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyExistsException) RequestID() string {
+func (s *AlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9520,12 +9520,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9533,21 +9533,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12601,12 +12601,12 @@ func newErrorDeviceNotRegisteredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DeviceNotRegisteredException) Code() string {
+func (s *DeviceNotRegisteredException) Code() string {
 	return "DeviceNotRegisteredException"
 }
 
 // Message returns the exception's message.
-func (s DeviceNotRegisteredException) Message() string {
+func (s *DeviceNotRegisteredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12614,21 +12614,21 @@ func (s DeviceNotRegisteredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeviceNotRegisteredException) OrigErr() error {
+func (s *DeviceNotRegisteredException) OrigErr() error {
 	return nil
 }
 
-func (s DeviceNotRegisteredException) Error() string {
+func (s *DeviceNotRegisteredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeviceNotRegisteredException) StatusCode() int {
+func (s *DeviceNotRegisteredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeviceNotRegisteredException) RequestID() string {
+func (s *DeviceNotRegisteredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14177,12 +14177,12 @@ func newErrorInvalidCertificateAuthorityException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidCertificateAuthorityException) Code() string {
+func (s *InvalidCertificateAuthorityException) Code() string {
 	return "InvalidCertificateAuthorityException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCertificateAuthorityException) Message() string {
+func (s *InvalidCertificateAuthorityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14190,21 +14190,21 @@ func (s InvalidCertificateAuthorityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCertificateAuthorityException) OrigErr() error {
+func (s *InvalidCertificateAuthorityException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCertificateAuthorityException) Error() string {
+func (s *InvalidCertificateAuthorityException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCertificateAuthorityException) StatusCode() int {
+func (s *InvalidCertificateAuthorityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCertificateAuthorityException) RequestID() string {
+func (s *InvalidCertificateAuthorityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14233,12 +14233,12 @@ func newErrorInvalidDeviceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDeviceException) Code() string {
+func (s *InvalidDeviceException) Code() string {
 	return "InvalidDeviceException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeviceException) Message() string {
+func (s *InvalidDeviceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14246,21 +14246,21 @@ func (s InvalidDeviceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeviceException) OrigErr() error {
+func (s *InvalidDeviceException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeviceException) Error() string {
+func (s *InvalidDeviceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeviceException) StatusCode() int {
+func (s *InvalidDeviceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeviceException) RequestID() string {
+func (s *InvalidDeviceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14289,12 +14289,12 @@ func newErrorInvalidSecretsManagerResourceException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s InvalidSecretsManagerResourceException) Code() string {
+func (s *InvalidSecretsManagerResourceException) Code() string {
 	return "InvalidSecretsManagerResourceException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSecretsManagerResourceException) Message() string {
+func (s *InvalidSecretsManagerResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14302,21 +14302,21 @@ func (s InvalidSecretsManagerResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSecretsManagerResourceException) OrigErr() error {
+func (s *InvalidSecretsManagerResourceException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSecretsManagerResourceException) Error() string {
+func (s *InvalidSecretsManagerResourceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSecretsManagerResourceException) StatusCode() int {
+func (s *InvalidSecretsManagerResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSecretsManagerResourceException) RequestID() string {
+func (s *InvalidSecretsManagerResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14345,12 +14345,12 @@ func newErrorInvalidServiceLinkedRoleStateException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s InvalidServiceLinkedRoleStateException) Code() string {
+func (s *InvalidServiceLinkedRoleStateException) Code() string {
 	return "InvalidServiceLinkedRoleStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidServiceLinkedRoleStateException) Message() string {
+func (s *InvalidServiceLinkedRoleStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14358,21 +14358,21 @@ func (s InvalidServiceLinkedRoleStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidServiceLinkedRoleStateException) OrigErr() error {
+func (s *InvalidServiceLinkedRoleStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidServiceLinkedRoleStateException) Error() string {
+func (s *InvalidServiceLinkedRoleStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidServiceLinkedRoleStateException) StatusCode() int {
+func (s *InvalidServiceLinkedRoleStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidServiceLinkedRoleStateException) RequestID() string {
+func (s *InvalidServiceLinkedRoleStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14401,12 +14401,12 @@ func newErrorInvalidUserStatusException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidUserStatusException) Code() string {
+func (s *InvalidUserStatusException) Code() string {
 	return "InvalidUserStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidUserStatusException) Message() string {
+func (s *InvalidUserStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14414,21 +14414,21 @@ func (s InvalidUserStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidUserStatusException) OrigErr() error {
+func (s *InvalidUserStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidUserStatusException) Error() string {
+func (s *InvalidUserStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidUserStatusException) StatusCode() int {
+func (s *InvalidUserStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidUserStatusException) RequestID() string {
+func (s *InvalidUserStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14457,12 +14457,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14470,21 +14470,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15538,12 +15538,12 @@ func newErrorNameInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NameInUseException) Code() string {
+func (s *NameInUseException) Code() string {
 	return "NameInUseException"
 }
 
 // Message returns the exception's message.
-func (s NameInUseException) Message() string {
+func (s *NameInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15551,21 +15551,21 @@ func (s NameInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NameInUseException) OrigErr() error {
+func (s *NameInUseException) OrigErr() error {
 	return nil
 }
 
-func (s NameInUseException) Error() string {
+func (s *NameInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NameInUseException) StatusCode() int {
+func (s *NameInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NameInUseException) RequestID() string {
+func (s *NameInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15786,12 +15786,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15799,21 +15799,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16818,12 +16818,12 @@ func newErrorResourceAssociatedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAssociatedException) Code() string {
+func (s *ResourceAssociatedException) Code() string {
 	return "ResourceAssociatedException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAssociatedException) Message() string {
+func (s *ResourceAssociatedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16831,21 +16831,21 @@ func (s ResourceAssociatedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAssociatedException) OrigErr() error {
+func (s *ResourceAssociatedException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAssociatedException) Error() string {
+func (s *ResourceAssociatedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAssociatedException) StatusCode() int {
+func (s *ResourceAssociatedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAssociatedException) RequestID() string {
+func (s *ResourceAssociatedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16877,12 +16877,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16890,21 +16890,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18642,12 +18642,12 @@ func newErrorSkillNotLinkedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SkillNotLinkedException) Code() string {
+func (s *SkillNotLinkedException) Code() string {
 	return "SkillNotLinkedException"
 }
 
 // Message returns the exception's message.
-func (s SkillNotLinkedException) Message() string {
+func (s *SkillNotLinkedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18655,21 +18655,21 @@ func (s SkillNotLinkedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SkillNotLinkedException) OrigErr() error {
+func (s *SkillNotLinkedException) OrigErr() error {
 	return nil
 }
 
-func (s SkillNotLinkedException) Error() string {
+func (s *SkillNotLinkedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SkillNotLinkedException) StatusCode() int {
+func (s *SkillNotLinkedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SkillNotLinkedException) RequestID() string {
+func (s *SkillNotLinkedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19299,12 +19299,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19312,21 +19312,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/amplify/api.go
+++ b/service/amplify/api.go
@@ -3862,12 +3862,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3875,21 +3875,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5686,12 +5686,12 @@ func newErrorDependentServiceFailureException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s DependentServiceFailureException) Code() string {
+func (s *DependentServiceFailureException) Code() string {
 	return "DependentServiceFailureException"
 }
 
 // Message returns the exception's message.
-func (s DependentServiceFailureException) Message() string {
+func (s *DependentServiceFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5699,21 +5699,21 @@ func (s DependentServiceFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DependentServiceFailureException) OrigErr() error {
+func (s *DependentServiceFailureException) OrigErr() error {
 	return nil
 }
 
-func (s DependentServiceFailureException) Error() string {
+func (s *DependentServiceFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DependentServiceFailureException) StatusCode() int {
+func (s *DependentServiceFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DependentServiceFailureException) RequestID() string {
+func (s *DependentServiceFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6502,12 +6502,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6515,21 +6515,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6710,12 +6710,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6723,21 +6723,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7585,12 +7585,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7598,21 +7598,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7694,12 +7694,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7707,21 +7707,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8404,12 +8404,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8417,21 +8417,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -11790,12 +11790,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11803,21 +11803,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12027,12 +12027,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12040,21 +12040,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20308,12 +20308,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20321,21 +20321,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20953,12 +20953,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20966,21 +20966,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22420,12 +22420,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22433,21 +22433,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23203,12 +23203,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23216,21 +23216,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23259,12 +23259,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23272,21 +23272,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/apigatewaymanagementapi/api.go
+++ b/service/apigatewaymanagementapi/api.go
@@ -354,12 +354,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -367,21 +367,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -487,12 +487,12 @@ func newErrorGoneException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s GoneException) Code() string {
+func (s *GoneException) Code() string {
 	return "GoneException"
 }
 
 // Message returns the exception's message.
-func (s GoneException) Message() string {
+func (s *GoneException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -500,21 +500,21 @@ func (s GoneException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GoneException) OrigErr() error {
+func (s *GoneException) OrigErr() error {
 	return nil
 }
 
-func (s GoneException) Error() string {
+func (s *GoneException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GoneException) StatusCode() int {
+func (s *GoneException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GoneException) RequestID() string {
+func (s *GoneException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -580,12 +580,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -593,21 +593,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -636,12 +636,12 @@ func newErrorPayloadTooLargeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PayloadTooLargeException) Code() string {
+func (s *PayloadTooLargeException) Code() string {
 	return "PayloadTooLargeException"
 }
 
 // Message returns the exception's message.
-func (s PayloadTooLargeException) Message() string {
+func (s *PayloadTooLargeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -649,21 +649,21 @@ func (s PayloadTooLargeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PayloadTooLargeException) OrigErr() error {
+func (s *PayloadTooLargeException) OrigErr() error {
 	return nil
 }
 
-func (s PayloadTooLargeException) Error() string {
+func (s *PayloadTooLargeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PayloadTooLargeException) StatusCode() int {
+func (s *PayloadTooLargeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PayloadTooLargeException) RequestID() string {
+func (s *PayloadTooLargeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/apigatewayv2/api.go
+++ b/service/apigatewayv2/api.go
@@ -6167,12 +6167,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6180,21 +6180,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6598,12 +6598,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6611,21 +6611,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6657,12 +6657,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6670,21 +6670,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14301,12 +14301,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14314,21 +14314,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15138,12 +15138,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15151,21 +15151,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/appconfig/api.go
+++ b/service/appconfig/api.go
@@ -2887,12 +2887,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2900,21 +2900,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3004,12 +3004,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3017,21 +3017,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5176,12 +5176,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5189,21 +5189,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5832,12 +5832,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5845,21 +5845,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/applicationautoscaling/api.go
+++ b/service/applicationautoscaling/api.go
@@ -1367,12 +1367,12 @@ func newErrorConcurrentUpdateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConcurrentUpdateException) Code() string {
+func (s *ConcurrentUpdateException) Code() string {
 	return "ConcurrentUpdateException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentUpdateException) Message() string {
+func (s *ConcurrentUpdateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1380,21 +1380,21 @@ func (s ConcurrentUpdateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentUpdateException) OrigErr() error {
+func (s *ConcurrentUpdateException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentUpdateException) Error() string {
+func (s *ConcurrentUpdateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentUpdateException) StatusCode() int {
+func (s *ConcurrentUpdateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentUpdateException) RequestID() string {
+func (s *ConcurrentUpdateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2886,12 +2886,12 @@ func newErrorFailedResourceAccessException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FailedResourceAccessException) Code() string {
+func (s *FailedResourceAccessException) Code() string {
 	return "FailedResourceAccessException"
 }
 
 // Message returns the exception's message.
-func (s FailedResourceAccessException) Message() string {
+func (s *FailedResourceAccessException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2899,21 +2899,21 @@ func (s FailedResourceAccessException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FailedResourceAccessException) OrigErr() error {
+func (s *FailedResourceAccessException) OrigErr() error {
 	return nil
 }
 
-func (s FailedResourceAccessException) Error() string {
+func (s *FailedResourceAccessException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FailedResourceAccessException) StatusCode() int {
+func (s *FailedResourceAccessException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FailedResourceAccessException) RequestID() string {
+func (s *FailedResourceAccessException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2942,12 +2942,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2955,21 +2955,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2998,12 +2998,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3011,21 +3011,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3055,12 +3055,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3068,21 +3068,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3168,12 +3168,12 @@ func newErrorObjectNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ObjectNotFoundException) Code() string {
+func (s *ObjectNotFoundException) Code() string {
 	return "ObjectNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ObjectNotFoundException) Message() string {
+func (s *ObjectNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3181,21 +3181,21 @@ func (s ObjectNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ObjectNotFoundException) OrigErr() error {
+func (s *ObjectNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ObjectNotFoundException) Error() string {
+func (s *ObjectNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ObjectNotFoundException) StatusCode() int {
+func (s *ObjectNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ObjectNotFoundException) RequestID() string {
+func (s *ObjectNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5236,12 +5236,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5249,21 +5249,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/applicationdiscoveryservice/api.go
+++ b/service/applicationdiscoveryservice/api.go
@@ -2924,12 +2924,12 @@ func newErrorAuthorizationErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AuthorizationErrorException) Code() string {
+func (s *AuthorizationErrorException) Code() string {
 	return "AuthorizationErrorException"
 }
 
 // Message returns the exception's message.
-func (s AuthorizationErrorException) Message() string {
+func (s *AuthorizationErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2937,21 +2937,21 @@ func (s AuthorizationErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AuthorizationErrorException) OrigErr() error {
+func (s *AuthorizationErrorException) OrigErr() error {
 	return nil
 }
 
-func (s AuthorizationErrorException) Error() string {
+func (s *AuthorizationErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AuthorizationErrorException) StatusCode() int {
+func (s *AuthorizationErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AuthorizationErrorException) RequestID() string {
+func (s *AuthorizationErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3151,12 +3151,12 @@ func newErrorConflictErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictErrorException) Code() string {
+func (s *ConflictErrorException) Code() string {
 	return "ConflictErrorException"
 }
 
 // Message returns the exception's message.
-func (s ConflictErrorException) Message() string {
+func (s *ConflictErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3164,21 +3164,21 @@ func (s ConflictErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictErrorException) OrigErr() error {
+func (s *ConflictErrorException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictErrorException) Error() string {
+func (s *ConflictErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictErrorException) StatusCode() int {
+func (s *ConflictErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictErrorException) RequestID() string {
+func (s *ConflictErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4897,12 +4897,12 @@ func newErrorHomeRegionNotSetException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s HomeRegionNotSetException) Code() string {
+func (s *HomeRegionNotSetException) Code() string {
 	return "HomeRegionNotSetException"
 }
 
 // Message returns the exception's message.
-func (s HomeRegionNotSetException) Message() string {
+func (s *HomeRegionNotSetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4910,21 +4910,21 @@ func (s HomeRegionNotSetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s HomeRegionNotSetException) OrigErr() error {
+func (s *HomeRegionNotSetException) OrigErr() error {
 	return nil
 }
 
-func (s HomeRegionNotSetException) Error() string {
+func (s *HomeRegionNotSetException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s HomeRegionNotSetException) StatusCode() int {
+func (s *HomeRegionNotSetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s HomeRegionNotSetException) RequestID() string {
+func (s *HomeRegionNotSetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5164,12 +5164,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5177,21 +5177,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5221,12 +5221,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5234,21 +5234,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5611,12 +5611,12 @@ func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotPermittedException) Code() string {
+func (s *OperationNotPermittedException) Code() string {
 	return "OperationNotPermittedException"
 }
 
 // Message returns the exception's message.
-func (s OperationNotPermittedException) Message() string {
+func (s *OperationNotPermittedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5624,21 +5624,21 @@ func (s OperationNotPermittedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotPermittedException) OrigErr() error {
+func (s *OperationNotPermittedException) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotPermittedException) Error() string {
+func (s *OperationNotPermittedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotPermittedException) StatusCode() int {
+func (s *OperationNotPermittedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotPermittedException) RequestID() string {
+func (s *OperationNotPermittedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5719,12 +5719,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5732,21 +5732,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5776,12 +5776,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5789,21 +5789,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5832,12 +5832,12 @@ func newErrorServerInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServerInternalErrorException) Code() string {
+func (s *ServerInternalErrorException) Code() string {
 	return "ServerInternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s ServerInternalErrorException) Message() string {
+func (s *ServerInternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5845,21 +5845,21 @@ func (s ServerInternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServerInternalErrorException) OrigErr() error {
+func (s *ServerInternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s ServerInternalErrorException) Error() string {
+func (s *ServerInternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServerInternalErrorException) StatusCode() int {
+func (s *ServerInternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServerInternalErrorException) RequestID() string {
+func (s *ServerInternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/applicationinsights/api.go
+++ b/service/applicationinsights/api.go
@@ -2863,12 +2863,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2876,21 +2876,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4188,12 +4188,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4201,21 +4201,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5458,12 +5458,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5471,21 +5471,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5514,12 +5514,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5527,21 +5527,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5732,12 +5732,12 @@ func newErrorTagsAlreadyExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagsAlreadyExistException) Code() string {
+func (s *TagsAlreadyExistException) Code() string {
 	return "TagsAlreadyExistException"
 }
 
 // Message returns the exception's message.
-func (s TagsAlreadyExistException) Message() string {
+func (s *TagsAlreadyExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5745,21 +5745,21 @@ func (s TagsAlreadyExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagsAlreadyExistException) OrigErr() error {
+func (s *TagsAlreadyExistException) OrigErr() error {
 	return nil
 }
 
-func (s TagsAlreadyExistException) Error() string {
+func (s *TagsAlreadyExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagsAlreadyExistException) StatusCode() int {
+func (s *TagsAlreadyExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagsAlreadyExistException) RequestID() string {
+func (s *TagsAlreadyExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5792,12 +5792,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5805,21 +5805,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6351,12 +6351,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6364,21 +6364,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/appmesh/api.go
+++ b/service/appmesh/api.go
@@ -3533,12 +3533,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3546,21 +3546,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3690,12 +3690,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3703,21 +3703,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5437,12 +5437,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5450,21 +5450,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6468,12 +6468,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6481,21 +6481,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6526,12 +6526,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6539,21 +6539,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7697,12 +7697,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7710,21 +7710,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7806,12 +7806,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7819,21 +7819,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8253,12 +8253,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8266,21 +8266,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8711,12 +8711,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8724,21 +8724,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8769,12 +8769,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8782,21 +8782,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/appstream/api.go
+++ b/service/appstream/api.go
@@ -4800,12 +4800,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4813,21 +4813,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8863,12 +8863,12 @@ func newErrorIncompatibleImageException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncompatibleImageException) Code() string {
+func (s *IncompatibleImageException) Code() string {
 	return "IncompatibleImageException"
 }
 
 // Message returns the exception's message.
-func (s IncompatibleImageException) Message() string {
+func (s *IncompatibleImageException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8876,21 +8876,21 @@ func (s IncompatibleImageException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncompatibleImageException) OrigErr() error {
+func (s *IncompatibleImageException) OrigErr() error {
 	return nil
 }
 
-func (s IncompatibleImageException) Error() string {
+func (s *IncompatibleImageException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncompatibleImageException) StatusCode() int {
+func (s *IncompatibleImageException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncompatibleImageException) RequestID() string {
+func (s *IncompatibleImageException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8921,12 +8921,12 @@ func newErrorInvalidAccountStatusException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAccountStatusException) Code() string {
+func (s *InvalidAccountStatusException) Code() string {
 	return "InvalidAccountStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAccountStatusException) Message() string {
+func (s *InvalidAccountStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8934,21 +8934,21 @@ func (s InvalidAccountStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAccountStatusException) OrigErr() error {
+func (s *InvalidAccountStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAccountStatusException) Error() string {
+func (s *InvalidAccountStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAccountStatusException) StatusCode() int {
+func (s *InvalidAccountStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAccountStatusException) RequestID() string {
+func (s *InvalidAccountStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8978,12 +8978,12 @@ func newErrorInvalidParameterCombinationException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterCombinationException) Code() string {
+func (s *InvalidParameterCombinationException) Code() string {
 	return "InvalidParameterCombinationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterCombinationException) Message() string {
+func (s *InvalidParameterCombinationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8991,21 +8991,21 @@ func (s InvalidParameterCombinationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterCombinationException) OrigErr() error {
+func (s *InvalidParameterCombinationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterCombinationException) Error() string {
+func (s *InvalidParameterCombinationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterCombinationException) StatusCode() int {
+func (s *InvalidParameterCombinationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterCombinationException) RequestID() string {
+func (s *InvalidParameterCombinationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9035,12 +9035,12 @@ func newErrorInvalidRoleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRoleException) Code() string {
+func (s *InvalidRoleException) Code() string {
 	return "InvalidRoleException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRoleException) Message() string {
+func (s *InvalidRoleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9048,21 +9048,21 @@ func (s InvalidRoleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRoleException) OrigErr() error {
+func (s *InvalidRoleException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRoleException) Error() string {
+func (s *InvalidRoleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRoleException) StatusCode() int {
+func (s *InvalidRoleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRoleException) RequestID() string {
+func (s *InvalidRoleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9127,12 +9127,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9140,21 +9140,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9455,12 +9455,12 @@ func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotPermittedException) Code() string {
+func (s *OperationNotPermittedException) Code() string {
 	return "OperationNotPermittedException"
 }
 
 // Message returns the exception's message.
-func (s OperationNotPermittedException) Message() string {
+func (s *OperationNotPermittedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9468,21 +9468,21 @@ func (s OperationNotPermittedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotPermittedException) OrigErr() error {
+func (s *OperationNotPermittedException) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotPermittedException) Error() string {
+func (s *OperationNotPermittedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotPermittedException) StatusCode() int {
+func (s *OperationNotPermittedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotPermittedException) RequestID() string {
+func (s *OperationNotPermittedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9512,12 +9512,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9525,21 +9525,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9611,12 +9611,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9624,21 +9624,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9668,12 +9668,12 @@ func newErrorResourceNotAvailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotAvailableException) Code() string {
+func (s *ResourceNotAvailableException) Code() string {
 	return "ResourceNotAvailableException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotAvailableException) Message() string {
+func (s *ResourceNotAvailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9681,21 +9681,21 @@ func (s ResourceNotAvailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotAvailableException) OrigErr() error {
+func (s *ResourceNotAvailableException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotAvailableException) Error() string {
+func (s *ResourceNotAvailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotAvailableException) StatusCode() int {
+func (s *ResourceNotAvailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotAvailableException) RequestID() string {
+func (s *ResourceNotAvailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9725,12 +9725,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9738,21 +9738,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/appsync/api.go
+++ b/service/appsync/api.go
@@ -3861,12 +3861,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3874,21 +3874,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4159,12 +4159,12 @@ func newErrorApiKeyLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ApiKeyLimitExceededException) Code() string {
+func (s *ApiKeyLimitExceededException) Code() string {
 	return "ApiKeyLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ApiKeyLimitExceededException) Message() string {
+func (s *ApiKeyLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4172,21 +4172,21 @@ func (s ApiKeyLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApiKeyLimitExceededException) OrigErr() error {
+func (s *ApiKeyLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ApiKeyLimitExceededException) Error() string {
+func (s *ApiKeyLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApiKeyLimitExceededException) StatusCode() int {
+func (s *ApiKeyLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApiKeyLimitExceededException) RequestID() string {
+func (s *ApiKeyLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4216,12 +4216,12 @@ func newErrorApiKeyValidityOutOfBoundsException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s ApiKeyValidityOutOfBoundsException) Code() string {
+func (s *ApiKeyValidityOutOfBoundsException) Code() string {
 	return "ApiKeyValidityOutOfBoundsException"
 }
 
 // Message returns the exception's message.
-func (s ApiKeyValidityOutOfBoundsException) Message() string {
+func (s *ApiKeyValidityOutOfBoundsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4229,21 +4229,21 @@ func (s ApiKeyValidityOutOfBoundsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApiKeyValidityOutOfBoundsException) OrigErr() error {
+func (s *ApiKeyValidityOutOfBoundsException) OrigErr() error {
 	return nil
 }
 
-func (s ApiKeyValidityOutOfBoundsException) Error() string {
+func (s *ApiKeyValidityOutOfBoundsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApiKeyValidityOutOfBoundsException) StatusCode() int {
+func (s *ApiKeyValidityOutOfBoundsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApiKeyValidityOutOfBoundsException) RequestID() string {
+func (s *ApiKeyValidityOutOfBoundsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4272,12 +4272,12 @@ func newErrorApiLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ApiLimitExceededException) Code() string {
+func (s *ApiLimitExceededException) Code() string {
 	return "ApiLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ApiLimitExceededException) Message() string {
+func (s *ApiLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4285,21 +4285,21 @@ func (s ApiLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApiLimitExceededException) OrigErr() error {
+func (s *ApiLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ApiLimitExceededException) Error() string {
+func (s *ApiLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApiLimitExceededException) StatusCode() int {
+func (s *ApiLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApiLimitExceededException) RequestID() string {
+func (s *ApiLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4412,12 +4412,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4425,21 +4425,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4570,12 +4570,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4583,21 +4583,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7209,12 +7209,12 @@ func newErrorGraphQLSchemaException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s GraphQLSchemaException) Code() string {
+func (s *GraphQLSchemaException) Code() string {
 	return "GraphQLSchemaException"
 }
 
 // Message returns the exception's message.
-func (s GraphQLSchemaException) Message() string {
+func (s *GraphQLSchemaException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7222,21 +7222,21 @@ func (s GraphQLSchemaException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GraphQLSchemaException) OrigErr() error {
+func (s *GraphQLSchemaException) OrigErr() error {
 	return nil
 }
 
-func (s GraphQLSchemaException) Error() string {
+func (s *GraphQLSchemaException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GraphQLSchemaException) StatusCode() int {
+func (s *GraphQLSchemaException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GraphQLSchemaException) RequestID() string {
+func (s *GraphQLSchemaException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7430,12 +7430,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7443,21 +7443,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7550,12 +7550,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7563,21 +7563,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8447,12 +8447,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8460,21 +8460,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9076,12 +9076,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9089,21 +9089,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/athena/api.go
+++ b/service/athena/api.go
@@ -2926,12 +2926,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2939,21 +2939,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2987,12 +2987,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3000,21 +3000,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3763,12 +3763,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3776,21 +3776,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4358,12 +4358,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4371,21 +4371,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/augmentedairuntime/api.go
+++ b/service/augmentedairuntime/api.go
@@ -544,12 +544,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -557,21 +557,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -965,12 +965,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -978,21 +978,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1146,12 +1146,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1159,21 +1159,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1203,12 +1203,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1216,21 +1216,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1425,12 +1425,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1438,21 +1438,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1481,12 +1481,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1494,21 +1494,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/autoscalingplans/api.go
+++ b/service/autoscalingplans/api.go
@@ -635,12 +635,12 @@ func newErrorConcurrentUpdateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConcurrentUpdateException) Code() string {
+func (s *ConcurrentUpdateException) Code() string {
 	return "ConcurrentUpdateException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentUpdateException) Message() string {
+func (s *ConcurrentUpdateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -648,21 +648,21 @@ func (s ConcurrentUpdateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentUpdateException) OrigErr() error {
+func (s *ConcurrentUpdateException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentUpdateException) Error() string {
+func (s *ConcurrentUpdateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentUpdateException) StatusCode() int {
+func (s *ConcurrentUpdateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentUpdateException) RequestID() string {
+func (s *ConcurrentUpdateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1562,12 +1562,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1575,21 +1575,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1618,12 +1618,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1631,21 +1631,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1675,12 +1675,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1688,21 +1688,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1784,12 +1784,12 @@ func newErrorObjectNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ObjectNotFoundException) Code() string {
+func (s *ObjectNotFoundException) Code() string {
 	return "ObjectNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ObjectNotFoundException) Message() string {
+func (s *ObjectNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1797,21 +1797,21 @@ func (s ObjectNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ObjectNotFoundException) OrigErr() error {
+func (s *ObjectNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ObjectNotFoundException) Error() string {
+func (s *ObjectNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ObjectNotFoundException) StatusCode() int {
+func (s *ObjectNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ObjectNotFoundException) RequestID() string {
+func (s *ObjectNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2901,12 +2901,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2914,21 +2914,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/backup/api.go
+++ b/service/backup/api.go
@@ -4950,12 +4950,12 @@ func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyExistsException) Code() string {
+func (s *AlreadyExistsException) Code() string {
 	return "AlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyExistsException) Message() string {
+func (s *AlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4963,21 +4963,21 @@ func (s AlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyExistsException) OrigErr() error {
+func (s *AlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyExistsException) Error() string {
+func (s *AlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyExistsException) StatusCode() int {
+func (s *AlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyExistsException) RequestID() string {
+func (s *AlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6121,12 +6121,12 @@ func newErrorDependencyFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DependencyFailureException) Code() string {
+func (s *DependencyFailureException) Code() string {
 	return "DependencyFailureException"
 }
 
 // Message returns the exception's message.
-func (s DependencyFailureException) Message() string {
+func (s *DependencyFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6134,21 +6134,21 @@ func (s DependencyFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DependencyFailureException) OrigErr() error {
+func (s *DependencyFailureException) OrigErr() error {
 	return nil
 }
 
-func (s DependencyFailureException) Error() string {
+func (s *DependencyFailureException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DependencyFailureException) StatusCode() int {
+func (s *DependencyFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DependencyFailureException) RequestID() string {
+func (s *DependencyFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7929,12 +7929,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7942,21 +7942,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7992,12 +7992,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8005,21 +8005,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8292,12 +8292,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8305,21 +8305,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9644,12 +9644,12 @@ func newErrorMissingParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MissingParameterValueException) Code() string {
+func (s *MissingParameterValueException) Code() string {
 	return "MissingParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s MissingParameterValueException) Message() string {
+func (s *MissingParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9657,21 +9657,21 @@ func (s MissingParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MissingParameterValueException) OrigErr() error {
+func (s *MissingParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s MissingParameterValueException) Error() string {
+func (s *MissingParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MissingParameterValueException) StatusCode() int {
+func (s *MissingParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MissingParameterValueException) RequestID() string {
+func (s *MissingParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10470,12 +10470,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10483,21 +10483,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11062,12 +11062,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11075,21 +11075,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/batch/api.go
+++ b/service/batch/api.go
@@ -2001,12 +2001,12 @@ func newErrorClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientException) Code() string {
+func (s *ClientException) Code() string {
 	return "ClientException"
 }
 
 // Message returns the exception's message.
-func (s ClientException) Message() string {
+func (s *ClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2014,21 +2014,21 @@ func (s ClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientException) OrigErr() error {
+func (s *ClientException) OrigErr() error {
 	return nil
 }
 
-func (s ClientException) Error() string {
+func (s *ClientException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientException) StatusCode() int {
+func (s *ClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientException) RequestID() string {
+func (s *ClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5533,12 +5533,12 @@ func newErrorServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServerException) Code() string {
+func (s *ServerException) Code() string {
 	return "ServerException"
 }
 
 // Message returns the exception's message.
-func (s ServerException) Message() string {
+func (s *ServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5546,21 +5546,21 @@ func (s ServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServerException) OrigErr() error {
+func (s *ServerException) OrigErr() error {
 	return nil
 }
 
-func (s ServerException) Error() string {
+func (s *ServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServerException) StatusCode() int {
+func (s *ServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServerException) RequestID() string {
+func (s *ServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/budgets/api.go
+++ b/service/budgets/api.go
@@ -1342,12 +1342,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1355,21 +1355,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2284,12 +2284,12 @@ func newErrorCreationLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CreationLimitExceededException) Code() string {
+func (s *CreationLimitExceededException) Code() string {
 	return "CreationLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s CreationLimitExceededException) Message() string {
+func (s *CreationLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2297,21 +2297,21 @@ func (s CreationLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CreationLimitExceededException) OrigErr() error {
+func (s *CreationLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s CreationLimitExceededException) Error() string {
+func (s *CreationLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CreationLimitExceededException) StatusCode() int {
+func (s *CreationLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CreationLimitExceededException) RequestID() string {
+func (s *CreationLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3187,12 +3187,12 @@ func newErrorDuplicateRecordException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateRecordException) Code() string {
+func (s *DuplicateRecordException) Code() string {
 	return "DuplicateRecordException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateRecordException) Message() string {
+func (s *DuplicateRecordException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3200,21 +3200,21 @@ func (s DuplicateRecordException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateRecordException) OrigErr() error {
+func (s *DuplicateRecordException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateRecordException) Error() string {
+func (s *DuplicateRecordException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateRecordException) StatusCode() int {
+func (s *DuplicateRecordException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateRecordException) RequestID() string {
+func (s *DuplicateRecordException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3244,12 +3244,12 @@ func newErrorExpiredNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExpiredNextTokenException) Code() string {
+func (s *ExpiredNextTokenException) Code() string {
 	return "ExpiredNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s ExpiredNextTokenException) Message() string {
+func (s *ExpiredNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3257,21 +3257,21 @@ func (s ExpiredNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExpiredNextTokenException) OrigErr() error {
+func (s *ExpiredNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s ExpiredNextTokenException) Error() string {
+func (s *ExpiredNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExpiredNextTokenException) StatusCode() int {
+func (s *ExpiredNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExpiredNextTokenException) RequestID() string {
+func (s *ExpiredNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3302,12 +3302,12 @@ func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalErrorException) Code() string {
+func (s *InternalErrorException) Code() string {
 	return "InternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalErrorException) Message() string {
+func (s *InternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3315,21 +3315,21 @@ func (s InternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalErrorException) OrigErr() error {
+func (s *InternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalErrorException) Error() string {
+func (s *InternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalErrorException) StatusCode() int {
+func (s *InternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalErrorException) RequestID() string {
+func (s *InternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3359,12 +3359,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3372,21 +3372,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3417,12 +3417,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3430,21 +3430,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3474,12 +3474,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3487,21 +3487,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/chime/api.go
+++ b/service/chime/api.go
@@ -10137,12 +10137,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10150,21 +10150,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10742,12 +10742,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10755,21 +10755,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11508,12 +11508,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11521,21 +11521,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13701,12 +13701,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13714,21 +13714,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16748,12 +16748,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16761,21 +16761,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17983,12 +17983,12 @@ func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceededException) Code() string {
+func (s *ResourceLimitExceededException) Code() string {
 	return "ResourceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceededException) Message() string {
+func (s *ResourceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17996,21 +17996,21 @@ func (s ResourceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceededException) OrigErr() error {
+func (s *ResourceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceededException) Error() string {
+func (s *ResourceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceededException) StatusCode() int {
+func (s *ResourceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceededException) RequestID() string {
+func (s *ResourceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18350,12 +18350,12 @@ func newErrorServiceFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceFailureException) Code() string {
+func (s *ServiceFailureException) Code() string {
 	return "ServiceFailureException"
 }
 
 // Message returns the exception's message.
-func (s ServiceFailureException) Message() string {
+func (s *ServiceFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18363,21 +18363,21 @@ func (s ServiceFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceFailureException) OrigErr() error {
+func (s *ServiceFailureException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceFailureException) Error() string {
+func (s *ServiceFailureException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceFailureException) StatusCode() int {
+func (s *ServiceFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceFailureException) RequestID() string {
+func (s *ServiceFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18408,12 +18408,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18421,21 +18421,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18718,12 +18718,12 @@ func newErrorThrottledClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottledClientException) Code() string {
+func (s *ThrottledClientException) Code() string {
 	return "ThrottledClientException"
 }
 
 // Message returns the exception's message.
-func (s ThrottledClientException) Message() string {
+func (s *ThrottledClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18731,21 +18731,21 @@ func (s ThrottledClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottledClientException) OrigErr() error {
+func (s *ThrottledClientException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottledClientException) Error() string {
+func (s *ThrottledClientException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottledClientException) StatusCode() int {
+func (s *ThrottledClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottledClientException) RequestID() string {
+func (s *ThrottledClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18776,12 +18776,12 @@ func newErrorUnauthorizedClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedClientException) Code() string {
+func (s *UnauthorizedClientException) Code() string {
 	return "UnauthorizedClientException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedClientException) Message() string {
+func (s *UnauthorizedClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18789,21 +18789,21 @@ func (s UnauthorizedClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedClientException) OrigErr() error {
+func (s *UnauthorizedClientException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedClientException) Error() string {
+func (s *UnauthorizedClientException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedClientException) StatusCode() int {
+func (s *UnauthorizedClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedClientException) RequestID() string {
+func (s *UnauthorizedClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18835,12 +18835,12 @@ func newErrorUnprocessableEntityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnprocessableEntityException) Code() string {
+func (s *UnprocessableEntityException) Code() string {
 	return "UnprocessableEntityException"
 }
 
 // Message returns the exception's message.
-func (s UnprocessableEntityException) Message() string {
+func (s *UnprocessableEntityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18848,21 +18848,21 @@ func (s UnprocessableEntityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnprocessableEntityException) OrigErr() error {
+func (s *UnprocessableEntityException) OrigErr() error {
 	return nil
 }
 
-func (s UnprocessableEntityException) Error() string {
+func (s *UnprocessableEntityException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnprocessableEntityException) StatusCode() int {
+func (s *UnprocessableEntityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnprocessableEntityException) RequestID() string {
+func (s *UnprocessableEntityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cloud9/api.go
+++ b/service/cloud9/api.go
@@ -1392,12 +1392,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1405,21 +1405,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1448,12 +1448,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1461,21 +1461,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2341,12 +2341,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2354,21 +2354,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2397,12 +2397,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2410,21 +2410,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2453,12 +2453,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2466,21 +2466,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2643,12 +2643,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2656,21 +2656,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2836,12 +2836,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2849,21 +2849,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/clouddirectory/api.go
+++ b/service/clouddirectory/api.go
@@ -8743,12 +8743,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8756,21 +8756,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12851,12 +12851,12 @@ func newErrorBatchWriteException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BatchWriteException) Code() string {
+func (s *BatchWriteException) Code() string {
 	return "BatchWriteException"
 }
 
 // Message returns the exception's message.
-func (s BatchWriteException) Message() string {
+func (s *BatchWriteException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12864,21 +12864,21 @@ func (s BatchWriteException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BatchWriteException) OrigErr() error {
+func (s *BatchWriteException) OrigErr() error {
 	return nil
 }
 
-func (s BatchWriteException) Error() string {
+func (s *BatchWriteException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BatchWriteException) StatusCode() int {
+func (s *BatchWriteException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BatchWriteException) RequestID() string {
+func (s *BatchWriteException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13386,12 +13386,12 @@ func newErrorCannotListParentOfRootException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s CannotListParentOfRootException) Code() string {
+func (s *CannotListParentOfRootException) Code() string {
 	return "CannotListParentOfRootException"
 }
 
 // Message returns the exception's message.
-func (s CannotListParentOfRootException) Message() string {
+func (s *CannotListParentOfRootException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13399,21 +13399,21 @@ func (s CannotListParentOfRootException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CannotListParentOfRootException) OrigErr() error {
+func (s *CannotListParentOfRootException) OrigErr() error {
 	return nil
 }
 
-func (s CannotListParentOfRootException) Error() string {
+func (s *CannotListParentOfRootException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CannotListParentOfRootException) StatusCode() int {
+func (s *CannotListParentOfRootException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CannotListParentOfRootException) RequestID() string {
+func (s *CannotListParentOfRootException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14786,12 +14786,12 @@ func newErrorDirectoryAlreadyExistsException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s DirectoryAlreadyExistsException) Code() string {
+func (s *DirectoryAlreadyExistsException) Code() string {
 	return "DirectoryAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryAlreadyExistsException) Message() string {
+func (s *DirectoryAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14799,21 +14799,21 @@ func (s DirectoryAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryAlreadyExistsException) OrigErr() error {
+func (s *DirectoryAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryAlreadyExistsException) Error() string {
+func (s *DirectoryAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryAlreadyExistsException) StatusCode() int {
+func (s *DirectoryAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryAlreadyExistsException) RequestID() string {
+func (s *DirectoryAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14843,12 +14843,12 @@ func newErrorDirectoryDeletedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DirectoryDeletedException) Code() string {
+func (s *DirectoryDeletedException) Code() string {
 	return "DirectoryDeletedException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryDeletedException) Message() string {
+func (s *DirectoryDeletedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14856,21 +14856,21 @@ func (s DirectoryDeletedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryDeletedException) OrigErr() error {
+func (s *DirectoryDeletedException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryDeletedException) Error() string {
+func (s *DirectoryDeletedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryDeletedException) StatusCode() int {
+func (s *DirectoryDeletedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryDeletedException) RequestID() string {
+func (s *DirectoryDeletedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14899,12 +14899,12 @@ func newErrorDirectoryNotDisabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DirectoryNotDisabledException) Code() string {
+func (s *DirectoryNotDisabledException) Code() string {
 	return "DirectoryNotDisabledException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryNotDisabledException) Message() string {
+func (s *DirectoryNotDisabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14912,21 +14912,21 @@ func (s DirectoryNotDisabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryNotDisabledException) OrigErr() error {
+func (s *DirectoryNotDisabledException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryNotDisabledException) Error() string {
+func (s *DirectoryNotDisabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryNotDisabledException) StatusCode() int {
+func (s *DirectoryNotDisabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryNotDisabledException) RequestID() string {
+func (s *DirectoryNotDisabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14955,12 +14955,12 @@ func newErrorDirectoryNotEnabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DirectoryNotEnabledException) Code() string {
+func (s *DirectoryNotEnabledException) Code() string {
 	return "DirectoryNotEnabledException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryNotEnabledException) Message() string {
+func (s *DirectoryNotEnabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14968,21 +14968,21 @@ func (s DirectoryNotEnabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryNotEnabledException) OrigErr() error {
+func (s *DirectoryNotEnabledException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryNotEnabledException) Error() string {
+func (s *DirectoryNotEnabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryNotEnabledException) StatusCode() int {
+func (s *DirectoryNotEnabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryNotEnabledException) RequestID() string {
+func (s *DirectoryNotEnabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15184,12 +15184,12 @@ func newErrorFacetAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FacetAlreadyExistsException) Code() string {
+func (s *FacetAlreadyExistsException) Code() string {
 	return "FacetAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s FacetAlreadyExistsException) Message() string {
+func (s *FacetAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15197,21 +15197,21 @@ func (s FacetAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FacetAlreadyExistsException) OrigErr() error {
+func (s *FacetAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s FacetAlreadyExistsException) Error() string {
+func (s *FacetAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FacetAlreadyExistsException) StatusCode() int {
+func (s *FacetAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FacetAlreadyExistsException) RequestID() string {
+func (s *FacetAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15503,12 +15503,12 @@ func newErrorFacetInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FacetInUseException) Code() string {
+func (s *FacetInUseException) Code() string {
 	return "FacetInUseException"
 }
 
 // Message returns the exception's message.
-func (s FacetInUseException) Message() string {
+func (s *FacetInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15516,21 +15516,21 @@ func (s FacetInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FacetInUseException) OrigErr() error {
+func (s *FacetInUseException) OrigErr() error {
 	return nil
 }
 
-func (s FacetInUseException) Error() string {
+func (s *FacetInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FacetInUseException) StatusCode() int {
+func (s *FacetInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FacetInUseException) RequestID() string {
+func (s *FacetInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15559,12 +15559,12 @@ func newErrorFacetNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FacetNotFoundException) Code() string {
+func (s *FacetNotFoundException) Code() string {
 	return "FacetNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s FacetNotFoundException) Message() string {
+func (s *FacetNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15572,21 +15572,21 @@ func (s FacetNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FacetNotFoundException) OrigErr() error {
+func (s *FacetNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s FacetNotFoundException) Error() string {
+func (s *FacetNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FacetNotFoundException) StatusCode() int {
+func (s *FacetNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FacetNotFoundException) RequestID() string {
+func (s *FacetNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15616,12 +15616,12 @@ func newErrorFacetValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FacetValidationException) Code() string {
+func (s *FacetValidationException) Code() string {
 	return "FacetValidationException"
 }
 
 // Message returns the exception's message.
-func (s FacetValidationException) Message() string {
+func (s *FacetValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15629,21 +15629,21 @@ func (s FacetValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FacetValidationException) OrigErr() error {
+func (s *FacetValidationException) OrigErr() error {
 	return nil
 }
 
-func (s FacetValidationException) Error() string {
+func (s *FacetValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FacetValidationException) StatusCode() int {
+func (s *FacetValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FacetValidationException) RequestID() string {
+func (s *FacetValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16349,12 +16349,12 @@ func newErrorIncompatibleSchemaException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncompatibleSchemaException) Code() string {
+func (s *IncompatibleSchemaException) Code() string {
 	return "IncompatibleSchemaException"
 }
 
 // Message returns the exception's message.
-func (s IncompatibleSchemaException) Message() string {
+func (s *IncompatibleSchemaException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16362,21 +16362,21 @@ func (s IncompatibleSchemaException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncompatibleSchemaException) OrigErr() error {
+func (s *IncompatibleSchemaException) OrigErr() error {
 	return nil
 }
 
-func (s IncompatibleSchemaException) Error() string {
+func (s *IncompatibleSchemaException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncompatibleSchemaException) StatusCode() int {
+func (s *IncompatibleSchemaException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncompatibleSchemaException) RequestID() string {
+func (s *IncompatibleSchemaException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16442,12 +16442,12 @@ func newErrorIndexedAttributeMissingException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s IndexedAttributeMissingException) Code() string {
+func (s *IndexedAttributeMissingException) Code() string {
 	return "IndexedAttributeMissingException"
 }
 
 // Message returns the exception's message.
-func (s IndexedAttributeMissingException) Message() string {
+func (s *IndexedAttributeMissingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16455,21 +16455,21 @@ func (s IndexedAttributeMissingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IndexedAttributeMissingException) OrigErr() error {
+func (s *IndexedAttributeMissingException) OrigErr() error {
 	return nil
 }
 
-func (s IndexedAttributeMissingException) Error() string {
+func (s *IndexedAttributeMissingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IndexedAttributeMissingException) StatusCode() int {
+func (s *IndexedAttributeMissingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IndexedAttributeMissingException) RequestID() string {
+func (s *IndexedAttributeMissingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16501,12 +16501,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16514,21 +16514,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16557,12 +16557,12 @@ func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArnException) Code() string {
+func (s *InvalidArnException) Code() string {
 	return "InvalidArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArnException) Message() string {
+func (s *InvalidArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16570,21 +16570,21 @@ func (s InvalidArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArnException) OrigErr() error {
+func (s *InvalidArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArnException) Error() string {
+func (s *InvalidArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArnException) StatusCode() int {
+func (s *InvalidArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArnException) RequestID() string {
+func (s *InvalidArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16615,12 +16615,12 @@ func newErrorInvalidAttachmentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAttachmentException) Code() string {
+func (s *InvalidAttachmentException) Code() string {
 	return "InvalidAttachmentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAttachmentException) Message() string {
+func (s *InvalidAttachmentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16628,21 +16628,21 @@ func (s InvalidAttachmentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAttachmentException) OrigErr() error {
+func (s *InvalidAttachmentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAttachmentException) Error() string {
+func (s *InvalidAttachmentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAttachmentException) StatusCode() int {
+func (s *InvalidAttachmentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAttachmentException) RequestID() string {
+func (s *InvalidAttachmentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16671,12 +16671,12 @@ func newErrorInvalidFacetUpdateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFacetUpdateException) Code() string {
+func (s *InvalidFacetUpdateException) Code() string {
 	return "InvalidFacetUpdateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidFacetUpdateException) Message() string {
+func (s *InvalidFacetUpdateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16684,21 +16684,21 @@ func (s InvalidFacetUpdateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFacetUpdateException) OrigErr() error {
+func (s *InvalidFacetUpdateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFacetUpdateException) Error() string {
+func (s *InvalidFacetUpdateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFacetUpdateException) StatusCode() int {
+func (s *InvalidFacetUpdateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFacetUpdateException) RequestID() string {
+func (s *InvalidFacetUpdateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16727,12 +16727,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16740,21 +16740,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16783,12 +16783,12 @@ func newErrorInvalidRuleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRuleException) Code() string {
+func (s *InvalidRuleException) Code() string {
 	return "InvalidRuleException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRuleException) Message() string {
+func (s *InvalidRuleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16796,21 +16796,21 @@ func (s InvalidRuleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRuleException) OrigErr() error {
+func (s *InvalidRuleException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRuleException) Error() string {
+func (s *InvalidRuleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRuleException) StatusCode() int {
+func (s *InvalidRuleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRuleException) RequestID() string {
+func (s *InvalidRuleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16839,12 +16839,12 @@ func newErrorInvalidSchemaDocException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSchemaDocException) Code() string {
+func (s *InvalidSchemaDocException) Code() string {
 	return "InvalidSchemaDocException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSchemaDocException) Message() string {
+func (s *InvalidSchemaDocException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16852,21 +16852,21 @@ func (s InvalidSchemaDocException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSchemaDocException) OrigErr() error {
+func (s *InvalidSchemaDocException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSchemaDocException) Error() string {
+func (s *InvalidSchemaDocException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSchemaDocException) StatusCode() int {
+func (s *InvalidSchemaDocException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSchemaDocException) RequestID() string {
+func (s *InvalidSchemaDocException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16897,12 +16897,12 @@ func newErrorInvalidTaggingRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTaggingRequestException) Code() string {
+func (s *InvalidTaggingRequestException) Code() string {
 	return "InvalidTaggingRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTaggingRequestException) Message() string {
+func (s *InvalidTaggingRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16910,21 +16910,21 @@ func (s InvalidTaggingRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTaggingRequestException) OrigErr() error {
+func (s *InvalidTaggingRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTaggingRequestException) Error() string {
+func (s *InvalidTaggingRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTaggingRequestException) StatusCode() int {
+func (s *InvalidTaggingRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTaggingRequestException) RequestID() string {
+func (s *InvalidTaggingRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16954,12 +16954,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16967,21 +16967,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17093,12 +17093,12 @@ func newErrorLinkNameAlreadyInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LinkNameAlreadyInUseException) Code() string {
+func (s *LinkNameAlreadyInUseException) Code() string {
 	return "LinkNameAlreadyInUseException"
 }
 
 // Message returns the exception's message.
-func (s LinkNameAlreadyInUseException) Message() string {
+func (s *LinkNameAlreadyInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17106,21 +17106,21 @@ func (s LinkNameAlreadyInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LinkNameAlreadyInUseException) OrigErr() error {
+func (s *LinkNameAlreadyInUseException) OrigErr() error {
 	return nil
 }
 
-func (s LinkNameAlreadyInUseException) Error() string {
+func (s *LinkNameAlreadyInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LinkNameAlreadyInUseException) StatusCode() int {
+func (s *LinkNameAlreadyInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LinkNameAlreadyInUseException) RequestID() string {
+func (s *LinkNameAlreadyInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19474,12 +19474,12 @@ func newErrorNotIndexException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotIndexException) Code() string {
+func (s *NotIndexException) Code() string {
 	return "NotIndexException"
 }
 
 // Message returns the exception's message.
-func (s NotIndexException) Message() string {
+func (s *NotIndexException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19487,21 +19487,21 @@ func (s NotIndexException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotIndexException) OrigErr() error {
+func (s *NotIndexException) OrigErr() error {
 	return nil
 }
 
-func (s NotIndexException) Error() string {
+func (s *NotIndexException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotIndexException) StatusCode() int {
+func (s *NotIndexException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotIndexException) RequestID() string {
+func (s *NotIndexException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19531,12 +19531,12 @@ func newErrorNotNodeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotNodeException) Code() string {
+func (s *NotNodeException) Code() string {
 	return "NotNodeException"
 }
 
 // Message returns the exception's message.
-func (s NotNodeException) Message() string {
+func (s *NotNodeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19544,21 +19544,21 @@ func (s NotNodeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotNodeException) OrigErr() error {
+func (s *NotNodeException) OrigErr() error {
 	return nil
 }
 
-func (s NotNodeException) Error() string {
+func (s *NotNodeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotNodeException) StatusCode() int {
+func (s *NotNodeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotNodeException) RequestID() string {
+func (s *NotNodeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19587,12 +19587,12 @@ func newErrorNotPolicyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotPolicyException) Code() string {
+func (s *NotPolicyException) Code() string {
 	return "NotPolicyException"
 }
 
 // Message returns the exception's message.
-func (s NotPolicyException) Message() string {
+func (s *NotPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19600,21 +19600,21 @@ func (s NotPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotPolicyException) OrigErr() error {
+func (s *NotPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s NotPolicyException) Error() string {
+func (s *NotPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotPolicyException) StatusCode() int {
+func (s *NotPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotPolicyException) RequestID() string {
+func (s *NotPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19643,12 +19643,12 @@ func newErrorObjectAlreadyDetachedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ObjectAlreadyDetachedException) Code() string {
+func (s *ObjectAlreadyDetachedException) Code() string {
 	return "ObjectAlreadyDetachedException"
 }
 
 // Message returns the exception's message.
-func (s ObjectAlreadyDetachedException) Message() string {
+func (s *ObjectAlreadyDetachedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19656,21 +19656,21 @@ func (s ObjectAlreadyDetachedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ObjectAlreadyDetachedException) OrigErr() error {
+func (s *ObjectAlreadyDetachedException) OrigErr() error {
 	return nil
 }
 
-func (s ObjectAlreadyDetachedException) Error() string {
+func (s *ObjectAlreadyDetachedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ObjectAlreadyDetachedException) StatusCode() int {
+func (s *ObjectAlreadyDetachedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ObjectAlreadyDetachedException) RequestID() string {
+func (s *ObjectAlreadyDetachedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19867,12 +19867,12 @@ func newErrorObjectNotDetachedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ObjectNotDetachedException) Code() string {
+func (s *ObjectNotDetachedException) Code() string {
 	return "ObjectNotDetachedException"
 }
 
 // Message returns the exception's message.
-func (s ObjectNotDetachedException) Message() string {
+func (s *ObjectNotDetachedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19880,21 +19880,21 @@ func (s ObjectNotDetachedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ObjectNotDetachedException) OrigErr() error {
+func (s *ObjectNotDetachedException) OrigErr() error {
 	return nil
 }
 
-func (s ObjectNotDetachedException) Error() string {
+func (s *ObjectNotDetachedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ObjectNotDetachedException) StatusCode() int {
+func (s *ObjectNotDetachedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ObjectNotDetachedException) RequestID() string {
+func (s *ObjectNotDetachedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20341,12 +20341,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20354,21 +20354,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20402,12 +20402,12 @@ func newErrorRetryableConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RetryableConflictException) Code() string {
+func (s *RetryableConflictException) Code() string {
 	return "RetryableConflictException"
 }
 
 // Message returns the exception's message.
-func (s RetryableConflictException) Message() string {
+func (s *RetryableConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20415,21 +20415,21 @@ func (s RetryableConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RetryableConflictException) OrigErr() error {
+func (s *RetryableConflictException) OrigErr() error {
 	return nil
 }
 
-func (s RetryableConflictException) Error() string {
+func (s *RetryableConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RetryableConflictException) StatusCode() int {
+func (s *RetryableConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RetryableConflictException) RequestID() string {
+func (s *RetryableConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20493,12 +20493,12 @@ func newErrorSchemaAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SchemaAlreadyExistsException) Code() string {
+func (s *SchemaAlreadyExistsException) Code() string {
 	return "SchemaAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s SchemaAlreadyExistsException) Message() string {
+func (s *SchemaAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20506,21 +20506,21 @@ func (s SchemaAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SchemaAlreadyExistsException) OrigErr() error {
+func (s *SchemaAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s SchemaAlreadyExistsException) Error() string {
+func (s *SchemaAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SchemaAlreadyExistsException) StatusCode() int {
+func (s *SchemaAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SchemaAlreadyExistsException) RequestID() string {
+func (s *SchemaAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20549,12 +20549,12 @@ func newErrorSchemaAlreadyPublishedException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s SchemaAlreadyPublishedException) Code() string {
+func (s *SchemaAlreadyPublishedException) Code() string {
 	return "SchemaAlreadyPublishedException"
 }
 
 // Message returns the exception's message.
-func (s SchemaAlreadyPublishedException) Message() string {
+func (s *SchemaAlreadyPublishedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20562,21 +20562,21 @@ func (s SchemaAlreadyPublishedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SchemaAlreadyPublishedException) OrigErr() error {
+func (s *SchemaAlreadyPublishedException) OrigErr() error {
 	return nil
 }
 
-func (s SchemaAlreadyPublishedException) Error() string {
+func (s *SchemaAlreadyPublishedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SchemaAlreadyPublishedException) StatusCode() int {
+func (s *SchemaAlreadyPublishedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SchemaAlreadyPublishedException) RequestID() string {
+func (s *SchemaAlreadyPublishedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20654,12 +20654,12 @@ func newErrorStillContainsLinksException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StillContainsLinksException) Code() string {
+func (s *StillContainsLinksException) Code() string {
 	return "StillContainsLinksException"
 }
 
 // Message returns the exception's message.
-func (s StillContainsLinksException) Message() string {
+func (s *StillContainsLinksException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20667,21 +20667,21 @@ func (s StillContainsLinksException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StillContainsLinksException) OrigErr() error {
+func (s *StillContainsLinksException) OrigErr() error {
 	return nil
 }
 
-func (s StillContainsLinksException) Error() string {
+func (s *StillContainsLinksException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StillContainsLinksException) StatusCode() int {
+func (s *StillContainsLinksException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StillContainsLinksException) RequestID() string {
+func (s *StillContainsLinksException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21396,12 +21396,12 @@ func newErrorUnsupportedIndexTypeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedIndexTypeException) Code() string {
+func (s *UnsupportedIndexTypeException) Code() string {
 	return "UnsupportedIndexTypeException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedIndexTypeException) Message() string {
+func (s *UnsupportedIndexTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21409,21 +21409,21 @@ func (s UnsupportedIndexTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedIndexTypeException) OrigErr() error {
+func (s *UnsupportedIndexTypeException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedIndexTypeException) Error() string {
+func (s *UnsupportedIndexTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedIndexTypeException) StatusCode() int {
+func (s *UnsupportedIndexTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedIndexTypeException) RequestID() string {
+func (s *UnsupportedIndexTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22210,12 +22210,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22223,21 +22223,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -2041,12 +2041,12 @@ func newErrorCloudHsmInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CloudHsmInternalException) Code() string {
+func (s *CloudHsmInternalException) Code() string {
 	return "CloudHsmInternalException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmInternalException) Message() string {
+func (s *CloudHsmInternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2054,21 +2054,21 @@ func (s CloudHsmInternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmInternalException) OrigErr() error {
+func (s *CloudHsmInternalException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmInternalException) Error() string {
+func (s *CloudHsmInternalException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmInternalException) StatusCode() int {
+func (s *CloudHsmInternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmInternalException) RequestID() string {
+func (s *CloudHsmInternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2101,12 +2101,12 @@ func newErrorCloudHsmServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CloudHsmServiceException) Code() string {
+func (s *CloudHsmServiceException) Code() string {
 	return "CloudHsmServiceException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmServiceException) Message() string {
+func (s *CloudHsmServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2114,21 +2114,21 @@ func (s CloudHsmServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmServiceException) OrigErr() error {
+func (s *CloudHsmServiceException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmServiceException) Error() string {
+func (s *CloudHsmServiceException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmServiceException) StatusCode() int {
+func (s *CloudHsmServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmServiceException) RequestID() string {
+func (s *CloudHsmServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3218,12 +3218,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3231,21 +3231,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cloudhsmv2/api.go
+++ b/service/cloudhsmv2/api.go
@@ -1644,12 +1644,12 @@ func newErrorCloudHsmAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CloudHsmAccessDeniedException) Code() string {
+func (s *CloudHsmAccessDeniedException) Code() string {
 	return "CloudHsmAccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmAccessDeniedException) Message() string {
+func (s *CloudHsmAccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1657,21 +1657,21 @@ func (s CloudHsmAccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmAccessDeniedException) OrigErr() error {
+func (s *CloudHsmAccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmAccessDeniedException) Error() string {
+func (s *CloudHsmAccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmAccessDeniedException) StatusCode() int {
+func (s *CloudHsmAccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmAccessDeniedException) RequestID() string {
+func (s *CloudHsmAccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1701,12 +1701,12 @@ func newErrorCloudHsmInternalFailureException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s CloudHsmInternalFailureException) Code() string {
+func (s *CloudHsmInternalFailureException) Code() string {
 	return "CloudHsmInternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmInternalFailureException) Message() string {
+func (s *CloudHsmInternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1714,21 +1714,21 @@ func (s CloudHsmInternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmInternalFailureException) OrigErr() error {
+func (s *CloudHsmInternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmInternalFailureException) Error() string {
+func (s *CloudHsmInternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmInternalFailureException) StatusCode() int {
+func (s *CloudHsmInternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmInternalFailureException) RequestID() string {
+func (s *CloudHsmInternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1757,12 +1757,12 @@ func newErrorCloudHsmInvalidRequestException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s CloudHsmInvalidRequestException) Code() string {
+func (s *CloudHsmInvalidRequestException) Code() string {
 	return "CloudHsmInvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmInvalidRequestException) Message() string {
+func (s *CloudHsmInvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1770,21 +1770,21 @@ func (s CloudHsmInvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmInvalidRequestException) OrigErr() error {
+func (s *CloudHsmInvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmInvalidRequestException) Error() string {
+func (s *CloudHsmInvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmInvalidRequestException) StatusCode() int {
+func (s *CloudHsmInvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmInvalidRequestException) RequestID() string {
+func (s *CloudHsmInvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1813,12 +1813,12 @@ func newErrorCloudHsmResourceNotFoundException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s CloudHsmResourceNotFoundException) Code() string {
+func (s *CloudHsmResourceNotFoundException) Code() string {
 	return "CloudHsmResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmResourceNotFoundException) Message() string {
+func (s *CloudHsmResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1826,21 +1826,21 @@ func (s CloudHsmResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmResourceNotFoundException) OrigErr() error {
+func (s *CloudHsmResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmResourceNotFoundException) Error() string {
+func (s *CloudHsmResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmResourceNotFoundException) StatusCode() int {
+func (s *CloudHsmResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmResourceNotFoundException) RequestID() string {
+func (s *CloudHsmResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1869,12 +1869,12 @@ func newErrorCloudHsmServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CloudHsmServiceException) Code() string {
+func (s *CloudHsmServiceException) Code() string {
 	return "CloudHsmServiceException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmServiceException) Message() string {
+func (s *CloudHsmServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1882,21 +1882,21 @@ func (s CloudHsmServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmServiceException) OrigErr() error {
+func (s *CloudHsmServiceException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmServiceException) Error() string {
+func (s *CloudHsmServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmServiceException) StatusCode() int {
+func (s *CloudHsmServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmServiceException) RequestID() string {
+func (s *CloudHsmServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1924,12 +1924,12 @@ func newErrorCloudHsmTagException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CloudHsmTagException) Code() string {
+func (s *CloudHsmTagException) Code() string {
 	return "CloudHsmTagException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmTagException) Message() string {
+func (s *CloudHsmTagException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1937,21 +1937,21 @@ func (s CloudHsmTagException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmTagException) OrigErr() error {
+func (s *CloudHsmTagException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmTagException) Error() string {
+func (s *CloudHsmTagException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmTagException) StatusCode() int {
+func (s *CloudHsmTagException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmTagException) RequestID() string {
+func (s *CloudHsmTagException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -387,12 +387,12 @@ func newErrorDocumentServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DocumentServiceException) Code() string {
+func (s *DocumentServiceException) Code() string {
 	return "DocumentServiceException"
 }
 
 // Message returns the exception's message.
-func (s DocumentServiceException) Message() string {
+func (s *DocumentServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -400,21 +400,21 @@ func (s DocumentServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DocumentServiceException) OrigErr() error {
+func (s *DocumentServiceException) OrigErr() error {
 	return nil
 }
 
-func (s DocumentServiceException) Error() string {
+func (s *DocumentServiceException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DocumentServiceException) StatusCode() int {
+func (s *DocumentServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DocumentServiceException) RequestID() string {
+func (s *DocumentServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -681,12 +681,12 @@ func newErrorSearchException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SearchException) Code() string {
+func (s *SearchException) Code() string {
 	return "SearchException"
 }
 
 // Message returns the exception's message.
-func (s SearchException) Message() string {
+func (s *SearchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -694,21 +694,21 @@ func (s SearchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SearchException) OrigErr() error {
+func (s *SearchException) OrigErr() error {
 	return nil
 }
 
-func (s SearchException) Error() string {
+func (s *SearchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SearchException) StatusCode() int {
+func (s *SearchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SearchException) RequestID() string {
+func (s *SearchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -2547,12 +2547,12 @@ func newErrorARNInvalidException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ARNInvalidException) Code() string {
+func (s *ARNInvalidException) Code() string {
 	return "CloudTrailARNInvalidException"
 }
 
 // Message returns the exception's message.
-func (s ARNInvalidException) Message() string {
+func (s *ARNInvalidException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2560,21 +2560,21 @@ func (s ARNInvalidException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ARNInvalidException) OrigErr() error {
+func (s *ARNInvalidException) OrigErr() error {
 	return nil
 }
 
-func (s ARNInvalidException) Error() string {
+func (s *ARNInvalidException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ARNInvalidException) StatusCode() int {
+func (s *ARNInvalidException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ARNInvalidException) RequestID() string {
+func (s *ARNInvalidException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2606,12 +2606,12 @@ func newErrorAccessNotEnabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessNotEnabledException) Code() string {
+func (s *AccessNotEnabledException) Code() string {
 	return "CloudTrailAccessNotEnabledException"
 }
 
 // Message returns the exception's message.
-func (s AccessNotEnabledException) Message() string {
+func (s *AccessNotEnabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2619,21 +2619,21 @@ func (s AccessNotEnabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessNotEnabledException) OrigErr() error {
+func (s *AccessNotEnabledException) OrigErr() error {
 	return nil
 }
 
-func (s AccessNotEnabledException) Error() string {
+func (s *AccessNotEnabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessNotEnabledException) StatusCode() int {
+func (s *AccessNotEnabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessNotEnabledException) RequestID() string {
+func (s *AccessNotEnabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2739,12 +2739,12 @@ func newErrorCloudWatchLogsDeliveryUnavailableException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s CloudWatchLogsDeliveryUnavailableException) Code() string {
+func (s *CloudWatchLogsDeliveryUnavailableException) Code() string {
 	return "CloudWatchLogsDeliveryUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s CloudWatchLogsDeliveryUnavailableException) Message() string {
+func (s *CloudWatchLogsDeliveryUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2752,21 +2752,21 @@ func (s CloudWatchLogsDeliveryUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudWatchLogsDeliveryUnavailableException) OrigErr() error {
+func (s *CloudWatchLogsDeliveryUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s CloudWatchLogsDeliveryUnavailableException) Error() string {
+func (s *CloudWatchLogsDeliveryUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudWatchLogsDeliveryUnavailableException) StatusCode() int {
+func (s *CloudWatchLogsDeliveryUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudWatchLogsDeliveryUnavailableException) RequestID() string {
+func (s *CloudWatchLogsDeliveryUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4049,12 +4049,12 @@ func newErrorInsightNotEnabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InsightNotEnabledException) Code() string {
+func (s *InsightNotEnabledException) Code() string {
 	return "InsightNotEnabledException"
 }
 
 // Message returns the exception's message.
-func (s InsightNotEnabledException) Message() string {
+func (s *InsightNotEnabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4062,21 +4062,21 @@ func (s InsightNotEnabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsightNotEnabledException) OrigErr() error {
+func (s *InsightNotEnabledException) OrigErr() error {
 	return nil
 }
 
-func (s InsightNotEnabledException) Error() string {
+func (s *InsightNotEnabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsightNotEnabledException) StatusCode() int {
+func (s *InsightNotEnabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsightNotEnabledException) RequestID() string {
+func (s *InsightNotEnabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4134,12 +4134,12 @@ func newErrorInsufficientDependencyServiceAccessPermissionException(v protocol.R
 }
 
 // Code returns the exception type name.
-func (s InsufficientDependencyServiceAccessPermissionException) Code() string {
+func (s *InsufficientDependencyServiceAccessPermissionException) Code() string {
 	return "InsufficientDependencyServiceAccessPermissionException"
 }
 
 // Message returns the exception's message.
-func (s InsufficientDependencyServiceAccessPermissionException) Message() string {
+func (s *InsufficientDependencyServiceAccessPermissionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4147,21 +4147,21 @@ func (s InsufficientDependencyServiceAccessPermissionException) Message() string
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientDependencyServiceAccessPermissionException) OrigErr() error {
+func (s *InsufficientDependencyServiceAccessPermissionException) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientDependencyServiceAccessPermissionException) Error() string {
+func (s *InsufficientDependencyServiceAccessPermissionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientDependencyServiceAccessPermissionException) StatusCode() int {
+func (s *InsufficientDependencyServiceAccessPermissionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientDependencyServiceAccessPermissionException) RequestID() string {
+func (s *InsufficientDependencyServiceAccessPermissionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4191,12 +4191,12 @@ func newErrorInsufficientEncryptionPolicyException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s InsufficientEncryptionPolicyException) Code() string {
+func (s *InsufficientEncryptionPolicyException) Code() string {
 	return "InsufficientEncryptionPolicyException"
 }
 
 // Message returns the exception's message.
-func (s InsufficientEncryptionPolicyException) Message() string {
+func (s *InsufficientEncryptionPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4204,21 +4204,21 @@ func (s InsufficientEncryptionPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientEncryptionPolicyException) OrigErr() error {
+func (s *InsufficientEncryptionPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientEncryptionPolicyException) Error() string {
+func (s *InsufficientEncryptionPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientEncryptionPolicyException) StatusCode() int {
+func (s *InsufficientEncryptionPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientEncryptionPolicyException) RequestID() string {
+func (s *InsufficientEncryptionPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4247,12 +4247,12 @@ func newErrorInsufficientS3BucketPolicyException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InsufficientS3BucketPolicyException) Code() string {
+func (s *InsufficientS3BucketPolicyException) Code() string {
 	return "InsufficientS3BucketPolicyException"
 }
 
 // Message returns the exception's message.
-func (s InsufficientS3BucketPolicyException) Message() string {
+func (s *InsufficientS3BucketPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4260,21 +4260,21 @@ func (s InsufficientS3BucketPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientS3BucketPolicyException) OrigErr() error {
+func (s *InsufficientS3BucketPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientS3BucketPolicyException) Error() string {
+func (s *InsufficientS3BucketPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientS3BucketPolicyException) StatusCode() int {
+func (s *InsufficientS3BucketPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientS3BucketPolicyException) RequestID() string {
+func (s *InsufficientS3BucketPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4303,12 +4303,12 @@ func newErrorInsufficientSnsTopicPolicyException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InsufficientSnsTopicPolicyException) Code() string {
+func (s *InsufficientSnsTopicPolicyException) Code() string {
 	return "InsufficientSnsTopicPolicyException"
 }
 
 // Message returns the exception's message.
-func (s InsufficientSnsTopicPolicyException) Message() string {
+func (s *InsufficientSnsTopicPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4316,21 +4316,21 @@ func (s InsufficientSnsTopicPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientSnsTopicPolicyException) OrigErr() error {
+func (s *InsufficientSnsTopicPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientSnsTopicPolicyException) Error() string {
+func (s *InsufficientSnsTopicPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientSnsTopicPolicyException) StatusCode() int {
+func (s *InsufficientSnsTopicPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientSnsTopicPolicyException) RequestID() string {
+func (s *InsufficientSnsTopicPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4359,12 +4359,12 @@ func newErrorInvalidCloudWatchLogsLogGroupArnException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s InvalidCloudWatchLogsLogGroupArnException) Code() string {
+func (s *InvalidCloudWatchLogsLogGroupArnException) Code() string {
 	return "InvalidCloudWatchLogsLogGroupArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCloudWatchLogsLogGroupArnException) Message() string {
+func (s *InvalidCloudWatchLogsLogGroupArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4372,21 +4372,21 @@ func (s InvalidCloudWatchLogsLogGroupArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCloudWatchLogsLogGroupArnException) OrigErr() error {
+func (s *InvalidCloudWatchLogsLogGroupArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCloudWatchLogsLogGroupArnException) Error() string {
+func (s *InvalidCloudWatchLogsLogGroupArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCloudWatchLogsLogGroupArnException) StatusCode() int {
+func (s *InvalidCloudWatchLogsLogGroupArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCloudWatchLogsLogGroupArnException) RequestID() string {
+func (s *InvalidCloudWatchLogsLogGroupArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4415,12 +4415,12 @@ func newErrorInvalidCloudWatchLogsRoleArnException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s InvalidCloudWatchLogsRoleArnException) Code() string {
+func (s *InvalidCloudWatchLogsRoleArnException) Code() string {
 	return "InvalidCloudWatchLogsRoleArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCloudWatchLogsRoleArnException) Message() string {
+func (s *InvalidCloudWatchLogsRoleArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4428,21 +4428,21 @@ func (s InvalidCloudWatchLogsRoleArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCloudWatchLogsRoleArnException) OrigErr() error {
+func (s *InvalidCloudWatchLogsRoleArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCloudWatchLogsRoleArnException) Error() string {
+func (s *InvalidCloudWatchLogsRoleArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCloudWatchLogsRoleArnException) StatusCode() int {
+func (s *InvalidCloudWatchLogsRoleArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCloudWatchLogsRoleArnException) RequestID() string {
+func (s *InvalidCloudWatchLogsRoleArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4472,12 +4472,12 @@ func newErrorInvalidEventCategoryException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidEventCategoryException) Code() string {
+func (s *InvalidEventCategoryException) Code() string {
 	return "InvalidEventCategoryException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEventCategoryException) Message() string {
+func (s *InvalidEventCategoryException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4485,21 +4485,21 @@ func (s InvalidEventCategoryException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEventCategoryException) OrigErr() error {
+func (s *InvalidEventCategoryException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEventCategoryException) Error() string {
+func (s *InvalidEventCategoryException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEventCategoryException) StatusCode() int {
+func (s *InvalidEventCategoryException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEventCategoryException) RequestID() string {
+func (s *InvalidEventCategoryException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4546,12 +4546,12 @@ func newErrorInvalidEventSelectorsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidEventSelectorsException) Code() string {
+func (s *InvalidEventSelectorsException) Code() string {
 	return "InvalidEventSelectorsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEventSelectorsException) Message() string {
+func (s *InvalidEventSelectorsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4559,21 +4559,21 @@ func (s InvalidEventSelectorsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEventSelectorsException) OrigErr() error {
+func (s *InvalidEventSelectorsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEventSelectorsException) Error() string {
+func (s *InvalidEventSelectorsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEventSelectorsException) StatusCode() int {
+func (s *InvalidEventSelectorsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEventSelectorsException) RequestID() string {
+func (s *InvalidEventSelectorsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4603,12 +4603,12 @@ func newErrorInvalidHomeRegionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidHomeRegionException) Code() string {
+func (s *InvalidHomeRegionException) Code() string {
 	return "InvalidHomeRegionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidHomeRegionException) Message() string {
+func (s *InvalidHomeRegionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4616,21 +4616,21 @@ func (s InvalidHomeRegionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidHomeRegionException) OrigErr() error {
+func (s *InvalidHomeRegionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidHomeRegionException) Error() string {
+func (s *InvalidHomeRegionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidHomeRegionException) StatusCode() int {
+func (s *InvalidHomeRegionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidHomeRegionException) RequestID() string {
+func (s *InvalidHomeRegionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4661,12 +4661,12 @@ func newErrorInvalidInsightSelectorsException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidInsightSelectorsException) Code() string {
+func (s *InvalidInsightSelectorsException) Code() string {
 	return "InvalidInsightSelectorsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInsightSelectorsException) Message() string {
+func (s *InvalidInsightSelectorsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4674,21 +4674,21 @@ func (s InvalidInsightSelectorsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInsightSelectorsException) OrigErr() error {
+func (s *InvalidInsightSelectorsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInsightSelectorsException) Error() string {
+func (s *InvalidInsightSelectorsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInsightSelectorsException) StatusCode() int {
+func (s *InvalidInsightSelectorsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInsightSelectorsException) RequestID() string {
+func (s *InvalidInsightSelectorsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4717,12 +4717,12 @@ func newErrorInvalidKmsKeyIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidKmsKeyIdException) Code() string {
+func (s *InvalidKmsKeyIdException) Code() string {
 	return "InvalidKmsKeyIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidKmsKeyIdException) Message() string {
+func (s *InvalidKmsKeyIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4730,21 +4730,21 @@ func (s InvalidKmsKeyIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidKmsKeyIdException) OrigErr() error {
+func (s *InvalidKmsKeyIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidKmsKeyIdException) Error() string {
+func (s *InvalidKmsKeyIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidKmsKeyIdException) StatusCode() int {
+func (s *InvalidKmsKeyIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidKmsKeyIdException) RequestID() string {
+func (s *InvalidKmsKeyIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4773,12 +4773,12 @@ func newErrorInvalidLookupAttributesException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidLookupAttributesException) Code() string {
+func (s *InvalidLookupAttributesException) Code() string {
 	return "InvalidLookupAttributesException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLookupAttributesException) Message() string {
+func (s *InvalidLookupAttributesException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4786,21 +4786,21 @@ func (s InvalidLookupAttributesException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLookupAttributesException) OrigErr() error {
+func (s *InvalidLookupAttributesException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLookupAttributesException) Error() string {
+func (s *InvalidLookupAttributesException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLookupAttributesException) StatusCode() int {
+func (s *InvalidLookupAttributesException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLookupAttributesException) RequestID() string {
+func (s *InvalidLookupAttributesException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4829,12 +4829,12 @@ func newErrorInvalidMaxResultsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidMaxResultsException) Code() string {
+func (s *InvalidMaxResultsException) Code() string {
 	return "InvalidMaxResultsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidMaxResultsException) Message() string {
+func (s *InvalidMaxResultsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4842,21 +4842,21 @@ func (s InvalidMaxResultsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidMaxResultsException) OrigErr() error {
+func (s *InvalidMaxResultsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidMaxResultsException) Error() string {
+func (s *InvalidMaxResultsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidMaxResultsException) StatusCode() int {
+func (s *InvalidMaxResultsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidMaxResultsException) RequestID() string {
+func (s *InvalidMaxResultsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4886,12 +4886,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4899,21 +4899,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4943,12 +4943,12 @@ func newErrorInvalidParameterCombinationException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterCombinationException) Code() string {
+func (s *InvalidParameterCombinationException) Code() string {
 	return "InvalidParameterCombinationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterCombinationException) Message() string {
+func (s *InvalidParameterCombinationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4956,21 +4956,21 @@ func (s InvalidParameterCombinationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterCombinationException) OrigErr() error {
+func (s *InvalidParameterCombinationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterCombinationException) Error() string {
+func (s *InvalidParameterCombinationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterCombinationException) StatusCode() int {
+func (s *InvalidParameterCombinationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterCombinationException) RequestID() string {
+func (s *InvalidParameterCombinationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4999,12 +4999,12 @@ func newErrorInvalidS3BucketNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidS3BucketNameException) Code() string {
+func (s *InvalidS3BucketNameException) Code() string {
 	return "InvalidS3BucketNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidS3BucketNameException) Message() string {
+func (s *InvalidS3BucketNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5012,21 +5012,21 @@ func (s InvalidS3BucketNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidS3BucketNameException) OrigErr() error {
+func (s *InvalidS3BucketNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidS3BucketNameException) Error() string {
+func (s *InvalidS3BucketNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidS3BucketNameException) StatusCode() int {
+func (s *InvalidS3BucketNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidS3BucketNameException) RequestID() string {
+func (s *InvalidS3BucketNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5055,12 +5055,12 @@ func newErrorInvalidS3PrefixException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidS3PrefixException) Code() string {
+func (s *InvalidS3PrefixException) Code() string {
 	return "InvalidS3PrefixException"
 }
 
 // Message returns the exception's message.
-func (s InvalidS3PrefixException) Message() string {
+func (s *InvalidS3PrefixException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5068,21 +5068,21 @@ func (s InvalidS3PrefixException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidS3PrefixException) OrigErr() error {
+func (s *InvalidS3PrefixException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidS3PrefixException) Error() string {
+func (s *InvalidS3PrefixException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidS3PrefixException) StatusCode() int {
+func (s *InvalidS3PrefixException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidS3PrefixException) RequestID() string {
+func (s *InvalidS3PrefixException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5111,12 +5111,12 @@ func newErrorInvalidSnsTopicNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSnsTopicNameException) Code() string {
+func (s *InvalidSnsTopicNameException) Code() string {
 	return "InvalidSnsTopicNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSnsTopicNameException) Message() string {
+func (s *InvalidSnsTopicNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5124,21 +5124,21 @@ func (s InvalidSnsTopicNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSnsTopicNameException) OrigErr() error {
+func (s *InvalidSnsTopicNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSnsTopicNameException) Error() string {
+func (s *InvalidSnsTopicNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSnsTopicNameException) StatusCode() int {
+func (s *InvalidSnsTopicNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSnsTopicNameException) RequestID() string {
+func (s *InvalidSnsTopicNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5168,12 +5168,12 @@ func newErrorInvalidTagParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagParameterException) Code() string {
+func (s *InvalidTagParameterException) Code() string {
 	return "InvalidTagParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagParameterException) Message() string {
+func (s *InvalidTagParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5181,21 +5181,21 @@ func (s InvalidTagParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagParameterException) OrigErr() error {
+func (s *InvalidTagParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagParameterException) Error() string {
+func (s *InvalidTagParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagParameterException) StatusCode() int {
+func (s *InvalidTagParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagParameterException) RequestID() string {
+func (s *InvalidTagParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5225,12 +5225,12 @@ func newErrorInvalidTimeRangeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTimeRangeException) Code() string {
+func (s *InvalidTimeRangeException) Code() string {
 	return "InvalidTimeRangeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTimeRangeException) Message() string {
+func (s *InvalidTimeRangeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5238,21 +5238,21 @@ func (s InvalidTimeRangeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTimeRangeException) OrigErr() error {
+func (s *InvalidTimeRangeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTimeRangeException) Error() string {
+func (s *InvalidTimeRangeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTimeRangeException) StatusCode() int {
+func (s *InvalidTimeRangeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTimeRangeException) RequestID() string {
+func (s *InvalidTimeRangeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5281,12 +5281,12 @@ func newErrorInvalidTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTokenException) Code() string {
+func (s *InvalidTokenException) Code() string {
 	return "InvalidTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTokenException) Message() string {
+func (s *InvalidTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5294,21 +5294,21 @@ func (s InvalidTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTokenException) OrigErr() error {
+func (s *InvalidTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTokenException) Error() string {
+func (s *InvalidTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTokenException) StatusCode() int {
+func (s *InvalidTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTokenException) RequestID() string {
+func (s *InvalidTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5350,12 +5350,12 @@ func newErrorInvalidTrailNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTrailNameException) Code() string {
+func (s *InvalidTrailNameException) Code() string {
 	return "InvalidTrailNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTrailNameException) Message() string {
+func (s *InvalidTrailNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5363,21 +5363,21 @@ func (s InvalidTrailNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTrailNameException) OrigErr() error {
+func (s *InvalidTrailNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTrailNameException) Error() string {
+func (s *InvalidTrailNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTrailNameException) StatusCode() int {
+func (s *InvalidTrailNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTrailNameException) RequestID() string {
+func (s *InvalidTrailNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5407,12 +5407,12 @@ func newErrorKmsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KmsException) Code() string {
+func (s *KmsException) Code() string {
 	return "KmsException"
 }
 
 // Message returns the exception's message.
-func (s KmsException) Message() string {
+func (s *KmsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5420,21 +5420,21 @@ func (s KmsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KmsException) OrigErr() error {
+func (s *KmsException) OrigErr() error {
 	return nil
 }
 
-func (s KmsException) Error() string {
+func (s *KmsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KmsException) StatusCode() int {
+func (s *KmsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KmsException) RequestID() string {
+func (s *KmsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5465,12 +5465,12 @@ func newErrorKmsKeyDisabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KmsKeyDisabledException) Code() string {
+func (s *KmsKeyDisabledException) Code() string {
 	return "KmsKeyDisabledException"
 }
 
 // Message returns the exception's message.
-func (s KmsKeyDisabledException) Message() string {
+func (s *KmsKeyDisabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5478,21 +5478,21 @@ func (s KmsKeyDisabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KmsKeyDisabledException) OrigErr() error {
+func (s *KmsKeyDisabledException) OrigErr() error {
 	return nil
 }
 
-func (s KmsKeyDisabledException) Error() string {
+func (s *KmsKeyDisabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KmsKeyDisabledException) StatusCode() int {
+func (s *KmsKeyDisabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KmsKeyDisabledException) RequestID() string {
+func (s *KmsKeyDisabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5522,12 +5522,12 @@ func newErrorKmsKeyNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KmsKeyNotFoundException) Code() string {
+func (s *KmsKeyNotFoundException) Code() string {
 	return "KmsKeyNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s KmsKeyNotFoundException) Message() string {
+func (s *KmsKeyNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5535,21 +5535,21 @@ func (s KmsKeyNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KmsKeyNotFoundException) OrigErr() error {
+func (s *KmsKeyNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s KmsKeyNotFoundException) Error() string {
+func (s *KmsKeyNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KmsKeyNotFoundException) StatusCode() int {
+func (s *KmsKeyNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KmsKeyNotFoundException) RequestID() string {
+func (s *KmsKeyNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6004,12 +6004,12 @@ func newErrorMaximumNumberOfTrailsExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s MaximumNumberOfTrailsExceededException) Code() string {
+func (s *MaximumNumberOfTrailsExceededException) Code() string {
 	return "MaximumNumberOfTrailsExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumNumberOfTrailsExceededException) Message() string {
+func (s *MaximumNumberOfTrailsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6017,21 +6017,21 @@ func (s MaximumNumberOfTrailsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumNumberOfTrailsExceededException) OrigErr() error {
+func (s *MaximumNumberOfTrailsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumNumberOfTrailsExceededException) Error() string {
+func (s *MaximumNumberOfTrailsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumNumberOfTrailsExceededException) StatusCode() int {
+func (s *MaximumNumberOfTrailsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumNumberOfTrailsExceededException) RequestID() string {
+func (s *MaximumNumberOfTrailsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6063,12 +6063,12 @@ func newErrorNotOrganizationMasterAccountException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s NotOrganizationMasterAccountException) Code() string {
+func (s *NotOrganizationMasterAccountException) Code() string {
 	return "NotOrganizationMasterAccountException"
 }
 
 // Message returns the exception's message.
-func (s NotOrganizationMasterAccountException) Message() string {
+func (s *NotOrganizationMasterAccountException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6076,21 +6076,21 @@ func (s NotOrganizationMasterAccountException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotOrganizationMasterAccountException) OrigErr() error {
+func (s *NotOrganizationMasterAccountException) OrigErr() error {
 	return nil
 }
 
-func (s NotOrganizationMasterAccountException) Error() string {
+func (s *NotOrganizationMasterAccountException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotOrganizationMasterAccountException) StatusCode() int {
+func (s *NotOrganizationMasterAccountException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotOrganizationMasterAccountException) RequestID() string {
+func (s *NotOrganizationMasterAccountException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6119,12 +6119,12 @@ func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotPermittedException) Code() string {
+func (s *OperationNotPermittedException) Code() string {
 	return "OperationNotPermittedException"
 }
 
 // Message returns the exception's message.
-func (s OperationNotPermittedException) Message() string {
+func (s *OperationNotPermittedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6132,21 +6132,21 @@ func (s OperationNotPermittedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotPermittedException) OrigErr() error {
+func (s *OperationNotPermittedException) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotPermittedException) Error() string {
+func (s *OperationNotPermittedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotPermittedException) StatusCode() int {
+func (s *OperationNotPermittedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotPermittedException) RequestID() string {
+func (s *OperationNotPermittedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6178,12 +6178,12 @@ func newErrorOrganizationNotInAllFeaturesModeException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s OrganizationNotInAllFeaturesModeException) Code() string {
+func (s *OrganizationNotInAllFeaturesModeException) Code() string {
 	return "OrganizationNotInAllFeaturesModeException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationNotInAllFeaturesModeException) Message() string {
+func (s *OrganizationNotInAllFeaturesModeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6191,21 +6191,21 @@ func (s OrganizationNotInAllFeaturesModeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationNotInAllFeaturesModeException) OrigErr() error {
+func (s *OrganizationNotInAllFeaturesModeException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationNotInAllFeaturesModeException) Error() string {
+func (s *OrganizationNotInAllFeaturesModeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationNotInAllFeaturesModeException) StatusCode() int {
+func (s *OrganizationNotInAllFeaturesModeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationNotInAllFeaturesModeException) RequestID() string {
+func (s *OrganizationNotInAllFeaturesModeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6236,12 +6236,12 @@ func newErrorOrganizationsNotInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OrganizationsNotInUseException) Code() string {
+func (s *OrganizationsNotInUseException) Code() string {
 	return "OrganizationsNotInUseException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationsNotInUseException) Message() string {
+func (s *OrganizationsNotInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6249,21 +6249,21 @@ func (s OrganizationsNotInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationsNotInUseException) OrigErr() error {
+func (s *OrganizationsNotInUseException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationsNotInUseException) Error() string {
+func (s *OrganizationsNotInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationsNotInUseException) StatusCode() int {
+func (s *OrganizationsNotInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationsNotInUseException) RequestID() string {
+func (s *OrganizationsNotInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6655,12 +6655,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6668,21 +6668,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6745,12 +6745,12 @@ func newErrorResourceTypeNotSupportedException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ResourceTypeNotSupportedException) Code() string {
+func (s *ResourceTypeNotSupportedException) Code() string {
 	return "ResourceTypeNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s ResourceTypeNotSupportedException) Message() string {
+func (s *ResourceTypeNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6758,21 +6758,21 @@ func (s ResourceTypeNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceTypeNotSupportedException) OrigErr() error {
+func (s *ResourceTypeNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceTypeNotSupportedException) Error() string {
+func (s *ResourceTypeNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceTypeNotSupportedException) StatusCode() int {
+func (s *ResourceTypeNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceTypeNotSupportedException) RequestID() string {
+func (s *ResourceTypeNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6801,12 +6801,12 @@ func newErrorS3BucketDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s S3BucketDoesNotExistException) Code() string {
+func (s *S3BucketDoesNotExistException) Code() string {
 	return "S3BucketDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s S3BucketDoesNotExistException) Message() string {
+func (s *S3BucketDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6814,21 +6814,21 @@ func (s S3BucketDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s S3BucketDoesNotExistException) OrigErr() error {
+func (s *S3BucketDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s S3BucketDoesNotExistException) Error() string {
+func (s *S3BucketDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s S3BucketDoesNotExistException) StatusCode() int {
+func (s *S3BucketDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s S3BucketDoesNotExistException) RequestID() string {
+func (s *S3BucketDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7025,12 +7025,12 @@ func newErrorTagsLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagsLimitExceededException) Code() string {
+func (s *TagsLimitExceededException) Code() string {
 	return "TagsLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TagsLimitExceededException) Message() string {
+func (s *TagsLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7038,21 +7038,21 @@ func (s TagsLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagsLimitExceededException) OrigErr() error {
+func (s *TagsLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TagsLimitExceededException) Error() string {
+func (s *TagsLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagsLimitExceededException) StatusCode() int {
+func (s *TagsLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagsLimitExceededException) RequestID() string {
+func (s *TagsLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7258,12 +7258,12 @@ func newErrorTrailAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TrailAlreadyExistsException) Code() string {
+func (s *TrailAlreadyExistsException) Code() string {
 	return "TrailAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s TrailAlreadyExistsException) Message() string {
+func (s *TrailAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7271,21 +7271,21 @@ func (s TrailAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TrailAlreadyExistsException) OrigErr() error {
+func (s *TrailAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s TrailAlreadyExistsException) Error() string {
+func (s *TrailAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TrailAlreadyExistsException) StatusCode() int {
+func (s *TrailAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TrailAlreadyExistsException) RequestID() string {
+func (s *TrailAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7357,12 +7357,12 @@ func newErrorTrailNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TrailNotFoundException) Code() string {
+func (s *TrailNotFoundException) Code() string {
 	return "TrailNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s TrailNotFoundException) Message() string {
+func (s *TrailNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7370,21 +7370,21 @@ func (s TrailNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TrailNotFoundException) OrigErr() error {
+func (s *TrailNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s TrailNotFoundException) Error() string {
+func (s *TrailNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TrailNotFoundException) StatusCode() int {
+func (s *TrailNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TrailNotFoundException) RequestID() string {
+func (s *TrailNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7413,12 +7413,12 @@ func newErrorTrailNotProvidedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TrailNotProvidedException) Code() string {
+func (s *TrailNotProvidedException) Code() string {
 	return "TrailNotProvidedException"
 }
 
 // Message returns the exception's message.
-func (s TrailNotProvidedException) Message() string {
+func (s *TrailNotProvidedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7426,21 +7426,21 @@ func (s TrailNotProvidedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TrailNotProvidedException) OrigErr() error {
+func (s *TrailNotProvidedException) OrigErr() error {
 	return nil
 }
 
-func (s TrailNotProvidedException) Error() string {
+func (s *TrailNotProvidedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TrailNotProvidedException) StatusCode() int {
+func (s *TrailNotProvidedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TrailNotProvidedException) RequestID() string {
+func (s *TrailNotProvidedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7469,12 +7469,12 @@ func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedOperationException) Code() string {
+func (s *UnsupportedOperationException) Code() string {
 	return "UnsupportedOperationException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedOperationException) Message() string {
+func (s *UnsupportedOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7482,21 +7482,21 @@ func (s UnsupportedOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedOperationException) OrigErr() error {
+func (s *UnsupportedOperationException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedOperationException) Error() string {
+func (s *UnsupportedOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedOperationException) StatusCode() int {
+func (s *UnsupportedOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedOperationException) RequestID() string {
+func (s *UnsupportedOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cloudwatchevents/api.go
+++ b/service/cloudwatchevents/api.go
@@ -3265,12 +3265,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3278,21 +3278,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4731,12 +4731,12 @@ func newErrorInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalException) Code() string {
+func (s *InternalException) Code() string {
 	return "InternalException"
 }
 
 // Message returns the exception's message.
-func (s InternalException) Message() string {
+func (s *InternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4744,21 +4744,21 @@ func (s InternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalException) OrigErr() error {
+func (s *InternalException) OrigErr() error {
 	return nil
 }
 
-func (s InternalException) Error() string {
+func (s *InternalException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalException) StatusCode() int {
+func (s *InternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalException) RequestID() string {
+func (s *InternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4787,12 +4787,12 @@ func newErrorInvalidEventPatternException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidEventPatternException) Code() string {
+func (s *InvalidEventPatternException) Code() string {
 	return "InvalidEventPatternException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEventPatternException) Message() string {
+func (s *InvalidEventPatternException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4800,21 +4800,21 @@ func (s InvalidEventPatternException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEventPatternException) OrigErr() error {
+func (s *InvalidEventPatternException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEventPatternException) Error() string {
+func (s *InvalidEventPatternException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEventPatternException) StatusCode() int {
+func (s *InvalidEventPatternException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEventPatternException) RequestID() string {
+func (s *InvalidEventPatternException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4843,12 +4843,12 @@ func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidStateException) Code() string {
+func (s *InvalidStateException) Code() string {
 	return "InvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateException) Message() string {
+func (s *InvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4856,21 +4856,21 @@ func (s InvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateException) OrigErr() error {
+func (s *InvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateException) Error() string {
+func (s *InvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateException) StatusCode() int {
+func (s *InvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateException) RequestID() string {
+func (s *InvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4943,12 +4943,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4956,21 +4956,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5791,12 +5791,12 @@ func newErrorManagedRuleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ManagedRuleException) Code() string {
+func (s *ManagedRuleException) Code() string {
 	return "ManagedRuleException"
 }
 
 // Message returns the exception's message.
-func (s ManagedRuleException) Message() string {
+func (s *ManagedRuleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5804,21 +5804,21 @@ func (s ManagedRuleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ManagedRuleException) OrigErr() error {
+func (s *ManagedRuleException) OrigErr() error {
 	return nil
 }
 
-func (s ManagedRuleException) Error() string {
+func (s *ManagedRuleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ManagedRuleException) StatusCode() int {
+func (s *ManagedRuleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ManagedRuleException) RequestID() string {
+func (s *ManagedRuleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5979,12 +5979,12 @@ func newErrorPolicyLengthExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyLengthExceededException) Code() string {
+func (s *PolicyLengthExceededException) Code() string {
 	return "PolicyLengthExceededException"
 }
 
 // Message returns the exception's message.
-func (s PolicyLengthExceededException) Message() string {
+func (s *PolicyLengthExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5992,21 +5992,21 @@ func (s PolicyLengthExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyLengthExceededException) OrigErr() error {
+func (s *PolicyLengthExceededException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyLengthExceededException) Error() string {
+func (s *PolicyLengthExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyLengthExceededException) StatusCode() int {
+func (s *PolicyLengthExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyLengthExceededException) RequestID() string {
+func (s *PolicyLengthExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7119,12 +7119,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7132,21 +7132,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7175,12 +7175,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7188,21 +7188,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -4508,12 +4508,12 @@ func newErrorDataAlreadyAcceptedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DataAlreadyAcceptedException) Code() string {
+func (s *DataAlreadyAcceptedException) Code() string {
 	return "DataAlreadyAcceptedException"
 }
 
 // Message returns the exception's message.
-func (s DataAlreadyAcceptedException) Message() string {
+func (s *DataAlreadyAcceptedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4521,21 +4521,21 @@ func (s DataAlreadyAcceptedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DataAlreadyAcceptedException) OrigErr() error {
+func (s *DataAlreadyAcceptedException) OrigErr() error {
 	return nil
 }
 
-func (s DataAlreadyAcceptedException) Error() string {
+func (s *DataAlreadyAcceptedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DataAlreadyAcceptedException) StatusCode() int {
+func (s *DataAlreadyAcceptedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DataAlreadyAcceptedException) RequestID() string {
+func (s *DataAlreadyAcceptedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6861,12 +6861,12 @@ func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOperationException) Code() string {
+func (s *InvalidOperationException) Code() string {
 	return "InvalidOperationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOperationException) Message() string {
+func (s *InvalidOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6874,21 +6874,21 @@ func (s InvalidOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOperationException) OrigErr() error {
+func (s *InvalidOperationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOperationException) Error() string {
+func (s *InvalidOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOperationException) StatusCode() int {
+func (s *InvalidOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOperationException) RequestID() string {
+func (s *InvalidOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6917,12 +6917,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6930,21 +6930,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6976,12 +6976,12 @@ func newErrorInvalidSequenceTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSequenceTokenException) Code() string {
+func (s *InvalidSequenceTokenException) Code() string {
 	return "InvalidSequenceTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSequenceTokenException) Message() string {
+func (s *InvalidSequenceTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6989,21 +6989,21 @@ func (s InvalidSequenceTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSequenceTokenException) OrigErr() error {
+func (s *InvalidSequenceTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSequenceTokenException) Error() string {
+func (s *InvalidSequenceTokenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSequenceTokenException) StatusCode() int {
+func (s *InvalidSequenceTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSequenceTokenException) RequestID() string {
+func (s *InvalidSequenceTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7032,12 +7032,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7045,21 +7045,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7375,12 +7375,12 @@ func newErrorMalformedQueryException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MalformedQueryException) Code() string {
+func (s *MalformedQueryException) Code() string {
 	return "MalformedQueryException"
 }
 
 // Message returns the exception's message.
-func (s MalformedQueryException) Message() string {
+func (s *MalformedQueryException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7388,21 +7388,21 @@ func (s MalformedQueryException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MalformedQueryException) OrigErr() error {
+func (s *MalformedQueryException) OrigErr() error {
 	return nil
 }
 
-func (s MalformedQueryException) Error() string {
+func (s *MalformedQueryException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MalformedQueryException) StatusCode() int {
+func (s *MalformedQueryException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MalformedQueryException) RequestID() string {
+func (s *MalformedQueryException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7618,12 +7618,12 @@ func newErrorOperationAbortedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationAbortedException) Code() string {
+func (s *OperationAbortedException) Code() string {
 	return "OperationAbortedException"
 }
 
 // Message returns the exception's message.
-func (s OperationAbortedException) Message() string {
+func (s *OperationAbortedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7631,21 +7631,21 @@ func (s OperationAbortedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationAbortedException) OrigErr() error {
+func (s *OperationAbortedException) OrigErr() error {
 	return nil
 }
 
-func (s OperationAbortedException) Error() string {
+func (s *OperationAbortedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationAbortedException) StatusCode() int {
+func (s *OperationAbortedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationAbortedException) RequestID() string {
+func (s *OperationAbortedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8645,12 +8645,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8658,21 +8658,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8701,12 +8701,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8714,21 +8714,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8868,12 +8868,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8881,21 +8881,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9356,12 +9356,12 @@ func newErrorUnrecognizedClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnrecognizedClientException) Code() string {
+func (s *UnrecognizedClientException) Code() string {
 	return "UnrecognizedClientException"
 }
 
 // Message returns the exception's message.
-func (s UnrecognizedClientException) Message() string {
+func (s *UnrecognizedClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9369,21 +9369,21 @@ func (s UnrecognizedClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnrecognizedClientException) OrigErr() error {
+func (s *UnrecognizedClientException) OrigErr() error {
 	return nil
 }
 
-func (s UnrecognizedClientException) Error() string {
+func (s *UnrecognizedClientException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnrecognizedClientException) StatusCode() int {
+func (s *UnrecognizedClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnrecognizedClientException) RequestID() string {
+func (s *UnrecognizedClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/codebuild/api.go
+++ b/service/codebuild/api.go
@@ -2821,12 +2821,12 @@ func newErrorAccountLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccountLimitExceededException) Code() string {
+func (s *AccountLimitExceededException) Code() string {
 	return "AccountLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s AccountLimitExceededException) Message() string {
+func (s *AccountLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2834,21 +2834,21 @@ func (s AccountLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountLimitExceededException) OrigErr() error {
+func (s *AccountLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s AccountLimitExceededException) Error() string {
+func (s *AccountLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountLimitExceededException) StatusCode() int {
+func (s *AccountLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountLimitExceededException) RequestID() string {
+func (s *AccountLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5356,12 +5356,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5369,21 +5369,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6611,12 +6611,12 @@ func newErrorOAuthProviderException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OAuthProviderException) Code() string {
+func (s *OAuthProviderException) Code() string {
 	return "OAuthProviderException"
 }
 
 // Message returns the exception's message.
-func (s OAuthProviderException) Message() string {
+func (s *OAuthProviderException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6624,21 +6624,21 @@ func (s OAuthProviderException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OAuthProviderException) OrigErr() error {
+func (s *OAuthProviderException) OrigErr() error {
 	return nil
 }
 
-func (s OAuthProviderException) Error() string {
+func (s *OAuthProviderException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OAuthProviderException) StatusCode() int {
+func (s *OAuthProviderException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OAuthProviderException) RequestID() string {
+func (s *OAuthProviderException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8289,12 +8289,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8302,21 +8302,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8345,12 +8345,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8358,21 +8358,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -10377,12 +10377,12 @@ func newErrorActorDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ActorDoesNotExistException) Code() string {
+func (s *ActorDoesNotExistException) Code() string {
 	return "ActorDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s ActorDoesNotExistException) Message() string {
+func (s *ActorDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10390,21 +10390,21 @@ func (s ActorDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ActorDoesNotExistException) OrigErr() error {
+func (s *ActorDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s ActorDoesNotExistException) Error() string {
+func (s *ActorDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ActorDoesNotExistException) StatusCode() int {
+func (s *ActorDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ActorDoesNotExistException) RequestID() string {
+func (s *ActorDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10555,12 +10555,12 @@ func newErrorApprovalRuleContentRequiredException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s ApprovalRuleContentRequiredException) Code() string {
+func (s *ApprovalRuleContentRequiredException) Code() string {
 	return "ApprovalRuleContentRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalRuleContentRequiredException) Message() string {
+func (s *ApprovalRuleContentRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10568,21 +10568,21 @@ func (s ApprovalRuleContentRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalRuleContentRequiredException) OrigErr() error {
+func (s *ApprovalRuleContentRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalRuleContentRequiredException) Error() string {
+func (s *ApprovalRuleContentRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalRuleContentRequiredException) StatusCode() int {
+func (s *ApprovalRuleContentRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalRuleContentRequiredException) RequestID() string {
+func (s *ApprovalRuleContentRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10611,12 +10611,12 @@ func newErrorApprovalRuleDoesNotExistException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ApprovalRuleDoesNotExistException) Code() string {
+func (s *ApprovalRuleDoesNotExistException) Code() string {
 	return "ApprovalRuleDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalRuleDoesNotExistException) Message() string {
+func (s *ApprovalRuleDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10624,21 +10624,21 @@ func (s ApprovalRuleDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalRuleDoesNotExistException) OrigErr() error {
+func (s *ApprovalRuleDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalRuleDoesNotExistException) Error() string {
+func (s *ApprovalRuleDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalRuleDoesNotExistException) StatusCode() int {
+func (s *ApprovalRuleDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalRuleDoesNotExistException) RequestID() string {
+func (s *ApprovalRuleDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10710,12 +10710,12 @@ func newErrorApprovalRuleNameAlreadyExistsException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s ApprovalRuleNameAlreadyExistsException) Code() string {
+func (s *ApprovalRuleNameAlreadyExistsException) Code() string {
 	return "ApprovalRuleNameAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalRuleNameAlreadyExistsException) Message() string {
+func (s *ApprovalRuleNameAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10723,21 +10723,21 @@ func (s ApprovalRuleNameAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalRuleNameAlreadyExistsException) OrigErr() error {
+func (s *ApprovalRuleNameAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalRuleNameAlreadyExistsException) Error() string {
+func (s *ApprovalRuleNameAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalRuleNameAlreadyExistsException) StatusCode() int {
+func (s *ApprovalRuleNameAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalRuleNameAlreadyExistsException) RequestID() string {
+func (s *ApprovalRuleNameAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10766,12 +10766,12 @@ func newErrorApprovalRuleNameRequiredException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ApprovalRuleNameRequiredException) Code() string {
+func (s *ApprovalRuleNameRequiredException) Code() string {
 	return "ApprovalRuleNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalRuleNameRequiredException) Message() string {
+func (s *ApprovalRuleNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10779,21 +10779,21 @@ func (s ApprovalRuleNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalRuleNameRequiredException) OrigErr() error {
+func (s *ApprovalRuleNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalRuleNameRequiredException) Error() string {
+func (s *ApprovalRuleNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalRuleNameRequiredException) StatusCode() int {
+func (s *ApprovalRuleNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalRuleNameRequiredException) RequestID() string {
+func (s *ApprovalRuleNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10946,12 +10946,12 @@ func newErrorApprovalRuleTemplateContentRequiredException(v protocol.ResponseMet
 }
 
 // Code returns the exception type name.
-func (s ApprovalRuleTemplateContentRequiredException) Code() string {
+func (s *ApprovalRuleTemplateContentRequiredException) Code() string {
 	return "ApprovalRuleTemplateContentRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalRuleTemplateContentRequiredException) Message() string {
+func (s *ApprovalRuleTemplateContentRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10959,21 +10959,21 @@ func (s ApprovalRuleTemplateContentRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalRuleTemplateContentRequiredException) OrigErr() error {
+func (s *ApprovalRuleTemplateContentRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalRuleTemplateContentRequiredException) Error() string {
+func (s *ApprovalRuleTemplateContentRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalRuleTemplateContentRequiredException) StatusCode() int {
+func (s *ApprovalRuleTemplateContentRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalRuleTemplateContentRequiredException) RequestID() string {
+func (s *ApprovalRuleTemplateContentRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11004,12 +11004,12 @@ func newErrorApprovalRuleTemplateDoesNotExistException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s ApprovalRuleTemplateDoesNotExistException) Code() string {
+func (s *ApprovalRuleTemplateDoesNotExistException) Code() string {
 	return "ApprovalRuleTemplateDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalRuleTemplateDoesNotExistException) Message() string {
+func (s *ApprovalRuleTemplateDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11017,21 +11017,21 @@ func (s ApprovalRuleTemplateDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalRuleTemplateDoesNotExistException) OrigErr() error {
+func (s *ApprovalRuleTemplateDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalRuleTemplateDoesNotExistException) Error() string {
+func (s *ApprovalRuleTemplateDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalRuleTemplateDoesNotExistException) StatusCode() int {
+func (s *ApprovalRuleTemplateDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalRuleTemplateDoesNotExistException) RequestID() string {
+func (s *ApprovalRuleTemplateDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11062,12 +11062,12 @@ func newErrorApprovalRuleTemplateInUseException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s ApprovalRuleTemplateInUseException) Code() string {
+func (s *ApprovalRuleTemplateInUseException) Code() string {
 	return "ApprovalRuleTemplateInUseException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalRuleTemplateInUseException) Message() string {
+func (s *ApprovalRuleTemplateInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11075,21 +11075,21 @@ func (s ApprovalRuleTemplateInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalRuleTemplateInUseException) OrigErr() error {
+func (s *ApprovalRuleTemplateInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalRuleTemplateInUseException) Error() string {
+func (s *ApprovalRuleTemplateInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalRuleTemplateInUseException) StatusCode() int {
+func (s *ApprovalRuleTemplateInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalRuleTemplateInUseException) RequestID() string {
+func (s *ApprovalRuleTemplateInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11120,12 +11120,12 @@ func newErrorApprovalRuleTemplateNameAlreadyExistsException(v protocol.ResponseM
 }
 
 // Code returns the exception type name.
-func (s ApprovalRuleTemplateNameAlreadyExistsException) Code() string {
+func (s *ApprovalRuleTemplateNameAlreadyExistsException) Code() string {
 	return "ApprovalRuleTemplateNameAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalRuleTemplateNameAlreadyExistsException) Message() string {
+func (s *ApprovalRuleTemplateNameAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11133,21 +11133,21 @@ func (s ApprovalRuleTemplateNameAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalRuleTemplateNameAlreadyExistsException) OrigErr() error {
+func (s *ApprovalRuleTemplateNameAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalRuleTemplateNameAlreadyExistsException) Error() string {
+func (s *ApprovalRuleTemplateNameAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalRuleTemplateNameAlreadyExistsException) StatusCode() int {
+func (s *ApprovalRuleTemplateNameAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalRuleTemplateNameAlreadyExistsException) RequestID() string {
+func (s *ApprovalRuleTemplateNameAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11176,12 +11176,12 @@ func newErrorApprovalRuleTemplateNameRequiredException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s ApprovalRuleTemplateNameRequiredException) Code() string {
+func (s *ApprovalRuleTemplateNameRequiredException) Code() string {
 	return "ApprovalRuleTemplateNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalRuleTemplateNameRequiredException) Message() string {
+func (s *ApprovalRuleTemplateNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11189,21 +11189,21 @@ func (s ApprovalRuleTemplateNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalRuleTemplateNameRequiredException) OrigErr() error {
+func (s *ApprovalRuleTemplateNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalRuleTemplateNameRequiredException) Error() string {
+func (s *ApprovalRuleTemplateNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalRuleTemplateNameRequiredException) StatusCode() int {
+func (s *ApprovalRuleTemplateNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalRuleTemplateNameRequiredException) RequestID() string {
+func (s *ApprovalRuleTemplateNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11265,12 +11265,12 @@ func newErrorApprovalStateRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ApprovalStateRequiredException) Code() string {
+func (s *ApprovalStateRequiredException) Code() string {
 	return "ApprovalStateRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalStateRequiredException) Message() string {
+func (s *ApprovalStateRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11278,21 +11278,21 @@ func (s ApprovalStateRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalStateRequiredException) OrigErr() error {
+func (s *ApprovalStateRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalStateRequiredException) Error() string {
+func (s *ApprovalStateRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalStateRequiredException) StatusCode() int {
+func (s *ApprovalStateRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalStateRequiredException) RequestID() string {
+func (s *ApprovalStateRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11393,12 +11393,12 @@ func newErrorAuthorDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AuthorDoesNotExistException) Code() string {
+func (s *AuthorDoesNotExistException) Code() string {
 	return "AuthorDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s AuthorDoesNotExistException) Message() string {
+func (s *AuthorDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11406,21 +11406,21 @@ func (s AuthorDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AuthorDoesNotExistException) OrigErr() error {
+func (s *AuthorDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s AuthorDoesNotExistException) Error() string {
+func (s *AuthorDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AuthorDoesNotExistException) StatusCode() int {
+func (s *AuthorDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AuthorDoesNotExistException) RequestID() string {
+func (s *AuthorDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12218,12 +12218,12 @@ func newErrorBeforeCommitIdAndAfterCommitIdAreSameException(v protocol.ResponseM
 }
 
 // Code returns the exception type name.
-func (s BeforeCommitIdAndAfterCommitIdAreSameException) Code() string {
+func (s *BeforeCommitIdAndAfterCommitIdAreSameException) Code() string {
 	return "BeforeCommitIdAndAfterCommitIdAreSameException"
 }
 
 // Message returns the exception's message.
-func (s BeforeCommitIdAndAfterCommitIdAreSameException) Message() string {
+func (s *BeforeCommitIdAndAfterCommitIdAreSameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12231,21 +12231,21 @@ func (s BeforeCommitIdAndAfterCommitIdAreSameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BeforeCommitIdAndAfterCommitIdAreSameException) OrigErr() error {
+func (s *BeforeCommitIdAndAfterCommitIdAreSameException) OrigErr() error {
 	return nil
 }
 
-func (s BeforeCommitIdAndAfterCommitIdAreSameException) Error() string {
+func (s *BeforeCommitIdAndAfterCommitIdAreSameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BeforeCommitIdAndAfterCommitIdAreSameException) StatusCode() int {
+func (s *BeforeCommitIdAndAfterCommitIdAreSameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BeforeCommitIdAndAfterCommitIdAreSameException) RequestID() string {
+func (s *BeforeCommitIdAndAfterCommitIdAreSameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12274,12 +12274,12 @@ func newErrorBlobIdDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BlobIdDoesNotExistException) Code() string {
+func (s *BlobIdDoesNotExistException) Code() string {
 	return "BlobIdDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s BlobIdDoesNotExistException) Message() string {
+func (s *BlobIdDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12287,21 +12287,21 @@ func (s BlobIdDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BlobIdDoesNotExistException) OrigErr() error {
+func (s *BlobIdDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s BlobIdDoesNotExistException) Error() string {
+func (s *BlobIdDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BlobIdDoesNotExistException) StatusCode() int {
+func (s *BlobIdDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BlobIdDoesNotExistException) RequestID() string {
+func (s *BlobIdDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12330,12 +12330,12 @@ func newErrorBlobIdRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BlobIdRequiredException) Code() string {
+func (s *BlobIdRequiredException) Code() string {
 	return "BlobIdRequiredException"
 }
 
 // Message returns the exception's message.
-func (s BlobIdRequiredException) Message() string {
+func (s *BlobIdRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12343,21 +12343,21 @@ func (s BlobIdRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BlobIdRequiredException) OrigErr() error {
+func (s *BlobIdRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s BlobIdRequiredException) Error() string {
+func (s *BlobIdRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BlobIdRequiredException) StatusCode() int {
+func (s *BlobIdRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BlobIdRequiredException) RequestID() string {
+func (s *BlobIdRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12436,12 +12436,12 @@ func newErrorBranchDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BranchDoesNotExistException) Code() string {
+func (s *BranchDoesNotExistException) Code() string {
 	return "BranchDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s BranchDoesNotExistException) Message() string {
+func (s *BranchDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12449,21 +12449,21 @@ func (s BranchDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BranchDoesNotExistException) OrigErr() error {
+func (s *BranchDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s BranchDoesNotExistException) Error() string {
+func (s *BranchDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BranchDoesNotExistException) StatusCode() int {
+func (s *BranchDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BranchDoesNotExistException) RequestID() string {
+func (s *BranchDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12525,12 +12525,12 @@ func newErrorBranchNameExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BranchNameExistsException) Code() string {
+func (s *BranchNameExistsException) Code() string {
 	return "BranchNameExistsException"
 }
 
 // Message returns the exception's message.
-func (s BranchNameExistsException) Message() string {
+func (s *BranchNameExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12538,21 +12538,21 @@ func (s BranchNameExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BranchNameExistsException) OrigErr() error {
+func (s *BranchNameExistsException) OrigErr() error {
 	return nil
 }
 
-func (s BranchNameExistsException) Error() string {
+func (s *BranchNameExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BranchNameExistsException) StatusCode() int {
+func (s *BranchNameExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BranchNameExistsException) RequestID() string {
+func (s *BranchNameExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12583,12 +12583,12 @@ func newErrorBranchNameIsTagNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BranchNameIsTagNameException) Code() string {
+func (s *BranchNameIsTagNameException) Code() string {
 	return "BranchNameIsTagNameException"
 }
 
 // Message returns the exception's message.
-func (s BranchNameIsTagNameException) Message() string {
+func (s *BranchNameIsTagNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12596,21 +12596,21 @@ func (s BranchNameIsTagNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BranchNameIsTagNameException) OrigErr() error {
+func (s *BranchNameIsTagNameException) OrigErr() error {
 	return nil
 }
 
-func (s BranchNameIsTagNameException) Error() string {
+func (s *BranchNameIsTagNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BranchNameIsTagNameException) StatusCode() int {
+func (s *BranchNameIsTagNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BranchNameIsTagNameException) RequestID() string {
+func (s *BranchNameIsTagNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12639,12 +12639,12 @@ func newErrorBranchNameRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BranchNameRequiredException) Code() string {
+func (s *BranchNameRequiredException) Code() string {
 	return "BranchNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s BranchNameRequiredException) Message() string {
+func (s *BranchNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12652,21 +12652,21 @@ func (s BranchNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BranchNameRequiredException) OrigErr() error {
+func (s *BranchNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s BranchNameRequiredException) Error() string {
+func (s *BranchNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BranchNameRequiredException) StatusCode() int {
+func (s *BranchNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BranchNameRequiredException) RequestID() string {
+func (s *BranchNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12696,12 +12696,12 @@ func newErrorCannotDeleteApprovalRuleFromTemplateException(v protocol.ResponseMe
 }
 
 // Code returns the exception type name.
-func (s CannotDeleteApprovalRuleFromTemplateException) Code() string {
+func (s *CannotDeleteApprovalRuleFromTemplateException) Code() string {
 	return "CannotDeleteApprovalRuleFromTemplateException"
 }
 
 // Message returns the exception's message.
-func (s CannotDeleteApprovalRuleFromTemplateException) Message() string {
+func (s *CannotDeleteApprovalRuleFromTemplateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12709,21 +12709,21 @@ func (s CannotDeleteApprovalRuleFromTemplateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CannotDeleteApprovalRuleFromTemplateException) OrigErr() error {
+func (s *CannotDeleteApprovalRuleFromTemplateException) OrigErr() error {
 	return nil
 }
 
-func (s CannotDeleteApprovalRuleFromTemplateException) Error() string {
+func (s *CannotDeleteApprovalRuleFromTemplateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CannotDeleteApprovalRuleFromTemplateException) StatusCode() int {
+func (s *CannotDeleteApprovalRuleFromTemplateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CannotDeleteApprovalRuleFromTemplateException) RequestID() string {
+func (s *CannotDeleteApprovalRuleFromTemplateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12753,12 +12753,12 @@ func newErrorCannotModifyApprovalRuleFromTemplateException(v protocol.ResponseMe
 }
 
 // Code returns the exception type name.
-func (s CannotModifyApprovalRuleFromTemplateException) Code() string {
+func (s *CannotModifyApprovalRuleFromTemplateException) Code() string {
 	return "CannotModifyApprovalRuleFromTemplateException"
 }
 
 // Message returns the exception's message.
-func (s CannotModifyApprovalRuleFromTemplateException) Message() string {
+func (s *CannotModifyApprovalRuleFromTemplateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12766,21 +12766,21 @@ func (s CannotModifyApprovalRuleFromTemplateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CannotModifyApprovalRuleFromTemplateException) OrigErr() error {
+func (s *CannotModifyApprovalRuleFromTemplateException) OrigErr() error {
 	return nil
 }
 
-func (s CannotModifyApprovalRuleFromTemplateException) Error() string {
+func (s *CannotModifyApprovalRuleFromTemplateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CannotModifyApprovalRuleFromTemplateException) StatusCode() int {
+func (s *CannotModifyApprovalRuleFromTemplateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CannotModifyApprovalRuleFromTemplateException) RequestID() string {
+func (s *CannotModifyApprovalRuleFromTemplateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12813,12 +12813,12 @@ func newErrorClientRequestTokenRequiredException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s ClientRequestTokenRequiredException) Code() string {
+func (s *ClientRequestTokenRequiredException) Code() string {
 	return "ClientRequestTokenRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ClientRequestTokenRequiredException) Message() string {
+func (s *ClientRequestTokenRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12826,21 +12826,21 @@ func (s ClientRequestTokenRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientRequestTokenRequiredException) OrigErr() error {
+func (s *ClientRequestTokenRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ClientRequestTokenRequiredException) Error() string {
+func (s *ClientRequestTokenRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientRequestTokenRequiredException) StatusCode() int {
+func (s *ClientRequestTokenRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientRequestTokenRequiredException) RequestID() string {
+func (s *ClientRequestTokenRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12960,12 +12960,12 @@ func newErrorCommentContentRequiredException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s CommentContentRequiredException) Code() string {
+func (s *CommentContentRequiredException) Code() string {
 	return "CommentContentRequiredException"
 }
 
 // Message returns the exception's message.
-func (s CommentContentRequiredException) Message() string {
+func (s *CommentContentRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12973,21 +12973,21 @@ func (s CommentContentRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommentContentRequiredException) OrigErr() error {
+func (s *CommentContentRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s CommentContentRequiredException) Error() string {
+func (s *CommentContentRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommentContentRequiredException) StatusCode() int {
+func (s *CommentContentRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommentContentRequiredException) RequestID() string {
+func (s *CommentContentRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13016,12 +13016,12 @@ func newErrorCommentContentSizeLimitExceededException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s CommentContentSizeLimitExceededException) Code() string {
+func (s *CommentContentSizeLimitExceededException) Code() string {
 	return "CommentContentSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s CommentContentSizeLimitExceededException) Message() string {
+func (s *CommentContentSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13029,21 +13029,21 @@ func (s CommentContentSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommentContentSizeLimitExceededException) OrigErr() error {
+func (s *CommentContentSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s CommentContentSizeLimitExceededException) Error() string {
+func (s *CommentContentSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommentContentSizeLimitExceededException) StatusCode() int {
+func (s *CommentContentSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommentContentSizeLimitExceededException) RequestID() string {
+func (s *CommentContentSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13073,12 +13073,12 @@ func newErrorCommentDeletedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CommentDeletedException) Code() string {
+func (s *CommentDeletedException) Code() string {
 	return "CommentDeletedException"
 }
 
 // Message returns the exception's message.
-func (s CommentDeletedException) Message() string {
+func (s *CommentDeletedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13086,21 +13086,21 @@ func (s CommentDeletedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommentDeletedException) OrigErr() error {
+func (s *CommentDeletedException) OrigErr() error {
 	return nil
 }
 
-func (s CommentDeletedException) Error() string {
+func (s *CommentDeletedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommentDeletedException) StatusCode() int {
+func (s *CommentDeletedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommentDeletedException) RequestID() string {
+func (s *CommentDeletedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13130,12 +13130,12 @@ func newErrorCommentDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CommentDoesNotExistException) Code() string {
+func (s *CommentDoesNotExistException) Code() string {
 	return "CommentDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s CommentDoesNotExistException) Message() string {
+func (s *CommentDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13143,21 +13143,21 @@ func (s CommentDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommentDoesNotExistException) OrigErr() error {
+func (s *CommentDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s CommentDoesNotExistException) Error() string {
+func (s *CommentDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommentDoesNotExistException) StatusCode() int {
+func (s *CommentDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommentDoesNotExistException) RequestID() string {
+func (s *CommentDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13186,12 +13186,12 @@ func newErrorCommentIdRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CommentIdRequiredException) Code() string {
+func (s *CommentIdRequiredException) Code() string {
 	return "CommentIdRequiredException"
 }
 
 // Message returns the exception's message.
-func (s CommentIdRequiredException) Message() string {
+func (s *CommentIdRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13199,21 +13199,21 @@ func (s CommentIdRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommentIdRequiredException) OrigErr() error {
+func (s *CommentIdRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s CommentIdRequiredException) Error() string {
+func (s *CommentIdRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommentIdRequiredException) StatusCode() int {
+func (s *CommentIdRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommentIdRequiredException) RequestID() string {
+func (s *CommentIdRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13243,12 +13243,12 @@ func newErrorCommentNotCreatedByCallerException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s CommentNotCreatedByCallerException) Code() string {
+func (s *CommentNotCreatedByCallerException) Code() string {
 	return "CommentNotCreatedByCallerException"
 }
 
 // Message returns the exception's message.
-func (s CommentNotCreatedByCallerException) Message() string {
+func (s *CommentNotCreatedByCallerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13256,21 +13256,21 @@ func (s CommentNotCreatedByCallerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommentNotCreatedByCallerException) OrigErr() error {
+func (s *CommentNotCreatedByCallerException) OrigErr() error {
 	return nil
 }
 
-func (s CommentNotCreatedByCallerException) Error() string {
+func (s *CommentNotCreatedByCallerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommentNotCreatedByCallerException) StatusCode() int {
+func (s *CommentNotCreatedByCallerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommentNotCreatedByCallerException) RequestID() string {
+func (s *CommentNotCreatedByCallerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13564,12 +13564,12 @@ func newErrorCommitDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CommitDoesNotExistException) Code() string {
+func (s *CommitDoesNotExistException) Code() string {
 	return "CommitDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s CommitDoesNotExistException) Message() string {
+func (s *CommitDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13577,21 +13577,21 @@ func (s CommitDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommitDoesNotExistException) OrigErr() error {
+func (s *CommitDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s CommitDoesNotExistException) Error() string {
+func (s *CommitDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommitDoesNotExistException) StatusCode() int {
+func (s *CommitDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommitDoesNotExistException) RequestID() string {
+func (s *CommitDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13620,12 +13620,12 @@ func newErrorCommitIdDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CommitIdDoesNotExistException) Code() string {
+func (s *CommitIdDoesNotExistException) Code() string {
 	return "CommitIdDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s CommitIdDoesNotExistException) Message() string {
+func (s *CommitIdDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13633,21 +13633,21 @@ func (s CommitIdDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommitIdDoesNotExistException) OrigErr() error {
+func (s *CommitIdDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s CommitIdDoesNotExistException) Error() string {
+func (s *CommitIdDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommitIdDoesNotExistException) StatusCode() int {
+func (s *CommitIdDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommitIdDoesNotExistException) RequestID() string {
+func (s *CommitIdDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13676,12 +13676,12 @@ func newErrorCommitIdRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CommitIdRequiredException) Code() string {
+func (s *CommitIdRequiredException) Code() string {
 	return "CommitIdRequiredException"
 }
 
 // Message returns the exception's message.
-func (s CommitIdRequiredException) Message() string {
+func (s *CommitIdRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13689,21 +13689,21 @@ func (s CommitIdRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommitIdRequiredException) OrigErr() error {
+func (s *CommitIdRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s CommitIdRequiredException) Error() string {
+func (s *CommitIdRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommitIdRequiredException) StatusCode() int {
+func (s *CommitIdRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommitIdRequiredException) RequestID() string {
+func (s *CommitIdRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13734,12 +13734,12 @@ func newErrorCommitIdsLimitExceededException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s CommitIdsLimitExceededException) Code() string {
+func (s *CommitIdsLimitExceededException) Code() string {
 	return "CommitIdsLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s CommitIdsLimitExceededException) Message() string {
+func (s *CommitIdsLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13747,21 +13747,21 @@ func (s CommitIdsLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommitIdsLimitExceededException) OrigErr() error {
+func (s *CommitIdsLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s CommitIdsLimitExceededException) Error() string {
+func (s *CommitIdsLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommitIdsLimitExceededException) StatusCode() int {
+func (s *CommitIdsLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommitIdsLimitExceededException) RequestID() string {
+func (s *CommitIdsLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13791,12 +13791,12 @@ func newErrorCommitIdsListRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CommitIdsListRequiredException) Code() string {
+func (s *CommitIdsListRequiredException) Code() string {
 	return "CommitIdsListRequiredException"
 }
 
 // Message returns the exception's message.
-func (s CommitIdsListRequiredException) Message() string {
+func (s *CommitIdsListRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13804,21 +13804,21 @@ func (s CommitIdsListRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommitIdsListRequiredException) OrigErr() error {
+func (s *CommitIdsListRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s CommitIdsListRequiredException) Error() string {
+func (s *CommitIdsListRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommitIdsListRequiredException) StatusCode() int {
+func (s *CommitIdsListRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommitIdsListRequiredException) RequestID() string {
+func (s *CommitIdsListRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13847,12 +13847,12 @@ func newErrorCommitMessageLengthExceededException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s CommitMessageLengthExceededException) Code() string {
+func (s *CommitMessageLengthExceededException) Code() string {
 	return "CommitMessageLengthExceededException"
 }
 
 // Message returns the exception's message.
-func (s CommitMessageLengthExceededException) Message() string {
+func (s *CommitMessageLengthExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13860,21 +13860,21 @@ func (s CommitMessageLengthExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommitMessageLengthExceededException) OrigErr() error {
+func (s *CommitMessageLengthExceededException) OrigErr() error {
 	return nil
 }
 
-func (s CommitMessageLengthExceededException) Error() string {
+func (s *CommitMessageLengthExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommitMessageLengthExceededException) StatusCode() int {
+func (s *CommitMessageLengthExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommitMessageLengthExceededException) RequestID() string {
+func (s *CommitMessageLengthExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13903,12 +13903,12 @@ func newErrorCommitRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CommitRequiredException) Code() string {
+func (s *CommitRequiredException) Code() string {
 	return "CommitRequiredException"
 }
 
 // Message returns the exception's message.
-func (s CommitRequiredException) Message() string {
+func (s *CommitRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13916,21 +13916,21 @@ func (s CommitRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CommitRequiredException) OrigErr() error {
+func (s *CommitRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s CommitRequiredException) Error() string {
+func (s *CommitRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CommitRequiredException) StatusCode() int {
+func (s *CommitRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CommitRequiredException) RequestID() string {
+func (s *CommitRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13961,12 +13961,12 @@ func newErrorConcurrentReferenceUpdateException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s ConcurrentReferenceUpdateException) Code() string {
+func (s *ConcurrentReferenceUpdateException) Code() string {
 	return "ConcurrentReferenceUpdateException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentReferenceUpdateException) Message() string {
+func (s *ConcurrentReferenceUpdateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13974,21 +13974,21 @@ func (s ConcurrentReferenceUpdateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentReferenceUpdateException) OrigErr() error {
+func (s *ConcurrentReferenceUpdateException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentReferenceUpdateException) Error() string {
+func (s *ConcurrentReferenceUpdateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentReferenceUpdateException) StatusCode() int {
+func (s *ConcurrentReferenceUpdateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentReferenceUpdateException) RequestID() string {
+func (s *ConcurrentReferenceUpdateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15209,12 +15209,12 @@ func newErrorDefaultBranchCannotBeDeletedException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s DefaultBranchCannotBeDeletedException) Code() string {
+func (s *DefaultBranchCannotBeDeletedException) Code() string {
 	return "DefaultBranchCannotBeDeletedException"
 }
 
 // Message returns the exception's message.
-func (s DefaultBranchCannotBeDeletedException) Message() string {
+func (s *DefaultBranchCannotBeDeletedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15222,21 +15222,21 @@ func (s DefaultBranchCannotBeDeletedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DefaultBranchCannotBeDeletedException) OrigErr() error {
+func (s *DefaultBranchCannotBeDeletedException) OrigErr() error {
 	return nil
 }
 
-func (s DefaultBranchCannotBeDeletedException) Error() string {
+func (s *DefaultBranchCannotBeDeletedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DefaultBranchCannotBeDeletedException) StatusCode() int {
+func (s *DefaultBranchCannotBeDeletedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DefaultBranchCannotBeDeletedException) RequestID() string {
+func (s *DefaultBranchCannotBeDeletedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16246,12 +16246,12 @@ func newErrorDirectoryNameConflictsWithFileNameException(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s DirectoryNameConflictsWithFileNameException) Code() string {
+func (s *DirectoryNameConflictsWithFileNameException) Code() string {
 	return "DirectoryNameConflictsWithFileNameException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryNameConflictsWithFileNameException) Message() string {
+func (s *DirectoryNameConflictsWithFileNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16259,21 +16259,21 @@ func (s DirectoryNameConflictsWithFileNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryNameConflictsWithFileNameException) OrigErr() error {
+func (s *DirectoryNameConflictsWithFileNameException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryNameConflictsWithFileNameException) Error() string {
+func (s *DirectoryNameConflictsWithFileNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryNameConflictsWithFileNameException) StatusCode() int {
+func (s *DirectoryNameConflictsWithFileNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryNameConflictsWithFileNameException) RequestID() string {
+func (s *DirectoryNameConflictsWithFileNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16374,12 +16374,12 @@ func newErrorEncryptionIntegrityChecksFailedException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s EncryptionIntegrityChecksFailedException) Code() string {
+func (s *EncryptionIntegrityChecksFailedException) Code() string {
 	return "EncryptionIntegrityChecksFailedException"
 }
 
 // Message returns the exception's message.
-func (s EncryptionIntegrityChecksFailedException) Message() string {
+func (s *EncryptionIntegrityChecksFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16387,21 +16387,21 @@ func (s EncryptionIntegrityChecksFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EncryptionIntegrityChecksFailedException) OrigErr() error {
+func (s *EncryptionIntegrityChecksFailedException) OrigErr() error {
 	return nil
 }
 
-func (s EncryptionIntegrityChecksFailedException) Error() string {
+func (s *EncryptionIntegrityChecksFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EncryptionIntegrityChecksFailedException) StatusCode() int {
+func (s *EncryptionIntegrityChecksFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EncryptionIntegrityChecksFailedException) RequestID() string {
+func (s *EncryptionIntegrityChecksFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16430,12 +16430,12 @@ func newErrorEncryptionKeyAccessDeniedException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s EncryptionKeyAccessDeniedException) Code() string {
+func (s *EncryptionKeyAccessDeniedException) Code() string {
 	return "EncryptionKeyAccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s EncryptionKeyAccessDeniedException) Message() string {
+func (s *EncryptionKeyAccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16443,21 +16443,21 @@ func (s EncryptionKeyAccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EncryptionKeyAccessDeniedException) OrigErr() error {
+func (s *EncryptionKeyAccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s EncryptionKeyAccessDeniedException) Error() string {
+func (s *EncryptionKeyAccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EncryptionKeyAccessDeniedException) StatusCode() int {
+func (s *EncryptionKeyAccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EncryptionKeyAccessDeniedException) RequestID() string {
+func (s *EncryptionKeyAccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16486,12 +16486,12 @@ func newErrorEncryptionKeyDisabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EncryptionKeyDisabledException) Code() string {
+func (s *EncryptionKeyDisabledException) Code() string {
 	return "EncryptionKeyDisabledException"
 }
 
 // Message returns the exception's message.
-func (s EncryptionKeyDisabledException) Message() string {
+func (s *EncryptionKeyDisabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16499,21 +16499,21 @@ func (s EncryptionKeyDisabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EncryptionKeyDisabledException) OrigErr() error {
+func (s *EncryptionKeyDisabledException) OrigErr() error {
 	return nil
 }
 
-func (s EncryptionKeyDisabledException) Error() string {
+func (s *EncryptionKeyDisabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EncryptionKeyDisabledException) StatusCode() int {
+func (s *EncryptionKeyDisabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EncryptionKeyDisabledException) RequestID() string {
+func (s *EncryptionKeyDisabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16542,12 +16542,12 @@ func newErrorEncryptionKeyNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EncryptionKeyNotFoundException) Code() string {
+func (s *EncryptionKeyNotFoundException) Code() string {
 	return "EncryptionKeyNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s EncryptionKeyNotFoundException) Message() string {
+func (s *EncryptionKeyNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16555,21 +16555,21 @@ func (s EncryptionKeyNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EncryptionKeyNotFoundException) OrigErr() error {
+func (s *EncryptionKeyNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s EncryptionKeyNotFoundException) Error() string {
+func (s *EncryptionKeyNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EncryptionKeyNotFoundException) StatusCode() int {
+func (s *EncryptionKeyNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EncryptionKeyNotFoundException) RequestID() string {
+func (s *EncryptionKeyNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16598,12 +16598,12 @@ func newErrorEncryptionKeyUnavailableException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s EncryptionKeyUnavailableException) Code() string {
+func (s *EncryptionKeyUnavailableException) Code() string {
 	return "EncryptionKeyUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s EncryptionKeyUnavailableException) Message() string {
+func (s *EncryptionKeyUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16611,21 +16611,21 @@ func (s EncryptionKeyUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EncryptionKeyUnavailableException) OrigErr() error {
+func (s *EncryptionKeyUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s EncryptionKeyUnavailableException) Error() string {
+func (s *EncryptionKeyUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EncryptionKeyUnavailableException) StatusCode() int {
+func (s *EncryptionKeyUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EncryptionKeyUnavailableException) RequestID() string {
+func (s *EncryptionKeyUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16842,12 +16842,12 @@ func newErrorFileContentAndSourceFileSpecifiedException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s FileContentAndSourceFileSpecifiedException) Code() string {
+func (s *FileContentAndSourceFileSpecifiedException) Code() string {
 	return "FileContentAndSourceFileSpecifiedException"
 }
 
 // Message returns the exception's message.
-func (s FileContentAndSourceFileSpecifiedException) Message() string {
+func (s *FileContentAndSourceFileSpecifiedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16855,21 +16855,21 @@ func (s FileContentAndSourceFileSpecifiedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileContentAndSourceFileSpecifiedException) OrigErr() error {
+func (s *FileContentAndSourceFileSpecifiedException) OrigErr() error {
 	return nil
 }
 
-func (s FileContentAndSourceFileSpecifiedException) Error() string {
+func (s *FileContentAndSourceFileSpecifiedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileContentAndSourceFileSpecifiedException) StatusCode() int {
+func (s *FileContentAndSourceFileSpecifiedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileContentAndSourceFileSpecifiedException) RequestID() string {
+func (s *FileContentAndSourceFileSpecifiedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16899,12 +16899,12 @@ func newErrorFileContentRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileContentRequiredException) Code() string {
+func (s *FileContentRequiredException) Code() string {
 	return "FileContentRequiredException"
 }
 
 // Message returns the exception's message.
-func (s FileContentRequiredException) Message() string {
+func (s *FileContentRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16912,21 +16912,21 @@ func (s FileContentRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileContentRequiredException) OrigErr() error {
+func (s *FileContentRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s FileContentRequiredException) Error() string {
+func (s *FileContentRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileContentRequiredException) StatusCode() int {
+func (s *FileContentRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileContentRequiredException) RequestID() string {
+func (s *FileContentRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16957,12 +16957,12 @@ func newErrorFileContentSizeLimitExceededException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s FileContentSizeLimitExceededException) Code() string {
+func (s *FileContentSizeLimitExceededException) Code() string {
 	return "FileContentSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s FileContentSizeLimitExceededException) Message() string {
+func (s *FileContentSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16970,21 +16970,21 @@ func (s FileContentSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileContentSizeLimitExceededException) OrigErr() error {
+func (s *FileContentSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s FileContentSizeLimitExceededException) Error() string {
+func (s *FileContentSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileContentSizeLimitExceededException) StatusCode() int {
+func (s *FileContentSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileContentSizeLimitExceededException) RequestID() string {
+func (s *FileContentSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17014,12 +17014,12 @@ func newErrorFileDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileDoesNotExistException) Code() string {
+func (s *FileDoesNotExistException) Code() string {
 	return "FileDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s FileDoesNotExistException) Message() string {
+func (s *FileDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17027,21 +17027,21 @@ func (s FileDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileDoesNotExistException) OrigErr() error {
+func (s *FileDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s FileDoesNotExistException) Error() string {
+func (s *FileDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileDoesNotExistException) StatusCode() int {
+func (s *FileDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileDoesNotExistException) RequestID() string {
+func (s *FileDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17071,12 +17071,12 @@ func newErrorFileEntryRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileEntryRequiredException) Code() string {
+func (s *FileEntryRequiredException) Code() string {
 	return "FileEntryRequiredException"
 }
 
 // Message returns the exception's message.
-func (s FileEntryRequiredException) Message() string {
+func (s *FileEntryRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17084,21 +17084,21 @@ func (s FileEntryRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileEntryRequiredException) OrigErr() error {
+func (s *FileEntryRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s FileEntryRequiredException) Error() string {
+func (s *FileEntryRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileEntryRequiredException) StatusCode() int {
+func (s *FileEntryRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileEntryRequiredException) RequestID() string {
+func (s *FileEntryRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17172,12 +17172,12 @@ func newErrorFileModeRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileModeRequiredException) Code() string {
+func (s *FileModeRequiredException) Code() string {
 	return "FileModeRequiredException"
 }
 
 // Message returns the exception's message.
-func (s FileModeRequiredException) Message() string {
+func (s *FileModeRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17185,21 +17185,21 @@ func (s FileModeRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileModeRequiredException) OrigErr() error {
+func (s *FileModeRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s FileModeRequiredException) Error() string {
+func (s *FileModeRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileModeRequiredException) StatusCode() int {
+func (s *FileModeRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileModeRequiredException) RequestID() string {
+func (s *FileModeRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17273,12 +17273,12 @@ func newErrorFileNameConflictsWithDirectoryNameException(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s FileNameConflictsWithDirectoryNameException) Code() string {
+func (s *FileNameConflictsWithDirectoryNameException) Code() string {
 	return "FileNameConflictsWithDirectoryNameException"
 }
 
 // Message returns the exception's message.
-func (s FileNameConflictsWithDirectoryNameException) Message() string {
+func (s *FileNameConflictsWithDirectoryNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17286,21 +17286,21 @@ func (s FileNameConflictsWithDirectoryNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileNameConflictsWithDirectoryNameException) OrigErr() error {
+func (s *FileNameConflictsWithDirectoryNameException) OrigErr() error {
 	return nil
 }
 
-func (s FileNameConflictsWithDirectoryNameException) Error() string {
+func (s *FileNameConflictsWithDirectoryNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileNameConflictsWithDirectoryNameException) StatusCode() int {
+func (s *FileNameConflictsWithDirectoryNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileNameConflictsWithDirectoryNameException) RequestID() string {
+func (s *FileNameConflictsWithDirectoryNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17331,12 +17331,12 @@ func newErrorFilePathConflictsWithSubmodulePathException(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s FilePathConflictsWithSubmodulePathException) Code() string {
+func (s *FilePathConflictsWithSubmodulePathException) Code() string {
 	return "FilePathConflictsWithSubmodulePathException"
 }
 
 // Message returns the exception's message.
-func (s FilePathConflictsWithSubmodulePathException) Message() string {
+func (s *FilePathConflictsWithSubmodulePathException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17344,21 +17344,21 @@ func (s FilePathConflictsWithSubmodulePathException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FilePathConflictsWithSubmodulePathException) OrigErr() error {
+func (s *FilePathConflictsWithSubmodulePathException) OrigErr() error {
 	return nil
 }
 
-func (s FilePathConflictsWithSubmodulePathException) Error() string {
+func (s *FilePathConflictsWithSubmodulePathException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FilePathConflictsWithSubmodulePathException) StatusCode() int {
+func (s *FilePathConflictsWithSubmodulePathException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FilePathConflictsWithSubmodulePathException) RequestID() string {
+func (s *FilePathConflictsWithSubmodulePathException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17431,12 +17431,12 @@ func newErrorFileTooLargeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileTooLargeException) Code() string {
+func (s *FileTooLargeException) Code() string {
 	return "FileTooLargeException"
 }
 
 // Message returns the exception's message.
-func (s FileTooLargeException) Message() string {
+func (s *FileTooLargeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17444,21 +17444,21 @@ func (s FileTooLargeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileTooLargeException) OrigErr() error {
+func (s *FileTooLargeException) OrigErr() error {
 	return nil
 }
 
-func (s FileTooLargeException) Error() string {
+func (s *FileTooLargeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileTooLargeException) StatusCode() int {
+func (s *FileTooLargeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileTooLargeException) RequestID() string {
+func (s *FileTooLargeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17534,12 +17534,12 @@ func newErrorFolderContentSizeLimitExceededException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s FolderContentSizeLimitExceededException) Code() string {
+func (s *FolderContentSizeLimitExceededException) Code() string {
 	return "FolderContentSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s FolderContentSizeLimitExceededException) Message() string {
+func (s *FolderContentSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17547,21 +17547,21 @@ func (s FolderContentSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FolderContentSizeLimitExceededException) OrigErr() error {
+func (s *FolderContentSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s FolderContentSizeLimitExceededException) Error() string {
+func (s *FolderContentSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FolderContentSizeLimitExceededException) StatusCode() int {
+func (s *FolderContentSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FolderContentSizeLimitExceededException) RequestID() string {
+func (s *FolderContentSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17591,12 +17591,12 @@ func newErrorFolderDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FolderDoesNotExistException) Code() string {
+func (s *FolderDoesNotExistException) Code() string {
 	return "FolderDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s FolderDoesNotExistException) Message() string {
+func (s *FolderDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17604,21 +17604,21 @@ func (s FolderDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FolderDoesNotExistException) OrigErr() error {
+func (s *FolderDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s FolderDoesNotExistException) Error() string {
+func (s *FolderDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FolderDoesNotExistException) StatusCode() int {
+func (s *FolderDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FolderDoesNotExistException) RequestID() string {
+func (s *FolderDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19594,12 +19594,12 @@ func newErrorIdempotencyParameterMismatchException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s IdempotencyParameterMismatchException) Code() string {
+func (s *IdempotencyParameterMismatchException) Code() string {
 	return "IdempotencyParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotencyParameterMismatchException) Message() string {
+func (s *IdempotencyParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19607,21 +19607,21 @@ func (s IdempotencyParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotencyParameterMismatchException) OrigErr() error {
+func (s *IdempotencyParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotencyParameterMismatchException) Error() string {
+func (s *IdempotencyParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotencyParameterMismatchException) StatusCode() int {
+func (s *IdempotencyParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotencyParameterMismatchException) RequestID() string {
+func (s *IdempotencyParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19652,12 +19652,12 @@ func newErrorInvalidActorArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidActorArnException) Code() string {
+func (s *InvalidActorArnException) Code() string {
 	return "InvalidActorArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidActorArnException) Message() string {
+func (s *InvalidActorArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19665,21 +19665,21 @@ func (s InvalidActorArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidActorArnException) OrigErr() error {
+func (s *InvalidActorArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidActorArnException) Error() string {
+func (s *InvalidActorArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidActorArnException) StatusCode() int {
+func (s *InvalidActorArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidActorArnException) RequestID() string {
+func (s *InvalidActorArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19708,12 +19708,12 @@ func newErrorInvalidApprovalRuleContentException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InvalidApprovalRuleContentException) Code() string {
+func (s *InvalidApprovalRuleContentException) Code() string {
 	return "InvalidApprovalRuleContentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApprovalRuleContentException) Message() string {
+func (s *InvalidApprovalRuleContentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19721,21 +19721,21 @@ func (s InvalidApprovalRuleContentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApprovalRuleContentException) OrigErr() error {
+func (s *InvalidApprovalRuleContentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApprovalRuleContentException) Error() string {
+func (s *InvalidApprovalRuleContentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApprovalRuleContentException) StatusCode() int {
+func (s *InvalidApprovalRuleContentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApprovalRuleContentException) RequestID() string {
+func (s *InvalidApprovalRuleContentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19764,12 +19764,12 @@ func newErrorInvalidApprovalRuleNameException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidApprovalRuleNameException) Code() string {
+func (s *InvalidApprovalRuleNameException) Code() string {
 	return "InvalidApprovalRuleNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApprovalRuleNameException) Message() string {
+func (s *InvalidApprovalRuleNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19777,21 +19777,21 @@ func (s InvalidApprovalRuleNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApprovalRuleNameException) OrigErr() error {
+func (s *InvalidApprovalRuleNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApprovalRuleNameException) Error() string {
+func (s *InvalidApprovalRuleNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApprovalRuleNameException) StatusCode() int {
+func (s *InvalidApprovalRuleNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApprovalRuleNameException) RequestID() string {
+func (s *InvalidApprovalRuleNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19820,12 +19820,12 @@ func newErrorInvalidApprovalRuleTemplateContentException(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s InvalidApprovalRuleTemplateContentException) Code() string {
+func (s *InvalidApprovalRuleTemplateContentException) Code() string {
 	return "InvalidApprovalRuleTemplateContentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApprovalRuleTemplateContentException) Message() string {
+func (s *InvalidApprovalRuleTemplateContentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19833,21 +19833,21 @@ func (s InvalidApprovalRuleTemplateContentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApprovalRuleTemplateContentException) OrigErr() error {
+func (s *InvalidApprovalRuleTemplateContentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApprovalRuleTemplateContentException) Error() string {
+func (s *InvalidApprovalRuleTemplateContentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApprovalRuleTemplateContentException) StatusCode() int {
+func (s *InvalidApprovalRuleTemplateContentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApprovalRuleTemplateContentException) RequestID() string {
+func (s *InvalidApprovalRuleTemplateContentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19878,12 +19878,12 @@ func newErrorInvalidApprovalRuleTemplateDescriptionException(v protocol.Response
 }
 
 // Code returns the exception type name.
-func (s InvalidApprovalRuleTemplateDescriptionException) Code() string {
+func (s *InvalidApprovalRuleTemplateDescriptionException) Code() string {
 	return "InvalidApprovalRuleTemplateDescriptionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApprovalRuleTemplateDescriptionException) Message() string {
+func (s *InvalidApprovalRuleTemplateDescriptionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19891,21 +19891,21 @@ func (s InvalidApprovalRuleTemplateDescriptionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApprovalRuleTemplateDescriptionException) OrigErr() error {
+func (s *InvalidApprovalRuleTemplateDescriptionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApprovalRuleTemplateDescriptionException) Error() string {
+func (s *InvalidApprovalRuleTemplateDescriptionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApprovalRuleTemplateDescriptionException) StatusCode() int {
+func (s *InvalidApprovalRuleTemplateDescriptionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApprovalRuleTemplateDescriptionException) RequestID() string {
+func (s *InvalidApprovalRuleTemplateDescriptionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19936,12 +19936,12 @@ func newErrorInvalidApprovalRuleTemplateNameException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s InvalidApprovalRuleTemplateNameException) Code() string {
+func (s *InvalidApprovalRuleTemplateNameException) Code() string {
 	return "InvalidApprovalRuleTemplateNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApprovalRuleTemplateNameException) Message() string {
+func (s *InvalidApprovalRuleTemplateNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19949,21 +19949,21 @@ func (s InvalidApprovalRuleTemplateNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApprovalRuleTemplateNameException) OrigErr() error {
+func (s *InvalidApprovalRuleTemplateNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApprovalRuleTemplateNameException) Error() string {
+func (s *InvalidApprovalRuleTemplateNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApprovalRuleTemplateNameException) StatusCode() int {
+func (s *InvalidApprovalRuleTemplateNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApprovalRuleTemplateNameException) RequestID() string {
+func (s *InvalidApprovalRuleTemplateNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19993,12 +19993,12 @@ func newErrorInvalidApprovalStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidApprovalStateException) Code() string {
+func (s *InvalidApprovalStateException) Code() string {
 	return "InvalidApprovalStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApprovalStateException) Message() string {
+func (s *InvalidApprovalStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20006,21 +20006,21 @@ func (s InvalidApprovalStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApprovalStateException) OrigErr() error {
+func (s *InvalidApprovalStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApprovalStateException) Error() string {
+func (s *InvalidApprovalStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApprovalStateException) StatusCode() int {
+func (s *InvalidApprovalStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApprovalStateException) RequestID() string {
+func (s *InvalidApprovalStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20050,12 +20050,12 @@ func newErrorInvalidAuthorArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAuthorArnException) Code() string {
+func (s *InvalidAuthorArnException) Code() string {
 	return "InvalidAuthorArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAuthorArnException) Message() string {
+func (s *InvalidAuthorArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20063,21 +20063,21 @@ func (s InvalidAuthorArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAuthorArnException) OrigErr() error {
+func (s *InvalidAuthorArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAuthorArnException) Error() string {
+func (s *InvalidAuthorArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAuthorArnException) StatusCode() int {
+func (s *InvalidAuthorArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAuthorArnException) RequestID() string {
+func (s *InvalidAuthorArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20106,12 +20106,12 @@ func newErrorInvalidBlobIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidBlobIdException) Code() string {
+func (s *InvalidBlobIdException) Code() string {
 	return "InvalidBlobIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidBlobIdException) Message() string {
+func (s *InvalidBlobIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20119,21 +20119,21 @@ func (s InvalidBlobIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidBlobIdException) OrigErr() error {
+func (s *InvalidBlobIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidBlobIdException) Error() string {
+func (s *InvalidBlobIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidBlobIdException) StatusCode() int {
+func (s *InvalidBlobIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidBlobIdException) RequestID() string {
+func (s *InvalidBlobIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20162,12 +20162,12 @@ func newErrorInvalidBranchNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidBranchNameException) Code() string {
+func (s *InvalidBranchNameException) Code() string {
 	return "InvalidBranchNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidBranchNameException) Message() string {
+func (s *InvalidBranchNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20175,21 +20175,21 @@ func (s InvalidBranchNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidBranchNameException) OrigErr() error {
+func (s *InvalidBranchNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidBranchNameException) Error() string {
+func (s *InvalidBranchNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidBranchNameException) StatusCode() int {
+func (s *InvalidBranchNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidBranchNameException) RequestID() string {
+func (s *InvalidBranchNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20218,12 +20218,12 @@ func newErrorInvalidClientRequestTokenException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidClientRequestTokenException) Code() string {
+func (s *InvalidClientRequestTokenException) Code() string {
 	return "InvalidClientRequestTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidClientRequestTokenException) Message() string {
+func (s *InvalidClientRequestTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20231,21 +20231,21 @@ func (s InvalidClientRequestTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidClientRequestTokenException) OrigErr() error {
+func (s *InvalidClientRequestTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidClientRequestTokenException) Error() string {
+func (s *InvalidClientRequestTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidClientRequestTokenException) StatusCode() int {
+func (s *InvalidClientRequestTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidClientRequestTokenException) RequestID() string {
+func (s *InvalidClientRequestTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20275,12 +20275,12 @@ func newErrorInvalidCommentIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidCommentIdException) Code() string {
+func (s *InvalidCommentIdException) Code() string {
 	return "InvalidCommentIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCommentIdException) Message() string {
+func (s *InvalidCommentIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20288,21 +20288,21 @@ func (s InvalidCommentIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCommentIdException) OrigErr() error {
+func (s *InvalidCommentIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCommentIdException) Error() string {
+func (s *InvalidCommentIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCommentIdException) StatusCode() int {
+func (s *InvalidCommentIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCommentIdException) RequestID() string {
+func (s *InvalidCommentIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20331,12 +20331,12 @@ func newErrorInvalidCommitException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidCommitException) Code() string {
+func (s *InvalidCommitException) Code() string {
 	return "InvalidCommitException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCommitException) Message() string {
+func (s *InvalidCommitException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20344,21 +20344,21 @@ func (s InvalidCommitException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCommitException) OrigErr() error {
+func (s *InvalidCommitException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCommitException) Error() string {
+func (s *InvalidCommitException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCommitException) StatusCode() int {
+func (s *InvalidCommitException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCommitException) RequestID() string {
+func (s *InvalidCommitException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20387,12 +20387,12 @@ func newErrorInvalidCommitIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidCommitIdException) Code() string {
+func (s *InvalidCommitIdException) Code() string {
 	return "InvalidCommitIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCommitIdException) Message() string {
+func (s *InvalidCommitIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20400,21 +20400,21 @@ func (s InvalidCommitIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCommitIdException) OrigErr() error {
+func (s *InvalidCommitIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCommitIdException) Error() string {
+func (s *InvalidCommitIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCommitIdException) StatusCode() int {
+func (s *InvalidCommitIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCommitIdException) RequestID() string {
+func (s *InvalidCommitIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20443,12 +20443,12 @@ func newErrorInvalidConflictDetailLevelException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InvalidConflictDetailLevelException) Code() string {
+func (s *InvalidConflictDetailLevelException) Code() string {
 	return "InvalidConflictDetailLevelException"
 }
 
 // Message returns the exception's message.
-func (s InvalidConflictDetailLevelException) Message() string {
+func (s *InvalidConflictDetailLevelException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20456,21 +20456,21 @@ func (s InvalidConflictDetailLevelException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidConflictDetailLevelException) OrigErr() error {
+func (s *InvalidConflictDetailLevelException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidConflictDetailLevelException) Error() string {
+func (s *InvalidConflictDetailLevelException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidConflictDetailLevelException) StatusCode() int {
+func (s *InvalidConflictDetailLevelException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidConflictDetailLevelException) RequestID() string {
+func (s *InvalidConflictDetailLevelException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20499,12 +20499,12 @@ func newErrorInvalidConflictResolutionException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidConflictResolutionException) Code() string {
+func (s *InvalidConflictResolutionException) Code() string {
 	return "InvalidConflictResolutionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidConflictResolutionException) Message() string {
+func (s *InvalidConflictResolutionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20512,21 +20512,21 @@ func (s InvalidConflictResolutionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidConflictResolutionException) OrigErr() error {
+func (s *InvalidConflictResolutionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidConflictResolutionException) Error() string {
+func (s *InvalidConflictResolutionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidConflictResolutionException) StatusCode() int {
+func (s *InvalidConflictResolutionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidConflictResolutionException) RequestID() string {
+func (s *InvalidConflictResolutionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20555,12 +20555,12 @@ func newErrorInvalidConflictResolutionStrategyException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s InvalidConflictResolutionStrategyException) Code() string {
+func (s *InvalidConflictResolutionStrategyException) Code() string {
 	return "InvalidConflictResolutionStrategyException"
 }
 
 // Message returns the exception's message.
-func (s InvalidConflictResolutionStrategyException) Message() string {
+func (s *InvalidConflictResolutionStrategyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20568,21 +20568,21 @@ func (s InvalidConflictResolutionStrategyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidConflictResolutionStrategyException) OrigErr() error {
+func (s *InvalidConflictResolutionStrategyException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidConflictResolutionStrategyException) Error() string {
+func (s *InvalidConflictResolutionStrategyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidConflictResolutionStrategyException) StatusCode() int {
+func (s *InvalidConflictResolutionStrategyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidConflictResolutionStrategyException) RequestID() string {
+func (s *InvalidConflictResolutionStrategyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20611,12 +20611,12 @@ func newErrorInvalidContinuationTokenException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s InvalidContinuationTokenException) Code() string {
+func (s *InvalidContinuationTokenException) Code() string {
 	return "InvalidContinuationTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidContinuationTokenException) Message() string {
+func (s *InvalidContinuationTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20624,21 +20624,21 @@ func (s InvalidContinuationTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidContinuationTokenException) OrigErr() error {
+func (s *InvalidContinuationTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidContinuationTokenException) Error() string {
+func (s *InvalidContinuationTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidContinuationTokenException) StatusCode() int {
+func (s *InvalidContinuationTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidContinuationTokenException) RequestID() string {
+func (s *InvalidContinuationTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20667,12 +20667,12 @@ func newErrorInvalidDeletionParameterException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s InvalidDeletionParameterException) Code() string {
+func (s *InvalidDeletionParameterException) Code() string {
 	return "InvalidDeletionParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeletionParameterException) Message() string {
+func (s *InvalidDeletionParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20680,21 +20680,21 @@ func (s InvalidDeletionParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeletionParameterException) OrigErr() error {
+func (s *InvalidDeletionParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeletionParameterException) Error() string {
+func (s *InvalidDeletionParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeletionParameterException) StatusCode() int {
+func (s *InvalidDeletionParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeletionParameterException) RequestID() string {
+func (s *InvalidDeletionParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20724,12 +20724,12 @@ func newErrorInvalidDescriptionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDescriptionException) Code() string {
+func (s *InvalidDescriptionException) Code() string {
 	return "InvalidDescriptionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDescriptionException) Message() string {
+func (s *InvalidDescriptionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20737,21 +20737,21 @@ func (s InvalidDescriptionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDescriptionException) OrigErr() error {
+func (s *InvalidDescriptionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDescriptionException) Error() string {
+func (s *InvalidDescriptionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDescriptionException) StatusCode() int {
+func (s *InvalidDescriptionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDescriptionException) RequestID() string {
+func (s *InvalidDescriptionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20781,12 +20781,12 @@ func newErrorInvalidDestinationCommitSpecifierException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s InvalidDestinationCommitSpecifierException) Code() string {
+func (s *InvalidDestinationCommitSpecifierException) Code() string {
 	return "InvalidDestinationCommitSpecifierException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDestinationCommitSpecifierException) Message() string {
+func (s *InvalidDestinationCommitSpecifierException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20794,21 +20794,21 @@ func (s InvalidDestinationCommitSpecifierException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDestinationCommitSpecifierException) OrigErr() error {
+func (s *InvalidDestinationCommitSpecifierException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDestinationCommitSpecifierException) Error() string {
+func (s *InvalidDestinationCommitSpecifierException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDestinationCommitSpecifierException) StatusCode() int {
+func (s *InvalidDestinationCommitSpecifierException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDestinationCommitSpecifierException) RequestID() string {
+func (s *InvalidDestinationCommitSpecifierException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20839,12 +20839,12 @@ func newErrorInvalidEmailException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidEmailException) Code() string {
+func (s *InvalidEmailException) Code() string {
 	return "InvalidEmailException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEmailException) Message() string {
+func (s *InvalidEmailException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20852,21 +20852,21 @@ func (s InvalidEmailException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEmailException) OrigErr() error {
+func (s *InvalidEmailException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEmailException) Error() string {
+func (s *InvalidEmailException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEmailException) StatusCode() int {
+func (s *InvalidEmailException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEmailException) RequestID() string {
+func (s *InvalidEmailException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20896,12 +20896,12 @@ func newErrorInvalidFileLocationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFileLocationException) Code() string {
+func (s *InvalidFileLocationException) Code() string {
 	return "InvalidFileLocationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidFileLocationException) Message() string {
+func (s *InvalidFileLocationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20909,21 +20909,21 @@ func (s InvalidFileLocationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFileLocationException) OrigErr() error {
+func (s *InvalidFileLocationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFileLocationException) Error() string {
+func (s *InvalidFileLocationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFileLocationException) StatusCode() int {
+func (s *InvalidFileLocationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFileLocationException) RequestID() string {
+func (s *InvalidFileLocationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20953,12 +20953,12 @@ func newErrorInvalidFileModeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFileModeException) Code() string {
+func (s *InvalidFileModeException) Code() string {
 	return "InvalidFileModeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidFileModeException) Message() string {
+func (s *InvalidFileModeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20966,21 +20966,21 @@ func (s InvalidFileModeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFileModeException) OrigErr() error {
+func (s *InvalidFileModeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFileModeException) Error() string {
+func (s *InvalidFileModeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFileModeException) StatusCode() int {
+func (s *InvalidFileModeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFileModeException) RequestID() string {
+func (s *InvalidFileModeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21010,12 +21010,12 @@ func newErrorInvalidFilePositionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFilePositionException) Code() string {
+func (s *InvalidFilePositionException) Code() string {
 	return "InvalidFilePositionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidFilePositionException) Message() string {
+func (s *InvalidFilePositionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21023,21 +21023,21 @@ func (s InvalidFilePositionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFilePositionException) OrigErr() error {
+func (s *InvalidFilePositionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFilePositionException) Error() string {
+func (s *InvalidFilePositionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFilePositionException) StatusCode() int {
+func (s *InvalidFilePositionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFilePositionException) RequestID() string {
+func (s *InvalidFilePositionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21066,12 +21066,12 @@ func newErrorInvalidMaxConflictFilesException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidMaxConflictFilesException) Code() string {
+func (s *InvalidMaxConflictFilesException) Code() string {
 	return "InvalidMaxConflictFilesException"
 }
 
 // Message returns the exception's message.
-func (s InvalidMaxConflictFilesException) Message() string {
+func (s *InvalidMaxConflictFilesException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21079,21 +21079,21 @@ func (s InvalidMaxConflictFilesException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidMaxConflictFilesException) OrigErr() error {
+func (s *InvalidMaxConflictFilesException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidMaxConflictFilesException) Error() string {
+func (s *InvalidMaxConflictFilesException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidMaxConflictFilesException) StatusCode() int {
+func (s *InvalidMaxConflictFilesException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidMaxConflictFilesException) RequestID() string {
+func (s *InvalidMaxConflictFilesException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21122,12 +21122,12 @@ func newErrorInvalidMaxMergeHunksException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidMaxMergeHunksException) Code() string {
+func (s *InvalidMaxMergeHunksException) Code() string {
 	return "InvalidMaxMergeHunksException"
 }
 
 // Message returns the exception's message.
-func (s InvalidMaxMergeHunksException) Message() string {
+func (s *InvalidMaxMergeHunksException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21135,21 +21135,21 @@ func (s InvalidMaxMergeHunksException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidMaxMergeHunksException) OrigErr() error {
+func (s *InvalidMaxMergeHunksException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidMaxMergeHunksException) Error() string {
+func (s *InvalidMaxMergeHunksException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidMaxMergeHunksException) StatusCode() int {
+func (s *InvalidMaxMergeHunksException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidMaxMergeHunksException) RequestID() string {
+func (s *InvalidMaxMergeHunksException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21178,12 +21178,12 @@ func newErrorInvalidMaxResultsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidMaxResultsException) Code() string {
+func (s *InvalidMaxResultsException) Code() string {
 	return "InvalidMaxResultsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidMaxResultsException) Message() string {
+func (s *InvalidMaxResultsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21191,21 +21191,21 @@ func (s InvalidMaxResultsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidMaxResultsException) OrigErr() error {
+func (s *InvalidMaxResultsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidMaxResultsException) Error() string {
+func (s *InvalidMaxResultsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidMaxResultsException) StatusCode() int {
+func (s *InvalidMaxResultsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidMaxResultsException) RequestID() string {
+func (s *InvalidMaxResultsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21235,12 +21235,12 @@ func newErrorInvalidMergeOptionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidMergeOptionException) Code() string {
+func (s *InvalidMergeOptionException) Code() string {
 	return "InvalidMergeOptionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidMergeOptionException) Message() string {
+func (s *InvalidMergeOptionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21248,21 +21248,21 @@ func (s InvalidMergeOptionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidMergeOptionException) OrigErr() error {
+func (s *InvalidMergeOptionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidMergeOptionException) Error() string {
+func (s *InvalidMergeOptionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidMergeOptionException) StatusCode() int {
+func (s *InvalidMergeOptionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidMergeOptionException) RequestID() string {
+func (s *InvalidMergeOptionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21291,12 +21291,12 @@ func newErrorInvalidOrderException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOrderException) Code() string {
+func (s *InvalidOrderException) Code() string {
 	return "InvalidOrderException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOrderException) Message() string {
+func (s *InvalidOrderException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21304,21 +21304,21 @@ func (s InvalidOrderException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOrderException) OrigErr() error {
+func (s *InvalidOrderException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOrderException) Error() string {
+func (s *InvalidOrderException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOrderException) StatusCode() int {
+func (s *InvalidOrderException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOrderException) RequestID() string {
+func (s *InvalidOrderException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21347,12 +21347,12 @@ func newErrorInvalidOverrideStatusException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOverrideStatusException) Code() string {
+func (s *InvalidOverrideStatusException) Code() string {
 	return "InvalidOverrideStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOverrideStatusException) Message() string {
+func (s *InvalidOverrideStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21360,21 +21360,21 @@ func (s InvalidOverrideStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOverrideStatusException) OrigErr() error {
+func (s *InvalidOverrideStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOverrideStatusException) Error() string {
+func (s *InvalidOverrideStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOverrideStatusException) StatusCode() int {
+func (s *InvalidOverrideStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOverrideStatusException) RequestID() string {
+func (s *InvalidOverrideStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21405,12 +21405,12 @@ func newErrorInvalidParentCommitIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParentCommitIdException) Code() string {
+func (s *InvalidParentCommitIdException) Code() string {
 	return "InvalidParentCommitIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParentCommitIdException) Message() string {
+func (s *InvalidParentCommitIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21418,21 +21418,21 @@ func (s InvalidParentCommitIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParentCommitIdException) OrigErr() error {
+func (s *InvalidParentCommitIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParentCommitIdException) Error() string {
+func (s *InvalidParentCommitIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParentCommitIdException) StatusCode() int {
+func (s *InvalidParentCommitIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParentCommitIdException) RequestID() string {
+func (s *InvalidParentCommitIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21461,12 +21461,12 @@ func newErrorInvalidPathException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPathException) Code() string {
+func (s *InvalidPathException) Code() string {
 	return "InvalidPathException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPathException) Message() string {
+func (s *InvalidPathException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21474,21 +21474,21 @@ func (s InvalidPathException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPathException) OrigErr() error {
+func (s *InvalidPathException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPathException) Error() string {
+func (s *InvalidPathException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPathException) StatusCode() int {
+func (s *InvalidPathException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPathException) RequestID() string {
+func (s *InvalidPathException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21517,12 +21517,12 @@ func newErrorInvalidPullRequestEventTypeException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidPullRequestEventTypeException) Code() string {
+func (s *InvalidPullRequestEventTypeException) Code() string {
 	return "InvalidPullRequestEventTypeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPullRequestEventTypeException) Message() string {
+func (s *InvalidPullRequestEventTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21530,21 +21530,21 @@ func (s InvalidPullRequestEventTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPullRequestEventTypeException) OrigErr() error {
+func (s *InvalidPullRequestEventTypeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPullRequestEventTypeException) Error() string {
+func (s *InvalidPullRequestEventTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPullRequestEventTypeException) StatusCode() int {
+func (s *InvalidPullRequestEventTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPullRequestEventTypeException) RequestID() string {
+func (s *InvalidPullRequestEventTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21575,12 +21575,12 @@ func newErrorInvalidPullRequestIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPullRequestIdException) Code() string {
+func (s *InvalidPullRequestIdException) Code() string {
 	return "InvalidPullRequestIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPullRequestIdException) Message() string {
+func (s *InvalidPullRequestIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21588,21 +21588,21 @@ func (s InvalidPullRequestIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPullRequestIdException) OrigErr() error {
+func (s *InvalidPullRequestIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPullRequestIdException) Error() string {
+func (s *InvalidPullRequestIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPullRequestIdException) StatusCode() int {
+func (s *InvalidPullRequestIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPullRequestIdException) RequestID() string {
+func (s *InvalidPullRequestIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21632,12 +21632,12 @@ func newErrorInvalidPullRequestStatusException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s InvalidPullRequestStatusException) Code() string {
+func (s *InvalidPullRequestStatusException) Code() string {
 	return "InvalidPullRequestStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPullRequestStatusException) Message() string {
+func (s *InvalidPullRequestStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21645,21 +21645,21 @@ func (s InvalidPullRequestStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPullRequestStatusException) OrigErr() error {
+func (s *InvalidPullRequestStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPullRequestStatusException) Error() string {
+func (s *InvalidPullRequestStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPullRequestStatusException) StatusCode() int {
+func (s *InvalidPullRequestStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPullRequestStatusException) RequestID() string {
+func (s *InvalidPullRequestStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21689,12 +21689,12 @@ func newErrorInvalidPullRequestStatusUpdateException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s InvalidPullRequestStatusUpdateException) Code() string {
+func (s *InvalidPullRequestStatusUpdateException) Code() string {
 	return "InvalidPullRequestStatusUpdateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPullRequestStatusUpdateException) Message() string {
+func (s *InvalidPullRequestStatusUpdateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21702,21 +21702,21 @@ func (s InvalidPullRequestStatusUpdateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPullRequestStatusUpdateException) OrigErr() error {
+func (s *InvalidPullRequestStatusUpdateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPullRequestStatusUpdateException) Error() string {
+func (s *InvalidPullRequestStatusUpdateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPullRequestStatusUpdateException) StatusCode() int {
+func (s *InvalidPullRequestStatusUpdateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPullRequestStatusUpdateException) RequestID() string {
+func (s *InvalidPullRequestStatusUpdateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21748,12 +21748,12 @@ func newErrorInvalidReferenceNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidReferenceNameException) Code() string {
+func (s *InvalidReferenceNameException) Code() string {
 	return "InvalidReferenceNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidReferenceNameException) Message() string {
+func (s *InvalidReferenceNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21761,21 +21761,21 @@ func (s InvalidReferenceNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidReferenceNameException) OrigErr() error {
+func (s *InvalidReferenceNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidReferenceNameException) Error() string {
+func (s *InvalidReferenceNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidReferenceNameException) StatusCode() int {
+func (s *InvalidReferenceNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidReferenceNameException) RequestID() string {
+func (s *InvalidReferenceNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21805,12 +21805,12 @@ func newErrorInvalidRelativeFileVersionEnumException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s InvalidRelativeFileVersionEnumException) Code() string {
+func (s *InvalidRelativeFileVersionEnumException) Code() string {
 	return "InvalidRelativeFileVersionEnumException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRelativeFileVersionEnumException) Message() string {
+func (s *InvalidRelativeFileVersionEnumException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21818,21 +21818,21 @@ func (s InvalidRelativeFileVersionEnumException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRelativeFileVersionEnumException) OrigErr() error {
+func (s *InvalidRelativeFileVersionEnumException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRelativeFileVersionEnumException) Error() string {
+func (s *InvalidRelativeFileVersionEnumException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRelativeFileVersionEnumException) StatusCode() int {
+func (s *InvalidRelativeFileVersionEnumException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRelativeFileVersionEnumException) RequestID() string {
+func (s *InvalidRelativeFileVersionEnumException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21862,12 +21862,12 @@ func newErrorInvalidReplacementContentException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidReplacementContentException) Code() string {
+func (s *InvalidReplacementContentException) Code() string {
 	return "InvalidReplacementContentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidReplacementContentException) Message() string {
+func (s *InvalidReplacementContentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21875,21 +21875,21 @@ func (s InvalidReplacementContentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidReplacementContentException) OrigErr() error {
+func (s *InvalidReplacementContentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidReplacementContentException) Error() string {
+func (s *InvalidReplacementContentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidReplacementContentException) StatusCode() int {
+func (s *InvalidReplacementContentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidReplacementContentException) RequestID() string {
+func (s *InvalidReplacementContentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21919,12 +21919,12 @@ func newErrorInvalidReplacementTypeException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidReplacementTypeException) Code() string {
+func (s *InvalidReplacementTypeException) Code() string {
 	return "InvalidReplacementTypeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidReplacementTypeException) Message() string {
+func (s *InvalidReplacementTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21932,21 +21932,21 @@ func (s InvalidReplacementTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidReplacementTypeException) OrigErr() error {
+func (s *InvalidReplacementTypeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidReplacementTypeException) Error() string {
+func (s *InvalidReplacementTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidReplacementTypeException) StatusCode() int {
+func (s *InvalidReplacementTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidReplacementTypeException) RequestID() string {
+func (s *InvalidReplacementTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21975,12 +21975,12 @@ func newErrorInvalidRepositoryDescriptionException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s InvalidRepositoryDescriptionException) Code() string {
+func (s *InvalidRepositoryDescriptionException) Code() string {
 	return "InvalidRepositoryDescriptionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRepositoryDescriptionException) Message() string {
+func (s *InvalidRepositoryDescriptionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21988,21 +21988,21 @@ func (s InvalidRepositoryDescriptionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRepositoryDescriptionException) OrigErr() error {
+func (s *InvalidRepositoryDescriptionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRepositoryDescriptionException) Error() string {
+func (s *InvalidRepositoryDescriptionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRepositoryDescriptionException) StatusCode() int {
+func (s *InvalidRepositoryDescriptionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRepositoryDescriptionException) RequestID() string {
+func (s *InvalidRepositoryDescriptionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22035,12 +22035,12 @@ func newErrorInvalidRepositoryNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRepositoryNameException) Code() string {
+func (s *InvalidRepositoryNameException) Code() string {
 	return "InvalidRepositoryNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRepositoryNameException) Message() string {
+func (s *InvalidRepositoryNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22048,21 +22048,21 @@ func (s InvalidRepositoryNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRepositoryNameException) OrigErr() error {
+func (s *InvalidRepositoryNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRepositoryNameException) Error() string {
+func (s *InvalidRepositoryNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRepositoryNameException) StatusCode() int {
+func (s *InvalidRepositoryNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRepositoryNameException) RequestID() string {
+func (s *InvalidRepositoryNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22091,12 +22091,12 @@ func newErrorInvalidRepositoryTriggerBranchNameException(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s InvalidRepositoryTriggerBranchNameException) Code() string {
+func (s *InvalidRepositoryTriggerBranchNameException) Code() string {
 	return "InvalidRepositoryTriggerBranchNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRepositoryTriggerBranchNameException) Message() string {
+func (s *InvalidRepositoryTriggerBranchNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22104,21 +22104,21 @@ func (s InvalidRepositoryTriggerBranchNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRepositoryTriggerBranchNameException) OrigErr() error {
+func (s *InvalidRepositoryTriggerBranchNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRepositoryTriggerBranchNameException) Error() string {
+func (s *InvalidRepositoryTriggerBranchNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRepositoryTriggerBranchNameException) StatusCode() int {
+func (s *InvalidRepositoryTriggerBranchNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRepositoryTriggerBranchNameException) RequestID() string {
+func (s *InvalidRepositoryTriggerBranchNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22147,12 +22147,12 @@ func newErrorInvalidRepositoryTriggerCustomDataException(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s InvalidRepositoryTriggerCustomDataException) Code() string {
+func (s *InvalidRepositoryTriggerCustomDataException) Code() string {
 	return "InvalidRepositoryTriggerCustomDataException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRepositoryTriggerCustomDataException) Message() string {
+func (s *InvalidRepositoryTriggerCustomDataException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22160,21 +22160,21 @@ func (s InvalidRepositoryTriggerCustomDataException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRepositoryTriggerCustomDataException) OrigErr() error {
+func (s *InvalidRepositoryTriggerCustomDataException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRepositoryTriggerCustomDataException) Error() string {
+func (s *InvalidRepositoryTriggerCustomDataException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRepositoryTriggerCustomDataException) StatusCode() int {
+func (s *InvalidRepositoryTriggerCustomDataException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRepositoryTriggerCustomDataException) RequestID() string {
+func (s *InvalidRepositoryTriggerCustomDataException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22205,12 +22205,12 @@ func newErrorInvalidRepositoryTriggerDestinationArnException(v protocol.Response
 }
 
 // Code returns the exception type name.
-func (s InvalidRepositoryTriggerDestinationArnException) Code() string {
+func (s *InvalidRepositoryTriggerDestinationArnException) Code() string {
 	return "InvalidRepositoryTriggerDestinationArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRepositoryTriggerDestinationArnException) Message() string {
+func (s *InvalidRepositoryTriggerDestinationArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22218,21 +22218,21 @@ func (s InvalidRepositoryTriggerDestinationArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRepositoryTriggerDestinationArnException) OrigErr() error {
+func (s *InvalidRepositoryTriggerDestinationArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRepositoryTriggerDestinationArnException) Error() string {
+func (s *InvalidRepositoryTriggerDestinationArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRepositoryTriggerDestinationArnException) StatusCode() int {
+func (s *InvalidRepositoryTriggerDestinationArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRepositoryTriggerDestinationArnException) RequestID() string {
+func (s *InvalidRepositoryTriggerDestinationArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22262,12 +22262,12 @@ func newErrorInvalidRepositoryTriggerEventsException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s InvalidRepositoryTriggerEventsException) Code() string {
+func (s *InvalidRepositoryTriggerEventsException) Code() string {
 	return "InvalidRepositoryTriggerEventsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRepositoryTriggerEventsException) Message() string {
+func (s *InvalidRepositoryTriggerEventsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22275,21 +22275,21 @@ func (s InvalidRepositoryTriggerEventsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRepositoryTriggerEventsException) OrigErr() error {
+func (s *InvalidRepositoryTriggerEventsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRepositoryTriggerEventsException) Error() string {
+func (s *InvalidRepositoryTriggerEventsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRepositoryTriggerEventsException) StatusCode() int {
+func (s *InvalidRepositoryTriggerEventsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRepositoryTriggerEventsException) RequestID() string {
+func (s *InvalidRepositoryTriggerEventsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22318,12 +22318,12 @@ func newErrorInvalidRepositoryTriggerNameException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s InvalidRepositoryTriggerNameException) Code() string {
+func (s *InvalidRepositoryTriggerNameException) Code() string {
 	return "InvalidRepositoryTriggerNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRepositoryTriggerNameException) Message() string {
+func (s *InvalidRepositoryTriggerNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22331,21 +22331,21 @@ func (s InvalidRepositoryTriggerNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRepositoryTriggerNameException) OrigErr() error {
+func (s *InvalidRepositoryTriggerNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRepositoryTriggerNameException) Error() string {
+func (s *InvalidRepositoryTriggerNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRepositoryTriggerNameException) StatusCode() int {
+func (s *InvalidRepositoryTriggerNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRepositoryTriggerNameException) RequestID() string {
+func (s *InvalidRepositoryTriggerNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22376,12 +22376,12 @@ func newErrorInvalidRepositoryTriggerRegionException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s InvalidRepositoryTriggerRegionException) Code() string {
+func (s *InvalidRepositoryTriggerRegionException) Code() string {
 	return "InvalidRepositoryTriggerRegionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRepositoryTriggerRegionException) Message() string {
+func (s *InvalidRepositoryTriggerRegionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22389,21 +22389,21 @@ func (s InvalidRepositoryTriggerRegionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRepositoryTriggerRegionException) OrigErr() error {
+func (s *InvalidRepositoryTriggerRegionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRepositoryTriggerRegionException) Error() string {
+func (s *InvalidRepositoryTriggerRegionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRepositoryTriggerRegionException) StatusCode() int {
+func (s *InvalidRepositoryTriggerRegionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRepositoryTriggerRegionException) RequestID() string {
+func (s *InvalidRepositoryTriggerRegionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22434,12 +22434,12 @@ func newErrorInvalidResourceArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceArnException) Code() string {
+func (s *InvalidResourceArnException) Code() string {
 	return "InvalidResourceArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceArnException) Message() string {
+func (s *InvalidResourceArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22447,21 +22447,21 @@ func (s InvalidResourceArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceArnException) OrigErr() error {
+func (s *InvalidResourceArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceArnException) Error() string {
+func (s *InvalidResourceArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceArnException) StatusCode() int {
+func (s *InvalidResourceArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceArnException) RequestID() string {
+func (s *InvalidResourceArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22490,12 +22490,12 @@ func newErrorInvalidRevisionIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRevisionIdException) Code() string {
+func (s *InvalidRevisionIdException) Code() string {
 	return "InvalidRevisionIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRevisionIdException) Message() string {
+func (s *InvalidRevisionIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22503,21 +22503,21 @@ func (s InvalidRevisionIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRevisionIdException) OrigErr() error {
+func (s *InvalidRevisionIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRevisionIdException) Error() string {
+func (s *InvalidRevisionIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRevisionIdException) StatusCode() int {
+func (s *InvalidRevisionIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRevisionIdException) RequestID() string {
+func (s *InvalidRevisionIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22546,12 +22546,12 @@ func newErrorInvalidRuleContentSha256Exception(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s InvalidRuleContentSha256Exception) Code() string {
+func (s *InvalidRuleContentSha256Exception) Code() string {
 	return "InvalidRuleContentSha256Exception"
 }
 
 // Message returns the exception's message.
-func (s InvalidRuleContentSha256Exception) Message() string {
+func (s *InvalidRuleContentSha256Exception) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22559,21 +22559,21 @@ func (s InvalidRuleContentSha256Exception) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRuleContentSha256Exception) OrigErr() error {
+func (s *InvalidRuleContentSha256Exception) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRuleContentSha256Exception) Error() string {
+func (s *InvalidRuleContentSha256Exception) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRuleContentSha256Exception) StatusCode() int {
+func (s *InvalidRuleContentSha256Exception) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRuleContentSha256Exception) RequestID() string {
+func (s *InvalidRuleContentSha256Exception) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22602,12 +22602,12 @@ func newErrorInvalidSortByException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSortByException) Code() string {
+func (s *InvalidSortByException) Code() string {
 	return "InvalidSortByException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSortByException) Message() string {
+func (s *InvalidSortByException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22615,21 +22615,21 @@ func (s InvalidSortByException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSortByException) OrigErr() error {
+func (s *InvalidSortByException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSortByException) Error() string {
+func (s *InvalidSortByException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSortByException) StatusCode() int {
+func (s *InvalidSortByException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSortByException) RequestID() string {
+func (s *InvalidSortByException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22659,12 +22659,12 @@ func newErrorInvalidSourceCommitSpecifierException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s InvalidSourceCommitSpecifierException) Code() string {
+func (s *InvalidSourceCommitSpecifierException) Code() string {
 	return "InvalidSourceCommitSpecifierException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSourceCommitSpecifierException) Message() string {
+func (s *InvalidSourceCommitSpecifierException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22672,21 +22672,21 @@ func (s InvalidSourceCommitSpecifierException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSourceCommitSpecifierException) OrigErr() error {
+func (s *InvalidSourceCommitSpecifierException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSourceCommitSpecifierException) Error() string {
+func (s *InvalidSourceCommitSpecifierException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSourceCommitSpecifierException) StatusCode() int {
+func (s *InvalidSourceCommitSpecifierException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSourceCommitSpecifierException) RequestID() string {
+func (s *InvalidSourceCommitSpecifierException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22715,12 +22715,12 @@ func newErrorInvalidSystemTagUsageException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSystemTagUsageException) Code() string {
+func (s *InvalidSystemTagUsageException) Code() string {
 	return "InvalidSystemTagUsageException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSystemTagUsageException) Message() string {
+func (s *InvalidSystemTagUsageException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22728,21 +22728,21 @@ func (s InvalidSystemTagUsageException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSystemTagUsageException) OrigErr() error {
+func (s *InvalidSystemTagUsageException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSystemTagUsageException) Error() string {
+func (s *InvalidSystemTagUsageException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSystemTagUsageException) StatusCode() int {
+func (s *InvalidSystemTagUsageException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSystemTagUsageException) RequestID() string {
+func (s *InvalidSystemTagUsageException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22771,12 +22771,12 @@ func newErrorInvalidTagKeysListException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagKeysListException) Code() string {
+func (s *InvalidTagKeysListException) Code() string {
 	return "InvalidTagKeysListException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagKeysListException) Message() string {
+func (s *InvalidTagKeysListException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22784,21 +22784,21 @@ func (s InvalidTagKeysListException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagKeysListException) OrigErr() error {
+func (s *InvalidTagKeysListException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagKeysListException) Error() string {
+func (s *InvalidTagKeysListException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagKeysListException) StatusCode() int {
+func (s *InvalidTagKeysListException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagKeysListException) RequestID() string {
+func (s *InvalidTagKeysListException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22827,12 +22827,12 @@ func newErrorInvalidTagsMapException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagsMapException) Code() string {
+func (s *InvalidTagsMapException) Code() string {
 	return "InvalidTagsMapException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagsMapException) Message() string {
+func (s *InvalidTagsMapException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22840,21 +22840,21 @@ func (s InvalidTagsMapException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagsMapException) OrigErr() error {
+func (s *InvalidTagsMapException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagsMapException) Error() string {
+func (s *InvalidTagsMapException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagsMapException) StatusCode() int {
+func (s *InvalidTagsMapException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagsMapException) RequestID() string {
+func (s *InvalidTagsMapException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22883,12 +22883,12 @@ func newErrorInvalidTargetBranchException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTargetBranchException) Code() string {
+func (s *InvalidTargetBranchException) Code() string {
 	return "InvalidTargetBranchException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTargetBranchException) Message() string {
+func (s *InvalidTargetBranchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22896,21 +22896,21 @@ func (s InvalidTargetBranchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTargetBranchException) OrigErr() error {
+func (s *InvalidTargetBranchException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTargetBranchException) Error() string {
+func (s *InvalidTargetBranchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTargetBranchException) StatusCode() int {
+func (s *InvalidTargetBranchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTargetBranchException) RequestID() string {
+func (s *InvalidTargetBranchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22941,12 +22941,12 @@ func newErrorInvalidTargetException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTargetException) Code() string {
+func (s *InvalidTargetException) Code() string {
 	return "InvalidTargetException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTargetException) Message() string {
+func (s *InvalidTargetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22954,21 +22954,21 @@ func (s InvalidTargetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTargetException) OrigErr() error {
+func (s *InvalidTargetException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTargetException) Error() string {
+func (s *InvalidTargetException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTargetException) StatusCode() int {
+func (s *InvalidTargetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTargetException) RequestID() string {
+func (s *InvalidTargetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23000,12 +23000,12 @@ func newErrorInvalidTargetsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTargetsException) Code() string {
+func (s *InvalidTargetsException) Code() string {
 	return "InvalidTargetsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTargetsException) Message() string {
+func (s *InvalidTargetsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23013,21 +23013,21 @@ func (s InvalidTargetsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTargetsException) OrigErr() error {
+func (s *InvalidTargetsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTargetsException) Error() string {
+func (s *InvalidTargetsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTargetsException) StatusCode() int {
+func (s *InvalidTargetsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTargetsException) RequestID() string {
+func (s *InvalidTargetsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23057,12 +23057,12 @@ func newErrorInvalidTitleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTitleException) Code() string {
+func (s *InvalidTitleException) Code() string {
 	return "InvalidTitleException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTitleException) Message() string {
+func (s *InvalidTitleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23070,21 +23070,21 @@ func (s InvalidTitleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTitleException) OrigErr() error {
+func (s *InvalidTitleException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTitleException) Error() string {
+func (s *InvalidTitleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTitleException) StatusCode() int {
+func (s *InvalidTitleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTitleException) RequestID() string {
+func (s *InvalidTitleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23824,12 +23824,12 @@ func newErrorManualMergeRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ManualMergeRequiredException) Code() string {
+func (s *ManualMergeRequiredException) Code() string {
 	return "ManualMergeRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ManualMergeRequiredException) Message() string {
+func (s *ManualMergeRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23837,21 +23837,21 @@ func (s ManualMergeRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ManualMergeRequiredException) OrigErr() error {
+func (s *ManualMergeRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ManualMergeRequiredException) Error() string {
+func (s *ManualMergeRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ManualMergeRequiredException) StatusCode() int {
+func (s *ManualMergeRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ManualMergeRequiredException) RequestID() string {
+func (s *ManualMergeRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23880,12 +23880,12 @@ func newErrorMaximumBranchesExceededException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s MaximumBranchesExceededException) Code() string {
+func (s *MaximumBranchesExceededException) Code() string {
 	return "MaximumBranchesExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumBranchesExceededException) Message() string {
+func (s *MaximumBranchesExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23893,21 +23893,21 @@ func (s MaximumBranchesExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumBranchesExceededException) OrigErr() error {
+func (s *MaximumBranchesExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumBranchesExceededException) Error() string {
+func (s *MaximumBranchesExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumBranchesExceededException) StatusCode() int {
+func (s *MaximumBranchesExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumBranchesExceededException) RequestID() string {
+func (s *MaximumBranchesExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23936,12 +23936,12 @@ func newErrorMaximumConflictResolutionEntriesExceededException(v protocol.Respon
 }
 
 // Code returns the exception type name.
-func (s MaximumConflictResolutionEntriesExceededException) Code() string {
+func (s *MaximumConflictResolutionEntriesExceededException) Code() string {
 	return "MaximumConflictResolutionEntriesExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumConflictResolutionEntriesExceededException) Message() string {
+func (s *MaximumConflictResolutionEntriesExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23949,21 +23949,21 @@ func (s MaximumConflictResolutionEntriesExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumConflictResolutionEntriesExceededException) OrigErr() error {
+func (s *MaximumConflictResolutionEntriesExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumConflictResolutionEntriesExceededException) Error() string {
+func (s *MaximumConflictResolutionEntriesExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumConflictResolutionEntriesExceededException) StatusCode() int {
+func (s *MaximumConflictResolutionEntriesExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumConflictResolutionEntriesExceededException) RequestID() string {
+func (s *MaximumConflictResolutionEntriesExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23992,12 +23992,12 @@ func newErrorMaximumFileContentToLoadExceededException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s MaximumFileContentToLoadExceededException) Code() string {
+func (s *MaximumFileContentToLoadExceededException) Code() string {
 	return "MaximumFileContentToLoadExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumFileContentToLoadExceededException) Message() string {
+func (s *MaximumFileContentToLoadExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24005,21 +24005,21 @@ func (s MaximumFileContentToLoadExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumFileContentToLoadExceededException) OrigErr() error {
+func (s *MaximumFileContentToLoadExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumFileContentToLoadExceededException) Error() string {
+func (s *MaximumFileContentToLoadExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumFileContentToLoadExceededException) StatusCode() int {
+func (s *MaximumFileContentToLoadExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumFileContentToLoadExceededException) RequestID() string {
+func (s *MaximumFileContentToLoadExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24050,12 +24050,12 @@ func newErrorMaximumFileEntriesExceededException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s MaximumFileEntriesExceededException) Code() string {
+func (s *MaximumFileEntriesExceededException) Code() string {
 	return "MaximumFileEntriesExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumFileEntriesExceededException) Message() string {
+func (s *MaximumFileEntriesExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24063,21 +24063,21 @@ func (s MaximumFileEntriesExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumFileEntriesExceededException) OrigErr() error {
+func (s *MaximumFileEntriesExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumFileEntriesExceededException) Error() string {
+func (s *MaximumFileEntriesExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumFileEntriesExceededException) StatusCode() int {
+func (s *MaximumFileEntriesExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumFileEntriesExceededException) RequestID() string {
+func (s *MaximumFileEntriesExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24107,12 +24107,12 @@ func newErrorMaximumItemsToCompareExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s MaximumItemsToCompareExceededException) Code() string {
+func (s *MaximumItemsToCompareExceededException) Code() string {
 	return "MaximumItemsToCompareExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumItemsToCompareExceededException) Message() string {
+func (s *MaximumItemsToCompareExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24120,21 +24120,21 @@ func (s MaximumItemsToCompareExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumItemsToCompareExceededException) OrigErr() error {
+func (s *MaximumItemsToCompareExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumItemsToCompareExceededException) Error() string {
+func (s *MaximumItemsToCompareExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumItemsToCompareExceededException) StatusCode() int {
+func (s *MaximumItemsToCompareExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumItemsToCompareExceededException) RequestID() string {
+func (s *MaximumItemsToCompareExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24164,12 +24164,12 @@ func newErrorMaximumNumberOfApprovalsExceededException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s MaximumNumberOfApprovalsExceededException) Code() string {
+func (s *MaximumNumberOfApprovalsExceededException) Code() string {
 	return "MaximumNumberOfApprovalsExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumNumberOfApprovalsExceededException) Message() string {
+func (s *MaximumNumberOfApprovalsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24177,21 +24177,21 @@ func (s MaximumNumberOfApprovalsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumNumberOfApprovalsExceededException) OrigErr() error {
+func (s *MaximumNumberOfApprovalsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumNumberOfApprovalsExceededException) Error() string {
+func (s *MaximumNumberOfApprovalsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumNumberOfApprovalsExceededException) StatusCode() int {
+func (s *MaximumNumberOfApprovalsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumNumberOfApprovalsExceededException) RequestID() string {
+func (s *MaximumNumberOfApprovalsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24222,12 +24222,12 @@ func newErrorMaximumOpenPullRequestsExceededException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s MaximumOpenPullRequestsExceededException) Code() string {
+func (s *MaximumOpenPullRequestsExceededException) Code() string {
 	return "MaximumOpenPullRequestsExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumOpenPullRequestsExceededException) Message() string {
+func (s *MaximumOpenPullRequestsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24235,21 +24235,21 @@ func (s MaximumOpenPullRequestsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumOpenPullRequestsExceededException) OrigErr() error {
+func (s *MaximumOpenPullRequestsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumOpenPullRequestsExceededException) Error() string {
+func (s *MaximumOpenPullRequestsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumOpenPullRequestsExceededException) StatusCode() int {
+func (s *MaximumOpenPullRequestsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumOpenPullRequestsExceededException) RequestID() string {
+func (s *MaximumOpenPullRequestsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24279,12 +24279,12 @@ func newErrorMaximumRepositoryNamesExceededException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s MaximumRepositoryNamesExceededException) Code() string {
+func (s *MaximumRepositoryNamesExceededException) Code() string {
 	return "MaximumRepositoryNamesExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumRepositoryNamesExceededException) Message() string {
+func (s *MaximumRepositoryNamesExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24292,21 +24292,21 @@ func (s MaximumRepositoryNamesExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumRepositoryNamesExceededException) OrigErr() error {
+func (s *MaximumRepositoryNamesExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumRepositoryNamesExceededException) Error() string {
+func (s *MaximumRepositoryNamesExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumRepositoryNamesExceededException) StatusCode() int {
+func (s *MaximumRepositoryNamesExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumRepositoryNamesExceededException) RequestID() string {
+func (s *MaximumRepositoryNamesExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24335,12 +24335,12 @@ func newErrorMaximumRepositoryTriggersExceededException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s MaximumRepositoryTriggersExceededException) Code() string {
+func (s *MaximumRepositoryTriggersExceededException) Code() string {
 	return "MaximumRepositoryTriggersExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaximumRepositoryTriggersExceededException) Message() string {
+func (s *MaximumRepositoryTriggersExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24348,21 +24348,21 @@ func (s MaximumRepositoryTriggersExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumRepositoryTriggersExceededException) OrigErr() error {
+func (s *MaximumRepositoryTriggersExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumRepositoryTriggersExceededException) Error() string {
+func (s *MaximumRepositoryTriggersExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumRepositoryTriggersExceededException) StatusCode() int {
+func (s *MaximumRepositoryTriggersExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumRepositoryTriggersExceededException) RequestID() string {
+func (s *MaximumRepositoryTriggersExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24392,12 +24392,12 @@ func newErrorMaximumRuleTemplatesAssociatedWithRepositoryException(v protocol.Re
 }
 
 // Code returns the exception type name.
-func (s MaximumRuleTemplatesAssociatedWithRepositoryException) Code() string {
+func (s *MaximumRuleTemplatesAssociatedWithRepositoryException) Code() string {
 	return "MaximumRuleTemplatesAssociatedWithRepositoryException"
 }
 
 // Message returns the exception's message.
-func (s MaximumRuleTemplatesAssociatedWithRepositoryException) Message() string {
+func (s *MaximumRuleTemplatesAssociatedWithRepositoryException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24405,21 +24405,21 @@ func (s MaximumRuleTemplatesAssociatedWithRepositoryException) Message() string 
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaximumRuleTemplatesAssociatedWithRepositoryException) OrigErr() error {
+func (s *MaximumRuleTemplatesAssociatedWithRepositoryException) OrigErr() error {
 	return nil
 }
 
-func (s MaximumRuleTemplatesAssociatedWithRepositoryException) Error() string {
+func (s *MaximumRuleTemplatesAssociatedWithRepositoryException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaximumRuleTemplatesAssociatedWithRepositoryException) StatusCode() int {
+func (s *MaximumRuleTemplatesAssociatedWithRepositoryException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaximumRuleTemplatesAssociatedWithRepositoryException) RequestID() string {
+func (s *MaximumRuleTemplatesAssociatedWithRepositoryException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25137,12 +25137,12 @@ func newErrorMergeOptionRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MergeOptionRequiredException) Code() string {
+func (s *MergeOptionRequiredException) Code() string {
 	return "MergeOptionRequiredException"
 }
 
 // Message returns the exception's message.
-func (s MergeOptionRequiredException) Message() string {
+func (s *MergeOptionRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25150,21 +25150,21 @@ func (s MergeOptionRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MergeOptionRequiredException) OrigErr() error {
+func (s *MergeOptionRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s MergeOptionRequiredException) Error() string {
+func (s *MergeOptionRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MergeOptionRequiredException) StatusCode() int {
+func (s *MergeOptionRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MergeOptionRequiredException) RequestID() string {
+func (s *MergeOptionRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25619,12 +25619,12 @@ func newErrorMultipleConflictResolutionEntriesException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s MultipleConflictResolutionEntriesException) Code() string {
+func (s *MultipleConflictResolutionEntriesException) Code() string {
 	return "MultipleConflictResolutionEntriesException"
 }
 
 // Message returns the exception's message.
-func (s MultipleConflictResolutionEntriesException) Message() string {
+func (s *MultipleConflictResolutionEntriesException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25632,21 +25632,21 @@ func (s MultipleConflictResolutionEntriesException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MultipleConflictResolutionEntriesException) OrigErr() error {
+func (s *MultipleConflictResolutionEntriesException) OrigErr() error {
 	return nil
 }
 
-func (s MultipleConflictResolutionEntriesException) Error() string {
+func (s *MultipleConflictResolutionEntriesException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MultipleConflictResolutionEntriesException) StatusCode() int {
+func (s *MultipleConflictResolutionEntriesException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MultipleConflictResolutionEntriesException) RequestID() string {
+func (s *MultipleConflictResolutionEntriesException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25677,12 +25677,12 @@ func newErrorMultipleRepositoriesInPullRequestException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s MultipleRepositoriesInPullRequestException) Code() string {
+func (s *MultipleRepositoriesInPullRequestException) Code() string {
 	return "MultipleRepositoriesInPullRequestException"
 }
 
 // Message returns the exception's message.
-func (s MultipleRepositoriesInPullRequestException) Message() string {
+func (s *MultipleRepositoriesInPullRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25690,21 +25690,21 @@ func (s MultipleRepositoriesInPullRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MultipleRepositoriesInPullRequestException) OrigErr() error {
+func (s *MultipleRepositoriesInPullRequestException) OrigErr() error {
 	return nil
 }
 
-func (s MultipleRepositoriesInPullRequestException) Error() string {
+func (s *MultipleRepositoriesInPullRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MultipleRepositoriesInPullRequestException) StatusCode() int {
+func (s *MultipleRepositoriesInPullRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MultipleRepositoriesInPullRequestException) RequestID() string {
+func (s *MultipleRepositoriesInPullRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25734,12 +25734,12 @@ func newErrorNameLengthExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NameLengthExceededException) Code() string {
+func (s *NameLengthExceededException) Code() string {
 	return "NameLengthExceededException"
 }
 
 // Message returns the exception's message.
-func (s NameLengthExceededException) Message() string {
+func (s *NameLengthExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25747,21 +25747,21 @@ func (s NameLengthExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NameLengthExceededException) OrigErr() error {
+func (s *NameLengthExceededException) OrigErr() error {
 	return nil
 }
 
-func (s NameLengthExceededException) Error() string {
+func (s *NameLengthExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NameLengthExceededException) StatusCode() int {
+func (s *NameLengthExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NameLengthExceededException) RequestID() string {
+func (s *NameLengthExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25791,12 +25791,12 @@ func newErrorNoChangeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoChangeException) Code() string {
+func (s *NoChangeException) Code() string {
 	return "NoChangeException"
 }
 
 // Message returns the exception's message.
-func (s NoChangeException) Message() string {
+func (s *NoChangeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25804,21 +25804,21 @@ func (s NoChangeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoChangeException) OrigErr() error {
+func (s *NoChangeException) OrigErr() error {
 	return nil
 }
 
-func (s NoChangeException) Error() string {
+func (s *NoChangeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoChangeException) StatusCode() int {
+func (s *NoChangeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoChangeException) RequestID() string {
+func (s *NoChangeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25848,12 +25848,12 @@ func newErrorNumberOfRuleTemplatesExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s NumberOfRuleTemplatesExceededException) Code() string {
+func (s *NumberOfRuleTemplatesExceededException) Code() string {
 	return "NumberOfRuleTemplatesExceededException"
 }
 
 // Message returns the exception's message.
-func (s NumberOfRuleTemplatesExceededException) Message() string {
+func (s *NumberOfRuleTemplatesExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25861,21 +25861,21 @@ func (s NumberOfRuleTemplatesExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NumberOfRuleTemplatesExceededException) OrigErr() error {
+func (s *NumberOfRuleTemplatesExceededException) OrigErr() error {
 	return nil
 }
 
-func (s NumberOfRuleTemplatesExceededException) Error() string {
+func (s *NumberOfRuleTemplatesExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NumberOfRuleTemplatesExceededException) StatusCode() int {
+func (s *NumberOfRuleTemplatesExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NumberOfRuleTemplatesExceededException) RequestID() string {
+func (s *NumberOfRuleTemplatesExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25905,12 +25905,12 @@ func newErrorNumberOfRulesExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NumberOfRulesExceededException) Code() string {
+func (s *NumberOfRulesExceededException) Code() string {
 	return "NumberOfRulesExceededException"
 }
 
 // Message returns the exception's message.
-func (s NumberOfRulesExceededException) Message() string {
+func (s *NumberOfRulesExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25918,21 +25918,21 @@ func (s NumberOfRulesExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NumberOfRulesExceededException) OrigErr() error {
+func (s *NumberOfRulesExceededException) OrigErr() error {
 	return nil
 }
 
-func (s NumberOfRulesExceededException) Error() string {
+func (s *NumberOfRulesExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NumberOfRulesExceededException) StatusCode() int {
+func (s *NumberOfRulesExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NumberOfRulesExceededException) RequestID() string {
+func (s *NumberOfRulesExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26037,12 +26037,12 @@ func newErrorOverrideAlreadySetException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OverrideAlreadySetException) Code() string {
+func (s *OverrideAlreadySetException) Code() string {
 	return "OverrideAlreadySetException"
 }
 
 // Message returns the exception's message.
-func (s OverrideAlreadySetException) Message() string {
+func (s *OverrideAlreadySetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26050,21 +26050,21 @@ func (s OverrideAlreadySetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OverrideAlreadySetException) OrigErr() error {
+func (s *OverrideAlreadySetException) OrigErr() error {
 	return nil
 }
 
-func (s OverrideAlreadySetException) Error() string {
+func (s *OverrideAlreadySetException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OverrideAlreadySetException) StatusCode() int {
+func (s *OverrideAlreadySetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OverrideAlreadySetException) RequestID() string {
+func (s *OverrideAlreadySetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26179,12 +26179,12 @@ func newErrorOverrideStatusRequiredException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s OverrideStatusRequiredException) Code() string {
+func (s *OverrideStatusRequiredException) Code() string {
 	return "OverrideStatusRequiredException"
 }
 
 // Message returns the exception's message.
-func (s OverrideStatusRequiredException) Message() string {
+func (s *OverrideStatusRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26192,21 +26192,21 @@ func (s OverrideStatusRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OverrideStatusRequiredException) OrigErr() error {
+func (s *OverrideStatusRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s OverrideStatusRequiredException) Error() string {
+func (s *OverrideStatusRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OverrideStatusRequiredException) StatusCode() int {
+func (s *OverrideStatusRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OverrideStatusRequiredException) RequestID() string {
+func (s *OverrideStatusRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26236,12 +26236,12 @@ func newErrorParentCommitDoesNotExistException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ParentCommitDoesNotExistException) Code() string {
+func (s *ParentCommitDoesNotExistException) Code() string {
 	return "ParentCommitDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s ParentCommitDoesNotExistException) Message() string {
+func (s *ParentCommitDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26249,21 +26249,21 @@ func (s ParentCommitDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParentCommitDoesNotExistException) OrigErr() error {
+func (s *ParentCommitDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s ParentCommitDoesNotExistException) Error() string {
+func (s *ParentCommitDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParentCommitDoesNotExistException) StatusCode() int {
+func (s *ParentCommitDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParentCommitDoesNotExistException) RequestID() string {
+func (s *ParentCommitDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26294,12 +26294,12 @@ func newErrorParentCommitIdOutdatedException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ParentCommitIdOutdatedException) Code() string {
+func (s *ParentCommitIdOutdatedException) Code() string {
 	return "ParentCommitIdOutdatedException"
 }
 
 // Message returns the exception's message.
-func (s ParentCommitIdOutdatedException) Message() string {
+func (s *ParentCommitIdOutdatedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26307,21 +26307,21 @@ func (s ParentCommitIdOutdatedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParentCommitIdOutdatedException) OrigErr() error {
+func (s *ParentCommitIdOutdatedException) OrigErr() error {
 	return nil
 }
 
-func (s ParentCommitIdOutdatedException) Error() string {
+func (s *ParentCommitIdOutdatedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParentCommitIdOutdatedException) StatusCode() int {
+func (s *ParentCommitIdOutdatedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParentCommitIdOutdatedException) RequestID() string {
+func (s *ParentCommitIdOutdatedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26352,12 +26352,12 @@ func newErrorParentCommitIdRequiredException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ParentCommitIdRequiredException) Code() string {
+func (s *ParentCommitIdRequiredException) Code() string {
 	return "ParentCommitIdRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ParentCommitIdRequiredException) Message() string {
+func (s *ParentCommitIdRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26365,21 +26365,21 @@ func (s ParentCommitIdRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParentCommitIdRequiredException) OrigErr() error {
+func (s *ParentCommitIdRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ParentCommitIdRequiredException) Error() string {
+func (s *ParentCommitIdRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParentCommitIdRequiredException) StatusCode() int {
+func (s *ParentCommitIdRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParentCommitIdRequiredException) RequestID() string {
+func (s *ParentCommitIdRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26408,12 +26408,12 @@ func newErrorPathDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PathDoesNotExistException) Code() string {
+func (s *PathDoesNotExistException) Code() string {
 	return "PathDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s PathDoesNotExistException) Message() string {
+func (s *PathDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26421,21 +26421,21 @@ func (s PathDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PathDoesNotExistException) OrigErr() error {
+func (s *PathDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s PathDoesNotExistException) Error() string {
+func (s *PathDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PathDoesNotExistException) StatusCode() int {
+func (s *PathDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PathDoesNotExistException) RequestID() string {
+func (s *PathDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26464,12 +26464,12 @@ func newErrorPathRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PathRequiredException) Code() string {
+func (s *PathRequiredException) Code() string {
 	return "PathRequiredException"
 }
 
 // Message returns the exception's message.
-func (s PathRequiredException) Message() string {
+func (s *PathRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26477,21 +26477,21 @@ func (s PathRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PathRequiredException) OrigErr() error {
+func (s *PathRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s PathRequiredException) Error() string {
+func (s *PathRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PathRequiredException) StatusCode() int {
+func (s *PathRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PathRequiredException) RequestID() string {
+func (s *PathRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27122,12 +27122,12 @@ func newErrorPullRequestAlreadyClosedException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s PullRequestAlreadyClosedException) Code() string {
+func (s *PullRequestAlreadyClosedException) Code() string {
 	return "PullRequestAlreadyClosedException"
 }
 
 // Message returns the exception's message.
-func (s PullRequestAlreadyClosedException) Message() string {
+func (s *PullRequestAlreadyClosedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27135,21 +27135,21 @@ func (s PullRequestAlreadyClosedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PullRequestAlreadyClosedException) OrigErr() error {
+func (s *PullRequestAlreadyClosedException) OrigErr() error {
 	return nil
 }
 
-func (s PullRequestAlreadyClosedException) Error() string {
+func (s *PullRequestAlreadyClosedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PullRequestAlreadyClosedException) StatusCode() int {
+func (s *PullRequestAlreadyClosedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PullRequestAlreadyClosedException) RequestID() string {
+func (s *PullRequestAlreadyClosedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27179,12 +27179,12 @@ func newErrorPullRequestApprovalRulesNotSatisfiedException(v protocol.ResponseMe
 }
 
 // Code returns the exception type name.
-func (s PullRequestApprovalRulesNotSatisfiedException) Code() string {
+func (s *PullRequestApprovalRulesNotSatisfiedException) Code() string {
 	return "PullRequestApprovalRulesNotSatisfiedException"
 }
 
 // Message returns the exception's message.
-func (s PullRequestApprovalRulesNotSatisfiedException) Message() string {
+func (s *PullRequestApprovalRulesNotSatisfiedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27192,21 +27192,21 @@ func (s PullRequestApprovalRulesNotSatisfiedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PullRequestApprovalRulesNotSatisfiedException) OrigErr() error {
+func (s *PullRequestApprovalRulesNotSatisfiedException) OrigErr() error {
 	return nil
 }
 
-func (s PullRequestApprovalRulesNotSatisfiedException) Error() string {
+func (s *PullRequestApprovalRulesNotSatisfiedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PullRequestApprovalRulesNotSatisfiedException) StatusCode() int {
+func (s *PullRequestApprovalRulesNotSatisfiedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PullRequestApprovalRulesNotSatisfiedException) RequestID() string {
+func (s *PullRequestApprovalRulesNotSatisfiedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27237,12 +27237,12 @@ func newErrorPullRequestCannotBeApprovedByAuthorException(v protocol.ResponseMet
 }
 
 // Code returns the exception type name.
-func (s PullRequestCannotBeApprovedByAuthorException) Code() string {
+func (s *PullRequestCannotBeApprovedByAuthorException) Code() string {
 	return "PullRequestCannotBeApprovedByAuthorException"
 }
 
 // Message returns the exception's message.
-func (s PullRequestCannotBeApprovedByAuthorException) Message() string {
+func (s *PullRequestCannotBeApprovedByAuthorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27250,21 +27250,21 @@ func (s PullRequestCannotBeApprovedByAuthorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PullRequestCannotBeApprovedByAuthorException) OrigErr() error {
+func (s *PullRequestCannotBeApprovedByAuthorException) OrigErr() error {
 	return nil
 }
 
-func (s PullRequestCannotBeApprovedByAuthorException) Error() string {
+func (s *PullRequestCannotBeApprovedByAuthorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PullRequestCannotBeApprovedByAuthorException) StatusCode() int {
+func (s *PullRequestCannotBeApprovedByAuthorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PullRequestCannotBeApprovedByAuthorException) RequestID() string {
+func (s *PullRequestCannotBeApprovedByAuthorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27348,12 +27348,12 @@ func newErrorPullRequestDoesNotExistException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s PullRequestDoesNotExistException) Code() string {
+func (s *PullRequestDoesNotExistException) Code() string {
 	return "PullRequestDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s PullRequestDoesNotExistException) Message() string {
+func (s *PullRequestDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27361,21 +27361,21 @@ func (s PullRequestDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PullRequestDoesNotExistException) OrigErr() error {
+func (s *PullRequestDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s PullRequestDoesNotExistException) Error() string {
+func (s *PullRequestDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PullRequestDoesNotExistException) StatusCode() int {
+func (s *PullRequestDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PullRequestDoesNotExistException) RequestID() string {
+func (s *PullRequestDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27521,12 +27521,12 @@ func newErrorPullRequestIdRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PullRequestIdRequiredException) Code() string {
+func (s *PullRequestIdRequiredException) Code() string {
 	return "PullRequestIdRequiredException"
 }
 
 // Message returns the exception's message.
-func (s PullRequestIdRequiredException) Message() string {
+func (s *PullRequestIdRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27534,21 +27534,21 @@ func (s PullRequestIdRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PullRequestIdRequiredException) OrigErr() error {
+func (s *PullRequestIdRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s PullRequestIdRequiredException) Error() string {
+func (s *PullRequestIdRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PullRequestIdRequiredException) StatusCode() int {
+func (s *PullRequestIdRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PullRequestIdRequiredException) RequestID() string {
+func (s *PullRequestIdRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27698,12 +27698,12 @@ func newErrorPullRequestStatusRequiredException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s PullRequestStatusRequiredException) Code() string {
+func (s *PullRequestStatusRequiredException) Code() string {
 	return "PullRequestStatusRequiredException"
 }
 
 // Message returns the exception's message.
-func (s PullRequestStatusRequiredException) Message() string {
+func (s *PullRequestStatusRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27711,21 +27711,21 @@ func (s PullRequestStatusRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PullRequestStatusRequiredException) OrigErr() error {
+func (s *PullRequestStatusRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s PullRequestStatusRequiredException) Error() string {
+func (s *PullRequestStatusRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PullRequestStatusRequiredException) StatusCode() int {
+func (s *PullRequestStatusRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PullRequestStatusRequiredException) RequestID() string {
+func (s *PullRequestStatusRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27916,12 +27916,12 @@ func newErrorPutFileEntryConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PutFileEntryConflictException) Code() string {
+func (s *PutFileEntryConflictException) Code() string {
 	return "PutFileEntryConflictException"
 }
 
 // Message returns the exception's message.
-func (s PutFileEntryConflictException) Message() string {
+func (s *PutFileEntryConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27929,21 +27929,21 @@ func (s PutFileEntryConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PutFileEntryConflictException) OrigErr() error {
+func (s *PutFileEntryConflictException) OrigErr() error {
 	return nil
 }
 
-func (s PutFileEntryConflictException) Error() string {
+func (s *PutFileEntryConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PutFileEntryConflictException) StatusCode() int {
+func (s *PutFileEntryConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PutFileEntryConflictException) RequestID() string {
+func (s *PutFileEntryConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28256,12 +28256,12 @@ func newErrorReferenceDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ReferenceDoesNotExistException) Code() string {
+func (s *ReferenceDoesNotExistException) Code() string {
 	return "ReferenceDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s ReferenceDoesNotExistException) Message() string {
+func (s *ReferenceDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28269,21 +28269,21 @@ func (s ReferenceDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReferenceDoesNotExistException) OrigErr() error {
+func (s *ReferenceDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s ReferenceDoesNotExistException) Error() string {
+func (s *ReferenceDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReferenceDoesNotExistException) StatusCode() int {
+func (s *ReferenceDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReferenceDoesNotExistException) RequestID() string {
+func (s *ReferenceDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28312,12 +28312,12 @@ func newErrorReferenceNameRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ReferenceNameRequiredException) Code() string {
+func (s *ReferenceNameRequiredException) Code() string {
 	return "ReferenceNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ReferenceNameRequiredException) Message() string {
+func (s *ReferenceNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28325,21 +28325,21 @@ func (s ReferenceNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReferenceNameRequiredException) OrigErr() error {
+func (s *ReferenceNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ReferenceNameRequiredException) Error() string {
+func (s *ReferenceNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReferenceNameRequiredException) StatusCode() int {
+func (s *ReferenceNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReferenceNameRequiredException) RequestID() string {
+func (s *ReferenceNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28368,12 +28368,12 @@ func newErrorReferenceTypeNotSupportedException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s ReferenceTypeNotSupportedException) Code() string {
+func (s *ReferenceTypeNotSupportedException) Code() string {
 	return "ReferenceTypeNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s ReferenceTypeNotSupportedException) Message() string {
+func (s *ReferenceTypeNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28381,21 +28381,21 @@ func (s ReferenceTypeNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReferenceTypeNotSupportedException) OrigErr() error {
+func (s *ReferenceTypeNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s ReferenceTypeNotSupportedException) Error() string {
+func (s *ReferenceTypeNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReferenceTypeNotSupportedException) StatusCode() int {
+func (s *ReferenceTypeNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReferenceTypeNotSupportedException) RequestID() string {
+func (s *ReferenceTypeNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28498,12 +28498,12 @@ func newErrorReplacementContentRequiredException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s ReplacementContentRequiredException) Code() string {
+func (s *ReplacementContentRequiredException) Code() string {
 	return "ReplacementContentRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ReplacementContentRequiredException) Message() string {
+func (s *ReplacementContentRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28511,21 +28511,21 @@ func (s ReplacementContentRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReplacementContentRequiredException) OrigErr() error {
+func (s *ReplacementContentRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ReplacementContentRequiredException) Error() string {
+func (s *ReplacementContentRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReplacementContentRequiredException) StatusCode() int {
+func (s *ReplacementContentRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReplacementContentRequiredException) RequestID() string {
+func (s *ReplacementContentRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28554,12 +28554,12 @@ func newErrorReplacementTypeRequiredException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s ReplacementTypeRequiredException) Code() string {
+func (s *ReplacementTypeRequiredException) Code() string {
 	return "ReplacementTypeRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ReplacementTypeRequiredException) Message() string {
+func (s *ReplacementTypeRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28567,21 +28567,21 @@ func (s ReplacementTypeRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReplacementTypeRequiredException) OrigErr() error {
+func (s *ReplacementTypeRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ReplacementTypeRequiredException) Error() string {
+func (s *ReplacementTypeRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReplacementTypeRequiredException) StatusCode() int {
+func (s *ReplacementTypeRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReplacementTypeRequiredException) RequestID() string {
+func (s *ReplacementTypeRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28610,12 +28610,12 @@ func newErrorRepositoryDoesNotExistException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s RepositoryDoesNotExistException) Code() string {
+func (s *RepositoryDoesNotExistException) Code() string {
 	return "RepositoryDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryDoesNotExistException) Message() string {
+func (s *RepositoryDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28623,21 +28623,21 @@ func (s RepositoryDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryDoesNotExistException) OrigErr() error {
+func (s *RepositoryDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryDoesNotExistException) Error() string {
+func (s *RepositoryDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryDoesNotExistException) StatusCode() int {
+func (s *RepositoryDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryDoesNotExistException) RequestID() string {
+func (s *RepositoryDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28666,12 +28666,12 @@ func newErrorRepositoryLimitExceededException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s RepositoryLimitExceededException) Code() string {
+func (s *RepositoryLimitExceededException) Code() string {
 	return "RepositoryLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryLimitExceededException) Message() string {
+func (s *RepositoryLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28679,21 +28679,21 @@ func (s RepositoryLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryLimitExceededException) OrigErr() error {
+func (s *RepositoryLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryLimitExceededException) Error() string {
+func (s *RepositoryLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryLimitExceededException) StatusCode() int {
+func (s *RepositoryLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryLimitExceededException) RequestID() string {
+func (s *RepositoryLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28827,12 +28827,12 @@ func newErrorRepositoryNameExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RepositoryNameExistsException) Code() string {
+func (s *RepositoryNameExistsException) Code() string {
 	return "RepositoryNameExistsException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryNameExistsException) Message() string {
+func (s *RepositoryNameExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28840,21 +28840,21 @@ func (s RepositoryNameExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryNameExistsException) OrigErr() error {
+func (s *RepositoryNameExistsException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryNameExistsException) Error() string {
+func (s *RepositoryNameExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryNameExistsException) StatusCode() int {
+func (s *RepositoryNameExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryNameExistsException) RequestID() string {
+func (s *RepositoryNameExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28916,12 +28916,12 @@ func newErrorRepositoryNameRequiredException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s RepositoryNameRequiredException) Code() string {
+func (s *RepositoryNameRequiredException) Code() string {
 	return "RepositoryNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryNameRequiredException) Message() string {
+func (s *RepositoryNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28929,21 +28929,21 @@ func (s RepositoryNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryNameRequiredException) OrigErr() error {
+func (s *RepositoryNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryNameRequiredException) Error() string {
+func (s *RepositoryNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryNameRequiredException) StatusCode() int {
+func (s *RepositoryNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryNameRequiredException) RequestID() string {
+func (s *RepositoryNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28972,12 +28972,12 @@ func newErrorRepositoryNamesRequiredException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s RepositoryNamesRequiredException) Code() string {
+func (s *RepositoryNamesRequiredException) Code() string {
 	return "RepositoryNamesRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryNamesRequiredException) Message() string {
+func (s *RepositoryNamesRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28985,21 +28985,21 @@ func (s RepositoryNamesRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryNamesRequiredException) OrigErr() error {
+func (s *RepositoryNamesRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryNamesRequiredException) Error() string {
+func (s *RepositoryNamesRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryNamesRequiredException) StatusCode() int {
+func (s *RepositoryNamesRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryNamesRequiredException) RequestID() string {
+func (s *RepositoryNamesRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29030,12 +29030,12 @@ func newErrorRepositoryNotAssociatedWithPullRequestException(v protocol.Response
 }
 
 // Code returns the exception type name.
-func (s RepositoryNotAssociatedWithPullRequestException) Code() string {
+func (s *RepositoryNotAssociatedWithPullRequestException) Code() string {
 	return "RepositoryNotAssociatedWithPullRequestException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryNotAssociatedWithPullRequestException) Message() string {
+func (s *RepositoryNotAssociatedWithPullRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29043,21 +29043,21 @@ func (s RepositoryNotAssociatedWithPullRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryNotAssociatedWithPullRequestException) OrigErr() error {
+func (s *RepositoryNotAssociatedWithPullRequestException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryNotAssociatedWithPullRequestException) Error() string {
+func (s *RepositoryNotAssociatedWithPullRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryNotAssociatedWithPullRequestException) StatusCode() int {
+func (s *RepositoryNotAssociatedWithPullRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryNotAssociatedWithPullRequestException) RequestID() string {
+func (s *RepositoryNotAssociatedWithPullRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29181,12 +29181,12 @@ func newErrorRepositoryTriggerBranchNameListRequiredException(v protocol.Respons
 }
 
 // Code returns the exception type name.
-func (s RepositoryTriggerBranchNameListRequiredException) Code() string {
+func (s *RepositoryTriggerBranchNameListRequiredException) Code() string {
 	return "RepositoryTriggerBranchNameListRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryTriggerBranchNameListRequiredException) Message() string {
+func (s *RepositoryTriggerBranchNameListRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29194,21 +29194,21 @@ func (s RepositoryTriggerBranchNameListRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryTriggerBranchNameListRequiredException) OrigErr() error {
+func (s *RepositoryTriggerBranchNameListRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryTriggerBranchNameListRequiredException) Error() string {
+func (s *RepositoryTriggerBranchNameListRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryTriggerBranchNameListRequiredException) StatusCode() int {
+func (s *RepositoryTriggerBranchNameListRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryTriggerBranchNameListRequiredException) RequestID() string {
+func (s *RepositoryTriggerBranchNameListRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29238,12 +29238,12 @@ func newErrorRepositoryTriggerDestinationArnRequiredException(v protocol.Respons
 }
 
 // Code returns the exception type name.
-func (s RepositoryTriggerDestinationArnRequiredException) Code() string {
+func (s *RepositoryTriggerDestinationArnRequiredException) Code() string {
 	return "RepositoryTriggerDestinationArnRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryTriggerDestinationArnRequiredException) Message() string {
+func (s *RepositoryTriggerDestinationArnRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29251,21 +29251,21 @@ func (s RepositoryTriggerDestinationArnRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryTriggerDestinationArnRequiredException) OrigErr() error {
+func (s *RepositoryTriggerDestinationArnRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryTriggerDestinationArnRequiredException) Error() string {
+func (s *RepositoryTriggerDestinationArnRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryTriggerDestinationArnRequiredException) StatusCode() int {
+func (s *RepositoryTriggerDestinationArnRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryTriggerDestinationArnRequiredException) RequestID() string {
+func (s *RepositoryTriggerDestinationArnRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29294,12 +29294,12 @@ func newErrorRepositoryTriggerEventsListRequiredException(v protocol.ResponseMet
 }
 
 // Code returns the exception type name.
-func (s RepositoryTriggerEventsListRequiredException) Code() string {
+func (s *RepositoryTriggerEventsListRequiredException) Code() string {
 	return "RepositoryTriggerEventsListRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryTriggerEventsListRequiredException) Message() string {
+func (s *RepositoryTriggerEventsListRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29307,21 +29307,21 @@ func (s RepositoryTriggerEventsListRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryTriggerEventsListRequiredException) OrigErr() error {
+func (s *RepositoryTriggerEventsListRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryTriggerEventsListRequiredException) Error() string {
+func (s *RepositoryTriggerEventsListRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryTriggerEventsListRequiredException) StatusCode() int {
+func (s *RepositoryTriggerEventsListRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryTriggerEventsListRequiredException) RequestID() string {
+func (s *RepositoryTriggerEventsListRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29383,12 +29383,12 @@ func newErrorRepositoryTriggerNameRequiredException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s RepositoryTriggerNameRequiredException) Code() string {
+func (s *RepositoryTriggerNameRequiredException) Code() string {
 	return "RepositoryTriggerNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryTriggerNameRequiredException) Message() string {
+func (s *RepositoryTriggerNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29396,21 +29396,21 @@ func (s RepositoryTriggerNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryTriggerNameRequiredException) OrigErr() error {
+func (s *RepositoryTriggerNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryTriggerNameRequiredException) Error() string {
+func (s *RepositoryTriggerNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryTriggerNameRequiredException) StatusCode() int {
+func (s *RepositoryTriggerNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryTriggerNameRequiredException) RequestID() string {
+func (s *RepositoryTriggerNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29439,12 +29439,12 @@ func newErrorRepositoryTriggersListRequiredException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s RepositoryTriggersListRequiredException) Code() string {
+func (s *RepositoryTriggersListRequiredException) Code() string {
 	return "RepositoryTriggersListRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryTriggersListRequiredException) Message() string {
+func (s *RepositoryTriggersListRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29452,21 +29452,21 @@ func (s RepositoryTriggersListRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryTriggersListRequiredException) OrigErr() error {
+func (s *RepositoryTriggersListRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryTriggersListRequiredException) Error() string {
+func (s *RepositoryTriggersListRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryTriggersListRequiredException) StatusCode() int {
+func (s *RepositoryTriggersListRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryTriggersListRequiredException) RequestID() string {
+func (s *RepositoryTriggersListRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29498,12 +29498,12 @@ func newErrorResourceArnRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceArnRequiredException) Code() string {
+func (s *ResourceArnRequiredException) Code() string {
 	return "ResourceArnRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ResourceArnRequiredException) Message() string {
+func (s *ResourceArnRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29511,21 +29511,21 @@ func (s ResourceArnRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceArnRequiredException) OrigErr() error {
+func (s *ResourceArnRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceArnRequiredException) Error() string {
+func (s *ResourceArnRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceArnRequiredException) StatusCode() int {
+func (s *ResourceArnRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceArnRequiredException) RequestID() string {
+func (s *ResourceArnRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29555,12 +29555,12 @@ func newErrorRestrictedSourceFileException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RestrictedSourceFileException) Code() string {
+func (s *RestrictedSourceFileException) Code() string {
 	return "RestrictedSourceFileException"
 }
 
 // Message returns the exception's message.
-func (s RestrictedSourceFileException) Message() string {
+func (s *RestrictedSourceFileException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29568,21 +29568,21 @@ func (s RestrictedSourceFileException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RestrictedSourceFileException) OrigErr() error {
+func (s *RestrictedSourceFileException) OrigErr() error {
 	return nil
 }
 
-func (s RestrictedSourceFileException) Error() string {
+func (s *RestrictedSourceFileException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RestrictedSourceFileException) StatusCode() int {
+func (s *RestrictedSourceFileException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RestrictedSourceFileException) RequestID() string {
+func (s *RestrictedSourceFileException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29611,12 +29611,12 @@ func newErrorRevisionIdRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RevisionIdRequiredException) Code() string {
+func (s *RevisionIdRequiredException) Code() string {
 	return "RevisionIdRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RevisionIdRequiredException) Message() string {
+func (s *RevisionIdRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29624,21 +29624,21 @@ func (s RevisionIdRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RevisionIdRequiredException) OrigErr() error {
+func (s *RevisionIdRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RevisionIdRequiredException) Error() string {
+func (s *RevisionIdRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RevisionIdRequiredException) StatusCode() int {
+func (s *RevisionIdRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RevisionIdRequiredException) RequestID() string {
+func (s *RevisionIdRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29668,12 +29668,12 @@ func newErrorRevisionNotCurrentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RevisionNotCurrentException) Code() string {
+func (s *RevisionNotCurrentException) Code() string {
 	return "RevisionNotCurrentException"
 }
 
 // Message returns the exception's message.
-func (s RevisionNotCurrentException) Message() string {
+func (s *RevisionNotCurrentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29681,21 +29681,21 @@ func (s RevisionNotCurrentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RevisionNotCurrentException) OrigErr() error {
+func (s *RevisionNotCurrentException) OrigErr() error {
 	return nil
 }
 
-func (s RevisionNotCurrentException) Error() string {
+func (s *RevisionNotCurrentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RevisionNotCurrentException) StatusCode() int {
+func (s *RevisionNotCurrentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RevisionNotCurrentException) RequestID() string {
+func (s *RevisionNotCurrentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29726,12 +29726,12 @@ func newErrorSameFileContentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SameFileContentException) Code() string {
+func (s *SameFileContentException) Code() string {
 	return "SameFileContentException"
 }
 
 // Message returns the exception's message.
-func (s SameFileContentException) Message() string {
+func (s *SameFileContentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29739,21 +29739,21 @@ func (s SameFileContentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SameFileContentException) OrigErr() error {
+func (s *SameFileContentException) OrigErr() error {
 	return nil
 }
 
-func (s SameFileContentException) Error() string {
+func (s *SameFileContentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SameFileContentException) StatusCode() int {
+func (s *SameFileContentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SameFileContentException) RequestID() string {
+func (s *SameFileContentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29785,12 +29785,12 @@ func newErrorSamePathRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SamePathRequestException) Code() string {
+func (s *SamePathRequestException) Code() string {
 	return "SamePathRequestException"
 }
 
 // Message returns the exception's message.
-func (s SamePathRequestException) Message() string {
+func (s *SamePathRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29798,21 +29798,21 @@ func (s SamePathRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SamePathRequestException) OrigErr() error {
+func (s *SamePathRequestException) OrigErr() error {
 	return nil
 }
 
-func (s SamePathRequestException) Error() string {
+func (s *SamePathRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SamePathRequestException) StatusCode() int {
+func (s *SamePathRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SamePathRequestException) RequestID() string {
+func (s *SamePathRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29895,12 +29895,12 @@ func newErrorSourceAndDestinationAreSameException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s SourceAndDestinationAreSameException) Code() string {
+func (s *SourceAndDestinationAreSameException) Code() string {
 	return "SourceAndDestinationAreSameException"
 }
 
 // Message returns the exception's message.
-func (s SourceAndDestinationAreSameException) Message() string {
+func (s *SourceAndDestinationAreSameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29908,21 +29908,21 @@ func (s SourceAndDestinationAreSameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SourceAndDestinationAreSameException) OrigErr() error {
+func (s *SourceAndDestinationAreSameException) OrigErr() error {
 	return nil
 }
 
-func (s SourceAndDestinationAreSameException) Error() string {
+func (s *SourceAndDestinationAreSameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SourceAndDestinationAreSameException) StatusCode() int {
+func (s *SourceAndDestinationAreSameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SourceAndDestinationAreSameException) RequestID() string {
+func (s *SourceAndDestinationAreSameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29952,12 +29952,12 @@ func newErrorSourceFileOrContentRequiredException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s SourceFileOrContentRequiredException) Code() string {
+func (s *SourceFileOrContentRequiredException) Code() string {
 	return "SourceFileOrContentRequiredException"
 }
 
 // Message returns the exception's message.
-func (s SourceFileOrContentRequiredException) Message() string {
+func (s *SourceFileOrContentRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29965,21 +29965,21 @@ func (s SourceFileOrContentRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SourceFileOrContentRequiredException) OrigErr() error {
+func (s *SourceFileOrContentRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s SourceFileOrContentRequiredException) Error() string {
+func (s *SourceFileOrContentRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SourceFileOrContentRequiredException) StatusCode() int {
+func (s *SourceFileOrContentRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SourceFileOrContentRequiredException) RequestID() string {
+func (s *SourceFileOrContentRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30151,12 +30151,12 @@ func newErrorTagKeysListRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagKeysListRequiredException) Code() string {
+func (s *TagKeysListRequiredException) Code() string {
 	return "TagKeysListRequiredException"
 }
 
 // Message returns the exception's message.
-func (s TagKeysListRequiredException) Message() string {
+func (s *TagKeysListRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30164,21 +30164,21 @@ func (s TagKeysListRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagKeysListRequiredException) OrigErr() error {
+func (s *TagKeysListRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s TagKeysListRequiredException) Error() string {
+func (s *TagKeysListRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagKeysListRequiredException) StatusCode() int {
+func (s *TagKeysListRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagKeysListRequiredException) RequestID() string {
+func (s *TagKeysListRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30207,12 +30207,12 @@ func newErrorTagPolicyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagPolicyException) Code() string {
+func (s *TagPolicyException) Code() string {
 	return "TagPolicyException"
 }
 
 // Message returns the exception's message.
-func (s TagPolicyException) Message() string {
+func (s *TagPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30220,21 +30220,21 @@ func (s TagPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagPolicyException) OrigErr() error {
+func (s *TagPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s TagPolicyException) Error() string {
+func (s *TagPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagPolicyException) StatusCode() int {
+func (s *TagPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagPolicyException) RequestID() string {
+func (s *TagPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30330,12 +30330,12 @@ func newErrorTagsMapRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagsMapRequiredException) Code() string {
+func (s *TagsMapRequiredException) Code() string {
 	return "TagsMapRequiredException"
 }
 
 // Message returns the exception's message.
-func (s TagsMapRequiredException) Message() string {
+func (s *TagsMapRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30343,21 +30343,21 @@ func (s TagsMapRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagsMapRequiredException) OrigErr() error {
+func (s *TagsMapRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s TagsMapRequiredException) Error() string {
+func (s *TagsMapRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagsMapRequiredException) StatusCode() int {
+func (s *TagsMapRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagsMapRequiredException) RequestID() string {
+func (s *TagsMapRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30455,12 +30455,12 @@ func newErrorTargetRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TargetRequiredException) Code() string {
+func (s *TargetRequiredException) Code() string {
 	return "TargetRequiredException"
 }
 
 // Message returns the exception's message.
-func (s TargetRequiredException) Message() string {
+func (s *TargetRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30468,21 +30468,21 @@ func (s TargetRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TargetRequiredException) OrigErr() error {
+func (s *TargetRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s TargetRequiredException) Error() string {
+func (s *TargetRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TargetRequiredException) StatusCode() int {
+func (s *TargetRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TargetRequiredException) RequestID() string {
+func (s *TargetRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30511,12 +30511,12 @@ func newErrorTargetsRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TargetsRequiredException) Code() string {
+func (s *TargetsRequiredException) Code() string {
 	return "TargetsRequiredException"
 }
 
 // Message returns the exception's message.
-func (s TargetsRequiredException) Message() string {
+func (s *TargetsRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30524,21 +30524,21 @@ func (s TargetsRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TargetsRequiredException) OrigErr() error {
+func (s *TargetsRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s TargetsRequiredException) Error() string {
+func (s *TargetsRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TargetsRequiredException) StatusCode() int {
+func (s *TargetsRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TargetsRequiredException) RequestID() string {
+func (s *TargetsRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30670,12 +30670,12 @@ func newErrorTipOfSourceReferenceIsDifferentException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s TipOfSourceReferenceIsDifferentException) Code() string {
+func (s *TipOfSourceReferenceIsDifferentException) Code() string {
 	return "TipOfSourceReferenceIsDifferentException"
 }
 
 // Message returns the exception's message.
-func (s TipOfSourceReferenceIsDifferentException) Message() string {
+func (s *TipOfSourceReferenceIsDifferentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30683,21 +30683,21 @@ func (s TipOfSourceReferenceIsDifferentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TipOfSourceReferenceIsDifferentException) OrigErr() error {
+func (s *TipOfSourceReferenceIsDifferentException) OrigErr() error {
 	return nil
 }
 
-func (s TipOfSourceReferenceIsDifferentException) Error() string {
+func (s *TipOfSourceReferenceIsDifferentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TipOfSourceReferenceIsDifferentException) StatusCode() int {
+func (s *TipOfSourceReferenceIsDifferentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TipOfSourceReferenceIsDifferentException) RequestID() string {
+func (s *TipOfSourceReferenceIsDifferentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30728,12 +30728,12 @@ func newErrorTipsDivergenceExceededException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s TipsDivergenceExceededException) Code() string {
+func (s *TipsDivergenceExceededException) Code() string {
 	return "TipsDivergenceExceededException"
 }
 
 // Message returns the exception's message.
-func (s TipsDivergenceExceededException) Message() string {
+func (s *TipsDivergenceExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30741,21 +30741,21 @@ func (s TipsDivergenceExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TipsDivergenceExceededException) OrigErr() error {
+func (s *TipsDivergenceExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TipsDivergenceExceededException) Error() string {
+func (s *TipsDivergenceExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TipsDivergenceExceededException) StatusCode() int {
+func (s *TipsDivergenceExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TipsDivergenceExceededException) RequestID() string {
+func (s *TipsDivergenceExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30784,12 +30784,12 @@ func newErrorTitleRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TitleRequiredException) Code() string {
+func (s *TitleRequiredException) Code() string {
 	return "TitleRequiredException"
 }
 
 // Message returns the exception's message.
-func (s TitleRequiredException) Message() string {
+func (s *TitleRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30797,21 +30797,21 @@ func (s TitleRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TitleRequiredException) OrigErr() error {
+func (s *TitleRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s TitleRequiredException) Error() string {
+func (s *TitleRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TitleRequiredException) StatusCode() int {
+func (s *TitleRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TitleRequiredException) RequestID() string {
+func (s *TitleRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30840,12 +30840,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30853,21 +30853,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -5199,12 +5199,12 @@ func newErrorAlarmsLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlarmsLimitExceededException) Code() string {
+func (s *AlarmsLimitExceededException) Code() string {
 	return "AlarmsLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s AlarmsLimitExceededException) Message() string {
+func (s *AlarmsLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5212,21 +5212,21 @@ func (s AlarmsLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlarmsLimitExceededException) OrigErr() error {
+func (s *AlarmsLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s AlarmsLimitExceededException) Error() string {
+func (s *AlarmsLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlarmsLimitExceededException) StatusCode() int {
+func (s *AlarmsLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlarmsLimitExceededException) RequestID() string {
+func (s *AlarmsLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5303,12 +5303,12 @@ func newErrorApplicationAlreadyExistsException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ApplicationAlreadyExistsException) Code() string {
+func (s *ApplicationAlreadyExistsException) Code() string {
 	return "ApplicationAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ApplicationAlreadyExistsException) Message() string {
+func (s *ApplicationAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5316,21 +5316,21 @@ func (s ApplicationAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApplicationAlreadyExistsException) OrigErr() error {
+func (s *ApplicationAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ApplicationAlreadyExistsException) Error() string {
+func (s *ApplicationAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApplicationAlreadyExistsException) StatusCode() int {
+func (s *ApplicationAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApplicationAlreadyExistsException) RequestID() string {
+func (s *ApplicationAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5359,12 +5359,12 @@ func newErrorApplicationDoesNotExistException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s ApplicationDoesNotExistException) Code() string {
+func (s *ApplicationDoesNotExistException) Code() string {
 	return "ApplicationDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s ApplicationDoesNotExistException) Message() string {
+func (s *ApplicationDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5372,21 +5372,21 @@ func (s ApplicationDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApplicationDoesNotExistException) OrigErr() error {
+func (s *ApplicationDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s ApplicationDoesNotExistException) Error() string {
+func (s *ApplicationDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApplicationDoesNotExistException) StatusCode() int {
+func (s *ApplicationDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApplicationDoesNotExistException) RequestID() string {
+func (s *ApplicationDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5486,12 +5486,12 @@ func newErrorApplicationLimitExceededException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ApplicationLimitExceededException) Code() string {
+func (s *ApplicationLimitExceededException) Code() string {
 	return "ApplicationLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ApplicationLimitExceededException) Message() string {
+func (s *ApplicationLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5499,21 +5499,21 @@ func (s ApplicationLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApplicationLimitExceededException) OrigErr() error {
+func (s *ApplicationLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ApplicationLimitExceededException) Error() string {
+func (s *ApplicationLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApplicationLimitExceededException) StatusCode() int {
+func (s *ApplicationLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApplicationLimitExceededException) RequestID() string {
+func (s *ApplicationLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5542,12 +5542,12 @@ func newErrorApplicationNameRequiredException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s ApplicationNameRequiredException) Code() string {
+func (s *ApplicationNameRequiredException) Code() string {
 	return "ApplicationNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ApplicationNameRequiredException) Message() string {
+func (s *ApplicationNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5555,21 +5555,21 @@ func (s ApplicationNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApplicationNameRequiredException) OrigErr() error {
+func (s *ApplicationNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ApplicationNameRequiredException) Error() string {
+func (s *ApplicationNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApplicationNameRequiredException) StatusCode() int {
+func (s *ApplicationNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApplicationNameRequiredException) RequestID() string {
+func (s *ApplicationNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5599,12 +5599,12 @@ func newErrorArnNotSupportedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ArnNotSupportedException) Code() string {
+func (s *ArnNotSupportedException) Code() string {
 	return "ArnNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s ArnNotSupportedException) Message() string {
+func (s *ArnNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5612,21 +5612,21 @@ func (s ArnNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ArnNotSupportedException) OrigErr() error {
+func (s *ArnNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s ArnNotSupportedException) Error() string {
+func (s *ArnNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ArnNotSupportedException) StatusCode() int {
+func (s *ArnNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ArnNotSupportedException) RequestID() string {
+func (s *ArnNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6268,12 +6268,12 @@ func newErrorBatchLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BatchLimitExceededException) Code() string {
+func (s *BatchLimitExceededException) Code() string {
 	return "BatchLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s BatchLimitExceededException) Message() string {
+func (s *BatchLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6281,21 +6281,21 @@ func (s BatchLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BatchLimitExceededException) OrigErr() error {
+func (s *BatchLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s BatchLimitExceededException) Error() string {
+func (s *BatchLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BatchLimitExceededException) StatusCode() int {
+func (s *BatchLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BatchLimitExceededException) RequestID() string {
+func (s *BatchLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6417,12 +6417,12 @@ func newErrorBucketNameFilterRequiredException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s BucketNameFilterRequiredException) Code() string {
+func (s *BucketNameFilterRequiredException) Code() string {
 	return "BucketNameFilterRequiredException"
 }
 
 // Message returns the exception's message.
-func (s BucketNameFilterRequiredException) Message() string {
+func (s *BucketNameFilterRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6430,21 +6430,21 @@ func (s BucketNameFilterRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BucketNameFilterRequiredException) OrigErr() error {
+func (s *BucketNameFilterRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s BucketNameFilterRequiredException) Error() string {
+func (s *BucketNameFilterRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BucketNameFilterRequiredException) StatusCode() int {
+func (s *BucketNameFilterRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BucketNameFilterRequiredException) RequestID() string {
+func (s *BucketNameFilterRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7425,12 +7425,12 @@ func newErrorDeploymentAlreadyCompletedException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s DeploymentAlreadyCompletedException) Code() string {
+func (s *DeploymentAlreadyCompletedException) Code() string {
 	return "DeploymentAlreadyCompletedException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentAlreadyCompletedException) Message() string {
+func (s *DeploymentAlreadyCompletedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7438,21 +7438,21 @@ func (s DeploymentAlreadyCompletedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentAlreadyCompletedException) OrigErr() error {
+func (s *DeploymentAlreadyCompletedException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentAlreadyCompletedException) Error() string {
+func (s *DeploymentAlreadyCompletedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentAlreadyCompletedException) StatusCode() int {
+func (s *DeploymentAlreadyCompletedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentAlreadyCompletedException) RequestID() string {
+func (s *DeploymentAlreadyCompletedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7482,12 +7482,12 @@ func newErrorDeploymentConfigAlreadyExistsException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s DeploymentConfigAlreadyExistsException) Code() string {
+func (s *DeploymentConfigAlreadyExistsException) Code() string {
 	return "DeploymentConfigAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentConfigAlreadyExistsException) Message() string {
+func (s *DeploymentConfigAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7495,21 +7495,21 @@ func (s DeploymentConfigAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentConfigAlreadyExistsException) OrigErr() error {
+func (s *DeploymentConfigAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentConfigAlreadyExistsException) Error() string {
+func (s *DeploymentConfigAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentConfigAlreadyExistsException) StatusCode() int {
+func (s *DeploymentConfigAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentConfigAlreadyExistsException) RequestID() string {
+func (s *DeploymentConfigAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7538,12 +7538,12 @@ func newErrorDeploymentConfigDoesNotExistException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s DeploymentConfigDoesNotExistException) Code() string {
+func (s *DeploymentConfigDoesNotExistException) Code() string {
 	return "DeploymentConfigDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentConfigDoesNotExistException) Message() string {
+func (s *DeploymentConfigDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7551,21 +7551,21 @@ func (s DeploymentConfigDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentConfigDoesNotExistException) OrigErr() error {
+func (s *DeploymentConfigDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentConfigDoesNotExistException) Error() string {
+func (s *DeploymentConfigDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentConfigDoesNotExistException) StatusCode() int {
+func (s *DeploymentConfigDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentConfigDoesNotExistException) RequestID() string {
+func (s *DeploymentConfigDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7594,12 +7594,12 @@ func newErrorDeploymentConfigInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DeploymentConfigInUseException) Code() string {
+func (s *DeploymentConfigInUseException) Code() string {
 	return "DeploymentConfigInUseException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentConfigInUseException) Message() string {
+func (s *DeploymentConfigInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7607,21 +7607,21 @@ func (s DeploymentConfigInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentConfigInUseException) OrigErr() error {
+func (s *DeploymentConfigInUseException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentConfigInUseException) Error() string {
+func (s *DeploymentConfigInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentConfigInUseException) StatusCode() int {
+func (s *DeploymentConfigInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentConfigInUseException) RequestID() string {
+func (s *DeploymentConfigInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7720,12 +7720,12 @@ func newErrorDeploymentConfigLimitExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s DeploymentConfigLimitExceededException) Code() string {
+func (s *DeploymentConfigLimitExceededException) Code() string {
 	return "DeploymentConfigLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentConfigLimitExceededException) Message() string {
+func (s *DeploymentConfigLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7733,21 +7733,21 @@ func (s DeploymentConfigLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentConfigLimitExceededException) OrigErr() error {
+func (s *DeploymentConfigLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentConfigLimitExceededException) Error() string {
+func (s *DeploymentConfigLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentConfigLimitExceededException) StatusCode() int {
+func (s *DeploymentConfigLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentConfigLimitExceededException) RequestID() string {
+func (s *DeploymentConfigLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7776,12 +7776,12 @@ func newErrorDeploymentConfigNameRequiredException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s DeploymentConfigNameRequiredException) Code() string {
+func (s *DeploymentConfigNameRequiredException) Code() string {
 	return "DeploymentConfigNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentConfigNameRequiredException) Message() string {
+func (s *DeploymentConfigNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7789,21 +7789,21 @@ func (s DeploymentConfigNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentConfigNameRequiredException) OrigErr() error {
+func (s *DeploymentConfigNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentConfigNameRequiredException) Error() string {
+func (s *DeploymentConfigNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentConfigNameRequiredException) StatusCode() int {
+func (s *DeploymentConfigNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentConfigNameRequiredException) RequestID() string {
+func (s *DeploymentConfigNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7832,12 +7832,12 @@ func newErrorDeploymentDoesNotExistException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s DeploymentDoesNotExistException) Code() string {
+func (s *DeploymentDoesNotExistException) Code() string {
 	return "DeploymentDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentDoesNotExistException) Message() string {
+func (s *DeploymentDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7845,21 +7845,21 @@ func (s DeploymentDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentDoesNotExistException) OrigErr() error {
+func (s *DeploymentDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentDoesNotExistException) Error() string {
+func (s *DeploymentDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentDoesNotExistException) StatusCode() int {
+func (s *DeploymentDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentDoesNotExistException) RequestID() string {
+func (s *DeploymentDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7889,12 +7889,12 @@ func newErrorDeploymentGroupAlreadyExistsException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s DeploymentGroupAlreadyExistsException) Code() string {
+func (s *DeploymentGroupAlreadyExistsException) Code() string {
 	return "DeploymentGroupAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentGroupAlreadyExistsException) Message() string {
+func (s *DeploymentGroupAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7902,21 +7902,21 @@ func (s DeploymentGroupAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentGroupAlreadyExistsException) OrigErr() error {
+func (s *DeploymentGroupAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentGroupAlreadyExistsException) Error() string {
+func (s *DeploymentGroupAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentGroupAlreadyExistsException) StatusCode() int {
+func (s *DeploymentGroupAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentGroupAlreadyExistsException) RequestID() string {
+func (s *DeploymentGroupAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7945,12 +7945,12 @@ func newErrorDeploymentGroupDoesNotExistException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s DeploymentGroupDoesNotExistException) Code() string {
+func (s *DeploymentGroupDoesNotExistException) Code() string {
 	return "DeploymentGroupDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentGroupDoesNotExistException) Message() string {
+func (s *DeploymentGroupDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7958,21 +7958,21 @@ func (s DeploymentGroupDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentGroupDoesNotExistException) OrigErr() error {
+func (s *DeploymentGroupDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentGroupDoesNotExistException) Error() string {
+func (s *DeploymentGroupDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentGroupDoesNotExistException) StatusCode() int {
+func (s *DeploymentGroupDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentGroupDoesNotExistException) RequestID() string {
+func (s *DeploymentGroupDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8222,12 +8222,12 @@ func newErrorDeploymentGroupLimitExceededException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s DeploymentGroupLimitExceededException) Code() string {
+func (s *DeploymentGroupLimitExceededException) Code() string {
 	return "DeploymentGroupLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentGroupLimitExceededException) Message() string {
+func (s *DeploymentGroupLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8235,21 +8235,21 @@ func (s DeploymentGroupLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentGroupLimitExceededException) OrigErr() error {
+func (s *DeploymentGroupLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentGroupLimitExceededException) Error() string {
+func (s *DeploymentGroupLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentGroupLimitExceededException) StatusCode() int {
+func (s *DeploymentGroupLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentGroupLimitExceededException) RequestID() string {
+func (s *DeploymentGroupLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8278,12 +8278,12 @@ func newErrorDeploymentGroupNameRequiredException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s DeploymentGroupNameRequiredException) Code() string {
+func (s *DeploymentGroupNameRequiredException) Code() string {
 	return "DeploymentGroupNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentGroupNameRequiredException) Message() string {
+func (s *DeploymentGroupNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8291,21 +8291,21 @@ func (s DeploymentGroupNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentGroupNameRequiredException) OrigErr() error {
+func (s *DeploymentGroupNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentGroupNameRequiredException) Error() string {
+func (s *DeploymentGroupNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentGroupNameRequiredException) StatusCode() int {
+func (s *DeploymentGroupNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentGroupNameRequiredException) RequestID() string {
+func (s *DeploymentGroupNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8334,12 +8334,12 @@ func newErrorDeploymentIdRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DeploymentIdRequiredException) Code() string {
+func (s *DeploymentIdRequiredException) Code() string {
 	return "DeploymentIdRequiredException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentIdRequiredException) Message() string {
+func (s *DeploymentIdRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8347,21 +8347,21 @@ func (s DeploymentIdRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentIdRequiredException) OrigErr() error {
+func (s *DeploymentIdRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentIdRequiredException) Error() string {
+func (s *DeploymentIdRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentIdRequiredException) StatusCode() int {
+func (s *DeploymentIdRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentIdRequiredException) RequestID() string {
+func (s *DeploymentIdRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8702,12 +8702,12 @@ func newErrorDeploymentIsNotInReadyStateException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s DeploymentIsNotInReadyStateException) Code() string {
+func (s *DeploymentIsNotInReadyStateException) Code() string {
 	return "DeploymentIsNotInReadyStateException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentIsNotInReadyStateException) Message() string {
+func (s *DeploymentIsNotInReadyStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8715,21 +8715,21 @@ func (s DeploymentIsNotInReadyStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentIsNotInReadyStateException) OrigErr() error {
+func (s *DeploymentIsNotInReadyStateException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentIsNotInReadyStateException) Error() string {
+func (s *DeploymentIsNotInReadyStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentIsNotInReadyStateException) StatusCode() int {
+func (s *DeploymentIsNotInReadyStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentIsNotInReadyStateException) RequestID() string {
+func (s *DeploymentIsNotInReadyStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8758,12 +8758,12 @@ func newErrorDeploymentLimitExceededException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s DeploymentLimitExceededException) Code() string {
+func (s *DeploymentLimitExceededException) Code() string {
 	return "DeploymentLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentLimitExceededException) Message() string {
+func (s *DeploymentLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8771,21 +8771,21 @@ func (s DeploymentLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentLimitExceededException) OrigErr() error {
+func (s *DeploymentLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentLimitExceededException) Error() string {
+func (s *DeploymentLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentLimitExceededException) StatusCode() int {
+func (s *DeploymentLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentLimitExceededException) RequestID() string {
+func (s *DeploymentLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8814,12 +8814,12 @@ func newErrorDeploymentNotStartedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DeploymentNotStartedException) Code() string {
+func (s *DeploymentNotStartedException) Code() string {
 	return "DeploymentNotStartedException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentNotStartedException) Message() string {
+func (s *DeploymentNotStartedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8827,21 +8827,21 @@ func (s DeploymentNotStartedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentNotStartedException) OrigErr() error {
+func (s *DeploymentNotStartedException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentNotStartedException) Error() string {
+func (s *DeploymentNotStartedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentNotStartedException) StatusCode() int {
+func (s *DeploymentNotStartedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentNotStartedException) RequestID() string {
+func (s *DeploymentNotStartedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9075,12 +9075,12 @@ func newErrorDeploymentTargetDoesNotExistException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s DeploymentTargetDoesNotExistException) Code() string {
+func (s *DeploymentTargetDoesNotExistException) Code() string {
 	return "DeploymentTargetDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentTargetDoesNotExistException) Message() string {
+func (s *DeploymentTargetDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9088,21 +9088,21 @@ func (s DeploymentTargetDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentTargetDoesNotExistException) OrigErr() error {
+func (s *DeploymentTargetDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentTargetDoesNotExistException) Error() string {
+func (s *DeploymentTargetDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentTargetDoesNotExistException) StatusCode() int {
+func (s *DeploymentTargetDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentTargetDoesNotExistException) RequestID() string {
+func (s *DeploymentTargetDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9131,12 +9131,12 @@ func newErrorDeploymentTargetIdRequiredException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s DeploymentTargetIdRequiredException) Code() string {
+func (s *DeploymentTargetIdRequiredException) Code() string {
 	return "DeploymentTargetIdRequiredException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentTargetIdRequiredException) Message() string {
+func (s *DeploymentTargetIdRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9144,21 +9144,21 @@ func (s DeploymentTargetIdRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentTargetIdRequiredException) OrigErr() error {
+func (s *DeploymentTargetIdRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentTargetIdRequiredException) Error() string {
+func (s *DeploymentTargetIdRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentTargetIdRequiredException) StatusCode() int {
+func (s *DeploymentTargetIdRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentTargetIdRequiredException) RequestID() string {
+func (s *DeploymentTargetIdRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9190,12 +9190,12 @@ func newErrorDeploymentTargetListSizeExceededException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s DeploymentTargetListSizeExceededException) Code() string {
+func (s *DeploymentTargetListSizeExceededException) Code() string {
 	return "DeploymentTargetListSizeExceededException"
 }
 
 // Message returns the exception's message.
-func (s DeploymentTargetListSizeExceededException) Message() string {
+func (s *DeploymentTargetListSizeExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9203,21 +9203,21 @@ func (s DeploymentTargetListSizeExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeploymentTargetListSizeExceededException) OrigErr() error {
+func (s *DeploymentTargetListSizeExceededException) OrigErr() error {
 	return nil
 }
 
-func (s DeploymentTargetListSizeExceededException) Error() string {
+func (s *DeploymentTargetListSizeExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeploymentTargetListSizeExceededException) StatusCode() int {
+func (s *DeploymentTargetListSizeExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeploymentTargetListSizeExceededException) RequestID() string {
+func (s *DeploymentTargetListSizeExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9299,12 +9299,12 @@ func newErrorDescriptionTooLongException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DescriptionTooLongException) Code() string {
+func (s *DescriptionTooLongException) Code() string {
 	return "DescriptionTooLongException"
 }
 
 // Message returns the exception's message.
-func (s DescriptionTooLongException) Message() string {
+func (s *DescriptionTooLongException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9312,21 +9312,21 @@ func (s DescriptionTooLongException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DescriptionTooLongException) OrigErr() error {
+func (s *DescriptionTooLongException) OrigErr() error {
 	return nil
 }
 
-func (s DescriptionTooLongException) Error() string {
+func (s *DescriptionTooLongException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DescriptionTooLongException) StatusCode() int {
+func (s *DescriptionTooLongException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DescriptionTooLongException) RequestID() string {
+func (s *DescriptionTooLongException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9532,12 +9532,12 @@ func newErrorECSServiceMappingLimitExceededException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s ECSServiceMappingLimitExceededException) Code() string {
+func (s *ECSServiceMappingLimitExceededException) Code() string {
 	return "ECSServiceMappingLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ECSServiceMappingLimitExceededException) Message() string {
+func (s *ECSServiceMappingLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9545,21 +9545,21 @@ func (s ECSServiceMappingLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ECSServiceMappingLimitExceededException) OrigErr() error {
+func (s *ECSServiceMappingLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ECSServiceMappingLimitExceededException) Error() string {
+func (s *ECSServiceMappingLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ECSServiceMappingLimitExceededException) StatusCode() int {
+func (s *ECSServiceMappingLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ECSServiceMappingLimitExceededException) RequestID() string {
+func (s *ECSServiceMappingLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10514,12 +10514,12 @@ func newErrorGitHubAccountTokenDoesNotExistException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s GitHubAccountTokenDoesNotExistException) Code() string {
+func (s *GitHubAccountTokenDoesNotExistException) Code() string {
 	return "GitHubAccountTokenDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s GitHubAccountTokenDoesNotExistException) Message() string {
+func (s *GitHubAccountTokenDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10527,21 +10527,21 @@ func (s GitHubAccountTokenDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GitHubAccountTokenDoesNotExistException) OrigErr() error {
+func (s *GitHubAccountTokenDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s GitHubAccountTokenDoesNotExistException) Error() string {
+func (s *GitHubAccountTokenDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GitHubAccountTokenDoesNotExistException) StatusCode() int {
+func (s *GitHubAccountTokenDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GitHubAccountTokenDoesNotExistException) RequestID() string {
+func (s *GitHubAccountTokenDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10570,12 +10570,12 @@ func newErrorGitHubAccountTokenNameRequiredException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s GitHubAccountTokenNameRequiredException) Code() string {
+func (s *GitHubAccountTokenNameRequiredException) Code() string {
 	return "GitHubAccountTokenNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s GitHubAccountTokenNameRequiredException) Message() string {
+func (s *GitHubAccountTokenNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10583,21 +10583,21 @@ func (s GitHubAccountTokenNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GitHubAccountTokenNameRequiredException) OrigErr() error {
+func (s *GitHubAccountTokenNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s GitHubAccountTokenNameRequiredException) Error() string {
+func (s *GitHubAccountTokenNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GitHubAccountTokenNameRequiredException) StatusCode() int {
+func (s *GitHubAccountTokenNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GitHubAccountTokenNameRequiredException) RequestID() string {
+func (s *GitHubAccountTokenNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10695,12 +10695,12 @@ func newErrorIamArnRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IamArnRequiredException) Code() string {
+func (s *IamArnRequiredException) Code() string {
 	return "IamArnRequiredException"
 }
 
 // Message returns the exception's message.
-func (s IamArnRequiredException) Message() string {
+func (s *IamArnRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10708,21 +10708,21 @@ func (s IamArnRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IamArnRequiredException) OrigErr() error {
+func (s *IamArnRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s IamArnRequiredException) Error() string {
+func (s *IamArnRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IamArnRequiredException) StatusCode() int {
+func (s *IamArnRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IamArnRequiredException) RequestID() string {
+func (s *IamArnRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10752,12 +10752,12 @@ func newErrorIamSessionArnAlreadyRegisteredException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s IamSessionArnAlreadyRegisteredException) Code() string {
+func (s *IamSessionArnAlreadyRegisteredException) Code() string {
 	return "IamSessionArnAlreadyRegisteredException"
 }
 
 // Message returns the exception's message.
-func (s IamSessionArnAlreadyRegisteredException) Message() string {
+func (s *IamSessionArnAlreadyRegisteredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10765,21 +10765,21 @@ func (s IamSessionArnAlreadyRegisteredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IamSessionArnAlreadyRegisteredException) OrigErr() error {
+func (s *IamSessionArnAlreadyRegisteredException) OrigErr() error {
 	return nil
 }
 
-func (s IamSessionArnAlreadyRegisteredException) Error() string {
+func (s *IamSessionArnAlreadyRegisteredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IamSessionArnAlreadyRegisteredException) StatusCode() int {
+func (s *IamSessionArnAlreadyRegisteredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IamSessionArnAlreadyRegisteredException) RequestID() string {
+func (s *IamSessionArnAlreadyRegisteredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10808,12 +10808,12 @@ func newErrorIamUserArnAlreadyRegisteredException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IamUserArnAlreadyRegisteredException) Code() string {
+func (s *IamUserArnAlreadyRegisteredException) Code() string {
 	return "IamUserArnAlreadyRegisteredException"
 }
 
 // Message returns the exception's message.
-func (s IamUserArnAlreadyRegisteredException) Message() string {
+func (s *IamUserArnAlreadyRegisteredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10821,21 +10821,21 @@ func (s IamUserArnAlreadyRegisteredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IamUserArnAlreadyRegisteredException) OrigErr() error {
+func (s *IamUserArnAlreadyRegisteredException) OrigErr() error {
 	return nil
 }
 
-func (s IamUserArnAlreadyRegisteredException) Error() string {
+func (s *IamUserArnAlreadyRegisteredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IamUserArnAlreadyRegisteredException) StatusCode() int {
+func (s *IamUserArnAlreadyRegisteredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IamUserArnAlreadyRegisteredException) RequestID() string {
+func (s *IamUserArnAlreadyRegisteredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10864,12 +10864,12 @@ func newErrorIamUserArnRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IamUserArnRequiredException) Code() string {
+func (s *IamUserArnRequiredException) Code() string {
 	return "IamUserArnRequiredException"
 }
 
 // Message returns the exception's message.
-func (s IamUserArnRequiredException) Message() string {
+func (s *IamUserArnRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10877,21 +10877,21 @@ func (s IamUserArnRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IamUserArnRequiredException) OrigErr() error {
+func (s *IamUserArnRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s IamUserArnRequiredException) Error() string {
+func (s *IamUserArnRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IamUserArnRequiredException) StatusCode() int {
+func (s *IamUserArnRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IamUserArnRequiredException) RequestID() string {
+func (s *IamUserArnRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10922,12 +10922,12 @@ func newErrorInstanceDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InstanceDoesNotExistException) Code() string {
+func (s *InstanceDoesNotExistException) Code() string {
 	return "InstanceDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s InstanceDoesNotExistException) Message() string {
+func (s *InstanceDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10935,21 +10935,21 @@ func (s InstanceDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InstanceDoesNotExistException) OrigErr() error {
+func (s *InstanceDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s InstanceDoesNotExistException) Error() string {
+func (s *InstanceDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InstanceDoesNotExistException) StatusCode() int {
+func (s *InstanceDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InstanceDoesNotExistException) RequestID() string {
+func (s *InstanceDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10980,12 +10980,12 @@ func newErrorInstanceIdRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InstanceIdRequiredException) Code() string {
+func (s *InstanceIdRequiredException) Code() string {
 	return "InstanceIdRequiredException"
 }
 
 // Message returns the exception's message.
-func (s InstanceIdRequiredException) Message() string {
+func (s *InstanceIdRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10993,21 +10993,21 @@ func (s InstanceIdRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InstanceIdRequiredException) OrigErr() error {
+func (s *InstanceIdRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s InstanceIdRequiredException) Error() string {
+func (s *InstanceIdRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InstanceIdRequiredException) StatusCode() int {
+func (s *InstanceIdRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InstanceIdRequiredException) RequestID() string {
+func (s *InstanceIdRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11116,12 +11116,12 @@ func newErrorInstanceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InstanceLimitExceededException) Code() string {
+func (s *InstanceLimitExceededException) Code() string {
 	return "InstanceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s InstanceLimitExceededException) Message() string {
+func (s *InstanceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11129,21 +11129,21 @@ func (s InstanceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InstanceLimitExceededException) OrigErr() error {
+func (s *InstanceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s InstanceLimitExceededException) Error() string {
+func (s *InstanceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InstanceLimitExceededException) StatusCode() int {
+func (s *InstanceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InstanceLimitExceededException) RequestID() string {
+func (s *InstanceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11172,12 +11172,12 @@ func newErrorInstanceNameAlreadyRegisteredException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s InstanceNameAlreadyRegisteredException) Code() string {
+func (s *InstanceNameAlreadyRegisteredException) Code() string {
 	return "InstanceNameAlreadyRegisteredException"
 }
 
 // Message returns the exception's message.
-func (s InstanceNameAlreadyRegisteredException) Message() string {
+func (s *InstanceNameAlreadyRegisteredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11185,21 +11185,21 @@ func (s InstanceNameAlreadyRegisteredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InstanceNameAlreadyRegisteredException) OrigErr() error {
+func (s *InstanceNameAlreadyRegisteredException) OrigErr() error {
 	return nil
 }
 
-func (s InstanceNameAlreadyRegisteredException) Error() string {
+func (s *InstanceNameAlreadyRegisteredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InstanceNameAlreadyRegisteredException) StatusCode() int {
+func (s *InstanceNameAlreadyRegisteredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InstanceNameAlreadyRegisteredException) RequestID() string {
+func (s *InstanceNameAlreadyRegisteredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11228,12 +11228,12 @@ func newErrorInstanceNameRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InstanceNameRequiredException) Code() string {
+func (s *InstanceNameRequiredException) Code() string {
 	return "InstanceNameRequiredException"
 }
 
 // Message returns the exception's message.
-func (s InstanceNameRequiredException) Message() string {
+func (s *InstanceNameRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11241,21 +11241,21 @@ func (s InstanceNameRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InstanceNameRequiredException) OrigErr() error {
+func (s *InstanceNameRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s InstanceNameRequiredException) Error() string {
+func (s *InstanceNameRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InstanceNameRequiredException) StatusCode() int {
+func (s *InstanceNameRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InstanceNameRequiredException) RequestID() string {
+func (s *InstanceNameRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11284,12 +11284,12 @@ func newErrorInstanceNotRegisteredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InstanceNotRegisteredException) Code() string {
+func (s *InstanceNotRegisteredException) Code() string {
 	return "InstanceNotRegisteredException"
 }
 
 // Message returns the exception's message.
-func (s InstanceNotRegisteredException) Message() string {
+func (s *InstanceNotRegisteredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11297,21 +11297,21 @@ func (s InstanceNotRegisteredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InstanceNotRegisteredException) OrigErr() error {
+func (s *InstanceNotRegisteredException) OrigErr() error {
 	return nil
 }
 
-func (s InstanceNotRegisteredException) Error() string {
+func (s *InstanceNotRegisteredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InstanceNotRegisteredException) StatusCode() int {
+func (s *InstanceNotRegisteredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InstanceNotRegisteredException) RequestID() string {
+func (s *InstanceNotRegisteredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11518,12 +11518,12 @@ func newErrorInvalidAlarmConfigException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAlarmConfigException) Code() string {
+func (s *InvalidAlarmConfigException) Code() string {
 	return "InvalidAlarmConfigException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAlarmConfigException) Message() string {
+func (s *InvalidAlarmConfigException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11531,21 +11531,21 @@ func (s InvalidAlarmConfigException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAlarmConfigException) OrigErr() error {
+func (s *InvalidAlarmConfigException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAlarmConfigException) Error() string {
+func (s *InvalidAlarmConfigException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAlarmConfigException) StatusCode() int {
+func (s *InvalidAlarmConfigException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAlarmConfigException) RequestID() string {
+func (s *InvalidAlarmConfigException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11574,12 +11574,12 @@ func newErrorInvalidApplicationNameException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidApplicationNameException) Code() string {
+func (s *InvalidApplicationNameException) Code() string {
 	return "InvalidApplicationNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApplicationNameException) Message() string {
+func (s *InvalidApplicationNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11587,21 +11587,21 @@ func (s InvalidApplicationNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApplicationNameException) OrigErr() error {
+func (s *InvalidApplicationNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApplicationNameException) Error() string {
+func (s *InvalidApplicationNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApplicationNameException) StatusCode() int {
+func (s *InvalidApplicationNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApplicationNameException) RequestID() string {
+func (s *InvalidApplicationNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11630,12 +11630,12 @@ func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArnException) Code() string {
+func (s *InvalidArnException) Code() string {
 	return "InvalidArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArnException) Message() string {
+func (s *InvalidArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11643,21 +11643,21 @@ func (s InvalidArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArnException) OrigErr() error {
+func (s *InvalidArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArnException) Error() string {
+func (s *InvalidArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArnException) StatusCode() int {
+func (s *InvalidArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArnException) RequestID() string {
+func (s *InvalidArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11688,12 +11688,12 @@ func newErrorInvalidAutoRollbackConfigException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidAutoRollbackConfigException) Code() string {
+func (s *InvalidAutoRollbackConfigException) Code() string {
 	return "InvalidAutoRollbackConfigException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAutoRollbackConfigException) Message() string {
+func (s *InvalidAutoRollbackConfigException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11701,21 +11701,21 @@ func (s InvalidAutoRollbackConfigException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAutoRollbackConfigException) OrigErr() error {
+func (s *InvalidAutoRollbackConfigException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAutoRollbackConfigException) Error() string {
+func (s *InvalidAutoRollbackConfigException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAutoRollbackConfigException) StatusCode() int {
+func (s *InvalidAutoRollbackConfigException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAutoRollbackConfigException) RequestID() string {
+func (s *InvalidAutoRollbackConfigException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11744,12 +11744,12 @@ func newErrorInvalidAutoScalingGroupException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidAutoScalingGroupException) Code() string {
+func (s *InvalidAutoScalingGroupException) Code() string {
 	return "InvalidAutoScalingGroupException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAutoScalingGroupException) Message() string {
+func (s *InvalidAutoScalingGroupException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11757,21 +11757,21 @@ func (s InvalidAutoScalingGroupException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAutoScalingGroupException) OrigErr() error {
+func (s *InvalidAutoScalingGroupException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAutoScalingGroupException) Error() string {
+func (s *InvalidAutoScalingGroupException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAutoScalingGroupException) StatusCode() int {
+func (s *InvalidAutoScalingGroupException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAutoScalingGroupException) RequestID() string {
+func (s *InvalidAutoScalingGroupException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11802,12 +11802,12 @@ func newErrorInvalidBlueGreenDeploymentConfigurationException(v protocol.Respons
 }
 
 // Code returns the exception type name.
-func (s InvalidBlueGreenDeploymentConfigurationException) Code() string {
+func (s *InvalidBlueGreenDeploymentConfigurationException) Code() string {
 	return "InvalidBlueGreenDeploymentConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidBlueGreenDeploymentConfigurationException) Message() string {
+func (s *InvalidBlueGreenDeploymentConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11815,21 +11815,21 @@ func (s InvalidBlueGreenDeploymentConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidBlueGreenDeploymentConfigurationException) OrigErr() error {
+func (s *InvalidBlueGreenDeploymentConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidBlueGreenDeploymentConfigurationException) Error() string {
+func (s *InvalidBlueGreenDeploymentConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidBlueGreenDeploymentConfigurationException) StatusCode() int {
+func (s *InvalidBlueGreenDeploymentConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidBlueGreenDeploymentConfigurationException) RequestID() string {
+func (s *InvalidBlueGreenDeploymentConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11858,12 +11858,12 @@ func newErrorInvalidBucketNameFilterException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidBucketNameFilterException) Code() string {
+func (s *InvalidBucketNameFilterException) Code() string {
 	return "InvalidBucketNameFilterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidBucketNameFilterException) Message() string {
+func (s *InvalidBucketNameFilterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11871,21 +11871,21 @@ func (s InvalidBucketNameFilterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidBucketNameFilterException) OrigErr() error {
+func (s *InvalidBucketNameFilterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidBucketNameFilterException) Error() string {
+func (s *InvalidBucketNameFilterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidBucketNameFilterException) StatusCode() int {
+func (s *InvalidBucketNameFilterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidBucketNameFilterException) RequestID() string {
+func (s *InvalidBucketNameFilterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11914,12 +11914,12 @@ func newErrorInvalidComputePlatformException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidComputePlatformException) Code() string {
+func (s *InvalidComputePlatformException) Code() string {
 	return "InvalidComputePlatformException"
 }
 
 // Message returns the exception's message.
-func (s InvalidComputePlatformException) Message() string {
+func (s *InvalidComputePlatformException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11927,21 +11927,21 @@ func (s InvalidComputePlatformException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidComputePlatformException) OrigErr() error {
+func (s *InvalidComputePlatformException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidComputePlatformException) Error() string {
+func (s *InvalidComputePlatformException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidComputePlatformException) StatusCode() int {
+func (s *InvalidComputePlatformException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidComputePlatformException) RequestID() string {
+func (s *InvalidComputePlatformException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11970,12 +11970,12 @@ func newErrorInvalidDeployedStateFilterException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InvalidDeployedStateFilterException) Code() string {
+func (s *InvalidDeployedStateFilterException) Code() string {
 	return "InvalidDeployedStateFilterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeployedStateFilterException) Message() string {
+func (s *InvalidDeployedStateFilterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11983,21 +11983,21 @@ func (s InvalidDeployedStateFilterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeployedStateFilterException) OrigErr() error {
+func (s *InvalidDeployedStateFilterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeployedStateFilterException) Error() string {
+func (s *InvalidDeployedStateFilterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeployedStateFilterException) StatusCode() int {
+func (s *InvalidDeployedStateFilterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeployedStateFilterException) RequestID() string {
+func (s *InvalidDeployedStateFilterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12026,12 +12026,12 @@ func newErrorInvalidDeploymentConfigNameException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidDeploymentConfigNameException) Code() string {
+func (s *InvalidDeploymentConfigNameException) Code() string {
 	return "InvalidDeploymentConfigNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeploymentConfigNameException) Message() string {
+func (s *InvalidDeploymentConfigNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12039,21 +12039,21 @@ func (s InvalidDeploymentConfigNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeploymentConfigNameException) OrigErr() error {
+func (s *InvalidDeploymentConfigNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeploymentConfigNameException) Error() string {
+func (s *InvalidDeploymentConfigNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeploymentConfigNameException) StatusCode() int {
+func (s *InvalidDeploymentConfigNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeploymentConfigNameException) RequestID() string {
+func (s *InvalidDeploymentConfigNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12082,12 +12082,12 @@ func newErrorInvalidDeploymentGroupNameException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InvalidDeploymentGroupNameException) Code() string {
+func (s *InvalidDeploymentGroupNameException) Code() string {
 	return "InvalidDeploymentGroupNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeploymentGroupNameException) Message() string {
+func (s *InvalidDeploymentGroupNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12095,21 +12095,21 @@ func (s InvalidDeploymentGroupNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeploymentGroupNameException) OrigErr() error {
+func (s *InvalidDeploymentGroupNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeploymentGroupNameException) Error() string {
+func (s *InvalidDeploymentGroupNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeploymentGroupNameException) StatusCode() int {
+func (s *InvalidDeploymentGroupNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeploymentGroupNameException) RequestID() string {
+func (s *InvalidDeploymentGroupNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12138,12 +12138,12 @@ func newErrorInvalidDeploymentIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDeploymentIdException) Code() string {
+func (s *InvalidDeploymentIdException) Code() string {
 	return "InvalidDeploymentIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeploymentIdException) Message() string {
+func (s *InvalidDeploymentIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12151,21 +12151,21 @@ func (s InvalidDeploymentIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeploymentIdException) OrigErr() error {
+func (s *InvalidDeploymentIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeploymentIdException) Error() string {
+func (s *InvalidDeploymentIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeploymentIdException) StatusCode() int {
+func (s *InvalidDeploymentIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeploymentIdException) RequestID() string {
+func (s *InvalidDeploymentIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12195,12 +12195,12 @@ func newErrorInvalidDeploymentInstanceTypeException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s InvalidDeploymentInstanceTypeException) Code() string {
+func (s *InvalidDeploymentInstanceTypeException) Code() string {
 	return "InvalidDeploymentInstanceTypeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeploymentInstanceTypeException) Message() string {
+func (s *InvalidDeploymentInstanceTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12208,21 +12208,21 @@ func (s InvalidDeploymentInstanceTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeploymentInstanceTypeException) OrigErr() error {
+func (s *InvalidDeploymentInstanceTypeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeploymentInstanceTypeException) Error() string {
+func (s *InvalidDeploymentInstanceTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeploymentInstanceTypeException) StatusCode() int {
+func (s *InvalidDeploymentInstanceTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeploymentInstanceTypeException) RequestID() string {
+func (s *InvalidDeploymentInstanceTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12251,12 +12251,12 @@ func newErrorInvalidDeploymentStatusException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidDeploymentStatusException) Code() string {
+func (s *InvalidDeploymentStatusException) Code() string {
 	return "InvalidDeploymentStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeploymentStatusException) Message() string {
+func (s *InvalidDeploymentStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12264,21 +12264,21 @@ func (s InvalidDeploymentStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeploymentStatusException) OrigErr() error {
+func (s *InvalidDeploymentStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeploymentStatusException) Error() string {
+func (s *InvalidDeploymentStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeploymentStatusException) StatusCode() int {
+func (s *InvalidDeploymentStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeploymentStatusException) RequestID() string {
+func (s *InvalidDeploymentStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12309,12 +12309,12 @@ func newErrorInvalidDeploymentStyleException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidDeploymentStyleException) Code() string {
+func (s *InvalidDeploymentStyleException) Code() string {
 	return "InvalidDeploymentStyleException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeploymentStyleException) Message() string {
+func (s *InvalidDeploymentStyleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12322,21 +12322,21 @@ func (s InvalidDeploymentStyleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeploymentStyleException) OrigErr() error {
+func (s *InvalidDeploymentStyleException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeploymentStyleException) Error() string {
+func (s *InvalidDeploymentStyleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeploymentStyleException) StatusCode() int {
+func (s *InvalidDeploymentStyleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeploymentStyleException) RequestID() string {
+func (s *InvalidDeploymentStyleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12365,12 +12365,12 @@ func newErrorInvalidDeploymentTargetIdException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidDeploymentTargetIdException) Code() string {
+func (s *InvalidDeploymentTargetIdException) Code() string {
 	return "InvalidDeploymentTargetIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeploymentTargetIdException) Message() string {
+func (s *InvalidDeploymentTargetIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12378,21 +12378,21 @@ func (s InvalidDeploymentTargetIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeploymentTargetIdException) OrigErr() error {
+func (s *InvalidDeploymentTargetIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeploymentTargetIdException) Error() string {
+func (s *InvalidDeploymentTargetIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeploymentTargetIdException) StatusCode() int {
+func (s *InvalidDeploymentTargetIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeploymentTargetIdException) RequestID() string {
+func (s *InvalidDeploymentTargetIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12421,12 +12421,12 @@ func newErrorInvalidDeploymentWaitTypeException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidDeploymentWaitTypeException) Code() string {
+func (s *InvalidDeploymentWaitTypeException) Code() string {
 	return "InvalidDeploymentWaitTypeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeploymentWaitTypeException) Message() string {
+func (s *InvalidDeploymentWaitTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12434,21 +12434,21 @@ func (s InvalidDeploymentWaitTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeploymentWaitTypeException) OrigErr() error {
+func (s *InvalidDeploymentWaitTypeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeploymentWaitTypeException) Error() string {
+func (s *InvalidDeploymentWaitTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeploymentWaitTypeException) StatusCode() int {
+func (s *InvalidDeploymentWaitTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeploymentWaitTypeException) RequestID() string {
+func (s *InvalidDeploymentWaitTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12478,12 +12478,12 @@ func newErrorInvalidEC2TagCombinationException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s InvalidEC2TagCombinationException) Code() string {
+func (s *InvalidEC2TagCombinationException) Code() string {
 	return "InvalidEC2TagCombinationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEC2TagCombinationException) Message() string {
+func (s *InvalidEC2TagCombinationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12491,21 +12491,21 @@ func (s InvalidEC2TagCombinationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEC2TagCombinationException) OrigErr() error {
+func (s *InvalidEC2TagCombinationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEC2TagCombinationException) Error() string {
+func (s *InvalidEC2TagCombinationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEC2TagCombinationException) StatusCode() int {
+func (s *InvalidEC2TagCombinationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEC2TagCombinationException) RequestID() string {
+func (s *InvalidEC2TagCombinationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12534,12 +12534,12 @@ func newErrorInvalidEC2TagException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidEC2TagException) Code() string {
+func (s *InvalidEC2TagException) Code() string {
 	return "InvalidEC2TagException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEC2TagException) Message() string {
+func (s *InvalidEC2TagException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12547,21 +12547,21 @@ func (s InvalidEC2TagException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEC2TagException) OrigErr() error {
+func (s *InvalidEC2TagException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEC2TagException) Error() string {
+func (s *InvalidEC2TagException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEC2TagException) StatusCode() int {
+func (s *InvalidEC2TagException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEC2TagException) RequestID() string {
+func (s *InvalidEC2TagException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12590,12 +12590,12 @@ func newErrorInvalidECSServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidECSServiceException) Code() string {
+func (s *InvalidECSServiceException) Code() string {
 	return "InvalidECSServiceException"
 }
 
 // Message returns the exception's message.
-func (s InvalidECSServiceException) Message() string {
+func (s *InvalidECSServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12603,21 +12603,21 @@ func (s InvalidECSServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidECSServiceException) OrigErr() error {
+func (s *InvalidECSServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidECSServiceException) Error() string {
+func (s *InvalidECSServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidECSServiceException) StatusCode() int {
+func (s *InvalidECSServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidECSServiceException) RequestID() string {
+func (s *InvalidECSServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12649,12 +12649,12 @@ func newErrorInvalidFileExistsBehaviorException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidFileExistsBehaviorException) Code() string {
+func (s *InvalidFileExistsBehaviorException) Code() string {
 	return "InvalidFileExistsBehaviorException"
 }
 
 // Message returns the exception's message.
-func (s InvalidFileExistsBehaviorException) Message() string {
+func (s *InvalidFileExistsBehaviorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12662,21 +12662,21 @@ func (s InvalidFileExistsBehaviorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFileExistsBehaviorException) OrigErr() error {
+func (s *InvalidFileExistsBehaviorException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFileExistsBehaviorException) Error() string {
+func (s *InvalidFileExistsBehaviorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFileExistsBehaviorException) StatusCode() int {
+func (s *InvalidFileExistsBehaviorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFileExistsBehaviorException) RequestID() string {
+func (s *InvalidFileExistsBehaviorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12705,12 +12705,12 @@ func newErrorInvalidGitHubAccountTokenException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidGitHubAccountTokenException) Code() string {
+func (s *InvalidGitHubAccountTokenException) Code() string {
 	return "InvalidGitHubAccountTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidGitHubAccountTokenException) Message() string {
+func (s *InvalidGitHubAccountTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12718,21 +12718,21 @@ func (s InvalidGitHubAccountTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidGitHubAccountTokenException) OrigErr() error {
+func (s *InvalidGitHubAccountTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidGitHubAccountTokenException) Error() string {
+func (s *InvalidGitHubAccountTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidGitHubAccountTokenException) StatusCode() int {
+func (s *InvalidGitHubAccountTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidGitHubAccountTokenException) RequestID() string {
+func (s *InvalidGitHubAccountTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12761,12 +12761,12 @@ func newErrorInvalidGitHubAccountTokenNameException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s InvalidGitHubAccountTokenNameException) Code() string {
+func (s *InvalidGitHubAccountTokenNameException) Code() string {
 	return "InvalidGitHubAccountTokenNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidGitHubAccountTokenNameException) Message() string {
+func (s *InvalidGitHubAccountTokenNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12774,21 +12774,21 @@ func (s InvalidGitHubAccountTokenNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidGitHubAccountTokenNameException) OrigErr() error {
+func (s *InvalidGitHubAccountTokenNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidGitHubAccountTokenNameException) Error() string {
+func (s *InvalidGitHubAccountTokenNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidGitHubAccountTokenNameException) StatusCode() int {
+func (s *InvalidGitHubAccountTokenNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidGitHubAccountTokenNameException) RequestID() string {
+func (s *InvalidGitHubAccountTokenNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12817,12 +12817,12 @@ func newErrorInvalidIamSessionArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidIamSessionArnException) Code() string {
+func (s *InvalidIamSessionArnException) Code() string {
 	return "InvalidIamSessionArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidIamSessionArnException) Message() string {
+func (s *InvalidIamSessionArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12830,21 +12830,21 @@ func (s InvalidIamSessionArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidIamSessionArnException) OrigErr() error {
+func (s *InvalidIamSessionArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidIamSessionArnException) Error() string {
+func (s *InvalidIamSessionArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidIamSessionArnException) StatusCode() int {
+func (s *InvalidIamSessionArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidIamSessionArnException) RequestID() string {
+func (s *InvalidIamSessionArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12873,12 +12873,12 @@ func newErrorInvalidIamUserArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidIamUserArnException) Code() string {
+func (s *InvalidIamUserArnException) Code() string {
 	return "InvalidIamUserArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidIamUserArnException) Message() string {
+func (s *InvalidIamUserArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12886,21 +12886,21 @@ func (s InvalidIamUserArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidIamUserArnException) OrigErr() error {
+func (s *InvalidIamUserArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidIamUserArnException) Error() string {
+func (s *InvalidIamUserArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidIamUserArnException) StatusCode() int {
+func (s *InvalidIamUserArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidIamUserArnException) RequestID() string {
+func (s *InvalidIamUserArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12930,12 +12930,12 @@ func newErrorInvalidIgnoreApplicationStopFailuresValueException(v protocol.Respo
 }
 
 // Code returns the exception type name.
-func (s InvalidIgnoreApplicationStopFailuresValueException) Code() string {
+func (s *InvalidIgnoreApplicationStopFailuresValueException) Code() string {
 	return "InvalidIgnoreApplicationStopFailuresValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidIgnoreApplicationStopFailuresValueException) Message() string {
+func (s *InvalidIgnoreApplicationStopFailuresValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12943,21 +12943,21 @@ func (s InvalidIgnoreApplicationStopFailuresValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidIgnoreApplicationStopFailuresValueException) OrigErr() error {
+func (s *InvalidIgnoreApplicationStopFailuresValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidIgnoreApplicationStopFailuresValueException) Error() string {
+func (s *InvalidIgnoreApplicationStopFailuresValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidIgnoreApplicationStopFailuresValueException) StatusCode() int {
+func (s *InvalidIgnoreApplicationStopFailuresValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidIgnoreApplicationStopFailuresValueException) RequestID() string {
+func (s *InvalidIgnoreApplicationStopFailuresValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12986,12 +12986,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12999,21 +12999,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13042,12 +13042,12 @@ func newErrorInvalidInstanceNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInstanceNameException) Code() string {
+func (s *InvalidInstanceNameException) Code() string {
 	return "InvalidInstanceNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInstanceNameException) Message() string {
+func (s *InvalidInstanceNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13055,21 +13055,21 @@ func (s InvalidInstanceNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInstanceNameException) OrigErr() error {
+func (s *InvalidInstanceNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInstanceNameException) Error() string {
+func (s *InvalidInstanceNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInstanceNameException) StatusCode() int {
+func (s *InvalidInstanceNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInstanceNameException) RequestID() string {
+func (s *InvalidInstanceNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13098,12 +13098,12 @@ func newErrorInvalidInstanceStatusException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInstanceStatusException) Code() string {
+func (s *InvalidInstanceStatusException) Code() string {
 	return "InvalidInstanceStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInstanceStatusException) Message() string {
+func (s *InvalidInstanceStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13111,21 +13111,21 @@ func (s InvalidInstanceStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInstanceStatusException) OrigErr() error {
+func (s *InvalidInstanceStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInstanceStatusException) Error() string {
+func (s *InvalidInstanceStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInstanceStatusException) StatusCode() int {
+func (s *InvalidInstanceStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInstanceStatusException) RequestID() string {
+func (s *InvalidInstanceStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13156,12 +13156,12 @@ func newErrorInvalidInstanceTypeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInstanceTypeException) Code() string {
+func (s *InvalidInstanceTypeException) Code() string {
 	return "InvalidInstanceTypeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInstanceTypeException) Message() string {
+func (s *InvalidInstanceTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13169,21 +13169,21 @@ func (s InvalidInstanceTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInstanceTypeException) OrigErr() error {
+func (s *InvalidInstanceTypeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInstanceTypeException) Error() string {
+func (s *InvalidInstanceTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInstanceTypeException) StatusCode() int {
+func (s *InvalidInstanceTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInstanceTypeException) RequestID() string {
+func (s *InvalidInstanceTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13212,12 +13212,12 @@ func newErrorInvalidKeyPrefixFilterException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidKeyPrefixFilterException) Code() string {
+func (s *InvalidKeyPrefixFilterException) Code() string {
 	return "InvalidKeyPrefixFilterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidKeyPrefixFilterException) Message() string {
+func (s *InvalidKeyPrefixFilterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13225,21 +13225,21 @@ func (s InvalidKeyPrefixFilterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidKeyPrefixFilterException) OrigErr() error {
+func (s *InvalidKeyPrefixFilterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidKeyPrefixFilterException) Error() string {
+func (s *InvalidKeyPrefixFilterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidKeyPrefixFilterException) StatusCode() int {
+func (s *InvalidKeyPrefixFilterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidKeyPrefixFilterException) RequestID() string {
+func (s *InvalidKeyPrefixFilterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13269,12 +13269,12 @@ func newErrorInvalidLifecycleEventHookExecutionIdException(v protocol.ResponseMe
 }
 
 // Code returns the exception type name.
-func (s InvalidLifecycleEventHookExecutionIdException) Code() string {
+func (s *InvalidLifecycleEventHookExecutionIdException) Code() string {
 	return "InvalidLifecycleEventHookExecutionIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLifecycleEventHookExecutionIdException) Message() string {
+func (s *InvalidLifecycleEventHookExecutionIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13282,21 +13282,21 @@ func (s InvalidLifecycleEventHookExecutionIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLifecycleEventHookExecutionIdException) OrigErr() error {
+func (s *InvalidLifecycleEventHookExecutionIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLifecycleEventHookExecutionIdException) Error() string {
+func (s *InvalidLifecycleEventHookExecutionIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLifecycleEventHookExecutionIdException) StatusCode() int {
+func (s *InvalidLifecycleEventHookExecutionIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLifecycleEventHookExecutionIdException) RequestID() string {
+func (s *InvalidLifecycleEventHookExecutionIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13326,12 +13326,12 @@ func newErrorInvalidLifecycleEventHookExecutionStatusException(v protocol.Respon
 }
 
 // Code returns the exception type name.
-func (s InvalidLifecycleEventHookExecutionStatusException) Code() string {
+func (s *InvalidLifecycleEventHookExecutionStatusException) Code() string {
 	return "InvalidLifecycleEventHookExecutionStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLifecycleEventHookExecutionStatusException) Message() string {
+func (s *InvalidLifecycleEventHookExecutionStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13339,21 +13339,21 @@ func (s InvalidLifecycleEventHookExecutionStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLifecycleEventHookExecutionStatusException) OrigErr() error {
+func (s *InvalidLifecycleEventHookExecutionStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLifecycleEventHookExecutionStatusException) Error() string {
+func (s *InvalidLifecycleEventHookExecutionStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLifecycleEventHookExecutionStatusException) StatusCode() int {
+func (s *InvalidLifecycleEventHookExecutionStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLifecycleEventHookExecutionStatusException) RequestID() string {
+func (s *InvalidLifecycleEventHookExecutionStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13382,12 +13382,12 @@ func newErrorInvalidLoadBalancerInfoException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidLoadBalancerInfoException) Code() string {
+func (s *InvalidLoadBalancerInfoException) Code() string {
 	return "InvalidLoadBalancerInfoException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLoadBalancerInfoException) Message() string {
+func (s *InvalidLoadBalancerInfoException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13395,21 +13395,21 @@ func (s InvalidLoadBalancerInfoException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLoadBalancerInfoException) OrigErr() error {
+func (s *InvalidLoadBalancerInfoException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLoadBalancerInfoException) Error() string {
+func (s *InvalidLoadBalancerInfoException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLoadBalancerInfoException) StatusCode() int {
+func (s *InvalidLoadBalancerInfoException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLoadBalancerInfoException) RequestID() string {
+func (s *InvalidLoadBalancerInfoException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13438,12 +13438,12 @@ func newErrorInvalidMinimumHealthyHostValueException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s InvalidMinimumHealthyHostValueException) Code() string {
+func (s *InvalidMinimumHealthyHostValueException) Code() string {
 	return "InvalidMinimumHealthyHostValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidMinimumHealthyHostValueException) Message() string {
+func (s *InvalidMinimumHealthyHostValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13451,21 +13451,21 @@ func (s InvalidMinimumHealthyHostValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidMinimumHealthyHostValueException) OrigErr() error {
+func (s *InvalidMinimumHealthyHostValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidMinimumHealthyHostValueException) Error() string {
+func (s *InvalidMinimumHealthyHostValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidMinimumHealthyHostValueException) StatusCode() int {
+func (s *InvalidMinimumHealthyHostValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidMinimumHealthyHostValueException) RequestID() string {
+func (s *InvalidMinimumHealthyHostValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13494,12 +13494,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13507,21 +13507,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13551,12 +13551,12 @@ func newErrorInvalidOnPremisesTagCombinationException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s InvalidOnPremisesTagCombinationException) Code() string {
+func (s *InvalidOnPremisesTagCombinationException) Code() string {
 	return "InvalidOnPremisesTagCombinationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOnPremisesTagCombinationException) Message() string {
+func (s *InvalidOnPremisesTagCombinationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13564,21 +13564,21 @@ func (s InvalidOnPremisesTagCombinationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOnPremisesTagCombinationException) OrigErr() error {
+func (s *InvalidOnPremisesTagCombinationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOnPremisesTagCombinationException) Error() string {
+func (s *InvalidOnPremisesTagCombinationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOnPremisesTagCombinationException) StatusCode() int {
+func (s *InvalidOnPremisesTagCombinationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOnPremisesTagCombinationException) RequestID() string {
+func (s *InvalidOnPremisesTagCombinationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13607,12 +13607,12 @@ func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOperationException) Code() string {
+func (s *InvalidOperationException) Code() string {
 	return "InvalidOperationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOperationException) Message() string {
+func (s *InvalidOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13620,21 +13620,21 @@ func (s InvalidOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOperationException) OrigErr() error {
+func (s *InvalidOperationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOperationException) Error() string {
+func (s *InvalidOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOperationException) StatusCode() int {
+func (s *InvalidOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOperationException) RequestID() string {
+func (s *InvalidOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13663,12 +13663,12 @@ func newErrorInvalidRegistrationStatusException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidRegistrationStatusException) Code() string {
+func (s *InvalidRegistrationStatusException) Code() string {
 	return "InvalidRegistrationStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRegistrationStatusException) Message() string {
+func (s *InvalidRegistrationStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13676,21 +13676,21 @@ func (s InvalidRegistrationStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRegistrationStatusException) OrigErr() error {
+func (s *InvalidRegistrationStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRegistrationStatusException) Error() string {
+func (s *InvalidRegistrationStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRegistrationStatusException) StatusCode() int {
+func (s *InvalidRegistrationStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRegistrationStatusException) RequestID() string {
+func (s *InvalidRegistrationStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13719,12 +13719,12 @@ func newErrorInvalidRevisionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRevisionException) Code() string {
+func (s *InvalidRevisionException) Code() string {
 	return "InvalidRevisionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRevisionException) Message() string {
+func (s *InvalidRevisionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13732,21 +13732,21 @@ func (s InvalidRevisionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRevisionException) OrigErr() error {
+func (s *InvalidRevisionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRevisionException) Error() string {
+func (s *InvalidRevisionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRevisionException) StatusCode() int {
+func (s *InvalidRevisionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRevisionException) RequestID() string {
+func (s *InvalidRevisionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13777,12 +13777,12 @@ func newErrorInvalidRoleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRoleException) Code() string {
+func (s *InvalidRoleException) Code() string {
 	return "InvalidRoleException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRoleException) Message() string {
+func (s *InvalidRoleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13790,21 +13790,21 @@ func (s InvalidRoleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRoleException) OrigErr() error {
+func (s *InvalidRoleException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRoleException) Error() string {
+func (s *InvalidRoleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRoleException) StatusCode() int {
+func (s *InvalidRoleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRoleException) RequestID() string {
+func (s *InvalidRoleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13834,12 +13834,12 @@ func newErrorInvalidSortByException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSortByException) Code() string {
+func (s *InvalidSortByException) Code() string {
 	return "InvalidSortByException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSortByException) Message() string {
+func (s *InvalidSortByException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13847,21 +13847,21 @@ func (s InvalidSortByException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSortByException) OrigErr() error {
+func (s *InvalidSortByException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSortByException) Error() string {
+func (s *InvalidSortByException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSortByException) StatusCode() int {
+func (s *InvalidSortByException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSortByException) RequestID() string {
+func (s *InvalidSortByException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13890,12 +13890,12 @@ func newErrorInvalidSortOrderException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSortOrderException) Code() string {
+func (s *InvalidSortOrderException) Code() string {
 	return "InvalidSortOrderException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSortOrderException) Message() string {
+func (s *InvalidSortOrderException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13903,21 +13903,21 @@ func (s InvalidSortOrderException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSortOrderException) OrigErr() error {
+func (s *InvalidSortOrderException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSortOrderException) Error() string {
+func (s *InvalidSortOrderException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSortOrderException) StatusCode() int {
+func (s *InvalidSortOrderException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSortOrderException) RequestID() string {
+func (s *InvalidSortOrderException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13946,12 +13946,12 @@ func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagException) Code() string {
+func (s *InvalidTagException) Code() string {
 	return "InvalidTagException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagException) Message() string {
+func (s *InvalidTagException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13959,21 +13959,21 @@ func (s InvalidTagException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagException) OrigErr() error {
+func (s *InvalidTagException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagException) Error() string {
+func (s *InvalidTagException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagException) StatusCode() int {
+func (s *InvalidTagException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagException) RequestID() string {
+func (s *InvalidTagException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14002,12 +14002,12 @@ func newErrorInvalidTagFilterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagFilterException) Code() string {
+func (s *InvalidTagFilterException) Code() string {
 	return "InvalidTagFilterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagFilterException) Message() string {
+func (s *InvalidTagFilterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14015,21 +14015,21 @@ func (s InvalidTagFilterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagFilterException) OrigErr() error {
+func (s *InvalidTagFilterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagFilterException) Error() string {
+func (s *InvalidTagFilterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagFilterException) StatusCode() int {
+func (s *InvalidTagFilterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagFilterException) RequestID() string {
+func (s *InvalidTagFilterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14058,12 +14058,12 @@ func newErrorInvalidTagsToAddException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagsToAddException) Code() string {
+func (s *InvalidTagsToAddException) Code() string {
 	return "InvalidTagsToAddException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagsToAddException) Message() string {
+func (s *InvalidTagsToAddException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14071,21 +14071,21 @@ func (s InvalidTagsToAddException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagsToAddException) OrigErr() error {
+func (s *InvalidTagsToAddException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagsToAddException) Error() string {
+func (s *InvalidTagsToAddException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagsToAddException) StatusCode() int {
+func (s *InvalidTagsToAddException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagsToAddException) RequestID() string {
+func (s *InvalidTagsToAddException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14114,12 +14114,12 @@ func newErrorInvalidTargetFilterNameException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidTargetFilterNameException) Code() string {
+func (s *InvalidTargetFilterNameException) Code() string {
 	return "InvalidTargetFilterNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTargetFilterNameException) Message() string {
+func (s *InvalidTargetFilterNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14127,21 +14127,21 @@ func (s InvalidTargetFilterNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTargetFilterNameException) OrigErr() error {
+func (s *InvalidTargetFilterNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTargetFilterNameException) Error() string {
+func (s *InvalidTargetFilterNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTargetFilterNameException) StatusCode() int {
+func (s *InvalidTargetFilterNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTargetFilterNameException) RequestID() string {
+func (s *InvalidTargetFilterNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14170,12 +14170,12 @@ func newErrorInvalidTargetGroupPairException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidTargetGroupPairException) Code() string {
+func (s *InvalidTargetGroupPairException) Code() string {
 	return "InvalidTargetGroupPairException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTargetGroupPairException) Message() string {
+func (s *InvalidTargetGroupPairException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14183,21 +14183,21 @@ func (s InvalidTargetGroupPairException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTargetGroupPairException) OrigErr() error {
+func (s *InvalidTargetGroupPairException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTargetGroupPairException) Error() string {
+func (s *InvalidTargetGroupPairException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTargetGroupPairException) StatusCode() int {
+func (s *InvalidTargetGroupPairException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTargetGroupPairException) RequestID() string {
+func (s *InvalidTargetGroupPairException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14235,12 +14235,12 @@ func newErrorInvalidTargetInstancesException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidTargetInstancesException) Code() string {
+func (s *InvalidTargetInstancesException) Code() string {
 	return "InvalidTargetInstancesException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTargetInstancesException) Message() string {
+func (s *InvalidTargetInstancesException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14248,21 +14248,21 @@ func (s InvalidTargetInstancesException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTargetInstancesException) OrigErr() error {
+func (s *InvalidTargetInstancesException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTargetInstancesException) Error() string {
+func (s *InvalidTargetInstancesException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTargetInstancesException) StatusCode() int {
+func (s *InvalidTargetInstancesException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTargetInstancesException) RequestID() string {
+func (s *InvalidTargetInstancesException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14291,12 +14291,12 @@ func newErrorInvalidTimeRangeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTimeRangeException) Code() string {
+func (s *InvalidTimeRangeException) Code() string {
 	return "InvalidTimeRangeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTimeRangeException) Message() string {
+func (s *InvalidTimeRangeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14304,21 +14304,21 @@ func (s InvalidTimeRangeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTimeRangeException) OrigErr() error {
+func (s *InvalidTimeRangeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTimeRangeException) Error() string {
+func (s *InvalidTimeRangeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTimeRangeException) StatusCode() int {
+func (s *InvalidTimeRangeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTimeRangeException) RequestID() string {
+func (s *InvalidTimeRangeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14348,12 +14348,12 @@ func newErrorInvalidTrafficRoutingConfigurationException(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s InvalidTrafficRoutingConfigurationException) Code() string {
+func (s *InvalidTrafficRoutingConfigurationException) Code() string {
 	return "InvalidTrafficRoutingConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTrafficRoutingConfigurationException) Message() string {
+func (s *InvalidTrafficRoutingConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14361,21 +14361,21 @@ func (s InvalidTrafficRoutingConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTrafficRoutingConfigurationException) OrigErr() error {
+func (s *InvalidTrafficRoutingConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTrafficRoutingConfigurationException) Error() string {
+func (s *InvalidTrafficRoutingConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTrafficRoutingConfigurationException) StatusCode() int {
+func (s *InvalidTrafficRoutingConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTrafficRoutingConfigurationException) RequestID() string {
+func (s *InvalidTrafficRoutingConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14404,12 +14404,12 @@ func newErrorInvalidTriggerConfigException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTriggerConfigException) Code() string {
+func (s *InvalidTriggerConfigException) Code() string {
 	return "InvalidTriggerConfigException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTriggerConfigException) Message() string {
+func (s *InvalidTriggerConfigException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14417,21 +14417,21 @@ func (s InvalidTriggerConfigException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTriggerConfigException) OrigErr() error {
+func (s *InvalidTriggerConfigException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTriggerConfigException) Error() string {
+func (s *InvalidTriggerConfigException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTriggerConfigException) StatusCode() int {
+func (s *InvalidTriggerConfigException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTriggerConfigException) RequestID() string {
+func (s *InvalidTriggerConfigException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14461,12 +14461,12 @@ func newErrorInvalidUpdateOutdatedInstancesOnlyValueException(v protocol.Respons
 }
 
 // Code returns the exception type name.
-func (s InvalidUpdateOutdatedInstancesOnlyValueException) Code() string {
+func (s *InvalidUpdateOutdatedInstancesOnlyValueException) Code() string {
 	return "InvalidUpdateOutdatedInstancesOnlyValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidUpdateOutdatedInstancesOnlyValueException) Message() string {
+func (s *InvalidUpdateOutdatedInstancesOnlyValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14474,21 +14474,21 @@ func (s InvalidUpdateOutdatedInstancesOnlyValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidUpdateOutdatedInstancesOnlyValueException) OrigErr() error {
+func (s *InvalidUpdateOutdatedInstancesOnlyValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidUpdateOutdatedInstancesOnlyValueException) Error() string {
+func (s *InvalidUpdateOutdatedInstancesOnlyValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidUpdateOutdatedInstancesOnlyValueException) StatusCode() int {
+func (s *InvalidUpdateOutdatedInstancesOnlyValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidUpdateOutdatedInstancesOnlyValueException) RequestID() string {
+func (s *InvalidUpdateOutdatedInstancesOnlyValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14785,12 +14785,12 @@ func newErrorLifecycleEventAlreadyCompletedException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s LifecycleEventAlreadyCompletedException) Code() string {
+func (s *LifecycleEventAlreadyCompletedException) Code() string {
 	return "LifecycleEventAlreadyCompletedException"
 }
 
 // Message returns the exception's message.
-func (s LifecycleEventAlreadyCompletedException) Message() string {
+func (s *LifecycleEventAlreadyCompletedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14798,21 +14798,21 @@ func (s LifecycleEventAlreadyCompletedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LifecycleEventAlreadyCompletedException) OrigErr() error {
+func (s *LifecycleEventAlreadyCompletedException) OrigErr() error {
 	return nil
 }
 
-func (s LifecycleEventAlreadyCompletedException) Error() string {
+func (s *LifecycleEventAlreadyCompletedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LifecycleEventAlreadyCompletedException) StatusCode() int {
+func (s *LifecycleEventAlreadyCompletedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LifecycleEventAlreadyCompletedException) RequestID() string {
+func (s *LifecycleEventAlreadyCompletedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14841,12 +14841,12 @@ func newErrorLifecycleHookLimitExceededException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s LifecycleHookLimitExceededException) Code() string {
+func (s *LifecycleHookLimitExceededException) Code() string {
 	return "LifecycleHookLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LifecycleHookLimitExceededException) Message() string {
+func (s *LifecycleHookLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14854,21 +14854,21 @@ func (s LifecycleHookLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LifecycleHookLimitExceededException) OrigErr() error {
+func (s *LifecycleHookLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LifecycleHookLimitExceededException) Error() string {
+func (s *LifecycleHookLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LifecycleHookLimitExceededException) StatusCode() int {
+func (s *LifecycleHookLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LifecycleHookLimitExceededException) RequestID() string {
+func (s *LifecycleHookLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15948,12 +15948,12 @@ func newErrorMultipleIamArnsProvidedException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s MultipleIamArnsProvidedException) Code() string {
+func (s *MultipleIamArnsProvidedException) Code() string {
 	return "MultipleIamArnsProvidedException"
 }
 
 // Message returns the exception's message.
-func (s MultipleIamArnsProvidedException) Message() string {
+func (s *MultipleIamArnsProvidedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15961,21 +15961,21 @@ func (s MultipleIamArnsProvidedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MultipleIamArnsProvidedException) OrigErr() error {
+func (s *MultipleIamArnsProvidedException) OrigErr() error {
 	return nil
 }
 
-func (s MultipleIamArnsProvidedException) Error() string {
+func (s *MultipleIamArnsProvidedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MultipleIamArnsProvidedException) StatusCode() int {
+func (s *MultipleIamArnsProvidedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MultipleIamArnsProvidedException) RequestID() string {
+func (s *MultipleIamArnsProvidedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16030,12 +16030,12 @@ func newErrorOperationNotSupportedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotSupportedException) Code() string {
+func (s *OperationNotSupportedException) Code() string {
 	return "OperationNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s OperationNotSupportedException) Message() string {
+func (s *OperationNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16043,21 +16043,21 @@ func (s OperationNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotSupportedException) OrigErr() error {
+func (s *OperationNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotSupportedException) Error() string {
+func (s *OperationNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotSupportedException) StatusCode() int {
+func (s *OperationNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotSupportedException) RequestID() string {
+func (s *OperationNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16412,12 +16412,12 @@ func newErrorResourceArnRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceArnRequiredException) Code() string {
+func (s *ResourceArnRequiredException) Code() string {
 	return "ResourceArnRequiredException"
 }
 
 // Message returns the exception's message.
-func (s ResourceArnRequiredException) Message() string {
+func (s *ResourceArnRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16425,21 +16425,21 @@ func (s ResourceArnRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceArnRequiredException) OrigErr() error {
+func (s *ResourceArnRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceArnRequiredException) Error() string {
+func (s *ResourceArnRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceArnRequiredException) StatusCode() int {
+func (s *ResourceArnRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceArnRequiredException) RequestID() string {
+func (s *ResourceArnRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16468,12 +16468,12 @@ func newErrorResourceValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceValidationException) Code() string {
+func (s *ResourceValidationException) Code() string {
 	return "ResourceValidationException"
 }
 
 // Message returns the exception's message.
-func (s ResourceValidationException) Message() string {
+func (s *ResourceValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16481,21 +16481,21 @@ func (s ResourceValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceValidationException) OrigErr() error {
+func (s *ResourceValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceValidationException) Error() string {
+func (s *ResourceValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceValidationException) StatusCode() int {
+func (s *ResourceValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceValidationException) RequestID() string {
+func (s *ResourceValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16524,12 +16524,12 @@ func newErrorRevisionDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RevisionDoesNotExistException) Code() string {
+func (s *RevisionDoesNotExistException) Code() string {
 	return "RevisionDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s RevisionDoesNotExistException) Message() string {
+func (s *RevisionDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16537,21 +16537,21 @@ func (s RevisionDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RevisionDoesNotExistException) OrigErr() error {
+func (s *RevisionDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s RevisionDoesNotExistException) Error() string {
+func (s *RevisionDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RevisionDoesNotExistException) StatusCode() int {
+func (s *RevisionDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RevisionDoesNotExistException) RequestID() string {
+func (s *RevisionDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16684,12 +16684,12 @@ func newErrorRevisionRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RevisionRequiredException) Code() string {
+func (s *RevisionRequiredException) Code() string {
 	return "RevisionRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RevisionRequiredException) Message() string {
+func (s *RevisionRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16697,21 +16697,21 @@ func (s RevisionRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RevisionRequiredException) OrigErr() error {
+func (s *RevisionRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RevisionRequiredException) Error() string {
+func (s *RevisionRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RevisionRequiredException) StatusCode() int {
+func (s *RevisionRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RevisionRequiredException) RequestID() string {
+func (s *RevisionRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16740,12 +16740,12 @@ func newErrorRoleRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RoleRequiredException) Code() string {
+func (s *RoleRequiredException) Code() string {
 	return "RoleRequiredException"
 }
 
 // Message returns the exception's message.
-func (s RoleRequiredException) Message() string {
+func (s *RoleRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16753,21 +16753,21 @@ func (s RoleRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RoleRequiredException) OrigErr() error {
+func (s *RoleRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s RoleRequiredException) Error() string {
+func (s *RoleRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RoleRequiredException) StatusCode() int {
+func (s *RoleRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RoleRequiredException) RequestID() string {
+func (s *RoleRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17122,12 +17122,12 @@ func newErrorTagLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagLimitExceededException) Code() string {
+func (s *TagLimitExceededException) Code() string {
 	return "TagLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TagLimitExceededException) Message() string {
+func (s *TagLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17135,21 +17135,21 @@ func (s TagLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagLimitExceededException) OrigErr() error {
+func (s *TagLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TagLimitExceededException) Error() string {
+func (s *TagLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagLimitExceededException) StatusCode() int {
+func (s *TagLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagLimitExceededException) RequestID() string {
+func (s *TagLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17178,12 +17178,12 @@ func newErrorTagRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagRequiredException) Code() string {
+func (s *TagRequiredException) Code() string {
 	return "TagRequiredException"
 }
 
 // Message returns the exception's message.
-func (s TagRequiredException) Message() string {
+func (s *TagRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17191,21 +17191,21 @@ func (s TagRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagRequiredException) OrigErr() error {
+func (s *TagRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s TagRequiredException) Error() string {
+func (s *TagRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagRequiredException) StatusCode() int {
+func (s *TagRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagRequiredException) RequestID() string {
+func (s *TagRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17305,12 +17305,12 @@ func newErrorTagSetListLimitExceededException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s TagSetListLimitExceededException) Code() string {
+func (s *TagSetListLimitExceededException) Code() string {
 	return "TagSetListLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TagSetListLimitExceededException) Message() string {
+func (s *TagSetListLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17318,21 +17318,21 @@ func (s TagSetListLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagSetListLimitExceededException) OrigErr() error {
+func (s *TagSetListLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TagSetListLimitExceededException) Error() string {
+func (s *TagSetListLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagSetListLimitExceededException) StatusCode() int {
+func (s *TagSetListLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagSetListLimitExceededException) RequestID() string {
+func (s *TagSetListLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17488,12 +17488,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17501,21 +17501,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17775,12 +17775,12 @@ func newErrorTriggerTargetsLimitExceededException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s TriggerTargetsLimitExceededException) Code() string {
+func (s *TriggerTargetsLimitExceededException) Code() string {
 	return "TriggerTargetsLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TriggerTargetsLimitExceededException) Message() string {
+func (s *TriggerTargetsLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17788,21 +17788,21 @@ func (s TriggerTargetsLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TriggerTargetsLimitExceededException) OrigErr() error {
+func (s *TriggerTargetsLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TriggerTargetsLimitExceededException) Error() string {
+func (s *TriggerTargetsLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TriggerTargetsLimitExceededException) StatusCode() int {
+func (s *TriggerTargetsLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TriggerTargetsLimitExceededException) RequestID() string {
+func (s *TriggerTargetsLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17831,12 +17831,12 @@ func newErrorUnsupportedActionForDeploymentTypeException(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s UnsupportedActionForDeploymentTypeException) Code() string {
+func (s *UnsupportedActionForDeploymentTypeException) Code() string {
 	return "UnsupportedActionForDeploymentTypeException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedActionForDeploymentTypeException) Message() string {
+func (s *UnsupportedActionForDeploymentTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17844,21 +17844,21 @@ func (s UnsupportedActionForDeploymentTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedActionForDeploymentTypeException) OrigErr() error {
+func (s *UnsupportedActionForDeploymentTypeException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedActionForDeploymentTypeException) Error() string {
+func (s *UnsupportedActionForDeploymentTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedActionForDeploymentTypeException) StatusCode() int {
+func (s *UnsupportedActionForDeploymentTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedActionForDeploymentTypeException) RequestID() string {
+func (s *UnsupportedActionForDeploymentTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/codeguruprofiler/api.go
+++ b/service/codeguruprofiler/api.go
@@ -1140,12 +1140,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1153,21 +1153,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1568,12 +1568,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1581,21 +1581,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2131,12 +2131,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2144,21 +2144,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2189,12 +2189,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2202,21 +2202,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2245,12 +2245,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2258,21 +2258,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2386,12 +2386,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2399,21 +2399,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/codegurureviewer/api.go
+++ b/service/codegurureviewer/api.go
@@ -468,12 +468,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -481,21 +481,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -666,12 +666,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -679,21 +679,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -850,12 +850,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -863,21 +863,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1051,12 +1051,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1064,21 +1064,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1340,12 +1340,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1353,21 +1353,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1396,12 +1396,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1409,21 +1409,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -4707,12 +4707,12 @@ func newErrorActionNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ActionNotFoundException) Code() string {
+func (s *ActionNotFoundException) Code() string {
 	return "ActionNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ActionNotFoundException) Message() string {
+func (s *ActionNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4720,21 +4720,21 @@ func (s ActionNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ActionNotFoundException) OrigErr() error {
+func (s *ActionNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ActionNotFoundException) Error() string {
+func (s *ActionNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ActionNotFoundException) StatusCode() int {
+func (s *ActionNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ActionNotFoundException) RequestID() string {
+func (s *ActionNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5060,12 +5060,12 @@ func newErrorActionTypeNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ActionTypeNotFoundException) Code() string {
+func (s *ActionTypeNotFoundException) Code() string {
 	return "ActionTypeNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ActionTypeNotFoundException) Message() string {
+func (s *ActionTypeNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5073,21 +5073,21 @@ func (s ActionTypeNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ActionTypeNotFoundException) OrigErr() error {
+func (s *ActionTypeNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ActionTypeNotFoundException) Error() string {
+func (s *ActionTypeNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ActionTypeNotFoundException) StatusCode() int {
+func (s *ActionTypeNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ActionTypeNotFoundException) RequestID() string {
+func (s *ActionTypeNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5199,12 +5199,12 @@ func newErrorApprovalAlreadyCompletedException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ApprovalAlreadyCompletedException) Code() string {
+func (s *ApprovalAlreadyCompletedException) Code() string {
 	return "ApprovalAlreadyCompletedException"
 }
 
 // Message returns the exception's message.
-func (s ApprovalAlreadyCompletedException) Message() string {
+func (s *ApprovalAlreadyCompletedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5212,21 +5212,21 @@ func (s ApprovalAlreadyCompletedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ApprovalAlreadyCompletedException) OrigErr() error {
+func (s *ApprovalAlreadyCompletedException) OrigErr() error {
 	return nil
 }
 
-func (s ApprovalAlreadyCompletedException) Error() string {
+func (s *ApprovalAlreadyCompletedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ApprovalAlreadyCompletedException) StatusCode() int {
+func (s *ApprovalAlreadyCompletedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ApprovalAlreadyCompletedException) RequestID() string {
+func (s *ApprovalAlreadyCompletedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5684,12 +5684,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5697,21 +5697,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6488,12 +6488,12 @@ func newErrorDuplicatedStopRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicatedStopRequestException) Code() string {
+func (s *DuplicatedStopRequestException) Code() string {
 	return "DuplicatedStopRequestException"
 }
 
 // Message returns the exception's message.
-func (s DuplicatedStopRequestException) Message() string {
+func (s *DuplicatedStopRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6501,21 +6501,21 @@ func (s DuplicatedStopRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicatedStopRequestException) OrigErr() error {
+func (s *DuplicatedStopRequestException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicatedStopRequestException) Error() string {
+func (s *DuplicatedStopRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicatedStopRequestException) StatusCode() int {
+func (s *DuplicatedStopRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicatedStopRequestException) RequestID() string {
+func (s *DuplicatedStopRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7370,12 +7370,12 @@ func newErrorInvalidActionDeclarationException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s InvalidActionDeclarationException) Code() string {
+func (s *InvalidActionDeclarationException) Code() string {
 	return "InvalidActionDeclarationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidActionDeclarationException) Message() string {
+func (s *InvalidActionDeclarationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7383,21 +7383,21 @@ func (s InvalidActionDeclarationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidActionDeclarationException) OrigErr() error {
+func (s *InvalidActionDeclarationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidActionDeclarationException) Error() string {
+func (s *InvalidActionDeclarationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidActionDeclarationException) StatusCode() int {
+func (s *InvalidActionDeclarationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidActionDeclarationException) RequestID() string {
+func (s *InvalidActionDeclarationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7426,12 +7426,12 @@ func newErrorInvalidApprovalTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidApprovalTokenException) Code() string {
+func (s *InvalidApprovalTokenException) Code() string {
 	return "InvalidApprovalTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApprovalTokenException) Message() string {
+func (s *InvalidApprovalTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7439,21 +7439,21 @@ func (s InvalidApprovalTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApprovalTokenException) OrigErr() error {
+func (s *InvalidApprovalTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApprovalTokenException) Error() string {
+func (s *InvalidApprovalTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApprovalTokenException) StatusCode() int {
+func (s *InvalidApprovalTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApprovalTokenException) RequestID() string {
+func (s *InvalidApprovalTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7482,12 +7482,12 @@ func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArnException) Code() string {
+func (s *InvalidArnException) Code() string {
 	return "InvalidArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArnException) Message() string {
+func (s *InvalidArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7495,21 +7495,21 @@ func (s InvalidArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArnException) OrigErr() error {
+func (s *InvalidArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArnException) Error() string {
+func (s *InvalidArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArnException) StatusCode() int {
+func (s *InvalidArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArnException) RequestID() string {
+func (s *InvalidArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7538,12 +7538,12 @@ func newErrorInvalidBlockerDeclarationException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidBlockerDeclarationException) Code() string {
+func (s *InvalidBlockerDeclarationException) Code() string {
 	return "InvalidBlockerDeclarationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidBlockerDeclarationException) Message() string {
+func (s *InvalidBlockerDeclarationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7551,21 +7551,21 @@ func (s InvalidBlockerDeclarationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidBlockerDeclarationException) OrigErr() error {
+func (s *InvalidBlockerDeclarationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidBlockerDeclarationException) Error() string {
+func (s *InvalidBlockerDeclarationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidBlockerDeclarationException) StatusCode() int {
+func (s *InvalidBlockerDeclarationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidBlockerDeclarationException) RequestID() string {
+func (s *InvalidBlockerDeclarationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7594,12 +7594,12 @@ func newErrorInvalidClientTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidClientTokenException) Code() string {
+func (s *InvalidClientTokenException) Code() string {
 	return "InvalidClientTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidClientTokenException) Message() string {
+func (s *InvalidClientTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7607,21 +7607,21 @@ func (s InvalidClientTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidClientTokenException) OrigErr() error {
+func (s *InvalidClientTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidClientTokenException) Error() string {
+func (s *InvalidClientTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidClientTokenException) StatusCode() int {
+func (s *InvalidClientTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidClientTokenException) RequestID() string {
+func (s *InvalidClientTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7650,12 +7650,12 @@ func newErrorInvalidJobException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidJobException) Code() string {
+func (s *InvalidJobException) Code() string {
 	return "InvalidJobException"
 }
 
 // Message returns the exception's message.
-func (s InvalidJobException) Message() string {
+func (s *InvalidJobException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7663,21 +7663,21 @@ func (s InvalidJobException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidJobException) OrigErr() error {
+func (s *InvalidJobException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidJobException) Error() string {
+func (s *InvalidJobException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidJobException) StatusCode() int {
+func (s *InvalidJobException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidJobException) RequestID() string {
+func (s *InvalidJobException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7706,12 +7706,12 @@ func newErrorInvalidJobStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidJobStateException) Code() string {
+func (s *InvalidJobStateException) Code() string {
 	return "InvalidJobStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidJobStateException) Message() string {
+func (s *InvalidJobStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7719,21 +7719,21 @@ func (s InvalidJobStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidJobStateException) OrigErr() error {
+func (s *InvalidJobStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidJobStateException) Error() string {
+func (s *InvalidJobStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidJobStateException) StatusCode() int {
+func (s *InvalidJobStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidJobStateException) RequestID() string {
+func (s *InvalidJobStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7763,12 +7763,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7776,21 +7776,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7819,12 +7819,12 @@ func newErrorInvalidNonceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNonceException) Code() string {
+func (s *InvalidNonceException) Code() string {
 	return "InvalidNonceException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNonceException) Message() string {
+func (s *InvalidNonceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7832,21 +7832,21 @@ func (s InvalidNonceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNonceException) OrigErr() error {
+func (s *InvalidNonceException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNonceException) Error() string {
+func (s *InvalidNonceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNonceException) StatusCode() int {
+func (s *InvalidNonceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNonceException) RequestID() string {
+func (s *InvalidNonceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7875,12 +7875,12 @@ func newErrorInvalidStageDeclarationException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidStageDeclarationException) Code() string {
+func (s *InvalidStageDeclarationException) Code() string {
 	return "InvalidStageDeclarationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStageDeclarationException) Message() string {
+func (s *InvalidStageDeclarationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7888,21 +7888,21 @@ func (s InvalidStageDeclarationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStageDeclarationException) OrigErr() error {
+func (s *InvalidStageDeclarationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStageDeclarationException) Error() string {
+func (s *InvalidStageDeclarationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStageDeclarationException) StatusCode() int {
+func (s *InvalidStageDeclarationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStageDeclarationException) RequestID() string {
+func (s *InvalidStageDeclarationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7931,12 +7931,12 @@ func newErrorInvalidStructureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidStructureException) Code() string {
+func (s *InvalidStructureException) Code() string {
 	return "InvalidStructureException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStructureException) Message() string {
+func (s *InvalidStructureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7944,21 +7944,21 @@ func (s InvalidStructureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStructureException) OrigErr() error {
+func (s *InvalidStructureException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStructureException) Error() string {
+func (s *InvalidStructureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStructureException) StatusCode() int {
+func (s *InvalidStructureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStructureException) RequestID() string {
+func (s *InvalidStructureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7987,12 +7987,12 @@ func newErrorInvalidTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagsException) Code() string {
+func (s *InvalidTagsException) Code() string {
 	return "InvalidTagsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagsException) Message() string {
+func (s *InvalidTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8000,21 +8000,21 @@ func (s InvalidTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagsException) OrigErr() error {
+func (s *InvalidTagsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagsException) Error() string {
+func (s *InvalidTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagsException) StatusCode() int {
+func (s *InvalidTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagsException) RequestID() string {
+func (s *InvalidTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8043,12 +8043,12 @@ func newErrorInvalidWebhookAuthenticationParametersException(v protocol.Response
 }
 
 // Code returns the exception type name.
-func (s InvalidWebhookAuthenticationParametersException) Code() string {
+func (s *InvalidWebhookAuthenticationParametersException) Code() string {
 	return "InvalidWebhookAuthenticationParametersException"
 }
 
 // Message returns the exception's message.
-func (s InvalidWebhookAuthenticationParametersException) Message() string {
+func (s *InvalidWebhookAuthenticationParametersException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8056,21 +8056,21 @@ func (s InvalidWebhookAuthenticationParametersException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidWebhookAuthenticationParametersException) OrigErr() error {
+func (s *InvalidWebhookAuthenticationParametersException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidWebhookAuthenticationParametersException) Error() string {
+func (s *InvalidWebhookAuthenticationParametersException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidWebhookAuthenticationParametersException) StatusCode() int {
+func (s *InvalidWebhookAuthenticationParametersException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidWebhookAuthenticationParametersException) RequestID() string {
+func (s *InvalidWebhookAuthenticationParametersException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8099,12 +8099,12 @@ func newErrorInvalidWebhookFilterPatternException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidWebhookFilterPatternException) Code() string {
+func (s *InvalidWebhookFilterPatternException) Code() string {
 	return "InvalidWebhookFilterPatternException"
 }
 
 // Message returns the exception's message.
-func (s InvalidWebhookFilterPatternException) Message() string {
+func (s *InvalidWebhookFilterPatternException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8112,21 +8112,21 @@ func (s InvalidWebhookFilterPatternException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidWebhookFilterPatternException) OrigErr() error {
+func (s *InvalidWebhookFilterPatternException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidWebhookFilterPatternException) Error() string {
+func (s *InvalidWebhookFilterPatternException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidWebhookFilterPatternException) StatusCode() int {
+func (s *InvalidWebhookFilterPatternException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidWebhookFilterPatternException) RequestID() string {
+func (s *InvalidWebhookFilterPatternException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8346,12 +8346,12 @@ func newErrorJobNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s JobNotFoundException) Code() string {
+func (s *JobNotFoundException) Code() string {
 	return "JobNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s JobNotFoundException) Message() string {
+func (s *JobNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8359,21 +8359,21 @@ func (s JobNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s JobNotFoundException) OrigErr() error {
+func (s *JobNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s JobNotFoundException) Error() string {
+func (s *JobNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s JobNotFoundException) StatusCode() int {
+func (s *JobNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s JobNotFoundException) RequestID() string {
+func (s *JobNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8403,12 +8403,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8416,21 +8416,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9109,12 +9109,12 @@ func newErrorNotLatestPipelineExecutionException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s NotLatestPipelineExecutionException) Code() string {
+func (s *NotLatestPipelineExecutionException) Code() string {
 	return "NotLatestPipelineExecutionException"
 }
 
 // Message returns the exception's message.
-func (s NotLatestPipelineExecutionException) Message() string {
+func (s *NotLatestPipelineExecutionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9122,21 +9122,21 @@ func (s NotLatestPipelineExecutionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotLatestPipelineExecutionException) OrigErr() error {
+func (s *NotLatestPipelineExecutionException) OrigErr() error {
 	return nil
 }
 
-func (s NotLatestPipelineExecutionException) Error() string {
+func (s *NotLatestPipelineExecutionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotLatestPipelineExecutionException) StatusCode() int {
+func (s *NotLatestPipelineExecutionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotLatestPipelineExecutionException) RequestID() string {
+func (s *NotLatestPipelineExecutionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9215,12 +9215,12 @@ func newErrorOutputVariablesSizeExceededException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s OutputVariablesSizeExceededException) Code() string {
+func (s *OutputVariablesSizeExceededException) Code() string {
 	return "OutputVariablesSizeExceededException"
 }
 
 // Message returns the exception's message.
-func (s OutputVariablesSizeExceededException) Message() string {
+func (s *OutputVariablesSizeExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9228,21 +9228,21 @@ func (s OutputVariablesSizeExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OutputVariablesSizeExceededException) OrigErr() error {
+func (s *OutputVariablesSizeExceededException) OrigErr() error {
 	return nil
 }
 
-func (s OutputVariablesSizeExceededException) Error() string {
+func (s *OutputVariablesSizeExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OutputVariablesSizeExceededException) StatusCode() int {
+func (s *OutputVariablesSizeExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OutputVariablesSizeExceededException) RequestID() string {
+func (s *OutputVariablesSizeExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9555,12 +9555,12 @@ func newErrorPipelineExecutionNotFoundException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s PipelineExecutionNotFoundException) Code() string {
+func (s *PipelineExecutionNotFoundException) Code() string {
 	return "PipelineExecutionNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s PipelineExecutionNotFoundException) Message() string {
+func (s *PipelineExecutionNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9568,21 +9568,21 @@ func (s PipelineExecutionNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PipelineExecutionNotFoundException) OrigErr() error {
+func (s *PipelineExecutionNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s PipelineExecutionNotFoundException) Error() string {
+func (s *PipelineExecutionNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PipelineExecutionNotFoundException) StatusCode() int {
+func (s *PipelineExecutionNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PipelineExecutionNotFoundException) RequestID() string {
+func (s *PipelineExecutionNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9612,12 +9612,12 @@ func newErrorPipelineExecutionNotStoppableException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s PipelineExecutionNotStoppableException) Code() string {
+func (s *PipelineExecutionNotStoppableException) Code() string {
 	return "PipelineExecutionNotStoppableException"
 }
 
 // Message returns the exception's message.
-func (s PipelineExecutionNotStoppableException) Message() string {
+func (s *PipelineExecutionNotStoppableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9625,21 +9625,21 @@ func (s PipelineExecutionNotStoppableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PipelineExecutionNotStoppableException) OrigErr() error {
+func (s *PipelineExecutionNotStoppableException) OrigErr() error {
 	return nil
 }
 
-func (s PipelineExecutionNotStoppableException) Error() string {
+func (s *PipelineExecutionNotStoppableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PipelineExecutionNotStoppableException) StatusCode() int {
+func (s *PipelineExecutionNotStoppableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PipelineExecutionNotStoppableException) RequestID() string {
+func (s *PipelineExecutionNotStoppableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9809,12 +9809,12 @@ func newErrorPipelineNameInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PipelineNameInUseException) Code() string {
+func (s *PipelineNameInUseException) Code() string {
 	return "PipelineNameInUseException"
 }
 
 // Message returns the exception's message.
-func (s PipelineNameInUseException) Message() string {
+func (s *PipelineNameInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9822,21 +9822,21 @@ func (s PipelineNameInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PipelineNameInUseException) OrigErr() error {
+func (s *PipelineNameInUseException) OrigErr() error {
 	return nil
 }
 
-func (s PipelineNameInUseException) Error() string {
+func (s *PipelineNameInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PipelineNameInUseException) StatusCode() int {
+func (s *PipelineNameInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PipelineNameInUseException) RequestID() string {
+func (s *PipelineNameInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9865,12 +9865,12 @@ func newErrorPipelineNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PipelineNotFoundException) Code() string {
+func (s *PipelineNotFoundException) Code() string {
 	return "PipelineNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s PipelineNotFoundException) Message() string {
+func (s *PipelineNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9878,21 +9878,21 @@ func (s PipelineNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PipelineNotFoundException) OrigErr() error {
+func (s *PipelineNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s PipelineNotFoundException) Error() string {
+func (s *PipelineNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PipelineNotFoundException) StatusCode() int {
+func (s *PipelineNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PipelineNotFoundException) RequestID() string {
+func (s *PipelineNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9972,12 +9972,12 @@ func newErrorPipelineVersionNotFoundException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s PipelineVersionNotFoundException) Code() string {
+func (s *PipelineVersionNotFoundException) Code() string {
 	return "PipelineVersionNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s PipelineVersionNotFoundException) Message() string {
+func (s *PipelineVersionNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9985,21 +9985,21 @@ func (s PipelineVersionNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PipelineVersionNotFoundException) OrigErr() error {
+func (s *PipelineVersionNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s PipelineVersionNotFoundException) Error() string {
+func (s *PipelineVersionNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PipelineVersionNotFoundException) StatusCode() int {
+func (s *PipelineVersionNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PipelineVersionNotFoundException) RequestID() string {
+func (s *PipelineVersionNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11003,12 +11003,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11016,21 +11016,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11450,12 +11450,12 @@ func newErrorStageNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StageNotFoundException) Code() string {
+func (s *StageNotFoundException) Code() string {
 	return "StageNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s StageNotFoundException) Message() string {
+func (s *StageNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11463,21 +11463,21 @@ func (s StageNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StageNotFoundException) OrigErr() error {
+func (s *StageNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s StageNotFoundException) Error() string {
+func (s *StageNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StageNotFoundException) StatusCode() int {
+func (s *StageNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StageNotFoundException) RequestID() string {
+func (s *StageNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11507,12 +11507,12 @@ func newErrorStageNotRetryableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StageNotRetryableException) Code() string {
+func (s *StageNotRetryableException) Code() string {
 	return "StageNotRetryableException"
 }
 
 // Message returns the exception's message.
-func (s StageNotRetryableException) Message() string {
+func (s *StageNotRetryableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11520,21 +11520,21 @@ func (s StageNotRetryableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StageNotRetryableException) OrigErr() error {
+func (s *StageNotRetryableException) OrigErr() error {
 	return nil
 }
 
-func (s StageNotRetryableException) Error() string {
+func (s *StageNotRetryableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StageNotRetryableException) StatusCode() int {
+func (s *StageNotRetryableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StageNotRetryableException) RequestID() string {
+func (s *StageNotRetryableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12129,12 +12129,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12142,21 +12142,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12372,12 +12372,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12385,21 +12385,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12696,12 +12696,12 @@ func newErrorWebhookNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WebhookNotFoundException) Code() string {
+func (s *WebhookNotFoundException) Code() string {
 	return "WebhookNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s WebhookNotFoundException) Message() string {
+func (s *WebhookNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12709,21 +12709,21 @@ func (s WebhookNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WebhookNotFoundException) OrigErr() error {
+func (s *WebhookNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s WebhookNotFoundException) Error() string {
+func (s *WebhookNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WebhookNotFoundException) StatusCode() int {
+func (s *WebhookNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WebhookNotFoundException) RequestID() string {
+func (s *WebhookNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/codestar/api.go
+++ b/service/codestar/api.go
@@ -1971,12 +1971,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1984,21 +1984,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3007,12 +3007,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3020,21 +3020,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3063,12 +3063,12 @@ func newErrorInvalidServiceRoleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidServiceRoleException) Code() string {
+func (s *InvalidServiceRoleException) Code() string {
 	return "InvalidServiceRoleException"
 }
 
 // Message returns the exception's message.
-func (s InvalidServiceRoleException) Message() string {
+func (s *InvalidServiceRoleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3076,21 +3076,21 @@ func (s InvalidServiceRoleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidServiceRoleException) OrigErr() error {
+func (s *InvalidServiceRoleException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidServiceRoleException) Error() string {
+func (s *InvalidServiceRoleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidServiceRoleException) StatusCode() int {
+func (s *InvalidServiceRoleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidServiceRoleException) RequestID() string {
+func (s *InvalidServiceRoleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3119,12 +3119,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3132,21 +3132,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3642,12 +3642,12 @@ func newErrorProjectAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ProjectAlreadyExistsException) Code() string {
+func (s *ProjectAlreadyExistsException) Code() string {
 	return "ProjectAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ProjectAlreadyExistsException) Message() string {
+func (s *ProjectAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3655,21 +3655,21 @@ func (s ProjectAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProjectAlreadyExistsException) OrigErr() error {
+func (s *ProjectAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ProjectAlreadyExistsException) Error() string {
+func (s *ProjectAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProjectAlreadyExistsException) StatusCode() int {
+func (s *ProjectAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProjectAlreadyExistsException) RequestID() string {
+func (s *ProjectAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3698,12 +3698,12 @@ func newErrorProjectConfigurationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ProjectConfigurationException) Code() string {
+func (s *ProjectConfigurationException) Code() string {
 	return "ProjectConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s ProjectConfigurationException) Message() string {
+func (s *ProjectConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3711,21 +3711,21 @@ func (s ProjectConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProjectConfigurationException) OrigErr() error {
+func (s *ProjectConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s ProjectConfigurationException) Error() string {
+func (s *ProjectConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProjectConfigurationException) StatusCode() int {
+func (s *ProjectConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProjectConfigurationException) RequestID() string {
+func (s *ProjectConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3756,12 +3756,12 @@ func newErrorProjectCreationFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ProjectCreationFailedException) Code() string {
+func (s *ProjectCreationFailedException) Code() string {
 	return "ProjectCreationFailedException"
 }
 
 // Message returns the exception's message.
-func (s ProjectCreationFailedException) Message() string {
+func (s *ProjectCreationFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3769,21 +3769,21 @@ func (s ProjectCreationFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProjectCreationFailedException) OrigErr() error {
+func (s *ProjectCreationFailedException) OrigErr() error {
 	return nil
 }
 
-func (s ProjectCreationFailedException) Error() string {
+func (s *ProjectCreationFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProjectCreationFailedException) StatusCode() int {
+func (s *ProjectCreationFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProjectCreationFailedException) RequestID() string {
+func (s *ProjectCreationFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3812,12 +3812,12 @@ func newErrorProjectNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ProjectNotFoundException) Code() string {
+func (s *ProjectNotFoundException) Code() string {
 	return "ProjectNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ProjectNotFoundException) Message() string {
+func (s *ProjectNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3825,21 +3825,21 @@ func (s ProjectNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProjectNotFoundException) OrigErr() error {
+func (s *ProjectNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ProjectNotFoundException) Error() string {
+func (s *ProjectNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProjectNotFoundException) StatusCode() int {
+func (s *ProjectNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProjectNotFoundException) RequestID() string {
+func (s *ProjectNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4138,12 +4138,12 @@ func newErrorTeamMemberAlreadyAssociatedException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s TeamMemberAlreadyAssociatedException) Code() string {
+func (s *TeamMemberAlreadyAssociatedException) Code() string {
 	return "TeamMemberAlreadyAssociatedException"
 }
 
 // Message returns the exception's message.
-func (s TeamMemberAlreadyAssociatedException) Message() string {
+func (s *TeamMemberAlreadyAssociatedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4151,21 +4151,21 @@ func (s TeamMemberAlreadyAssociatedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TeamMemberAlreadyAssociatedException) OrigErr() error {
+func (s *TeamMemberAlreadyAssociatedException) OrigErr() error {
 	return nil
 }
 
-func (s TeamMemberAlreadyAssociatedException) Error() string {
+func (s *TeamMemberAlreadyAssociatedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TeamMemberAlreadyAssociatedException) StatusCode() int {
+func (s *TeamMemberAlreadyAssociatedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TeamMemberAlreadyAssociatedException) RequestID() string {
+func (s *TeamMemberAlreadyAssociatedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4194,12 +4194,12 @@ func newErrorTeamMemberNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TeamMemberNotFoundException) Code() string {
+func (s *TeamMemberNotFoundException) Code() string {
 	return "TeamMemberNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s TeamMemberNotFoundException) Message() string {
+func (s *TeamMemberNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4207,21 +4207,21 @@ func (s TeamMemberNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TeamMemberNotFoundException) OrigErr() error {
+func (s *TeamMemberNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s TeamMemberNotFoundException) Error() string {
+func (s *TeamMemberNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TeamMemberNotFoundException) StatusCode() int {
+func (s *TeamMemberNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TeamMemberNotFoundException) RequestID() string {
+func (s *TeamMemberNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4790,12 +4790,12 @@ func newErrorUserProfileAlreadyExistsException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s UserProfileAlreadyExistsException) Code() string {
+func (s *UserProfileAlreadyExistsException) Code() string {
 	return "UserProfileAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s UserProfileAlreadyExistsException) Message() string {
+func (s *UserProfileAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4803,21 +4803,21 @@ func (s UserProfileAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserProfileAlreadyExistsException) OrigErr() error {
+func (s *UserProfileAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s UserProfileAlreadyExistsException) Error() string {
+func (s *UserProfileAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserProfileAlreadyExistsException) StatusCode() int {
+func (s *UserProfileAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserProfileAlreadyExistsException) RequestID() string {
+func (s *UserProfileAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4846,12 +4846,12 @@ func newErrorUserProfileNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UserProfileNotFoundException) Code() string {
+func (s *UserProfileNotFoundException) Code() string {
 	return "UserProfileNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s UserProfileNotFoundException) Message() string {
+func (s *UserProfileNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4859,21 +4859,21 @@ func (s UserProfileNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserProfileNotFoundException) OrigErr() error {
+func (s *UserProfileNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s UserProfileNotFoundException) Error() string {
+func (s *UserProfileNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserProfileNotFoundException) StatusCode() int {
+func (s *UserProfileNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserProfileNotFoundException) RequestID() string {
+func (s *UserProfileNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4963,12 +4963,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4976,20 +4976,20 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }

--- a/service/codestarconnections/api.go
+++ b/service/codestarconnections/api.go
@@ -680,12 +680,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -693,21 +693,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -831,12 +831,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -844,21 +844,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/codestarnotifications/api.go
+++ b/service/codestarnotifications/api.go
@@ -1328,12 +1328,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1341,21 +1341,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1385,12 +1385,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1398,21 +1398,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1441,12 +1441,12 @@ func newErrorConfigurationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConfigurationException) Code() string {
+func (s *ConfigurationException) Code() string {
 	return "ConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s ConfigurationException) Message() string {
+func (s *ConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1454,21 +1454,21 @@ func (s ConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConfigurationException) OrigErr() error {
+func (s *ConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s ConfigurationException) Error() string {
+func (s *ConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConfigurationException) StatusCode() int {
+func (s *ConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConfigurationException) RequestID() string {
+func (s *ConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2012,12 +2012,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2025,21 +2025,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2070,12 +2070,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2083,21 +2083,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2700,12 +2700,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2713,21 +2713,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2757,12 +2757,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2770,21 +2770,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3335,12 +3335,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3348,21 +3348,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -2185,12 +2185,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2198,21 +2198,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2644,12 +2644,12 @@ func newErrorDeveloperUserAlreadyRegisteredException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s DeveloperUserAlreadyRegisteredException) Code() string {
+func (s *DeveloperUserAlreadyRegisteredException) Code() string {
 	return "DeveloperUserAlreadyRegisteredException"
 }
 
 // Message returns the exception's message.
-func (s DeveloperUserAlreadyRegisteredException) Message() string {
+func (s *DeveloperUserAlreadyRegisteredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2657,21 +2657,21 @@ func (s DeveloperUserAlreadyRegisteredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeveloperUserAlreadyRegisteredException) OrigErr() error {
+func (s *DeveloperUserAlreadyRegisteredException) OrigErr() error {
 	return nil
 }
 
-func (s DeveloperUserAlreadyRegisteredException) Error() string {
+func (s *DeveloperUserAlreadyRegisteredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeveloperUserAlreadyRegisteredException) StatusCode() int {
+func (s *DeveloperUserAlreadyRegisteredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeveloperUserAlreadyRegisteredException) RequestID() string {
+func (s *DeveloperUserAlreadyRegisteredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2702,12 +2702,12 @@ func newErrorExternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExternalServiceException) Code() string {
+func (s *ExternalServiceException) Code() string {
 	return "ExternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s ExternalServiceException) Message() string {
+func (s *ExternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2715,21 +2715,21 @@ func (s ExternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExternalServiceException) OrigErr() error {
+func (s *ExternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s ExternalServiceException) Error() string {
+func (s *ExternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExternalServiceException) StatusCode() int {
+func (s *ExternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExternalServiceException) RequestID() string {
+func (s *ExternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3513,12 +3513,12 @@ func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalErrorException) Code() string {
+func (s *InternalErrorException) Code() string {
 	return "InternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalErrorException) Message() string {
+func (s *InternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3526,21 +3526,21 @@ func (s InternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalErrorException) OrigErr() error {
+func (s *InternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalErrorException) Error() string {
+func (s *InternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalErrorException) StatusCode() int {
+func (s *InternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalErrorException) RequestID() string {
+func (s *InternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3571,12 +3571,12 @@ func newErrorInvalidIdentityPoolConfigurationException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s InvalidIdentityPoolConfigurationException) Code() string {
+func (s *InvalidIdentityPoolConfigurationException) Code() string {
 	return "InvalidIdentityPoolConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidIdentityPoolConfigurationException) Message() string {
+func (s *InvalidIdentityPoolConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3584,21 +3584,21 @@ func (s InvalidIdentityPoolConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidIdentityPoolConfigurationException) OrigErr() error {
+func (s *InvalidIdentityPoolConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidIdentityPoolConfigurationException) Error() string {
+func (s *InvalidIdentityPoolConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidIdentityPoolConfigurationException) StatusCode() int {
+func (s *InvalidIdentityPoolConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidIdentityPoolConfigurationException) RequestID() string {
+func (s *InvalidIdentityPoolConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3628,12 +3628,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3641,21 +3641,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3685,12 +3685,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3698,21 +3698,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4378,12 +4378,12 @@ func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotAuthorizedException) Code() string {
+func (s *NotAuthorizedException) Code() string {
 	return "NotAuthorizedException"
 }
 
 // Message returns the exception's message.
-func (s NotAuthorizedException) Message() string {
+func (s *NotAuthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4391,21 +4391,21 @@ func (s NotAuthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotAuthorizedException) OrigErr() error {
+func (s *NotAuthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s NotAuthorizedException) Error() string {
+func (s *NotAuthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotAuthorizedException) StatusCode() int {
+func (s *NotAuthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotAuthorizedException) RequestID() string {
+func (s *NotAuthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4503,12 +4503,12 @@ func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceConflictException) Code() string {
+func (s *ResourceConflictException) Code() string {
 	return "ResourceConflictException"
 }
 
 // Message returns the exception's message.
-func (s ResourceConflictException) Message() string {
+func (s *ResourceConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4516,21 +4516,21 @@ func (s ResourceConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceConflictException) OrigErr() error {
+func (s *ResourceConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceConflictException) Error() string {
+func (s *ResourceConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceConflictException) StatusCode() int {
+func (s *ResourceConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceConflictException) RequestID() string {
+func (s *ResourceConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4561,12 +4561,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4574,21 +4574,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4906,12 +4906,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4919,21 +4919,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cognitoidentityprovider/api.go
+++ b/service/cognitoidentityprovider/api.go
@@ -14797,12 +14797,12 @@ func newErrorAliasExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AliasExistsException) Code() string {
+func (s *AliasExistsException) Code() string {
 	return "AliasExistsException"
 }
 
 // Message returns the exception's message.
-func (s AliasExistsException) Message() string {
+func (s *AliasExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14810,21 +14810,21 @@ func (s AliasExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AliasExistsException) OrigErr() error {
+func (s *AliasExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AliasExistsException) Error() string {
+func (s *AliasExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AliasExistsException) StatusCode() int {
+func (s *AliasExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AliasExistsException) RequestID() string {
+func (s *AliasExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15425,12 +15425,12 @@ func newErrorCodeDeliveryFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CodeDeliveryFailureException) Code() string {
+func (s *CodeDeliveryFailureException) Code() string {
 	return "CodeDeliveryFailureException"
 }
 
 // Message returns the exception's message.
-func (s CodeDeliveryFailureException) Message() string {
+func (s *CodeDeliveryFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15438,21 +15438,21 @@ func (s CodeDeliveryFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CodeDeliveryFailureException) OrigErr() error {
+func (s *CodeDeliveryFailureException) OrigErr() error {
 	return nil
 }
 
-func (s CodeDeliveryFailureException) Error() string {
+func (s *CodeDeliveryFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CodeDeliveryFailureException) StatusCode() int {
+func (s *CodeDeliveryFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CodeDeliveryFailureException) RequestID() string {
+func (s *CodeDeliveryFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15483,12 +15483,12 @@ func newErrorCodeMismatchException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CodeMismatchException) Code() string {
+func (s *CodeMismatchException) Code() string {
 	return "CodeMismatchException"
 }
 
 // Message returns the exception's message.
-func (s CodeMismatchException) Message() string {
+func (s *CodeMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15496,21 +15496,21 @@ func (s CodeMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CodeMismatchException) OrigErr() error {
+func (s *CodeMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s CodeMismatchException) Error() string {
+func (s *CodeMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CodeMismatchException) StatusCode() int {
+func (s *CodeMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CodeMismatchException) RequestID() string {
+func (s *CodeMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15633,12 +15633,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15646,21 +15646,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18857,12 +18857,12 @@ func newErrorDuplicateProviderException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateProviderException) Code() string {
+func (s *DuplicateProviderException) Code() string {
 	return "DuplicateProviderException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateProviderException) Message() string {
+func (s *DuplicateProviderException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18870,21 +18870,21 @@ func (s DuplicateProviderException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateProviderException) OrigErr() error {
+func (s *DuplicateProviderException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateProviderException) Error() string {
+func (s *DuplicateProviderException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateProviderException) StatusCode() int {
+func (s *DuplicateProviderException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateProviderException) RequestID() string {
+func (s *DuplicateProviderException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19053,12 +19053,12 @@ func newErrorEnableSoftwareTokenMFAException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s EnableSoftwareTokenMFAException) Code() string {
+func (s *EnableSoftwareTokenMFAException) Code() string {
 	return "EnableSoftwareTokenMFAException"
 }
 
 // Message returns the exception's message.
-func (s EnableSoftwareTokenMFAException) Message() string {
+func (s *EnableSoftwareTokenMFAException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19066,21 +19066,21 @@ func (s EnableSoftwareTokenMFAException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EnableSoftwareTokenMFAException) OrigErr() error {
+func (s *EnableSoftwareTokenMFAException) OrigErr() error {
 	return nil
 }
 
-func (s EnableSoftwareTokenMFAException) Error() string {
+func (s *EnableSoftwareTokenMFAException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EnableSoftwareTokenMFAException) StatusCode() int {
+func (s *EnableSoftwareTokenMFAException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EnableSoftwareTokenMFAException) RequestID() string {
+func (s *EnableSoftwareTokenMFAException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19259,12 +19259,12 @@ func newErrorExpiredCodeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExpiredCodeException) Code() string {
+func (s *ExpiredCodeException) Code() string {
 	return "ExpiredCodeException"
 }
 
 // Message returns the exception's message.
-func (s ExpiredCodeException) Message() string {
+func (s *ExpiredCodeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19272,21 +19272,21 @@ func (s ExpiredCodeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExpiredCodeException) OrigErr() error {
+func (s *ExpiredCodeException) OrigErr() error {
 	return nil
 }
 
-func (s ExpiredCodeException) Error() string {
+func (s *ExpiredCodeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExpiredCodeException) StatusCode() int {
+func (s *ExpiredCodeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExpiredCodeException) RequestID() string {
+func (s *ExpiredCodeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20377,12 +20377,12 @@ func newErrorGroupExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s GroupExistsException) Code() string {
+func (s *GroupExistsException) Code() string {
 	return "GroupExistsException"
 }
 
 // Message returns the exception's message.
-func (s GroupExistsException) Message() string {
+func (s *GroupExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20390,21 +20390,21 @@ func (s GroupExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GroupExistsException) OrigErr() error {
+func (s *GroupExistsException) OrigErr() error {
 	return nil
 }
 
-func (s GroupExistsException) Error() string {
+func (s *GroupExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GroupExistsException) StatusCode() int {
+func (s *GroupExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GroupExistsException) RequestID() string {
+func (s *GroupExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20938,12 +20938,12 @@ func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalErrorException) Code() string {
+func (s *InternalErrorException) Code() string {
 	return "InternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalErrorException) Message() string {
+func (s *InternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20951,21 +20951,21 @@ func (s InternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalErrorException) OrigErr() error {
+func (s *InternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalErrorException) Error() string {
+func (s *InternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalErrorException) StatusCode() int {
+func (s *InternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalErrorException) RequestID() string {
+func (s *InternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20997,12 +20997,12 @@ func newErrorInvalidEmailRoleAccessPolicyException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s InvalidEmailRoleAccessPolicyException) Code() string {
+func (s *InvalidEmailRoleAccessPolicyException) Code() string {
 	return "InvalidEmailRoleAccessPolicyException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEmailRoleAccessPolicyException) Message() string {
+func (s *InvalidEmailRoleAccessPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21010,21 +21010,21 @@ func (s InvalidEmailRoleAccessPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEmailRoleAccessPolicyException) OrigErr() error {
+func (s *InvalidEmailRoleAccessPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEmailRoleAccessPolicyException) Error() string {
+func (s *InvalidEmailRoleAccessPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEmailRoleAccessPolicyException) StatusCode() int {
+func (s *InvalidEmailRoleAccessPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEmailRoleAccessPolicyException) RequestID() string {
+func (s *InvalidEmailRoleAccessPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21056,12 +21056,12 @@ func newErrorInvalidLambdaResponseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidLambdaResponseException) Code() string {
+func (s *InvalidLambdaResponseException) Code() string {
 	return "InvalidLambdaResponseException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLambdaResponseException) Message() string {
+func (s *InvalidLambdaResponseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21069,21 +21069,21 @@ func (s InvalidLambdaResponseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLambdaResponseException) OrigErr() error {
+func (s *InvalidLambdaResponseException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLambdaResponseException) Error() string {
+func (s *InvalidLambdaResponseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLambdaResponseException) StatusCode() int {
+func (s *InvalidLambdaResponseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLambdaResponseException) RequestID() string {
+func (s *InvalidLambdaResponseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21112,12 +21112,12 @@ func newErrorInvalidOAuthFlowException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOAuthFlowException) Code() string {
+func (s *InvalidOAuthFlowException) Code() string {
 	return "InvalidOAuthFlowException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOAuthFlowException) Message() string {
+func (s *InvalidOAuthFlowException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21125,21 +21125,21 @@ func (s InvalidOAuthFlowException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOAuthFlowException) OrigErr() error {
+func (s *InvalidOAuthFlowException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOAuthFlowException) Error() string {
+func (s *InvalidOAuthFlowException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOAuthFlowException) StatusCode() int {
+func (s *InvalidOAuthFlowException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOAuthFlowException) RequestID() string {
+func (s *InvalidOAuthFlowException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21171,12 +21171,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21184,21 +21184,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21230,12 +21230,12 @@ func newErrorInvalidPasswordException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPasswordException) Code() string {
+func (s *InvalidPasswordException) Code() string {
 	return "InvalidPasswordException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPasswordException) Message() string {
+func (s *InvalidPasswordException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21243,21 +21243,21 @@ func (s InvalidPasswordException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPasswordException) OrigErr() error {
+func (s *InvalidPasswordException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPasswordException) Error() string {
+func (s *InvalidPasswordException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPasswordException) StatusCode() int {
+func (s *InvalidPasswordException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPasswordException) RequestID() string {
+func (s *InvalidPasswordException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21289,12 +21289,12 @@ func newErrorInvalidSmsRoleAccessPolicyException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InvalidSmsRoleAccessPolicyException) Code() string {
+func (s *InvalidSmsRoleAccessPolicyException) Code() string {
 	return "InvalidSmsRoleAccessPolicyException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSmsRoleAccessPolicyException) Message() string {
+func (s *InvalidSmsRoleAccessPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21302,21 +21302,21 @@ func (s InvalidSmsRoleAccessPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSmsRoleAccessPolicyException) OrigErr() error {
+func (s *InvalidSmsRoleAccessPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSmsRoleAccessPolicyException) Error() string {
+func (s *InvalidSmsRoleAccessPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSmsRoleAccessPolicyException) StatusCode() int {
+func (s *InvalidSmsRoleAccessPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSmsRoleAccessPolicyException) RequestID() string {
+func (s *InvalidSmsRoleAccessPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21350,12 +21350,12 @@ func newErrorInvalidSmsRoleTrustRelationshipException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s InvalidSmsRoleTrustRelationshipException) Code() string {
+func (s *InvalidSmsRoleTrustRelationshipException) Code() string {
 	return "InvalidSmsRoleTrustRelationshipException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSmsRoleTrustRelationshipException) Message() string {
+func (s *InvalidSmsRoleTrustRelationshipException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21363,21 +21363,21 @@ func (s InvalidSmsRoleTrustRelationshipException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSmsRoleTrustRelationshipException) OrigErr() error {
+func (s *InvalidSmsRoleTrustRelationshipException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSmsRoleTrustRelationshipException) Error() string {
+func (s *InvalidSmsRoleTrustRelationshipException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSmsRoleTrustRelationshipException) StatusCode() int {
+func (s *InvalidSmsRoleTrustRelationshipException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSmsRoleTrustRelationshipException) RequestID() string {
+func (s *InvalidSmsRoleTrustRelationshipException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21407,12 +21407,12 @@ func newErrorInvalidUserPoolConfigurationException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s InvalidUserPoolConfigurationException) Code() string {
+func (s *InvalidUserPoolConfigurationException) Code() string {
 	return "InvalidUserPoolConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidUserPoolConfigurationException) Message() string {
+func (s *InvalidUserPoolConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21420,21 +21420,21 @@ func (s InvalidUserPoolConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidUserPoolConfigurationException) OrigErr() error {
+func (s *InvalidUserPoolConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidUserPoolConfigurationException) Error() string {
+func (s *InvalidUserPoolConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidUserPoolConfigurationException) StatusCode() int {
+func (s *InvalidUserPoolConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidUserPoolConfigurationException) RequestID() string {
+func (s *InvalidUserPoolConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21610,12 +21610,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21623,21 +21623,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22688,12 +22688,12 @@ func newErrorMFAMethodNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MFAMethodNotFoundException) Code() string {
+func (s *MFAMethodNotFoundException) Code() string {
 	return "MFAMethodNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s MFAMethodNotFoundException) Message() string {
+func (s *MFAMethodNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22701,21 +22701,21 @@ func (s MFAMethodNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MFAMethodNotFoundException) OrigErr() error {
+func (s *MFAMethodNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s MFAMethodNotFoundException) Error() string {
+func (s *MFAMethodNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MFAMethodNotFoundException) StatusCode() int {
+func (s *MFAMethodNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MFAMethodNotFoundException) RequestID() string {
+func (s *MFAMethodNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22894,12 +22894,12 @@ func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotAuthorizedException) Code() string {
+func (s *NotAuthorizedException) Code() string {
 	return "NotAuthorizedException"
 }
 
 // Message returns the exception's message.
-func (s NotAuthorizedException) Message() string {
+func (s *NotAuthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22907,21 +22907,21 @@ func (s NotAuthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotAuthorizedException) OrigErr() error {
+func (s *NotAuthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s NotAuthorizedException) Error() string {
+func (s *NotAuthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotAuthorizedException) StatusCode() int {
+func (s *NotAuthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotAuthorizedException) RequestID() string {
+func (s *NotAuthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23251,12 +23251,12 @@ func newErrorPasswordResetRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PasswordResetRequiredException) Code() string {
+func (s *PasswordResetRequiredException) Code() string {
 	return "PasswordResetRequiredException"
 }
 
 // Message returns the exception's message.
-func (s PasswordResetRequiredException) Message() string {
+func (s *PasswordResetRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23264,21 +23264,21 @@ func (s PasswordResetRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PasswordResetRequiredException) OrigErr() error {
+func (s *PasswordResetRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s PasswordResetRequiredException) Error() string {
+func (s *PasswordResetRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PasswordResetRequiredException) StatusCode() int {
+func (s *PasswordResetRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PasswordResetRequiredException) RequestID() string {
+func (s *PasswordResetRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23308,12 +23308,12 @@ func newErrorPreconditionNotMetException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PreconditionNotMetException) Code() string {
+func (s *PreconditionNotMetException) Code() string {
 	return "PreconditionNotMetException"
 }
 
 // Message returns the exception's message.
-func (s PreconditionNotMetException) Message() string {
+func (s *PreconditionNotMetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23321,21 +23321,21 @@ func (s PreconditionNotMetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PreconditionNotMetException) OrigErr() error {
+func (s *PreconditionNotMetException) OrigErr() error {
 	return nil
 }
 
-func (s PreconditionNotMetException) Error() string {
+func (s *PreconditionNotMetException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PreconditionNotMetException) StatusCode() int {
+func (s *PreconditionNotMetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PreconditionNotMetException) RequestID() string {
+func (s *PreconditionNotMetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23686,12 +23686,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23699,21 +23699,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24318,12 +24318,12 @@ func newErrorScopeDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ScopeDoesNotExistException) Code() string {
+func (s *ScopeDoesNotExistException) Code() string {
 	return "ScopeDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s ScopeDoesNotExistException) Message() string {
+func (s *ScopeDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24331,21 +24331,21 @@ func (s ScopeDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ScopeDoesNotExistException) OrigErr() error {
+func (s *ScopeDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s ScopeDoesNotExistException) Error() string {
+func (s *ScopeDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ScopeDoesNotExistException) StatusCode() int {
+func (s *ScopeDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ScopeDoesNotExistException) RequestID() string {
+func (s *ScopeDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25222,12 +25222,12 @@ func newErrorSoftwareTokenMFANotFoundException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s SoftwareTokenMFANotFoundException) Code() string {
+func (s *SoftwareTokenMFANotFoundException) Code() string {
 	return "SoftwareTokenMFANotFoundException"
 }
 
 // Message returns the exception's message.
-func (s SoftwareTokenMFANotFoundException) Message() string {
+func (s *SoftwareTokenMFANotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25235,21 +25235,21 @@ func (s SoftwareTokenMFANotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SoftwareTokenMFANotFoundException) OrigErr() error {
+func (s *SoftwareTokenMFANotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s SoftwareTokenMFANotFoundException) Error() string {
+func (s *SoftwareTokenMFANotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SoftwareTokenMFANotFoundException) StatusCode() int {
+func (s *SoftwareTokenMFANotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SoftwareTokenMFANotFoundException) RequestID() string {
+func (s *SoftwareTokenMFANotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25608,12 +25608,12 @@ func newErrorTooManyFailedAttemptsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyFailedAttemptsException) Code() string {
+func (s *TooManyFailedAttemptsException) Code() string {
 	return "TooManyFailedAttemptsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyFailedAttemptsException) Message() string {
+func (s *TooManyFailedAttemptsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25621,21 +25621,21 @@ func (s TooManyFailedAttemptsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyFailedAttemptsException) OrigErr() error {
+func (s *TooManyFailedAttemptsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyFailedAttemptsException) Error() string {
+func (s *TooManyFailedAttemptsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyFailedAttemptsException) StatusCode() int {
+func (s *TooManyFailedAttemptsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyFailedAttemptsException) RequestID() string {
+func (s *TooManyFailedAttemptsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25667,12 +25667,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25680,21 +25680,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25805,12 +25805,12 @@ func newErrorUnexpectedLambdaException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnexpectedLambdaException) Code() string {
+func (s *UnexpectedLambdaException) Code() string {
 	return "UnexpectedLambdaException"
 }
 
 // Message returns the exception's message.
-func (s UnexpectedLambdaException) Message() string {
+func (s *UnexpectedLambdaException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25818,21 +25818,21 @@ func (s UnexpectedLambdaException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnexpectedLambdaException) OrigErr() error {
+func (s *UnexpectedLambdaException) OrigErr() error {
 	return nil
 }
 
-func (s UnexpectedLambdaException) Error() string {
+func (s *UnexpectedLambdaException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnexpectedLambdaException) StatusCode() int {
+func (s *UnexpectedLambdaException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnexpectedLambdaException) RequestID() string {
+func (s *UnexpectedLambdaException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25861,12 +25861,12 @@ func newErrorUnsupportedIdentityProviderException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s UnsupportedIdentityProviderException) Code() string {
+func (s *UnsupportedIdentityProviderException) Code() string {
 	return "UnsupportedIdentityProviderException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedIdentityProviderException) Message() string {
+func (s *UnsupportedIdentityProviderException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25874,21 +25874,21 @@ func (s UnsupportedIdentityProviderException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedIdentityProviderException) OrigErr() error {
+func (s *UnsupportedIdentityProviderException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedIdentityProviderException) Error() string {
+func (s *UnsupportedIdentityProviderException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedIdentityProviderException) StatusCode() int {
+func (s *UnsupportedIdentityProviderException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedIdentityProviderException) RequestID() string {
+func (s *UnsupportedIdentityProviderException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25918,12 +25918,12 @@ func newErrorUnsupportedUserStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedUserStateException) Code() string {
+func (s *UnsupportedUserStateException) Code() string {
 	return "UnsupportedUserStateException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedUserStateException) Message() string {
+func (s *UnsupportedUserStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25931,21 +25931,21 @@ func (s UnsupportedUserStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedUserStateException) OrigErr() error {
+func (s *UnsupportedUserStateException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedUserStateException) Error() string {
+func (s *UnsupportedUserStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedUserStateException) StatusCode() int {
+func (s *UnsupportedUserStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedUserStateException) RequestID() string {
+func (s *UnsupportedUserStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27455,12 +27455,12 @@ func newErrorUserImportInProgressException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UserImportInProgressException) Code() string {
+func (s *UserImportInProgressException) Code() string {
 	return "UserImportInProgressException"
 }
 
 // Message returns the exception's message.
-func (s UserImportInProgressException) Message() string {
+func (s *UserImportInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27468,21 +27468,21 @@ func (s UserImportInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserImportInProgressException) OrigErr() error {
+func (s *UserImportInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s UserImportInProgressException) Error() string {
+func (s *UserImportInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserImportInProgressException) StatusCode() int {
+func (s *UserImportInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserImportInProgressException) RequestID() string {
+func (s *UserImportInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27669,12 +27669,12 @@ func newErrorUserLambdaValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UserLambdaValidationException) Code() string {
+func (s *UserLambdaValidationException) Code() string {
 	return "UserLambdaValidationException"
 }
 
 // Message returns the exception's message.
-func (s UserLambdaValidationException) Message() string {
+func (s *UserLambdaValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27682,21 +27682,21 @@ func (s UserLambdaValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserLambdaValidationException) OrigErr() error {
+func (s *UserLambdaValidationException) OrigErr() error {
 	return nil
 }
 
-func (s UserLambdaValidationException) Error() string {
+func (s *UserLambdaValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserLambdaValidationException) StatusCode() int {
+func (s *UserLambdaValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserLambdaValidationException) RequestID() string {
+func (s *UserLambdaValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27726,12 +27726,12 @@ func newErrorUserNotConfirmedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UserNotConfirmedException) Code() string {
+func (s *UserNotConfirmedException) Code() string {
 	return "UserNotConfirmedException"
 }
 
 // Message returns the exception's message.
-func (s UserNotConfirmedException) Message() string {
+func (s *UserNotConfirmedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27739,21 +27739,21 @@ func (s UserNotConfirmedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserNotConfirmedException) OrigErr() error {
+func (s *UserNotConfirmedException) OrigErr() error {
 	return nil
 }
 
-func (s UserNotConfirmedException) Error() string {
+func (s *UserNotConfirmedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserNotConfirmedException) StatusCode() int {
+func (s *UserNotConfirmedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserNotConfirmedException) RequestID() string {
+func (s *UserNotConfirmedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27783,12 +27783,12 @@ func newErrorUserNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UserNotFoundException) Code() string {
+func (s *UserNotFoundException) Code() string {
 	return "UserNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s UserNotFoundException) Message() string {
+func (s *UserNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27796,21 +27796,21 @@ func (s UserNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserNotFoundException) OrigErr() error {
+func (s *UserNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s UserNotFoundException) Error() string {
+func (s *UserNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserNotFoundException) StatusCode() int {
+func (s *UserNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserNotFoundException) RequestID() string {
+func (s *UserNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27839,12 +27839,12 @@ func newErrorUserPoolAddOnNotEnabledException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s UserPoolAddOnNotEnabledException) Code() string {
+func (s *UserPoolAddOnNotEnabledException) Code() string {
 	return "UserPoolAddOnNotEnabledException"
 }
 
 // Message returns the exception's message.
-func (s UserPoolAddOnNotEnabledException) Message() string {
+func (s *UserPoolAddOnNotEnabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27852,21 +27852,21 @@ func (s UserPoolAddOnNotEnabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserPoolAddOnNotEnabledException) OrigErr() error {
+func (s *UserPoolAddOnNotEnabledException) OrigErr() error {
 	return nil
 }
 
-func (s UserPoolAddOnNotEnabledException) Error() string {
+func (s *UserPoolAddOnNotEnabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserPoolAddOnNotEnabledException) StatusCode() int {
+func (s *UserPoolAddOnNotEnabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserPoolAddOnNotEnabledException) RequestID() string {
+func (s *UserPoolAddOnNotEnabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28377,12 +28377,12 @@ func newErrorUserPoolTaggingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UserPoolTaggingException) Code() string {
+func (s *UserPoolTaggingException) Code() string {
 	return "UserPoolTaggingException"
 }
 
 // Message returns the exception's message.
-func (s UserPoolTaggingException) Message() string {
+func (s *UserPoolTaggingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28390,21 +28390,21 @@ func (s UserPoolTaggingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserPoolTaggingException) OrigErr() error {
+func (s *UserPoolTaggingException) OrigErr() error {
 	return nil
 }
 
-func (s UserPoolTaggingException) Error() string {
+func (s *UserPoolTaggingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserPoolTaggingException) StatusCode() int {
+func (s *UserPoolTaggingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserPoolTaggingException) RequestID() string {
+func (s *UserPoolTaggingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28900,12 +28900,12 @@ func newErrorUsernameExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UsernameExistsException) Code() string {
+func (s *UsernameExistsException) Code() string {
 	return "UsernameExistsException"
 }
 
 // Message returns the exception's message.
-func (s UsernameExistsException) Message() string {
+func (s *UsernameExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28913,21 +28913,21 @@ func (s UsernameExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UsernameExistsException) OrigErr() error {
+func (s *UsernameExistsException) OrigErr() error {
 	return nil
 }
 
-func (s UsernameExistsException) Error() string {
+func (s *UsernameExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UsernameExistsException) StatusCode() int {
+func (s *UsernameExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UsernameExistsException) RequestID() string {
+func (s *UsernameExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -1697,12 +1697,12 @@ func newErrorAlreadyStreamedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyStreamedException) Code() string {
+func (s *AlreadyStreamedException) Code() string {
 	return "AlreadyStreamedException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyStreamedException) Message() string {
+func (s *AlreadyStreamedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1710,21 +1710,21 @@ func (s AlreadyStreamedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyStreamedException) OrigErr() error {
+func (s *AlreadyStreamedException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyStreamedException) Error() string {
+func (s *AlreadyStreamedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyStreamedException) StatusCode() int {
+func (s *AlreadyStreamedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyStreamedException) RequestID() string {
+func (s *AlreadyStreamedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1887,12 +1887,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1900,21 +1900,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2396,12 +2396,12 @@ func newErrorDuplicateRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateRequestException) Code() string {
+func (s *DuplicateRequestException) Code() string {
 	return "DuplicateRequestException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateRequestException) Message() string {
+func (s *DuplicateRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2409,21 +2409,21 @@ func (s DuplicateRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateRequestException) OrigErr() error {
+func (s *DuplicateRequestException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateRequestException) Error() string {
+func (s *DuplicateRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateRequestException) StatusCode() int {
+func (s *DuplicateRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateRequestException) RequestID() string {
+func (s *DuplicateRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2835,12 +2835,12 @@ func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalErrorException) Code() string {
+func (s *InternalErrorException) Code() string {
 	return "InternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalErrorException) Message() string {
+func (s *InternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2848,21 +2848,21 @@ func (s InternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalErrorException) OrigErr() error {
+func (s *InternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalErrorException) Error() string {
+func (s *InternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalErrorException) StatusCode() int {
+func (s *InternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalErrorException) RequestID() string {
+func (s *InternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2891,12 +2891,12 @@ func newErrorInvalidConfigurationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidConfigurationException) Code() string {
+func (s *InvalidConfigurationException) Code() string {
 	return "InvalidConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidConfigurationException) Message() string {
+func (s *InvalidConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2904,21 +2904,21 @@ func (s InvalidConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidConfigurationException) OrigErr() error {
+func (s *InvalidConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidConfigurationException) Error() string {
+func (s *InvalidConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidConfigurationException) StatusCode() int {
+func (s *InvalidConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidConfigurationException) RequestID() string {
+func (s *InvalidConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2948,12 +2948,12 @@ func newErrorInvalidLambdaFunctionOutputException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidLambdaFunctionOutputException) Code() string {
+func (s *InvalidLambdaFunctionOutputException) Code() string {
 	return "InvalidLambdaFunctionOutputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLambdaFunctionOutputException) Message() string {
+func (s *InvalidLambdaFunctionOutputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2961,21 +2961,21 @@ func (s InvalidLambdaFunctionOutputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLambdaFunctionOutputException) OrigErr() error {
+func (s *InvalidLambdaFunctionOutputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLambdaFunctionOutputException) Error() string {
+func (s *InvalidLambdaFunctionOutputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLambdaFunctionOutputException) StatusCode() int {
+func (s *InvalidLambdaFunctionOutputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLambdaFunctionOutputException) RequestID() string {
+func (s *InvalidLambdaFunctionOutputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3005,12 +3005,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3018,21 +3018,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3062,12 +3062,12 @@ func newErrorLambdaThrottledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LambdaThrottledException) Code() string {
+func (s *LambdaThrottledException) Code() string {
 	return "LambdaThrottledException"
 }
 
 // Message returns the exception's message.
-func (s LambdaThrottledException) Message() string {
+func (s *LambdaThrottledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3075,21 +3075,21 @@ func (s LambdaThrottledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LambdaThrottledException) OrigErr() error {
+func (s *LambdaThrottledException) OrigErr() error {
 	return nil
 }
 
-func (s LambdaThrottledException) Error() string {
+func (s *LambdaThrottledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LambdaThrottledException) StatusCode() int {
+func (s *LambdaThrottledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LambdaThrottledException) RequestID() string {
+func (s *LambdaThrottledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3119,12 +3119,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3132,21 +3132,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3592,12 +3592,12 @@ func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotAuthorizedException) Code() string {
+func (s *NotAuthorizedException) Code() string {
 	return "NotAuthorizedException"
 }
 
 // Message returns the exception's message.
-func (s NotAuthorizedException) Message() string {
+func (s *NotAuthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3605,21 +3605,21 @@ func (s NotAuthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotAuthorizedException) OrigErr() error {
+func (s *NotAuthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s NotAuthorizedException) Error() string {
+func (s *NotAuthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotAuthorizedException) StatusCode() int {
+func (s *NotAuthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotAuthorizedException) RequestID() string {
+func (s *NotAuthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3966,12 +3966,12 @@ func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceConflictException) Code() string {
+func (s *ResourceConflictException) Code() string {
 	return "ResourceConflictException"
 }
 
 // Message returns the exception's message.
-func (s ResourceConflictException) Message() string {
+func (s *ResourceConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3979,21 +3979,21 @@ func (s ResourceConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceConflictException) OrigErr() error {
+func (s *ResourceConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceConflictException) Error() string {
+func (s *ResourceConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceConflictException) StatusCode() int {
+func (s *ResourceConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceConflictException) RequestID() string {
+func (s *ResourceConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4023,12 +4023,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4036,21 +4036,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4374,12 +4374,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4387,21 +4387,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/comprehend/api.go
+++ b/service/comprehend/api.go
@@ -5983,12 +5983,12 @@ func newErrorBatchSizeLimitExceededException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s BatchSizeLimitExceededException) Code() string {
+func (s *BatchSizeLimitExceededException) Code() string {
 	return "BatchSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s BatchSizeLimitExceededException) Message() string {
+func (s *BatchSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5996,21 +5996,21 @@ func (s BatchSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BatchSizeLimitExceededException) OrigErr() error {
+func (s *BatchSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s BatchSizeLimitExceededException) Error() string {
+func (s *BatchSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BatchSizeLimitExceededException) StatusCode() int {
+func (s *BatchSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BatchSizeLimitExceededException) RequestID() string {
+func (s *BatchSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6298,12 +6298,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6311,21 +6311,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9996,12 +9996,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10009,21 +10009,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10052,12 +10052,12 @@ func newErrorInvalidFilterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFilterException) Code() string {
+func (s *InvalidFilterException) Code() string {
 	return "InvalidFilterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidFilterException) Message() string {
+func (s *InvalidFilterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10065,21 +10065,21 @@ func (s InvalidFilterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFilterException) OrigErr() error {
+func (s *InvalidFilterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFilterException) Error() string {
+func (s *InvalidFilterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFilterException) StatusCode() int {
+func (s *InvalidFilterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFilterException) RequestID() string {
+func (s *InvalidFilterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10108,12 +10108,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10121,21 +10121,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10164,12 +10164,12 @@ func newErrorJobNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s JobNotFoundException) Code() string {
+func (s *JobNotFoundException) Code() string {
 	return "JobNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s JobNotFoundException) Message() string {
+func (s *JobNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10177,21 +10177,21 @@ func (s JobNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s JobNotFoundException) OrigErr() error {
+func (s *JobNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s JobNotFoundException) Error() string {
+func (s *JobNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s JobNotFoundException) StatusCode() int {
+func (s *JobNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s JobNotFoundException) RequestID() string {
+func (s *JobNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10486,12 +10486,12 @@ func newErrorKmsKeyValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KmsKeyValidationException) Code() string {
+func (s *KmsKeyValidationException) Code() string {
 	return "KmsKeyValidationException"
 }
 
 // Message returns the exception's message.
-func (s KmsKeyValidationException) Message() string {
+func (s *KmsKeyValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10499,21 +10499,21 @@ func (s KmsKeyValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KmsKeyValidationException) OrigErr() error {
+func (s *KmsKeyValidationException) OrigErr() error {
 	return nil
 }
 
-func (s KmsKeyValidationException) Error() string {
+func (s *KmsKeyValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KmsKeyValidationException) StatusCode() int {
+func (s *KmsKeyValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KmsKeyValidationException) RequestID() string {
+func (s *KmsKeyValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11571,12 +11571,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11584,21 +11584,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11628,12 +11628,12 @@ func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceededException) Code() string {
+func (s *ResourceLimitExceededException) Code() string {
 	return "ResourceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceededException) Message() string {
+func (s *ResourceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11641,21 +11641,21 @@ func (s ResourceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceededException) OrigErr() error {
+func (s *ResourceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceededException) Error() string {
+func (s *ResourceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceededException) StatusCode() int {
+func (s *ResourceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceededException) RequestID() string {
+func (s *ResourceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11685,12 +11685,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11698,21 +11698,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11742,12 +11742,12 @@ func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceUnavailableException) Code() string {
+func (s *ResourceUnavailableException) Code() string {
 	return "ResourceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ResourceUnavailableException) Message() string {
+func (s *ResourceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11755,21 +11755,21 @@ func (s ResourceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceUnavailableException) OrigErr() error {
+func (s *ResourceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceUnavailableException) Error() string {
+func (s *ResourceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceUnavailableException) StatusCode() int {
+func (s *ResourceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceUnavailableException) RequestID() string {
+func (s *ResourceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13841,12 +13841,12 @@ func newErrorTextSizeLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TextSizeLimitExceededException) Code() string {
+func (s *TextSizeLimitExceededException) Code() string {
 	return "TextSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TextSizeLimitExceededException) Message() string {
+func (s *TextSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13854,21 +13854,21 @@ func (s TextSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TextSizeLimitExceededException) OrigErr() error {
+func (s *TextSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TextSizeLimitExceededException) Error() string {
+func (s *TextSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TextSizeLimitExceededException) StatusCode() int {
+func (s *TextSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TextSizeLimitExceededException) RequestID() string {
+func (s *TextSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13897,12 +13897,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13910,21 +13910,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13954,12 +13954,12 @@ func newErrorTooManyTagKeysException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagKeysException) Code() string {
+func (s *TooManyTagKeysException) Code() string {
 	return "TooManyTagKeysException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagKeysException) Message() string {
+func (s *TooManyTagKeysException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13967,21 +13967,21 @@ func (s TooManyTagKeysException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagKeysException) OrigErr() error {
+func (s *TooManyTagKeysException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagKeysException) Error() string {
+func (s *TooManyTagKeysException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagKeysException) StatusCode() int {
+func (s *TooManyTagKeysException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagKeysException) RequestID() string {
+func (s *TooManyTagKeysException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14012,12 +14012,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14025,21 +14025,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14278,12 +14278,12 @@ func newErrorUnsupportedLanguageException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedLanguageException) Code() string {
+func (s *UnsupportedLanguageException) Code() string {
 	return "UnsupportedLanguageException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedLanguageException) Message() string {
+func (s *UnsupportedLanguageException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14291,21 +14291,21 @@ func (s UnsupportedLanguageException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedLanguageException) OrigErr() error {
+func (s *UnsupportedLanguageException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedLanguageException) Error() string {
+func (s *UnsupportedLanguageException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedLanguageException) StatusCode() int {
+func (s *UnsupportedLanguageException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedLanguageException) RequestID() string {
+func (s *UnsupportedLanguageException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/comprehendmedical/api.go
+++ b/service/comprehendmedical/api.go
@@ -2696,12 +2696,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2709,21 +2709,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2753,12 +2753,12 @@ func newErrorInvalidEncodingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidEncodingException) Code() string {
+func (s *InvalidEncodingException) Code() string {
 	return "InvalidEncodingException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEncodingException) Message() string {
+func (s *InvalidEncodingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2766,21 +2766,21 @@ func (s InvalidEncodingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEncodingException) OrigErr() error {
+func (s *InvalidEncodingException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEncodingException) Error() string {
+func (s *InvalidEncodingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEncodingException) StatusCode() int {
+func (s *InvalidEncodingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEncodingException) RequestID() string {
+func (s *InvalidEncodingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2810,12 +2810,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2823,21 +2823,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3115,12 +3115,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3128,21 +3128,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3464,12 +3464,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3477,21 +3477,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3965,12 +3965,12 @@ func newErrorTextSizeLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TextSizeLimitExceededException) Code() string {
+func (s *TextSizeLimitExceededException) Code() string {
 	return "TextSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TextSizeLimitExceededException) Message() string {
+func (s *TextSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3978,21 +3978,21 @@ func (s TextSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TextSizeLimitExceededException) OrigErr() error {
+func (s *TextSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TextSizeLimitExceededException) Error() string {
+func (s *TextSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TextSizeLimitExceededException) StatusCode() int {
+func (s *TextSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TextSizeLimitExceededException) RequestID() string {
+func (s *TextSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4023,12 +4023,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4036,21 +4036,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4148,12 +4148,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4161,21 +4161,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/computeoptimizer/api.go
+++ b/service/computeoptimizer/api.go
@@ -660,12 +660,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -673,21 +673,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1705,12 +1705,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1718,21 +1718,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1761,12 +1761,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1774,21 +1774,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1818,12 +1818,12 @@ func newErrorMissingAuthenticationToken(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MissingAuthenticationToken) Code() string {
+func (s *MissingAuthenticationToken) Code() string {
 	return "MissingAuthenticationToken"
 }
 
 // Message returns the exception's message.
-func (s MissingAuthenticationToken) Message() string {
+func (s *MissingAuthenticationToken) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1831,21 +1831,21 @@ func (s MissingAuthenticationToken) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MissingAuthenticationToken) OrigErr() error {
+func (s *MissingAuthenticationToken) OrigErr() error {
 	return nil
 }
 
-func (s MissingAuthenticationToken) Error() string {
+func (s *MissingAuthenticationToken) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MissingAuthenticationToken) StatusCode() int {
+func (s *MissingAuthenticationToken) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MissingAuthenticationToken) RequestID() string {
+func (s *MissingAuthenticationToken) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1874,12 +1874,12 @@ func newErrorOptInRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OptInRequiredException) Code() string {
+func (s *OptInRequiredException) Code() string {
 	return "OptInRequiredException"
 }
 
 // Message returns the exception's message.
-func (s OptInRequiredException) Message() string {
+func (s *OptInRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1887,21 +1887,21 @@ func (s OptInRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OptInRequiredException) OrigErr() error {
+func (s *OptInRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s OptInRequiredException) Error() string {
+func (s *OptInRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OptInRequiredException) StatusCode() int {
+func (s *OptInRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OptInRequiredException) RequestID() string {
+func (s *OptInRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2101,12 +2101,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2114,21 +2114,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2157,12 +2157,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2170,21 +2170,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2246,12 +2246,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2259,21 +2259,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -10625,12 +10625,12 @@ func newErrorConformancePackTemplateValidationException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s ConformancePackTemplateValidationException) Code() string {
+func (s *ConformancePackTemplateValidationException) Code() string {
 	return "ConformancePackTemplateValidationException"
 }
 
 // Message returns the exception's message.
-func (s ConformancePackTemplateValidationException) Message() string {
+func (s *ConformancePackTemplateValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10638,21 +10638,21 @@ func (s ConformancePackTemplateValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConformancePackTemplateValidationException) OrigErr() error {
+func (s *ConformancePackTemplateValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ConformancePackTemplateValidationException) Error() string {
+func (s *ConformancePackTemplateValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConformancePackTemplateValidationException) StatusCode() int {
+func (s *ConformancePackTemplateValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConformancePackTemplateValidationException) RequestID() string {
+func (s *ConformancePackTemplateValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15647,12 +15647,12 @@ func newErrorInsufficientDeliveryPolicyException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InsufficientDeliveryPolicyException) Code() string {
+func (s *InsufficientDeliveryPolicyException) Code() string {
 	return "InsufficientDeliveryPolicyException"
 }
 
 // Message returns the exception's message.
-func (s InsufficientDeliveryPolicyException) Message() string {
+func (s *InsufficientDeliveryPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15660,21 +15660,21 @@ func (s InsufficientDeliveryPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientDeliveryPolicyException) OrigErr() error {
+func (s *InsufficientDeliveryPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientDeliveryPolicyException) Error() string {
+func (s *InsufficientDeliveryPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientDeliveryPolicyException) StatusCode() int {
+func (s *InsufficientDeliveryPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientDeliveryPolicyException) RequestID() string {
+func (s *InsufficientDeliveryPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15717,12 +15717,12 @@ func newErrorInsufficientPermissionsException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InsufficientPermissionsException) Code() string {
+func (s *InsufficientPermissionsException) Code() string {
 	return "InsufficientPermissionsException"
 }
 
 // Message returns the exception's message.
-func (s InsufficientPermissionsException) Message() string {
+func (s *InsufficientPermissionsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15730,21 +15730,21 @@ func (s InsufficientPermissionsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientPermissionsException) OrigErr() error {
+func (s *InsufficientPermissionsException) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientPermissionsException) Error() string {
+func (s *InsufficientPermissionsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientPermissionsException) StatusCode() int {
+func (s *InsufficientPermissionsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientPermissionsException) RequestID() string {
+func (s *InsufficientPermissionsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15773,12 +15773,12 @@ func newErrorInvalidConfigurationRecorderNameException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s InvalidConfigurationRecorderNameException) Code() string {
+func (s *InvalidConfigurationRecorderNameException) Code() string {
 	return "InvalidConfigurationRecorderNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidConfigurationRecorderNameException) Message() string {
+func (s *InvalidConfigurationRecorderNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15786,21 +15786,21 @@ func (s InvalidConfigurationRecorderNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidConfigurationRecorderNameException) OrigErr() error {
+func (s *InvalidConfigurationRecorderNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidConfigurationRecorderNameException) Error() string {
+func (s *InvalidConfigurationRecorderNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidConfigurationRecorderNameException) StatusCode() int {
+func (s *InvalidConfigurationRecorderNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidConfigurationRecorderNameException) RequestID() string {
+func (s *InvalidConfigurationRecorderNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15829,12 +15829,12 @@ func newErrorInvalidDeliveryChannelNameException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InvalidDeliveryChannelNameException) Code() string {
+func (s *InvalidDeliveryChannelNameException) Code() string {
 	return "InvalidDeliveryChannelNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeliveryChannelNameException) Message() string {
+func (s *InvalidDeliveryChannelNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15842,21 +15842,21 @@ func (s InvalidDeliveryChannelNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeliveryChannelNameException) OrigErr() error {
+func (s *InvalidDeliveryChannelNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeliveryChannelNameException) Error() string {
+func (s *InvalidDeliveryChannelNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeliveryChannelNameException) StatusCode() int {
+func (s *InvalidDeliveryChannelNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeliveryChannelNameException) RequestID() string {
+func (s *InvalidDeliveryChannelNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15885,12 +15885,12 @@ func newErrorInvalidExpressionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidExpressionException) Code() string {
+func (s *InvalidExpressionException) Code() string {
 	return "InvalidExpressionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidExpressionException) Message() string {
+func (s *InvalidExpressionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15898,21 +15898,21 @@ func (s InvalidExpressionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidExpressionException) OrigErr() error {
+func (s *InvalidExpressionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidExpressionException) Error() string {
+func (s *InvalidExpressionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidExpressionException) StatusCode() int {
+func (s *InvalidExpressionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidExpressionException) RequestID() string {
+func (s *InvalidExpressionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15941,12 +15941,12 @@ func newErrorInvalidLimitException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidLimitException) Code() string {
+func (s *InvalidLimitException) Code() string {
 	return "InvalidLimitException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLimitException) Message() string {
+func (s *InvalidLimitException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15954,21 +15954,21 @@ func (s InvalidLimitException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLimitException) OrigErr() error {
+func (s *InvalidLimitException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLimitException) Error() string {
+func (s *InvalidLimitException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLimitException) StatusCode() int {
+func (s *InvalidLimitException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLimitException) RequestID() string {
+func (s *InvalidLimitException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15998,12 +15998,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16011,21 +16011,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16055,12 +16055,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16068,21 +16068,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16112,12 +16112,12 @@ func newErrorInvalidRecordingGroupException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRecordingGroupException) Code() string {
+func (s *InvalidRecordingGroupException) Code() string {
 	return "InvalidRecordingGroupException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRecordingGroupException) Message() string {
+func (s *InvalidRecordingGroupException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16125,21 +16125,21 @@ func (s InvalidRecordingGroupException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRecordingGroupException) OrigErr() error {
+func (s *InvalidRecordingGroupException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRecordingGroupException) Error() string {
+func (s *InvalidRecordingGroupException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRecordingGroupException) StatusCode() int {
+func (s *InvalidRecordingGroupException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRecordingGroupException) RequestID() string {
+func (s *InvalidRecordingGroupException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16168,12 +16168,12 @@ func newErrorInvalidResultTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResultTokenException) Code() string {
+func (s *InvalidResultTokenException) Code() string {
 	return "InvalidResultTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResultTokenException) Message() string {
+func (s *InvalidResultTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16181,21 +16181,21 @@ func (s InvalidResultTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResultTokenException) OrigErr() error {
+func (s *InvalidResultTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResultTokenException) Error() string {
+func (s *InvalidResultTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResultTokenException) StatusCode() int {
+func (s *InvalidResultTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResultTokenException) RequestID() string {
+func (s *InvalidResultTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16224,12 +16224,12 @@ func newErrorInvalidRoleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRoleException) Code() string {
+func (s *InvalidRoleException) Code() string {
 	return "InvalidRoleException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRoleException) Message() string {
+func (s *InvalidRoleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16237,21 +16237,21 @@ func (s InvalidRoleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRoleException) OrigErr() error {
+func (s *InvalidRoleException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRoleException) Error() string {
+func (s *InvalidRoleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRoleException) StatusCode() int {
+func (s *InvalidRoleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRoleException) RequestID() string {
+func (s *InvalidRoleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16280,12 +16280,12 @@ func newErrorInvalidS3KeyPrefixException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidS3KeyPrefixException) Code() string {
+func (s *InvalidS3KeyPrefixException) Code() string {
 	return "InvalidS3KeyPrefixException"
 }
 
 // Message returns the exception's message.
-func (s InvalidS3KeyPrefixException) Message() string {
+func (s *InvalidS3KeyPrefixException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16293,21 +16293,21 @@ func (s InvalidS3KeyPrefixException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidS3KeyPrefixException) OrigErr() error {
+func (s *InvalidS3KeyPrefixException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidS3KeyPrefixException) Error() string {
+func (s *InvalidS3KeyPrefixException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidS3KeyPrefixException) StatusCode() int {
+func (s *InvalidS3KeyPrefixException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidS3KeyPrefixException) RequestID() string {
+func (s *InvalidS3KeyPrefixException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16336,12 +16336,12 @@ func newErrorInvalidSNSTopicARNException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSNSTopicARNException) Code() string {
+func (s *InvalidSNSTopicARNException) Code() string {
 	return "InvalidSNSTopicARNException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSNSTopicARNException) Message() string {
+func (s *InvalidSNSTopicARNException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16349,21 +16349,21 @@ func (s InvalidSNSTopicARNException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSNSTopicARNException) OrigErr() error {
+func (s *InvalidSNSTopicARNException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSNSTopicARNException) Error() string {
+func (s *InvalidSNSTopicARNException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSNSTopicARNException) StatusCode() int {
+func (s *InvalidSNSTopicARNException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSNSTopicARNException) RequestID() string {
+func (s *InvalidSNSTopicARNException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16393,12 +16393,12 @@ func newErrorInvalidTimeRangeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTimeRangeException) Code() string {
+func (s *InvalidTimeRangeException) Code() string {
 	return "InvalidTimeRangeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTimeRangeException) Message() string {
+func (s *InvalidTimeRangeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16406,21 +16406,21 @@ func (s InvalidTimeRangeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTimeRangeException) OrigErr() error {
+func (s *InvalidTimeRangeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTimeRangeException) Error() string {
+func (s *InvalidTimeRangeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTimeRangeException) StatusCode() int {
+func (s *InvalidTimeRangeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTimeRangeException) RequestID() string {
+func (s *InvalidTimeRangeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16450,12 +16450,12 @@ func newErrorLastDeliveryChannelDeleteFailedException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s LastDeliveryChannelDeleteFailedException) Code() string {
+func (s *LastDeliveryChannelDeleteFailedException) Code() string {
 	return "LastDeliveryChannelDeleteFailedException"
 }
 
 // Message returns the exception's message.
-func (s LastDeliveryChannelDeleteFailedException) Message() string {
+func (s *LastDeliveryChannelDeleteFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16463,21 +16463,21 @@ func (s LastDeliveryChannelDeleteFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LastDeliveryChannelDeleteFailedException) OrigErr() error {
+func (s *LastDeliveryChannelDeleteFailedException) OrigErr() error {
 	return nil
 }
 
-func (s LastDeliveryChannelDeleteFailedException) Error() string {
+func (s *LastDeliveryChannelDeleteFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LastDeliveryChannelDeleteFailedException) StatusCode() int {
+func (s *LastDeliveryChannelDeleteFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LastDeliveryChannelDeleteFailedException) RequestID() string {
+func (s *LastDeliveryChannelDeleteFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16511,12 +16511,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16524,21 +16524,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16913,12 +16913,12 @@ func newErrorMaxActiveResourcesExceededException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s MaxActiveResourcesExceededException) Code() string {
+func (s *MaxActiveResourcesExceededException) Code() string {
 	return "MaxActiveResourcesExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxActiveResourcesExceededException) Message() string {
+func (s *MaxActiveResourcesExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16926,21 +16926,21 @@ func (s MaxActiveResourcesExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxActiveResourcesExceededException) OrigErr() error {
+func (s *MaxActiveResourcesExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxActiveResourcesExceededException) Error() string {
+func (s *MaxActiveResourcesExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxActiveResourcesExceededException) StatusCode() int {
+func (s *MaxActiveResourcesExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxActiveResourcesExceededException) RequestID() string {
+func (s *MaxActiveResourcesExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16971,12 +16971,12 @@ func newErrorMaxNumberOfConfigRulesExceededException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s MaxNumberOfConfigRulesExceededException) Code() string {
+func (s *MaxNumberOfConfigRulesExceededException) Code() string {
 	return "MaxNumberOfConfigRulesExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxNumberOfConfigRulesExceededException) Message() string {
+func (s *MaxNumberOfConfigRulesExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16984,21 +16984,21 @@ func (s MaxNumberOfConfigRulesExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxNumberOfConfigRulesExceededException) OrigErr() error {
+func (s *MaxNumberOfConfigRulesExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxNumberOfConfigRulesExceededException) Error() string {
+func (s *MaxNumberOfConfigRulesExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxNumberOfConfigRulesExceededException) StatusCode() int {
+func (s *MaxNumberOfConfigRulesExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxNumberOfConfigRulesExceededException) RequestID() string {
+func (s *MaxNumberOfConfigRulesExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17027,12 +17027,12 @@ func newErrorMaxNumberOfConfigurationRecordersExceededException(v protocol.Respo
 }
 
 // Code returns the exception type name.
-func (s MaxNumberOfConfigurationRecordersExceededException) Code() string {
+func (s *MaxNumberOfConfigurationRecordersExceededException) Code() string {
 	return "MaxNumberOfConfigurationRecordersExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxNumberOfConfigurationRecordersExceededException) Message() string {
+func (s *MaxNumberOfConfigurationRecordersExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17040,21 +17040,21 @@ func (s MaxNumberOfConfigurationRecordersExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxNumberOfConfigurationRecordersExceededException) OrigErr() error {
+func (s *MaxNumberOfConfigurationRecordersExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxNumberOfConfigurationRecordersExceededException) Error() string {
+func (s *MaxNumberOfConfigurationRecordersExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxNumberOfConfigurationRecordersExceededException) StatusCode() int {
+func (s *MaxNumberOfConfigurationRecordersExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxNumberOfConfigurationRecordersExceededException) RequestID() string {
+func (s *MaxNumberOfConfigurationRecordersExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17084,12 +17084,12 @@ func newErrorMaxNumberOfConformancePacksExceededException(v protocol.ResponseMet
 }
 
 // Code returns the exception type name.
-func (s MaxNumberOfConformancePacksExceededException) Code() string {
+func (s *MaxNumberOfConformancePacksExceededException) Code() string {
 	return "MaxNumberOfConformancePacksExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxNumberOfConformancePacksExceededException) Message() string {
+func (s *MaxNumberOfConformancePacksExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17097,21 +17097,21 @@ func (s MaxNumberOfConformancePacksExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxNumberOfConformancePacksExceededException) OrigErr() error {
+func (s *MaxNumberOfConformancePacksExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxNumberOfConformancePacksExceededException) Error() string {
+func (s *MaxNumberOfConformancePacksExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxNumberOfConformancePacksExceededException) StatusCode() int {
+func (s *MaxNumberOfConformancePacksExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxNumberOfConformancePacksExceededException) RequestID() string {
+func (s *MaxNumberOfConformancePacksExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17140,12 +17140,12 @@ func newErrorMaxNumberOfDeliveryChannelsExceededException(v protocol.ResponseMet
 }
 
 // Code returns the exception type name.
-func (s MaxNumberOfDeliveryChannelsExceededException) Code() string {
+func (s *MaxNumberOfDeliveryChannelsExceededException) Code() string {
 	return "MaxNumberOfDeliveryChannelsExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxNumberOfDeliveryChannelsExceededException) Message() string {
+func (s *MaxNumberOfDeliveryChannelsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17153,21 +17153,21 @@ func (s MaxNumberOfDeliveryChannelsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxNumberOfDeliveryChannelsExceededException) OrigErr() error {
+func (s *MaxNumberOfDeliveryChannelsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxNumberOfDeliveryChannelsExceededException) Error() string {
+func (s *MaxNumberOfDeliveryChannelsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxNumberOfDeliveryChannelsExceededException) StatusCode() int {
+func (s *MaxNumberOfDeliveryChannelsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxNumberOfDeliveryChannelsExceededException) RequestID() string {
+func (s *MaxNumberOfDeliveryChannelsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17197,12 +17197,12 @@ func newErrorMaxNumberOfOrganizationConfigRulesExceededException(v protocol.Resp
 }
 
 // Code returns the exception type name.
-func (s MaxNumberOfOrganizationConfigRulesExceededException) Code() string {
+func (s *MaxNumberOfOrganizationConfigRulesExceededException) Code() string {
 	return "MaxNumberOfOrganizationConfigRulesExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxNumberOfOrganizationConfigRulesExceededException) Message() string {
+func (s *MaxNumberOfOrganizationConfigRulesExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17210,21 +17210,21 @@ func (s MaxNumberOfOrganizationConfigRulesExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxNumberOfOrganizationConfigRulesExceededException) OrigErr() error {
+func (s *MaxNumberOfOrganizationConfigRulesExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxNumberOfOrganizationConfigRulesExceededException) Error() string {
+func (s *MaxNumberOfOrganizationConfigRulesExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxNumberOfOrganizationConfigRulesExceededException) StatusCode() int {
+func (s *MaxNumberOfOrganizationConfigRulesExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxNumberOfOrganizationConfigRulesExceededException) RequestID() string {
+func (s *MaxNumberOfOrganizationConfigRulesExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17255,12 +17255,12 @@ func newErrorMaxNumberOfOrganizationConformancePacksExceededException(v protocol
 }
 
 // Code returns the exception type name.
-func (s MaxNumberOfOrganizationConformancePacksExceededException) Code() string {
+func (s *MaxNumberOfOrganizationConformancePacksExceededException) Code() string {
 	return "MaxNumberOfOrganizationConformancePacksExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxNumberOfOrganizationConformancePacksExceededException) Message() string {
+func (s *MaxNumberOfOrganizationConformancePacksExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17268,21 +17268,21 @@ func (s MaxNumberOfOrganizationConformancePacksExceededException) Message() stri
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxNumberOfOrganizationConformancePacksExceededException) OrigErr() error {
+func (s *MaxNumberOfOrganizationConformancePacksExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxNumberOfOrganizationConformancePacksExceededException) Error() string {
+func (s *MaxNumberOfOrganizationConformancePacksExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxNumberOfOrganizationConformancePacksExceededException) StatusCode() int {
+func (s *MaxNumberOfOrganizationConformancePacksExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxNumberOfOrganizationConformancePacksExceededException) RequestID() string {
+func (s *MaxNumberOfOrganizationConformancePacksExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17312,12 +17312,12 @@ func newErrorMaxNumberOfRetentionConfigurationsExceededException(v protocol.Resp
 }
 
 // Code returns the exception type name.
-func (s MaxNumberOfRetentionConfigurationsExceededException) Code() string {
+func (s *MaxNumberOfRetentionConfigurationsExceededException) Code() string {
 	return "MaxNumberOfRetentionConfigurationsExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxNumberOfRetentionConfigurationsExceededException) Message() string {
+func (s *MaxNumberOfRetentionConfigurationsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17325,21 +17325,21 @@ func (s MaxNumberOfRetentionConfigurationsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxNumberOfRetentionConfigurationsExceededException) OrigErr() error {
+func (s *MaxNumberOfRetentionConfigurationsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxNumberOfRetentionConfigurationsExceededException) Error() string {
+func (s *MaxNumberOfRetentionConfigurationsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxNumberOfRetentionConfigurationsExceededException) StatusCode() int {
+func (s *MaxNumberOfRetentionConfigurationsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxNumberOfRetentionConfigurationsExceededException) RequestID() string {
+func (s *MaxNumberOfRetentionConfigurationsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17473,12 +17473,12 @@ func newErrorNoAvailableConfigurationRecorderException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s NoAvailableConfigurationRecorderException) Code() string {
+func (s *NoAvailableConfigurationRecorderException) Code() string {
 	return "NoAvailableConfigurationRecorderException"
 }
 
 // Message returns the exception's message.
-func (s NoAvailableConfigurationRecorderException) Message() string {
+func (s *NoAvailableConfigurationRecorderException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17486,21 +17486,21 @@ func (s NoAvailableConfigurationRecorderException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoAvailableConfigurationRecorderException) OrigErr() error {
+func (s *NoAvailableConfigurationRecorderException) OrigErr() error {
 	return nil
 }
 
-func (s NoAvailableConfigurationRecorderException) Error() string {
+func (s *NoAvailableConfigurationRecorderException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoAvailableConfigurationRecorderException) StatusCode() int {
+func (s *NoAvailableConfigurationRecorderException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoAvailableConfigurationRecorderException) RequestID() string {
+func (s *NoAvailableConfigurationRecorderException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17529,12 +17529,12 @@ func newErrorNoAvailableDeliveryChannelException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s NoAvailableDeliveryChannelException) Code() string {
+func (s *NoAvailableDeliveryChannelException) Code() string {
 	return "NoAvailableDeliveryChannelException"
 }
 
 // Message returns the exception's message.
-func (s NoAvailableDeliveryChannelException) Message() string {
+func (s *NoAvailableDeliveryChannelException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17542,21 +17542,21 @@ func (s NoAvailableDeliveryChannelException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoAvailableDeliveryChannelException) OrigErr() error {
+func (s *NoAvailableDeliveryChannelException) OrigErr() error {
 	return nil
 }
 
-func (s NoAvailableDeliveryChannelException) Error() string {
+func (s *NoAvailableDeliveryChannelException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoAvailableDeliveryChannelException) StatusCode() int {
+func (s *NoAvailableDeliveryChannelException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoAvailableDeliveryChannelException) RequestID() string {
+func (s *NoAvailableDeliveryChannelException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17585,12 +17585,12 @@ func newErrorNoAvailableOrganizationException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s NoAvailableOrganizationException) Code() string {
+func (s *NoAvailableOrganizationException) Code() string {
 	return "NoAvailableOrganizationException"
 }
 
 // Message returns the exception's message.
-func (s NoAvailableOrganizationException) Message() string {
+func (s *NoAvailableOrganizationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17598,21 +17598,21 @@ func (s NoAvailableOrganizationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoAvailableOrganizationException) OrigErr() error {
+func (s *NoAvailableOrganizationException) OrigErr() error {
 	return nil
 }
 
-func (s NoAvailableOrganizationException) Error() string {
+func (s *NoAvailableOrganizationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoAvailableOrganizationException) StatusCode() int {
+func (s *NoAvailableOrganizationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoAvailableOrganizationException) RequestID() string {
+func (s *NoAvailableOrganizationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17641,12 +17641,12 @@ func newErrorNoRunningConfigurationRecorderException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s NoRunningConfigurationRecorderException) Code() string {
+func (s *NoRunningConfigurationRecorderException) Code() string {
 	return "NoRunningConfigurationRecorderException"
 }
 
 // Message returns the exception's message.
-func (s NoRunningConfigurationRecorderException) Message() string {
+func (s *NoRunningConfigurationRecorderException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17654,21 +17654,21 @@ func (s NoRunningConfigurationRecorderException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoRunningConfigurationRecorderException) OrigErr() error {
+func (s *NoRunningConfigurationRecorderException) OrigErr() error {
 	return nil
 }
 
-func (s NoRunningConfigurationRecorderException) Error() string {
+func (s *NoRunningConfigurationRecorderException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoRunningConfigurationRecorderException) StatusCode() int {
+func (s *NoRunningConfigurationRecorderException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoRunningConfigurationRecorderException) RequestID() string {
+func (s *NoRunningConfigurationRecorderException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17697,12 +17697,12 @@ func newErrorNoSuchBucketException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoSuchBucketException) Code() string {
+func (s *NoSuchBucketException) Code() string {
 	return "NoSuchBucketException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchBucketException) Message() string {
+func (s *NoSuchBucketException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17710,21 +17710,21 @@ func (s NoSuchBucketException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchBucketException) OrigErr() error {
+func (s *NoSuchBucketException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchBucketException) Error() string {
+func (s *NoSuchBucketException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchBucketException) StatusCode() int {
+func (s *NoSuchBucketException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchBucketException) RequestID() string {
+func (s *NoSuchBucketException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17754,12 +17754,12 @@ func newErrorNoSuchConfigRuleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoSuchConfigRuleException) Code() string {
+func (s *NoSuchConfigRuleException) Code() string {
 	return "NoSuchConfigRuleException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchConfigRuleException) Message() string {
+func (s *NoSuchConfigRuleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17767,21 +17767,21 @@ func (s NoSuchConfigRuleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchConfigRuleException) OrigErr() error {
+func (s *NoSuchConfigRuleException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchConfigRuleException) Error() string {
+func (s *NoSuchConfigRuleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchConfigRuleException) StatusCode() int {
+func (s *NoSuchConfigRuleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchConfigRuleException) RequestID() string {
+func (s *NoSuchConfigRuleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17810,12 +17810,12 @@ func newErrorNoSuchConfigRuleInConformancePackException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s NoSuchConfigRuleInConformancePackException) Code() string {
+func (s *NoSuchConfigRuleInConformancePackException) Code() string {
 	return "NoSuchConfigRuleInConformancePackException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchConfigRuleInConformancePackException) Message() string {
+func (s *NoSuchConfigRuleInConformancePackException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17823,21 +17823,21 @@ func (s NoSuchConfigRuleInConformancePackException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchConfigRuleInConformancePackException) OrigErr() error {
+func (s *NoSuchConfigRuleInConformancePackException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchConfigRuleInConformancePackException) Error() string {
+func (s *NoSuchConfigRuleInConformancePackException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchConfigRuleInConformancePackException) StatusCode() int {
+func (s *NoSuchConfigRuleInConformancePackException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchConfigRuleInConformancePackException) RequestID() string {
+func (s *NoSuchConfigRuleInConformancePackException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17866,12 +17866,12 @@ func newErrorNoSuchConfigurationAggregatorException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s NoSuchConfigurationAggregatorException) Code() string {
+func (s *NoSuchConfigurationAggregatorException) Code() string {
 	return "NoSuchConfigurationAggregatorException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchConfigurationAggregatorException) Message() string {
+func (s *NoSuchConfigurationAggregatorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17879,21 +17879,21 @@ func (s NoSuchConfigurationAggregatorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchConfigurationAggregatorException) OrigErr() error {
+func (s *NoSuchConfigurationAggregatorException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchConfigurationAggregatorException) Error() string {
+func (s *NoSuchConfigurationAggregatorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchConfigurationAggregatorException) StatusCode() int {
+func (s *NoSuchConfigurationAggregatorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchConfigurationAggregatorException) RequestID() string {
+func (s *NoSuchConfigurationAggregatorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17922,12 +17922,12 @@ func newErrorNoSuchConfigurationRecorderException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s NoSuchConfigurationRecorderException) Code() string {
+func (s *NoSuchConfigurationRecorderException) Code() string {
 	return "NoSuchConfigurationRecorderException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchConfigurationRecorderException) Message() string {
+func (s *NoSuchConfigurationRecorderException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17935,21 +17935,21 @@ func (s NoSuchConfigurationRecorderException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchConfigurationRecorderException) OrigErr() error {
+func (s *NoSuchConfigurationRecorderException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchConfigurationRecorderException) Error() string {
+func (s *NoSuchConfigurationRecorderException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchConfigurationRecorderException) StatusCode() int {
+func (s *NoSuchConfigurationRecorderException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchConfigurationRecorderException) RequestID() string {
+func (s *NoSuchConfigurationRecorderException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17978,12 +17978,12 @@ func newErrorNoSuchConformancePackException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoSuchConformancePackException) Code() string {
+func (s *NoSuchConformancePackException) Code() string {
 	return "NoSuchConformancePackException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchConformancePackException) Message() string {
+func (s *NoSuchConformancePackException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17991,21 +17991,21 @@ func (s NoSuchConformancePackException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchConformancePackException) OrigErr() error {
+func (s *NoSuchConformancePackException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchConformancePackException) Error() string {
+func (s *NoSuchConformancePackException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchConformancePackException) StatusCode() int {
+func (s *NoSuchConformancePackException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchConformancePackException) RequestID() string {
+func (s *NoSuchConformancePackException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18034,12 +18034,12 @@ func newErrorNoSuchDeliveryChannelException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoSuchDeliveryChannelException) Code() string {
+func (s *NoSuchDeliveryChannelException) Code() string {
 	return "NoSuchDeliveryChannelException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchDeliveryChannelException) Message() string {
+func (s *NoSuchDeliveryChannelException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18047,21 +18047,21 @@ func (s NoSuchDeliveryChannelException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchDeliveryChannelException) OrigErr() error {
+func (s *NoSuchDeliveryChannelException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchDeliveryChannelException) Error() string {
+func (s *NoSuchDeliveryChannelException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchDeliveryChannelException) StatusCode() int {
+func (s *NoSuchDeliveryChannelException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchDeliveryChannelException) RequestID() string {
+func (s *NoSuchDeliveryChannelException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18090,12 +18090,12 @@ func newErrorNoSuchOrganizationConfigRuleException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s NoSuchOrganizationConfigRuleException) Code() string {
+func (s *NoSuchOrganizationConfigRuleException) Code() string {
 	return "NoSuchOrganizationConfigRuleException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchOrganizationConfigRuleException) Message() string {
+func (s *NoSuchOrganizationConfigRuleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18103,21 +18103,21 @@ func (s NoSuchOrganizationConfigRuleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchOrganizationConfigRuleException) OrigErr() error {
+func (s *NoSuchOrganizationConfigRuleException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchOrganizationConfigRuleException) Error() string {
+func (s *NoSuchOrganizationConfigRuleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchOrganizationConfigRuleException) StatusCode() int {
+func (s *NoSuchOrganizationConfigRuleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchOrganizationConfigRuleException) RequestID() string {
+func (s *NoSuchOrganizationConfigRuleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18150,12 +18150,12 @@ func newErrorNoSuchOrganizationConformancePackException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s NoSuchOrganizationConformancePackException) Code() string {
+func (s *NoSuchOrganizationConformancePackException) Code() string {
 	return "NoSuchOrganizationConformancePackException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchOrganizationConformancePackException) Message() string {
+func (s *NoSuchOrganizationConformancePackException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18163,21 +18163,21 @@ func (s NoSuchOrganizationConformancePackException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchOrganizationConformancePackException) OrigErr() error {
+func (s *NoSuchOrganizationConformancePackException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchOrganizationConformancePackException) Error() string {
+func (s *NoSuchOrganizationConformancePackException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchOrganizationConformancePackException) StatusCode() int {
+func (s *NoSuchOrganizationConformancePackException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchOrganizationConformancePackException) RequestID() string {
+func (s *NoSuchOrganizationConformancePackException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18206,12 +18206,12 @@ func newErrorNoSuchRemediationConfigurationException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s NoSuchRemediationConfigurationException) Code() string {
+func (s *NoSuchRemediationConfigurationException) Code() string {
 	return "NoSuchRemediationConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchRemediationConfigurationException) Message() string {
+func (s *NoSuchRemediationConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18219,21 +18219,21 @@ func (s NoSuchRemediationConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchRemediationConfigurationException) OrigErr() error {
+func (s *NoSuchRemediationConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchRemediationConfigurationException) Error() string {
+func (s *NoSuchRemediationConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchRemediationConfigurationException) StatusCode() int {
+func (s *NoSuchRemediationConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchRemediationConfigurationException) RequestID() string {
+func (s *NoSuchRemediationConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18262,12 +18262,12 @@ func newErrorNoSuchRemediationExceptionException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s NoSuchRemediationExceptionException) Code() string {
+func (s *NoSuchRemediationExceptionException) Code() string {
 	return "NoSuchRemediationExceptionException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchRemediationExceptionException) Message() string {
+func (s *NoSuchRemediationExceptionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18275,21 +18275,21 @@ func (s NoSuchRemediationExceptionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchRemediationExceptionException) OrigErr() error {
+func (s *NoSuchRemediationExceptionException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchRemediationExceptionException) Error() string {
+func (s *NoSuchRemediationExceptionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchRemediationExceptionException) StatusCode() int {
+func (s *NoSuchRemediationExceptionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchRemediationExceptionException) RequestID() string {
+func (s *NoSuchRemediationExceptionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18318,12 +18318,12 @@ func newErrorNoSuchRetentionConfigurationException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s NoSuchRetentionConfigurationException) Code() string {
+func (s *NoSuchRetentionConfigurationException) Code() string {
 	return "NoSuchRetentionConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchRetentionConfigurationException) Message() string {
+func (s *NoSuchRetentionConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18331,21 +18331,21 @@ func (s NoSuchRetentionConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchRetentionConfigurationException) OrigErr() error {
+func (s *NoSuchRetentionConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchRetentionConfigurationException) Error() string {
+func (s *NoSuchRetentionConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchRetentionConfigurationException) StatusCode() int {
+func (s *NoSuchRetentionConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchRetentionConfigurationException) RequestID() string {
+func (s *NoSuchRetentionConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18379,12 +18379,12 @@ func newErrorOrganizationAccessDeniedException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s OrganizationAccessDeniedException) Code() string {
+func (s *OrganizationAccessDeniedException) Code() string {
 	return "OrganizationAccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationAccessDeniedException) Message() string {
+func (s *OrganizationAccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18392,21 +18392,21 @@ func (s OrganizationAccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationAccessDeniedException) OrigErr() error {
+func (s *OrganizationAccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationAccessDeniedException) Error() string {
+func (s *OrganizationAccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationAccessDeniedException) StatusCode() int {
+func (s *OrganizationAccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationAccessDeniedException) RequestID() string {
+func (s *OrganizationAccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18498,12 +18498,12 @@ func newErrorOrganizationAllFeaturesNotEnabledException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s OrganizationAllFeaturesNotEnabledException) Code() string {
+func (s *OrganizationAllFeaturesNotEnabledException) Code() string {
 	return "OrganizationAllFeaturesNotEnabledException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationAllFeaturesNotEnabledException) Message() string {
+func (s *OrganizationAllFeaturesNotEnabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18511,21 +18511,21 @@ func (s OrganizationAllFeaturesNotEnabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationAllFeaturesNotEnabledException) OrigErr() error {
+func (s *OrganizationAllFeaturesNotEnabledException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationAllFeaturesNotEnabledException) Error() string {
+func (s *OrganizationAllFeaturesNotEnabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationAllFeaturesNotEnabledException) StatusCode() int {
+func (s *OrganizationAllFeaturesNotEnabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationAllFeaturesNotEnabledException) RequestID() string {
+func (s *OrganizationAllFeaturesNotEnabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19032,12 +19032,12 @@ func newErrorOrganizationConformancePackTemplateValidationException(v protocol.R
 }
 
 // Code returns the exception type name.
-func (s OrganizationConformancePackTemplateValidationException) Code() string {
+func (s *OrganizationConformancePackTemplateValidationException) Code() string {
 	return "OrganizationConformancePackTemplateValidationException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationConformancePackTemplateValidationException) Message() string {
+func (s *OrganizationConformancePackTemplateValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19045,21 +19045,21 @@ func (s OrganizationConformancePackTemplateValidationException) Message() string
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationConformancePackTemplateValidationException) OrigErr() error {
+func (s *OrganizationConformancePackTemplateValidationException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationConformancePackTemplateValidationException) Error() string {
+func (s *OrganizationConformancePackTemplateValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationConformancePackTemplateValidationException) StatusCode() int {
+func (s *OrganizationConformancePackTemplateValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationConformancePackTemplateValidationException) RequestID() string {
+func (s *OrganizationConformancePackTemplateValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19443,12 +19443,12 @@ func newErrorOversizedConfigurationItemException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s OversizedConfigurationItemException) Code() string {
+func (s *OversizedConfigurationItemException) Code() string {
 	return "OversizedConfigurationItemException"
 }
 
 // Message returns the exception's message.
-func (s OversizedConfigurationItemException) Message() string {
+func (s *OversizedConfigurationItemException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19456,21 +19456,21 @@ func (s OversizedConfigurationItemException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OversizedConfigurationItemException) OrigErr() error {
+func (s *OversizedConfigurationItemException) OrigErr() error {
 	return nil
 }
 
-func (s OversizedConfigurationItemException) Error() string {
+func (s *OversizedConfigurationItemException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OversizedConfigurationItemException) StatusCode() int {
+func (s *OversizedConfigurationItemException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OversizedConfigurationItemException) RequestID() string {
+func (s *OversizedConfigurationItemException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21432,12 +21432,12 @@ func newErrorRemediationInProgressException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RemediationInProgressException) Code() string {
+func (s *RemediationInProgressException) Code() string {
 	return "RemediationInProgressException"
 }
 
 // Message returns the exception's message.
-func (s RemediationInProgressException) Message() string {
+func (s *RemediationInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21445,21 +21445,21 @@ func (s RemediationInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RemediationInProgressException) OrigErr() error {
+func (s *RemediationInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s RemediationInProgressException) Error() string {
+func (s *RemediationInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RemediationInProgressException) StatusCode() int {
+func (s *RemediationInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RemediationInProgressException) RequestID() string {
+func (s *RemediationInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21774,12 +21774,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21787,21 +21787,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21887,12 +21887,12 @@ func newErrorResourceNotDiscoveredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotDiscoveredException) Code() string {
+func (s *ResourceNotDiscoveredException) Code() string {
 	return "ResourceNotDiscoveredException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotDiscoveredException) Message() string {
+func (s *ResourceNotDiscoveredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21900,21 +21900,21 @@ func (s ResourceNotDiscoveredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotDiscoveredException) OrigErr() error {
+func (s *ResourceNotDiscoveredException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotDiscoveredException) Error() string {
+func (s *ResourceNotDiscoveredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotDiscoveredException) StatusCode() int {
+func (s *ResourceNotDiscoveredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotDiscoveredException) RequestID() string {
+func (s *ResourceNotDiscoveredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21943,12 +21943,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21956,21 +21956,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23097,12 +23097,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23110,21 +23110,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23227,12 +23227,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23240,21 +23240,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/connect/api.go
+++ b/service/connect/api.go
@@ -3432,12 +3432,12 @@ func newErrorContactNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ContactNotFoundException) Code() string {
+func (s *ContactNotFoundException) Code() string {
 	return "ContactNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ContactNotFoundException) Message() string {
+func (s *ContactNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3445,21 +3445,21 @@ func (s ContactNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ContactNotFoundException) OrigErr() error {
+func (s *ContactNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ContactNotFoundException) Error() string {
+func (s *ContactNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ContactNotFoundException) StatusCode() int {
+func (s *ContactNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ContactNotFoundException) RequestID() string {
+func (s *ContactNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4145,12 +4145,12 @@ func newErrorDestinationNotAllowedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DestinationNotAllowedException) Code() string {
+func (s *DestinationNotAllowedException) Code() string {
 	return "DestinationNotAllowedException"
 }
 
 // Message returns the exception's message.
-func (s DestinationNotAllowedException) Message() string {
+func (s *DestinationNotAllowedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4158,21 +4158,21 @@ func (s DestinationNotAllowedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DestinationNotAllowedException) OrigErr() error {
+func (s *DestinationNotAllowedException) OrigErr() error {
 	return nil
 }
 
-func (s DestinationNotAllowedException) Error() string {
+func (s *DestinationNotAllowedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DestinationNotAllowedException) StatusCode() int {
+func (s *DestinationNotAllowedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DestinationNotAllowedException) RequestID() string {
+func (s *DestinationNotAllowedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4234,12 +4234,12 @@ func newErrorDuplicateResourceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateResourceException) Code() string {
+func (s *DuplicateResourceException) Code() string {
 	return "DuplicateResourceException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateResourceException) Message() string {
+func (s *DuplicateResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4247,21 +4247,21 @@ func (s DuplicateResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateResourceException) OrigErr() error {
+func (s *DuplicateResourceException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateResourceException) Error() string {
+func (s *DuplicateResourceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateResourceException) StatusCode() int {
+func (s *DuplicateResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateResourceException) RequestID() string {
+func (s *DuplicateResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5466,12 +5466,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5479,21 +5479,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5523,12 +5523,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5536,21 +5536,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5580,12 +5580,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5593,21 +5593,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5637,12 +5637,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5650,21 +5650,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6554,12 +6554,12 @@ func newErrorOutboundContactNotPermittedException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s OutboundContactNotPermittedException) Code() string {
+func (s *OutboundContactNotPermittedException) Code() string {
 	return "OutboundContactNotPermittedException"
 }
 
 // Message returns the exception's message.
-func (s OutboundContactNotPermittedException) Message() string {
+func (s *OutboundContactNotPermittedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6567,21 +6567,21 @@ func (s OutboundContactNotPermittedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OutboundContactNotPermittedException) OrigErr() error {
+func (s *OutboundContactNotPermittedException) OrigErr() error {
 	return nil
 }
 
-func (s OutboundContactNotPermittedException) Error() string {
+func (s *OutboundContactNotPermittedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OutboundContactNotPermittedException) StatusCode() int {
+func (s *OutboundContactNotPermittedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OutboundContactNotPermittedException) RequestID() string {
+func (s *OutboundContactNotPermittedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6797,12 +6797,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6810,21 +6810,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7411,12 +7411,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7424,21 +7424,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8234,12 +8234,12 @@ func newErrorUserNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UserNotFoundException) Code() string {
+func (s *UserNotFoundException) Code() string {
 	return "UserNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s UserNotFoundException) Message() string {
+func (s *UserNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8247,21 +8247,21 @@ func (s UserNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserNotFoundException) OrigErr() error {
+func (s *UserNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s UserNotFoundException) Error() string {
+func (s *UserNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserNotFoundException) StatusCode() int {
+func (s *UserNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserNotFoundException) RequestID() string {
+func (s *UserNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/connectparticipant/api.go
+++ b/service/connectparticipant/api.go
@@ -562,12 +562,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -575,21 +575,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -962,12 +962,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -975,21 +975,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1410,12 +1410,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1423,21 +1423,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1466,12 +1466,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1479,21 +1479,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/costandusagereportservice/api.go
+++ b/service/costandusagereportservice/api.go
@@ -564,12 +564,12 @@ func newErrorDuplicateReportNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateReportNameException) Code() string {
+func (s *DuplicateReportNameException) Code() string {
 	return "DuplicateReportNameException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateReportNameException) Message() string {
+func (s *DuplicateReportNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -577,21 +577,21 @@ func (s DuplicateReportNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateReportNameException) OrigErr() error {
+func (s *DuplicateReportNameException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateReportNameException) Error() string {
+func (s *DuplicateReportNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateReportNameException) StatusCode() int {
+func (s *DuplicateReportNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateReportNameException) RequestID() string {
+func (s *DuplicateReportNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -622,12 +622,12 @@ func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalErrorException) Code() string {
+func (s *InternalErrorException) Code() string {
 	return "InternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalErrorException) Message() string {
+func (s *InternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -635,21 +635,21 @@ func (s InternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalErrorException) OrigErr() error {
+func (s *InternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalErrorException) Error() string {
+func (s *InternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalErrorException) StatusCode() int {
+func (s *InternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalErrorException) RequestID() string {
+func (s *InternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -988,12 +988,12 @@ func newErrorReportLimitReachedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ReportLimitReachedException) Code() string {
+func (s *ReportLimitReachedException) Code() string {
 	return "ReportLimitReachedException"
 }
 
 // Message returns the exception's message.
-func (s ReportLimitReachedException) Message() string {
+func (s *ReportLimitReachedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1001,21 +1001,21 @@ func (s ReportLimitReachedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReportLimitReachedException) OrigErr() error {
+func (s *ReportLimitReachedException) OrigErr() error {
 	return nil
 }
 
-func (s ReportLimitReachedException) Error() string {
+func (s *ReportLimitReachedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReportLimitReachedException) StatusCode() int {
+func (s *ReportLimitReachedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReportLimitReachedException) RequestID() string {
+func (s *ReportLimitReachedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1045,12 +1045,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1058,21 +1058,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/costexplorer/api.go
+++ b/service/costexplorer/api.go
@@ -1921,12 +1921,12 @@ func newErrorBillExpirationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BillExpirationException) Code() string {
+func (s *BillExpirationException) Code() string {
 	return "BillExpirationException"
 }
 
 // Message returns the exception's message.
-func (s BillExpirationException) Message() string {
+func (s *BillExpirationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1934,21 +1934,21 @@ func (s BillExpirationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BillExpirationException) OrigErr() error {
+func (s *BillExpirationException) OrigErr() error {
 	return nil
 }
 
-func (s BillExpirationException) Error() string {
+func (s *BillExpirationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BillExpirationException) StatusCode() int {
+func (s *BillExpirationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BillExpirationException) RequestID() string {
+func (s *BillExpirationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2701,12 +2701,12 @@ func newErrorDataUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DataUnavailableException) Code() string {
+func (s *DataUnavailableException) Code() string {
 	return "DataUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s DataUnavailableException) Message() string {
+func (s *DataUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2714,21 +2714,21 @@ func (s DataUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DataUnavailableException) OrigErr() error {
+func (s *DataUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s DataUnavailableException) Error() string {
+func (s *DataUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DataUnavailableException) StatusCode() int {
+func (s *DataUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DataUnavailableException) RequestID() string {
+func (s *DataUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6144,12 +6144,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6157,21 +6157,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6200,12 +6200,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6213,21 +6213,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6558,12 +6558,12 @@ func newErrorRequestChangedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestChangedException) Code() string {
+func (s *RequestChangedException) Code() string {
 	return "RequestChangedException"
 }
 
 // Message returns the exception's message.
-func (s RequestChangedException) Message() string {
+func (s *RequestChangedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6571,21 +6571,21 @@ func (s RequestChangedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestChangedException) OrigErr() error {
+func (s *RequestChangedException) OrigErr() error {
 	return nil
 }
 
-func (s RequestChangedException) Error() string {
+func (s *RequestChangedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestChangedException) StatusCode() int {
+func (s *RequestChangedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestChangedException) RequestID() string {
+func (s *RequestChangedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7232,12 +7232,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7245,21 +7245,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8385,12 +8385,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8398,21 +8398,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8605,12 +8605,12 @@ func newErrorUnresolvableUsageUnitException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnresolvableUsageUnitException) Code() string {
+func (s *UnresolvableUsageUnitException) Code() string {
 	return "UnresolvableUsageUnitException"
 }
 
 // Message returns the exception's message.
-func (s UnresolvableUsageUnitException) Message() string {
+func (s *UnresolvableUsageUnitException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8618,21 +8618,21 @@ func (s UnresolvableUsageUnitException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnresolvableUsageUnitException) OrigErr() error {
+func (s *UnresolvableUsageUnitException) OrigErr() error {
 	return nil
 }
 
-func (s UnresolvableUsageUnitException) Error() string {
+func (s *UnresolvableUsageUnitException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnresolvableUsageUnitException) StatusCode() int {
+func (s *UnresolvableUsageUnitException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnresolvableUsageUnitException) RequestID() string {
+func (s *UnresolvableUsageUnitException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/databasemigrationservice/api.go
+++ b/service/databasemigrationservice/api.go
@@ -4974,12 +4974,12 @@ func newErrorAccessDeniedFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedFault) Code() string {
+func (s *AccessDeniedFault) Code() string {
 	return "AccessDeniedFault"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedFault) Message() string {
+func (s *AccessDeniedFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4987,21 +4987,21 @@ func (s AccessDeniedFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedFault) OrigErr() error {
+func (s *AccessDeniedFault) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedFault) Error() string {
+func (s *AccessDeniedFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedFault) StatusCode() int {
+func (s *AccessDeniedFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedFault) RequestID() string {
+func (s *AccessDeniedFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9508,12 +9508,12 @@ func newErrorInsufficientResourceCapacityFault(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s InsufficientResourceCapacityFault) Code() string {
+func (s *InsufficientResourceCapacityFault) Code() string {
 	return "InsufficientResourceCapacityFault"
 }
 
 // Message returns the exception's message.
-func (s InsufficientResourceCapacityFault) Message() string {
+func (s *InsufficientResourceCapacityFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9521,21 +9521,21 @@ func (s InsufficientResourceCapacityFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientResourceCapacityFault) OrigErr() error {
+func (s *InsufficientResourceCapacityFault) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientResourceCapacityFault) Error() string {
+func (s *InsufficientResourceCapacityFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientResourceCapacityFault) StatusCode() int {
+func (s *InsufficientResourceCapacityFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientResourceCapacityFault) RequestID() string {
+func (s *InsufficientResourceCapacityFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9564,12 +9564,12 @@ func newErrorInvalidCertificateFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidCertificateFault) Code() string {
+func (s *InvalidCertificateFault) Code() string {
 	return "InvalidCertificateFault"
 }
 
 // Message returns the exception's message.
-func (s InvalidCertificateFault) Message() string {
+func (s *InvalidCertificateFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9577,21 +9577,21 @@ func (s InvalidCertificateFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCertificateFault) OrigErr() error {
+func (s *InvalidCertificateFault) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCertificateFault) Error() string {
+func (s *InvalidCertificateFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCertificateFault) StatusCode() int {
+func (s *InvalidCertificateFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCertificateFault) RequestID() string {
+func (s *InvalidCertificateFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9621,12 +9621,12 @@ func newErrorInvalidResourceStateFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceStateFault) Code() string {
+func (s *InvalidResourceStateFault) Code() string {
 	return "InvalidResourceStateFault"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceStateFault) Message() string {
+func (s *InvalidResourceStateFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9634,21 +9634,21 @@ func (s InvalidResourceStateFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceStateFault) OrigErr() error {
+func (s *InvalidResourceStateFault) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceStateFault) Error() string {
+func (s *InvalidResourceStateFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceStateFault) StatusCode() int {
+func (s *InvalidResourceStateFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceStateFault) RequestID() string {
+func (s *InvalidResourceStateFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9677,12 +9677,12 @@ func newErrorInvalidSubnet(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSubnet) Code() string {
+func (s *InvalidSubnet) Code() string {
 	return "InvalidSubnet"
 }
 
 // Message returns the exception's message.
-func (s InvalidSubnet) Message() string {
+func (s *InvalidSubnet) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9690,21 +9690,21 @@ func (s InvalidSubnet) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSubnet) OrigErr() error {
+func (s *InvalidSubnet) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSubnet) Error() string {
+func (s *InvalidSubnet) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSubnet) StatusCode() int {
+func (s *InvalidSubnet) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSubnet) RequestID() string {
+func (s *InvalidSubnet) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9734,12 +9734,12 @@ func newErrorKMSAccessDeniedFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSAccessDeniedFault) Code() string {
+func (s *KMSAccessDeniedFault) Code() string {
 	return "KMSAccessDeniedFault"
 }
 
 // Message returns the exception's message.
-func (s KMSAccessDeniedFault) Message() string {
+func (s *KMSAccessDeniedFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9747,21 +9747,21 @@ func (s KMSAccessDeniedFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSAccessDeniedFault) OrigErr() error {
+func (s *KMSAccessDeniedFault) OrigErr() error {
 	return nil
 }
 
-func (s KMSAccessDeniedFault) Error() string {
+func (s *KMSAccessDeniedFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSAccessDeniedFault) StatusCode() int {
+func (s *KMSAccessDeniedFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSAccessDeniedFault) RequestID() string {
+func (s *KMSAccessDeniedFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9790,12 +9790,12 @@ func newErrorKMSDisabledFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSDisabledFault) Code() string {
+func (s *KMSDisabledFault) Code() string {
 	return "KMSDisabledFault"
 }
 
 // Message returns the exception's message.
-func (s KMSDisabledFault) Message() string {
+func (s *KMSDisabledFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9803,21 +9803,21 @@ func (s KMSDisabledFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSDisabledFault) OrigErr() error {
+func (s *KMSDisabledFault) OrigErr() error {
 	return nil
 }
 
-func (s KMSDisabledFault) Error() string {
+func (s *KMSDisabledFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSDisabledFault) StatusCode() int {
+func (s *KMSDisabledFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSDisabledFault) RequestID() string {
+func (s *KMSDisabledFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9846,12 +9846,12 @@ func newErrorKMSInvalidStateFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSInvalidStateFault) Code() string {
+func (s *KMSInvalidStateFault) Code() string {
 	return "KMSInvalidStateFault"
 }
 
 // Message returns the exception's message.
-func (s KMSInvalidStateFault) Message() string {
+func (s *KMSInvalidStateFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9859,21 +9859,21 @@ func (s KMSInvalidStateFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSInvalidStateFault) OrigErr() error {
+func (s *KMSInvalidStateFault) OrigErr() error {
 	return nil
 }
 
-func (s KMSInvalidStateFault) Error() string {
+func (s *KMSInvalidStateFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSInvalidStateFault) StatusCode() int {
+func (s *KMSInvalidStateFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSInvalidStateFault) RequestID() string {
+func (s *KMSInvalidStateFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9902,12 +9902,12 @@ func newErrorKMSKeyNotAccessibleFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSKeyNotAccessibleFault) Code() string {
+func (s *KMSKeyNotAccessibleFault) Code() string {
 	return "KMSKeyNotAccessibleFault"
 }
 
 // Message returns the exception's message.
-func (s KMSKeyNotAccessibleFault) Message() string {
+func (s *KMSKeyNotAccessibleFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9915,21 +9915,21 @@ func (s KMSKeyNotAccessibleFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSKeyNotAccessibleFault) OrigErr() error {
+func (s *KMSKeyNotAccessibleFault) OrigErr() error {
 	return nil
 }
 
-func (s KMSKeyNotAccessibleFault) Error() string {
+func (s *KMSKeyNotAccessibleFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSKeyNotAccessibleFault) StatusCode() int {
+func (s *KMSKeyNotAccessibleFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSKeyNotAccessibleFault) RequestID() string {
+func (s *KMSKeyNotAccessibleFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9958,12 +9958,12 @@ func newErrorKMSNotFoundFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSNotFoundFault) Code() string {
+func (s *KMSNotFoundFault) Code() string {
 	return "KMSNotFoundFault"
 }
 
 // Message returns the exception's message.
-func (s KMSNotFoundFault) Message() string {
+func (s *KMSNotFoundFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9971,21 +9971,21 @@ func (s KMSNotFoundFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSNotFoundFault) OrigErr() error {
+func (s *KMSNotFoundFault) OrigErr() error {
 	return nil
 }
 
-func (s KMSNotFoundFault) Error() string {
+func (s *KMSNotFoundFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSNotFoundFault) StatusCode() int {
+func (s *KMSNotFoundFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSNotFoundFault) RequestID() string {
+func (s *KMSNotFoundFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10014,12 +10014,12 @@ func newErrorKMSThrottlingFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSThrottlingFault) Code() string {
+func (s *KMSThrottlingFault) Code() string {
 	return "KMSThrottlingFault"
 }
 
 // Message returns the exception's message.
-func (s KMSThrottlingFault) Message() string {
+func (s *KMSThrottlingFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10027,21 +10027,21 @@ func (s KMSThrottlingFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSThrottlingFault) OrigErr() error {
+func (s *KMSThrottlingFault) OrigErr() error {
 	return nil
 }
 
-func (s KMSThrottlingFault) Error() string {
+func (s *KMSThrottlingFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSThrottlingFault) StatusCode() int {
+func (s *KMSThrottlingFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSThrottlingFault) RequestID() string {
+func (s *KMSThrottlingFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12524,12 +12524,12 @@ func newErrorReplicationSubnetGroupDoesNotCoverEnoughAZs(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) Code() string {
+func (s *ReplicationSubnetGroupDoesNotCoverEnoughAZs) Code() string {
 	return "ReplicationSubnetGroupDoesNotCoverEnoughAZs"
 }
 
 // Message returns the exception's message.
-func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) Message() string {
+func (s *ReplicationSubnetGroupDoesNotCoverEnoughAZs) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12537,21 +12537,21 @@ func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) OrigErr() error {
+func (s *ReplicationSubnetGroupDoesNotCoverEnoughAZs) OrigErr() error {
 	return nil
 }
 
-func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) Error() string {
+func (s *ReplicationSubnetGroupDoesNotCoverEnoughAZs) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) StatusCode() int {
+func (s *ReplicationSubnetGroupDoesNotCoverEnoughAZs) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) RequestID() string {
+func (s *ReplicationSubnetGroupDoesNotCoverEnoughAZs) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12974,12 +12974,12 @@ func newErrorResourceAlreadyExistsFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsFault) Code() string {
+func (s *ResourceAlreadyExistsFault) Code() string {
 	return "ResourceAlreadyExistsFault"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsFault) Message() string {
+func (s *ResourceAlreadyExistsFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12987,21 +12987,21 @@ func (s ResourceAlreadyExistsFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsFault) OrigErr() error {
+func (s *ResourceAlreadyExistsFault) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsFault) Error() string {
+func (s *ResourceAlreadyExistsFault) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsFault) StatusCode() int {
+func (s *ResourceAlreadyExistsFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsFault) RequestID() string {
+func (s *ResourceAlreadyExistsFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13030,12 +13030,12 @@ func newErrorResourceNotFoundFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundFault) Code() string {
+func (s *ResourceNotFoundFault) Code() string {
 	return "ResourceNotFoundFault"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundFault) Message() string {
+func (s *ResourceNotFoundFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13043,21 +13043,21 @@ func (s ResourceNotFoundFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundFault) OrigErr() error {
+func (s *ResourceNotFoundFault) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundFault) Error() string {
+func (s *ResourceNotFoundFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundFault) StatusCode() int {
+func (s *ResourceNotFoundFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundFault) RequestID() string {
+func (s *ResourceNotFoundFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13122,12 +13122,12 @@ func newErrorResourceQuotaExceededFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceQuotaExceededFault) Code() string {
+func (s *ResourceQuotaExceededFault) Code() string {
 	return "ResourceQuotaExceededFault"
 }
 
 // Message returns the exception's message.
-func (s ResourceQuotaExceededFault) Message() string {
+func (s *ResourceQuotaExceededFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13135,21 +13135,21 @@ func (s ResourceQuotaExceededFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceQuotaExceededFault) OrigErr() error {
+func (s *ResourceQuotaExceededFault) OrigErr() error {
 	return nil
 }
 
-func (s ResourceQuotaExceededFault) Error() string {
+func (s *ResourceQuotaExceededFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceQuotaExceededFault) StatusCode() int {
+func (s *ResourceQuotaExceededFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceQuotaExceededFault) RequestID() string {
+func (s *ResourceQuotaExceededFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13552,12 +13552,12 @@ func newErrorSNSInvalidTopicFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SNSInvalidTopicFault) Code() string {
+func (s *SNSInvalidTopicFault) Code() string {
 	return "SNSInvalidTopicFault"
 }
 
 // Message returns the exception's message.
-func (s SNSInvalidTopicFault) Message() string {
+func (s *SNSInvalidTopicFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13565,21 +13565,21 @@ func (s SNSInvalidTopicFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SNSInvalidTopicFault) OrigErr() error {
+func (s *SNSInvalidTopicFault) OrigErr() error {
 	return nil
 }
 
-func (s SNSInvalidTopicFault) Error() string {
+func (s *SNSInvalidTopicFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SNSInvalidTopicFault) StatusCode() int {
+func (s *SNSInvalidTopicFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SNSInvalidTopicFault) RequestID() string {
+func (s *SNSInvalidTopicFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13608,12 +13608,12 @@ func newErrorSNSNoAuthorizationFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SNSNoAuthorizationFault) Code() string {
+func (s *SNSNoAuthorizationFault) Code() string {
 	return "SNSNoAuthorizationFault"
 }
 
 // Message returns the exception's message.
-func (s SNSNoAuthorizationFault) Message() string {
+func (s *SNSNoAuthorizationFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13621,21 +13621,21 @@ func (s SNSNoAuthorizationFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SNSNoAuthorizationFault) OrigErr() error {
+func (s *SNSNoAuthorizationFault) OrigErr() error {
 	return nil
 }
 
-func (s SNSNoAuthorizationFault) Error() string {
+func (s *SNSNoAuthorizationFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SNSNoAuthorizationFault) StatusCode() int {
+func (s *SNSNoAuthorizationFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SNSNoAuthorizationFault) RequestID() string {
+func (s *SNSNoAuthorizationFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13914,12 +13914,12 @@ func newErrorStorageQuotaExceededFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StorageQuotaExceededFault) Code() string {
+func (s *StorageQuotaExceededFault) Code() string {
 	return "StorageQuotaExceededFault"
 }
 
 // Message returns the exception's message.
-func (s StorageQuotaExceededFault) Message() string {
+func (s *StorageQuotaExceededFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13927,21 +13927,21 @@ func (s StorageQuotaExceededFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StorageQuotaExceededFault) OrigErr() error {
+func (s *StorageQuotaExceededFault) OrigErr() error {
 	return nil
 }
 
-func (s StorageQuotaExceededFault) Error() string {
+func (s *StorageQuotaExceededFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StorageQuotaExceededFault) StatusCode() int {
+func (s *StorageQuotaExceededFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StorageQuotaExceededFault) RequestID() string {
+func (s *StorageQuotaExceededFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14014,12 +14014,12 @@ func newErrorSubnetAlreadyInUse(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SubnetAlreadyInUse) Code() string {
+func (s *SubnetAlreadyInUse) Code() string {
 	return "SubnetAlreadyInUse"
 }
 
 // Message returns the exception's message.
-func (s SubnetAlreadyInUse) Message() string {
+func (s *SubnetAlreadyInUse) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14027,21 +14027,21 @@ func (s SubnetAlreadyInUse) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubnetAlreadyInUse) OrigErr() error {
+func (s *SubnetAlreadyInUse) OrigErr() error {
 	return nil
 }
 
-func (s SubnetAlreadyInUse) Error() string {
+func (s *SubnetAlreadyInUse) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubnetAlreadyInUse) StatusCode() int {
+func (s *SubnetAlreadyInUse) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubnetAlreadyInUse) RequestID() string {
+func (s *SubnetAlreadyInUse) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14500,12 +14500,12 @@ func newErrorUpgradeDependencyFailureFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UpgradeDependencyFailureFault) Code() string {
+func (s *UpgradeDependencyFailureFault) Code() string {
 	return "UpgradeDependencyFailureFault"
 }
 
 // Message returns the exception's message.
-func (s UpgradeDependencyFailureFault) Message() string {
+func (s *UpgradeDependencyFailureFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14513,21 +14513,21 @@ func (s UpgradeDependencyFailureFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UpgradeDependencyFailureFault) OrigErr() error {
+func (s *UpgradeDependencyFailureFault) OrigErr() error {
 	return nil
 }
 
-func (s UpgradeDependencyFailureFault) Error() string {
+func (s *UpgradeDependencyFailureFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UpgradeDependencyFailureFault) StatusCode() int {
+func (s *UpgradeDependencyFailureFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UpgradeDependencyFailureFault) RequestID() string {
+func (s *UpgradeDependencyFailureFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/dataexchange/api.go
+++ b/service/dataexchange/api.go
@@ -2235,12 +2235,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2248,21 +2248,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2622,12 +2622,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2635,21 +2635,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4707,12 +4707,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4720,21 +4720,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5490,12 +5490,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5503,21 +5503,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5734,12 +5734,12 @@ func newErrorServiceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceLimitExceededException) Code() string {
+func (s *ServiceLimitExceededException) Code() string {
 	return "ServiceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceLimitExceededException) Message() string {
+func (s *ServiceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5747,21 +5747,21 @@ func (s ServiceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceLimitExceededException) OrigErr() error {
+func (s *ServiceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceLimitExceededException) Error() string {
+func (s *ServiceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceLimitExceededException) StatusCode() int {
+func (s *ServiceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceLimitExceededException) RequestID() string {
+func (s *ServiceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5909,12 +5909,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5922,21 +5922,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6547,12 +6547,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6560,21 +6560,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -2923,12 +2923,12 @@ func newErrorInternalServiceError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceError) Code() string {
+func (s *InternalServiceError) Code() string {
 	return "InternalServiceError"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceError) Message() string {
+func (s *InternalServiceError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2936,21 +2936,21 @@ func (s InternalServiceError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceError) OrigErr() error {
+func (s *InternalServiceError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceError) Error() string {
+func (s *InternalServiceError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceError) StatusCode() int {
+func (s *InternalServiceError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceError) RequestID() string {
+func (s *InternalServiceError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2982,12 +2982,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2995,21 +2995,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3368,12 +3368,12 @@ func newErrorPipelineDeletedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PipelineDeletedException) Code() string {
+func (s *PipelineDeletedException) Code() string {
 	return "PipelineDeletedException"
 }
 
 // Message returns the exception's message.
-func (s PipelineDeletedException) Message() string {
+func (s *PipelineDeletedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3381,21 +3381,21 @@ func (s PipelineDeletedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PipelineDeletedException) OrigErr() error {
+func (s *PipelineDeletedException) OrigErr() error {
 	return nil
 }
 
-func (s PipelineDeletedException) Error() string {
+func (s *PipelineDeletedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PipelineDeletedException) StatusCode() int {
+func (s *PipelineDeletedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PipelineDeletedException) RequestID() string {
+func (s *PipelineDeletedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3531,12 +3531,12 @@ func newErrorPipelineNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PipelineNotFoundException) Code() string {
+func (s *PipelineNotFoundException) Code() string {
 	return "PipelineNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s PipelineNotFoundException) Message() string {
+func (s *PipelineNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3544,21 +3544,21 @@ func (s PipelineNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PipelineNotFoundException) OrigErr() error {
+func (s *PipelineNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s PipelineNotFoundException) Error() string {
+func (s *PipelineNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PipelineNotFoundException) StatusCode() int {
+func (s *PipelineNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PipelineNotFoundException) RequestID() string {
+func (s *PipelineNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4636,12 +4636,12 @@ func newErrorTaskNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TaskNotFoundException) Code() string {
+func (s *TaskNotFoundException) Code() string {
 	return "TaskNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s TaskNotFoundException) Message() string {
+func (s *TaskNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4649,21 +4649,21 @@ func (s TaskNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TaskNotFoundException) OrigErr() error {
+func (s *TaskNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s TaskNotFoundException) Error() string {
+func (s *TaskNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TaskNotFoundException) StatusCode() int {
+func (s *TaskNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TaskNotFoundException) RequestID() string {
+func (s *TaskNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/datasync/api.go
+++ b/service/datasync/api.go
@@ -5297,12 +5297,12 @@ func newErrorInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalException) Code() string {
+func (s *InternalException) Code() string {
 	return "InternalException"
 }
 
 // Message returns the exception's message.
-func (s InternalException) Message() string {
+func (s *InternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5310,21 +5310,21 @@ func (s InternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalException) OrigErr() error {
+func (s *InternalException) OrigErr() error {
 	return nil
 }
 
-func (s InternalException) Error() string {
+func (s *InternalException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalException) StatusCode() int {
+func (s *InternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalException) RequestID() string {
+func (s *InternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5355,12 +5355,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5368,21 +5368,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/dax/api.go
+++ b/service/dax/api.go
@@ -2211,12 +2211,12 @@ func newErrorClusterAlreadyExistsFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClusterAlreadyExistsFault) Code() string {
+func (s *ClusterAlreadyExistsFault) Code() string {
 	return "ClusterAlreadyExistsFault"
 }
 
 // Message returns the exception's message.
-func (s ClusterAlreadyExistsFault) Message() string {
+func (s *ClusterAlreadyExistsFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2224,21 +2224,21 @@ func (s ClusterAlreadyExistsFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClusterAlreadyExistsFault) OrigErr() error {
+func (s *ClusterAlreadyExistsFault) OrigErr() error {
 	return nil
 }
 
-func (s ClusterAlreadyExistsFault) Error() string {
+func (s *ClusterAlreadyExistsFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClusterAlreadyExistsFault) StatusCode() int {
+func (s *ClusterAlreadyExistsFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClusterAlreadyExistsFault) RequestID() string {
+func (s *ClusterAlreadyExistsFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2267,12 +2267,12 @@ func newErrorClusterNotFoundFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClusterNotFoundFault) Code() string {
+func (s *ClusterNotFoundFault) Code() string {
 	return "ClusterNotFoundFault"
 }
 
 // Message returns the exception's message.
-func (s ClusterNotFoundFault) Message() string {
+func (s *ClusterNotFoundFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2280,21 +2280,21 @@ func (s ClusterNotFoundFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClusterNotFoundFault) OrigErr() error {
+func (s *ClusterNotFoundFault) OrigErr() error {
 	return nil
 }
 
-func (s ClusterNotFoundFault) Error() string {
+func (s *ClusterNotFoundFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClusterNotFoundFault) StatusCode() int {
+func (s *ClusterNotFoundFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClusterNotFoundFault) RequestID() string {
+func (s *ClusterNotFoundFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2324,12 +2324,12 @@ func newErrorClusterQuotaForCustomerExceededFault(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s ClusterQuotaForCustomerExceededFault) Code() string {
+func (s *ClusterQuotaForCustomerExceededFault) Code() string {
 	return "ClusterQuotaForCustomerExceededFault"
 }
 
 // Message returns the exception's message.
-func (s ClusterQuotaForCustomerExceededFault) Message() string {
+func (s *ClusterQuotaForCustomerExceededFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2337,21 +2337,21 @@ func (s ClusterQuotaForCustomerExceededFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClusterQuotaForCustomerExceededFault) OrigErr() error {
+func (s *ClusterQuotaForCustomerExceededFault) OrigErr() error {
 	return nil
 }
 
-func (s ClusterQuotaForCustomerExceededFault) Error() string {
+func (s *ClusterQuotaForCustomerExceededFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClusterQuotaForCustomerExceededFault) StatusCode() int {
+func (s *ClusterQuotaForCustomerExceededFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClusterQuotaForCustomerExceededFault) RequestID() string {
+func (s *ClusterQuotaForCustomerExceededFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3767,12 +3767,12 @@ func newErrorInsufficientClusterCapacityFault(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InsufficientClusterCapacityFault) Code() string {
+func (s *InsufficientClusterCapacityFault) Code() string {
 	return "InsufficientClusterCapacityFault"
 }
 
 // Message returns the exception's message.
-func (s InsufficientClusterCapacityFault) Message() string {
+func (s *InsufficientClusterCapacityFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3780,21 +3780,21 @@ func (s InsufficientClusterCapacityFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientClusterCapacityFault) OrigErr() error {
+func (s *InsufficientClusterCapacityFault) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientClusterCapacityFault) Error() string {
+func (s *InsufficientClusterCapacityFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientClusterCapacityFault) StatusCode() int {
+func (s *InsufficientClusterCapacityFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientClusterCapacityFault) RequestID() string {
+func (s *InsufficientClusterCapacityFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3823,12 +3823,12 @@ func newErrorInvalidARNFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidARNFault) Code() string {
+func (s *InvalidARNFault) Code() string {
 	return "InvalidARNFault"
 }
 
 // Message returns the exception's message.
-func (s InvalidARNFault) Message() string {
+func (s *InvalidARNFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3836,21 +3836,21 @@ func (s InvalidARNFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidARNFault) OrigErr() error {
+func (s *InvalidARNFault) OrigErr() error {
 	return nil
 }
 
-func (s InvalidARNFault) Error() string {
+func (s *InvalidARNFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidARNFault) StatusCode() int {
+func (s *InvalidARNFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidARNFault) RequestID() string {
+func (s *InvalidARNFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3879,12 +3879,12 @@ func newErrorInvalidClusterStateFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidClusterStateFault) Code() string {
+func (s *InvalidClusterStateFault) Code() string {
 	return "InvalidClusterStateFault"
 }
 
 // Message returns the exception's message.
-func (s InvalidClusterStateFault) Message() string {
+func (s *InvalidClusterStateFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3892,21 +3892,21 @@ func (s InvalidClusterStateFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidClusterStateFault) OrigErr() error {
+func (s *InvalidClusterStateFault) OrigErr() error {
 	return nil
 }
 
-func (s InvalidClusterStateFault) Error() string {
+func (s *InvalidClusterStateFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidClusterStateFault) StatusCode() int {
+func (s *InvalidClusterStateFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidClusterStateFault) RequestID() string {
+func (s *InvalidClusterStateFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3935,12 +3935,12 @@ func newErrorInvalidParameterCombinationException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterCombinationException) Code() string {
+func (s *InvalidParameterCombinationException) Code() string {
 	return "InvalidParameterCombinationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterCombinationException) Message() string {
+func (s *InvalidParameterCombinationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3948,21 +3948,21 @@ func (s InvalidParameterCombinationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterCombinationException) OrigErr() error {
+func (s *InvalidParameterCombinationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterCombinationException) Error() string {
+func (s *InvalidParameterCombinationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterCombinationException) StatusCode() int {
+func (s *InvalidParameterCombinationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterCombinationException) RequestID() string {
+func (s *InvalidParameterCombinationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3991,12 +3991,12 @@ func newErrorInvalidParameterGroupStateFault(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterGroupStateFault) Code() string {
+func (s *InvalidParameterGroupStateFault) Code() string {
 	return "InvalidParameterGroupStateFault"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterGroupStateFault) Message() string {
+func (s *InvalidParameterGroupStateFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4004,21 +4004,21 @@ func (s InvalidParameterGroupStateFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterGroupStateFault) OrigErr() error {
+func (s *InvalidParameterGroupStateFault) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterGroupStateFault) Error() string {
+func (s *InvalidParameterGroupStateFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterGroupStateFault) StatusCode() int {
+func (s *InvalidParameterGroupStateFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterGroupStateFault) RequestID() string {
+func (s *InvalidParameterGroupStateFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4047,12 +4047,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4060,21 +4060,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4103,12 +4103,12 @@ func newErrorInvalidSubnet(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSubnet) Code() string {
+func (s *InvalidSubnet) Code() string {
 	return "InvalidSubnet"
 }
 
 // Message returns the exception's message.
-func (s InvalidSubnet) Message() string {
+func (s *InvalidSubnet) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4116,21 +4116,21 @@ func (s InvalidSubnet) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSubnet) OrigErr() error {
+func (s *InvalidSubnet) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSubnet) Error() string {
+func (s *InvalidSubnet) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSubnet) StatusCode() int {
+func (s *InvalidSubnet) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSubnet) RequestID() string {
+func (s *InvalidSubnet) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4159,12 +4159,12 @@ func newErrorInvalidVPCNetworkStateFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidVPCNetworkStateFault) Code() string {
+func (s *InvalidVPCNetworkStateFault) Code() string {
 	return "InvalidVPCNetworkStateFault"
 }
 
 // Message returns the exception's message.
-func (s InvalidVPCNetworkStateFault) Message() string {
+func (s *InvalidVPCNetworkStateFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4172,21 +4172,21 @@ func (s InvalidVPCNetworkStateFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidVPCNetworkStateFault) OrigErr() error {
+func (s *InvalidVPCNetworkStateFault) OrigErr() error {
 	return nil
 }
 
-func (s InvalidVPCNetworkStateFault) Error() string {
+func (s *InvalidVPCNetworkStateFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidVPCNetworkStateFault) StatusCode() int {
+func (s *InvalidVPCNetworkStateFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidVPCNetworkStateFault) RequestID() string {
+func (s *InvalidVPCNetworkStateFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4370,12 +4370,12 @@ func newErrorNodeNotFoundFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NodeNotFoundFault) Code() string {
+func (s *NodeNotFoundFault) Code() string {
 	return "NodeNotFoundFault"
 }
 
 // Message returns the exception's message.
-func (s NodeNotFoundFault) Message() string {
+func (s *NodeNotFoundFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4383,21 +4383,21 @@ func (s NodeNotFoundFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NodeNotFoundFault) OrigErr() error {
+func (s *NodeNotFoundFault) OrigErr() error {
 	return nil
 }
 
-func (s NodeNotFoundFault) Error() string {
+func (s *NodeNotFoundFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NodeNotFoundFault) StatusCode() int {
+func (s *NodeNotFoundFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NodeNotFoundFault) RequestID() string {
+func (s *NodeNotFoundFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4426,12 +4426,12 @@ func newErrorNodeQuotaForClusterExceededFault(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s NodeQuotaForClusterExceededFault) Code() string {
+func (s *NodeQuotaForClusterExceededFault) Code() string {
 	return "NodeQuotaForClusterExceededFault"
 }
 
 // Message returns the exception's message.
-func (s NodeQuotaForClusterExceededFault) Message() string {
+func (s *NodeQuotaForClusterExceededFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4439,21 +4439,21 @@ func (s NodeQuotaForClusterExceededFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NodeQuotaForClusterExceededFault) OrigErr() error {
+func (s *NodeQuotaForClusterExceededFault) OrigErr() error {
 	return nil
 }
 
-func (s NodeQuotaForClusterExceededFault) Error() string {
+func (s *NodeQuotaForClusterExceededFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NodeQuotaForClusterExceededFault) StatusCode() int {
+func (s *NodeQuotaForClusterExceededFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NodeQuotaForClusterExceededFault) RequestID() string {
+func (s *NodeQuotaForClusterExceededFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4482,12 +4482,12 @@ func newErrorNodeQuotaForCustomerExceededFault(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s NodeQuotaForCustomerExceededFault) Code() string {
+func (s *NodeQuotaForCustomerExceededFault) Code() string {
 	return "NodeQuotaForCustomerExceededFault"
 }
 
 // Message returns the exception's message.
-func (s NodeQuotaForCustomerExceededFault) Message() string {
+func (s *NodeQuotaForCustomerExceededFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4495,21 +4495,21 @@ func (s NodeQuotaForCustomerExceededFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NodeQuotaForCustomerExceededFault) OrigErr() error {
+func (s *NodeQuotaForCustomerExceededFault) OrigErr() error {
 	return nil
 }
 
-func (s NodeQuotaForCustomerExceededFault) Error() string {
+func (s *NodeQuotaForCustomerExceededFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NodeQuotaForCustomerExceededFault) StatusCode() int {
+func (s *NodeQuotaForCustomerExceededFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NodeQuotaForCustomerExceededFault) RequestID() string {
+func (s *NodeQuotaForCustomerExceededFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4748,12 +4748,12 @@ func newErrorParameterGroupAlreadyExistsFault(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s ParameterGroupAlreadyExistsFault) Code() string {
+func (s *ParameterGroupAlreadyExistsFault) Code() string {
 	return "ParameterGroupAlreadyExistsFault"
 }
 
 // Message returns the exception's message.
-func (s ParameterGroupAlreadyExistsFault) Message() string {
+func (s *ParameterGroupAlreadyExistsFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4761,21 +4761,21 @@ func (s ParameterGroupAlreadyExistsFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterGroupAlreadyExistsFault) OrigErr() error {
+func (s *ParameterGroupAlreadyExistsFault) OrigErr() error {
 	return nil
 }
 
-func (s ParameterGroupAlreadyExistsFault) Error() string {
+func (s *ParameterGroupAlreadyExistsFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterGroupAlreadyExistsFault) StatusCode() int {
+func (s *ParameterGroupAlreadyExistsFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterGroupAlreadyExistsFault) RequestID() string {
+func (s *ParameterGroupAlreadyExistsFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4804,12 +4804,12 @@ func newErrorParameterGroupNotFoundFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ParameterGroupNotFoundFault) Code() string {
+func (s *ParameterGroupNotFoundFault) Code() string {
 	return "ParameterGroupNotFoundFault"
 }
 
 // Message returns the exception's message.
-func (s ParameterGroupNotFoundFault) Message() string {
+func (s *ParameterGroupNotFoundFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4817,21 +4817,21 @@ func (s ParameterGroupNotFoundFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterGroupNotFoundFault) OrigErr() error {
+func (s *ParameterGroupNotFoundFault) OrigErr() error {
 	return nil
 }
 
-func (s ParameterGroupNotFoundFault) Error() string {
+func (s *ParameterGroupNotFoundFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterGroupNotFoundFault) StatusCode() int {
+func (s *ParameterGroupNotFoundFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterGroupNotFoundFault) RequestID() string {
+func (s *ParameterGroupNotFoundFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4860,12 +4860,12 @@ func newErrorParameterGroupQuotaExceededFault(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s ParameterGroupQuotaExceededFault) Code() string {
+func (s *ParameterGroupQuotaExceededFault) Code() string {
 	return "ParameterGroupQuotaExceededFault"
 }
 
 // Message returns the exception's message.
-func (s ParameterGroupQuotaExceededFault) Message() string {
+func (s *ParameterGroupQuotaExceededFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4873,21 +4873,21 @@ func (s ParameterGroupQuotaExceededFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterGroupQuotaExceededFault) OrigErr() error {
+func (s *ParameterGroupQuotaExceededFault) OrigErr() error {
 	return nil
 }
 
-func (s ParameterGroupQuotaExceededFault) Error() string {
+func (s *ParameterGroupQuotaExceededFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterGroupQuotaExceededFault) StatusCode() int {
+func (s *ParameterGroupQuotaExceededFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterGroupQuotaExceededFault) RequestID() string {
+func (s *ParameterGroupQuotaExceededFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5172,12 +5172,12 @@ func newErrorServiceLinkedRoleNotFoundFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceLinkedRoleNotFoundFault) Code() string {
+func (s *ServiceLinkedRoleNotFoundFault) Code() string {
 	return "ServiceLinkedRoleNotFoundFault"
 }
 
 // Message returns the exception's message.
-func (s ServiceLinkedRoleNotFoundFault) Message() string {
+func (s *ServiceLinkedRoleNotFoundFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5185,21 +5185,21 @@ func (s ServiceLinkedRoleNotFoundFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceLinkedRoleNotFoundFault) OrigErr() error {
+func (s *ServiceLinkedRoleNotFoundFault) OrigErr() error {
 	return nil
 }
 
-func (s ServiceLinkedRoleNotFoundFault) Error() string {
+func (s *ServiceLinkedRoleNotFoundFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceLinkedRoleNotFoundFault) StatusCode() int {
+func (s *ServiceLinkedRoleNotFoundFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceLinkedRoleNotFoundFault) RequestID() string {
+func (s *ServiceLinkedRoleNotFoundFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5318,12 +5318,12 @@ func newErrorSubnetGroupAlreadyExistsFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SubnetGroupAlreadyExistsFault) Code() string {
+func (s *SubnetGroupAlreadyExistsFault) Code() string {
 	return "SubnetGroupAlreadyExistsFault"
 }
 
 // Message returns the exception's message.
-func (s SubnetGroupAlreadyExistsFault) Message() string {
+func (s *SubnetGroupAlreadyExistsFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5331,21 +5331,21 @@ func (s SubnetGroupAlreadyExistsFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubnetGroupAlreadyExistsFault) OrigErr() error {
+func (s *SubnetGroupAlreadyExistsFault) OrigErr() error {
 	return nil
 }
 
-func (s SubnetGroupAlreadyExistsFault) Error() string {
+func (s *SubnetGroupAlreadyExistsFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubnetGroupAlreadyExistsFault) StatusCode() int {
+func (s *SubnetGroupAlreadyExistsFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubnetGroupAlreadyExistsFault) RequestID() string {
+func (s *SubnetGroupAlreadyExistsFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5374,12 +5374,12 @@ func newErrorSubnetGroupInUseFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SubnetGroupInUseFault) Code() string {
+func (s *SubnetGroupInUseFault) Code() string {
 	return "SubnetGroupInUseFault"
 }
 
 // Message returns the exception's message.
-func (s SubnetGroupInUseFault) Message() string {
+func (s *SubnetGroupInUseFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5387,21 +5387,21 @@ func (s SubnetGroupInUseFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubnetGroupInUseFault) OrigErr() error {
+func (s *SubnetGroupInUseFault) OrigErr() error {
 	return nil
 }
 
-func (s SubnetGroupInUseFault) Error() string {
+func (s *SubnetGroupInUseFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubnetGroupInUseFault) StatusCode() int {
+func (s *SubnetGroupInUseFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubnetGroupInUseFault) RequestID() string {
+func (s *SubnetGroupInUseFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5430,12 +5430,12 @@ func newErrorSubnetGroupNotFoundFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SubnetGroupNotFoundFault) Code() string {
+func (s *SubnetGroupNotFoundFault) Code() string {
 	return "SubnetGroupNotFoundFault"
 }
 
 // Message returns the exception's message.
-func (s SubnetGroupNotFoundFault) Message() string {
+func (s *SubnetGroupNotFoundFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5443,21 +5443,21 @@ func (s SubnetGroupNotFoundFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubnetGroupNotFoundFault) OrigErr() error {
+func (s *SubnetGroupNotFoundFault) OrigErr() error {
 	return nil
 }
 
-func (s SubnetGroupNotFoundFault) Error() string {
+func (s *SubnetGroupNotFoundFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubnetGroupNotFoundFault) StatusCode() int {
+func (s *SubnetGroupNotFoundFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubnetGroupNotFoundFault) RequestID() string {
+func (s *SubnetGroupNotFoundFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5487,12 +5487,12 @@ func newErrorSubnetGroupQuotaExceededFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SubnetGroupQuotaExceededFault) Code() string {
+func (s *SubnetGroupQuotaExceededFault) Code() string {
 	return "SubnetGroupQuotaExceededFault"
 }
 
 // Message returns the exception's message.
-func (s SubnetGroupQuotaExceededFault) Message() string {
+func (s *SubnetGroupQuotaExceededFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5500,21 +5500,21 @@ func (s SubnetGroupQuotaExceededFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubnetGroupQuotaExceededFault) OrigErr() error {
+func (s *SubnetGroupQuotaExceededFault) OrigErr() error {
 	return nil
 }
 
-func (s SubnetGroupQuotaExceededFault) Error() string {
+func (s *SubnetGroupQuotaExceededFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubnetGroupQuotaExceededFault) StatusCode() int {
+func (s *SubnetGroupQuotaExceededFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubnetGroupQuotaExceededFault) RequestID() string {
+func (s *SubnetGroupQuotaExceededFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5543,12 +5543,12 @@ func newErrorSubnetInUse(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SubnetInUse) Code() string {
+func (s *SubnetInUse) Code() string {
 	return "SubnetInUse"
 }
 
 // Message returns the exception's message.
-func (s SubnetInUse) Message() string {
+func (s *SubnetInUse) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5556,21 +5556,21 @@ func (s SubnetInUse) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubnetInUse) OrigErr() error {
+func (s *SubnetInUse) OrigErr() error {
 	return nil
 }
 
-func (s SubnetInUse) Error() string {
+func (s *SubnetInUse) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubnetInUse) StatusCode() int {
+func (s *SubnetInUse) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubnetInUse) RequestID() string {
+func (s *SubnetInUse) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5600,12 +5600,12 @@ func newErrorSubnetQuotaExceededFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SubnetQuotaExceededFault) Code() string {
+func (s *SubnetQuotaExceededFault) Code() string {
 	return "SubnetQuotaExceededFault"
 }
 
 // Message returns the exception's message.
-func (s SubnetQuotaExceededFault) Message() string {
+func (s *SubnetQuotaExceededFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5613,21 +5613,21 @@ func (s SubnetQuotaExceededFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubnetQuotaExceededFault) OrigErr() error {
+func (s *SubnetQuotaExceededFault) OrigErr() error {
 	return nil
 }
 
-func (s SubnetQuotaExceededFault) Error() string {
+func (s *SubnetQuotaExceededFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubnetQuotaExceededFault) StatusCode() int {
+func (s *SubnetQuotaExceededFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubnetQuotaExceededFault) RequestID() string {
+func (s *SubnetQuotaExceededFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5698,12 +5698,12 @@ func newErrorTagNotFoundFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagNotFoundFault) Code() string {
+func (s *TagNotFoundFault) Code() string {
 	return "TagNotFoundFault"
 }
 
 // Message returns the exception's message.
-func (s TagNotFoundFault) Message() string {
+func (s *TagNotFoundFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5711,21 +5711,21 @@ func (s TagNotFoundFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagNotFoundFault) OrigErr() error {
+func (s *TagNotFoundFault) OrigErr() error {
 	return nil
 }
 
-func (s TagNotFoundFault) Error() string {
+func (s *TagNotFoundFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagNotFoundFault) StatusCode() int {
+func (s *TagNotFoundFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagNotFoundFault) RequestID() string {
+func (s *TagNotFoundFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5754,12 +5754,12 @@ func newErrorTagQuotaPerResourceExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagQuotaPerResourceExceeded) Code() string {
+func (s *TagQuotaPerResourceExceeded) Code() string {
 	return "TagQuotaPerResourceExceeded"
 }
 
 // Message returns the exception's message.
-func (s TagQuotaPerResourceExceeded) Message() string {
+func (s *TagQuotaPerResourceExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5767,21 +5767,21 @@ func (s TagQuotaPerResourceExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagQuotaPerResourceExceeded) OrigErr() error {
+func (s *TagQuotaPerResourceExceeded) OrigErr() error {
 	return nil
 }
 
-func (s TagQuotaPerResourceExceeded) Error() string {
+func (s *TagQuotaPerResourceExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagQuotaPerResourceExceeded) StatusCode() int {
+func (s *TagQuotaPerResourceExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagQuotaPerResourceExceeded) RequestID() string {
+func (s *TagQuotaPerResourceExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/detective/api.go
+++ b/service/detective/api.go
@@ -1493,12 +1493,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1506,21 +1506,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2032,12 +2032,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2045,21 +2045,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2570,12 +2570,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2583,21 +2583,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2636,12 +2636,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2649,21 +2649,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2799,12 +2799,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2812,21 +2812,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -8031,12 +8031,12 @@ func newErrorArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ArgumentException) Code() string {
+func (s *ArgumentException) Code() string {
 	return "ArgumentException"
 }
 
 // Message returns the exception's message.
-func (s ArgumentException) Message() string {
+func (s *ArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8044,21 +8044,21 @@ func (s ArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ArgumentException) OrigErr() error {
+func (s *ArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s ArgumentException) Error() string {
+func (s *ArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ArgumentException) StatusCode() int {
+func (s *ArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ArgumentException) RequestID() string {
+func (s *ArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8251,12 +8251,12 @@ func newErrorCannotDeleteException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CannotDeleteException) Code() string {
+func (s *CannotDeleteException) Code() string {
 	return "CannotDeleteException"
 }
 
 // Message returns the exception's message.
-func (s CannotDeleteException) Message() string {
+func (s *CannotDeleteException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8264,21 +8264,21 @@ func (s CannotDeleteException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CannotDeleteException) OrigErr() error {
+func (s *CannotDeleteException) OrigErr() error {
 	return nil
 }
 
-func (s CannotDeleteException) Error() string {
+func (s *CannotDeleteException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CannotDeleteException) StatusCode() int {
+func (s *CannotDeleteException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CannotDeleteException) RequestID() string {
+func (s *CannotDeleteException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12201,12 +12201,12 @@ func newErrorIdempotencyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IdempotencyException) Code() string {
+func (s *IdempotencyException) Code() string {
 	return "IdempotencyException"
 }
 
 // Message returns the exception's message.
-func (s IdempotencyException) Message() string {
+func (s *IdempotencyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12214,21 +12214,21 @@ func (s IdempotencyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotencyException) OrigErr() error {
+func (s *IdempotencyException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotencyException) Error() string {
+func (s *IdempotencyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotencyException) StatusCode() int {
+func (s *IdempotencyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotencyException) RequestID() string {
+func (s *IdempotencyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12465,12 +12465,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12478,21 +12478,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12522,12 +12522,12 @@ func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOperationException) Code() string {
+func (s *InvalidOperationException) Code() string {
 	return "InvalidOperationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOperationException) Message() string {
+func (s *InvalidOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12535,21 +12535,21 @@ func (s InvalidOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOperationException) OrigErr() error {
+func (s *InvalidOperationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOperationException) Error() string {
+func (s *InvalidOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOperationException) StatusCode() int {
+func (s *InvalidOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOperationException) RequestID() string {
+func (s *InvalidOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12805,12 +12805,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12818,21 +12818,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15373,12 +15373,12 @@ func newErrorNotEligibleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotEligibleException) Code() string {
+func (s *NotEligibleException) Code() string {
 	return "NotEligibleException"
 }
 
 // Message returns the exception's message.
-func (s NotEligibleException) Message() string {
+func (s *NotEligibleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15386,21 +15386,21 @@ func (s NotEligibleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotEligibleException) OrigErr() error {
+func (s *NotEligibleException) OrigErr() error {
 	return nil
 }
 
-func (s NotEligibleException) Error() string {
+func (s *NotEligibleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotEligibleException) StatusCode() int {
+func (s *NotEligibleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotEligibleException) RequestID() string {
+func (s *NotEligibleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15430,12 +15430,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15443,21 +15443,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17481,12 +17481,12 @@ func newErrorServiceAccountException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceAccountException) Code() string {
+func (s *ServiceAccountException) Code() string {
 	return "ServiceAccountException"
 }
 
 // Message returns the exception's message.
-func (s ServiceAccountException) Message() string {
+func (s *ServiceAccountException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17494,21 +17494,21 @@ func (s ServiceAccountException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceAccountException) OrigErr() error {
+func (s *ServiceAccountException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceAccountException) Error() string {
+func (s *ServiceAccountException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceAccountException) StatusCode() int {
+func (s *ServiceAccountException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceAccountException) RequestID() string {
+func (s *ServiceAccountException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17988,12 +17988,12 @@ func newErrorTagOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagOperationException) Code() string {
+func (s *TagOperationException) Code() string {
 	return "TagOperationException"
 }
 
 // Message returns the exception's message.
-func (s TagOperationException) Message() string {
+func (s *TagOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18001,21 +18001,21 @@ func (s TagOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagOperationException) OrigErr() error {
+func (s *TagOperationException) OrigErr() error {
 	return nil
 }
 
-func (s TagOperationException) Error() string {
+func (s *TagOperationException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagOperationException) StatusCode() int {
+func (s *TagOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagOperationException) RequestID() string {
+func (s *TagOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18047,12 +18047,12 @@ func newErrorTagPolicyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagPolicyException) Code() string {
+func (s *TagPolicyException) Code() string {
 	return "TagPolicyException"
 }
 
 // Message returns the exception's message.
-func (s TagPolicyException) Message() string {
+func (s *TagPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18060,21 +18060,21 @@ func (s TagPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagPolicyException) OrigErr() error {
+func (s *TagPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s TagPolicyException) Error() string {
+func (s *TagPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagPolicyException) StatusCode() int {
+func (s *TagPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagPolicyException) RequestID() string {
+func (s *TagPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18606,12 +18606,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18619,21 +18619,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -5683,12 +5683,12 @@ func newErrorClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientException) Code() string {
+func (s *ClientException) Code() string {
 	return "DirectConnectClientException"
 }
 
 // Message returns the exception's message.
-func (s ClientException) Message() string {
+func (s *ClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5696,21 +5696,21 @@ func (s ClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientException) OrigErr() error {
+func (s *ClientException) OrigErr() error {
 	return nil
 }
 
-func (s ClientException) Error() string {
+func (s *ClientException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientException) StatusCode() int {
+func (s *ClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientException) RequestID() string {
+func (s *ClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8737,12 +8737,12 @@ func newErrorDuplicateTagKeysException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateTagKeysException) Code() string {
+func (s *DuplicateTagKeysException) Code() string {
 	return "DuplicateTagKeysException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateTagKeysException) Message() string {
+func (s *DuplicateTagKeysException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8750,21 +8750,21 @@ func (s DuplicateTagKeysException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateTagKeysException) OrigErr() error {
+func (s *DuplicateTagKeysException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateTagKeysException) Error() string {
+func (s *DuplicateTagKeysException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateTagKeysException) StatusCode() int {
+func (s *DuplicateTagKeysException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateTagKeysException) RequestID() string {
+func (s *DuplicateTagKeysException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10557,12 +10557,12 @@ func newErrorServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServerException) Code() string {
+func (s *ServerException) Code() string {
 	return "DirectConnectServerException"
 }
 
 // Message returns the exception's message.
-func (s ServerException) Message() string {
+func (s *ServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10570,21 +10570,21 @@ func (s ServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServerException) OrigErr() error {
+func (s *ServerException) OrigErr() error {
 	return nil
 }
 
-func (s ServerException) Error() string {
+func (s *ServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServerException) StatusCode() int {
+func (s *ServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServerException) RequestID() string {
+func (s *ServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10743,12 +10743,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10756,21 +10756,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -5596,12 +5596,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5609,21 +5609,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5899,12 +5899,12 @@ func newErrorAuthenticationFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AuthenticationFailedException) Code() string {
+func (s *AuthenticationFailedException) Code() string {
 	return "AuthenticationFailedException"
 }
 
 // Message returns the exception's message.
-func (s AuthenticationFailedException) Message() string {
+func (s *AuthenticationFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5912,21 +5912,21 @@ func (s AuthenticationFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AuthenticationFailedException) OrigErr() error {
+func (s *AuthenticationFailedException) OrigErr() error {
 	return nil
 }
 
-func (s AuthenticationFailedException) Error() string {
+func (s *AuthenticationFailedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AuthenticationFailedException) StatusCode() int {
+func (s *AuthenticationFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AuthenticationFailedException) RequestID() string {
+func (s *AuthenticationFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6094,12 +6094,12 @@ func newErrorCertificateAlreadyExistsException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s CertificateAlreadyExistsException) Code() string {
+func (s *CertificateAlreadyExistsException) Code() string {
 	return "CertificateAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s CertificateAlreadyExistsException) Message() string {
+func (s *CertificateAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6107,21 +6107,21 @@ func (s CertificateAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CertificateAlreadyExistsException) OrigErr() error {
+func (s *CertificateAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s CertificateAlreadyExistsException) Error() string {
+func (s *CertificateAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CertificateAlreadyExistsException) StatusCode() int {
+func (s *CertificateAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CertificateAlreadyExistsException) RequestID() string {
+func (s *CertificateAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6154,12 +6154,12 @@ func newErrorCertificateDoesNotExistException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s CertificateDoesNotExistException) Code() string {
+func (s *CertificateDoesNotExistException) Code() string {
 	return "CertificateDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s CertificateDoesNotExistException) Message() string {
+func (s *CertificateDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6167,21 +6167,21 @@ func (s CertificateDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CertificateDoesNotExistException) OrigErr() error {
+func (s *CertificateDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s CertificateDoesNotExistException) Error() string {
+func (s *CertificateDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CertificateDoesNotExistException) StatusCode() int {
+func (s *CertificateDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CertificateDoesNotExistException) RequestID() string {
+func (s *CertificateDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6215,12 +6215,12 @@ func newErrorCertificateInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CertificateInUseException) Code() string {
+func (s *CertificateInUseException) Code() string {
 	return "CertificateInUseException"
 }
 
 // Message returns the exception's message.
-func (s CertificateInUseException) Message() string {
+func (s *CertificateInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6228,21 +6228,21 @@ func (s CertificateInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CertificateInUseException) OrigErr() error {
+func (s *CertificateInUseException) OrigErr() error {
 	return nil
 }
 
-func (s CertificateInUseException) Error() string {
+func (s *CertificateInUseException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CertificateInUseException) StatusCode() int {
+func (s *CertificateInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CertificateInUseException) RequestID() string {
+func (s *CertificateInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6327,12 +6327,12 @@ func newErrorCertificateLimitExceededException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s CertificateLimitExceededException) Code() string {
+func (s *CertificateLimitExceededException) Code() string {
 	return "CertificateLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s CertificateLimitExceededException) Message() string {
+func (s *CertificateLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6340,21 +6340,21 @@ func (s CertificateLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CertificateLimitExceededException) OrigErr() error {
+func (s *CertificateLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s CertificateLimitExceededException) Error() string {
+func (s *CertificateLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CertificateLimitExceededException) StatusCode() int {
+func (s *CertificateLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CertificateLimitExceededException) RequestID() string {
+func (s *CertificateLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6387,12 +6387,12 @@ func newErrorClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientException) Code() string {
+func (s *ClientException) Code() string {
 	return "ClientException"
 }
 
 // Message returns the exception's message.
-func (s ClientException) Message() string {
+func (s *ClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6400,21 +6400,21 @@ func (s ClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientException) OrigErr() error {
+func (s *ClientException) OrigErr() error {
 	return nil
 }
 
-func (s ClientException) Error() string {
+func (s *ClientException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientException) StatusCode() int {
+func (s *ClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientException) RequestID() string {
+func (s *ClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8840,12 +8840,12 @@ func newErrorDirectoryAlreadySharedException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s DirectoryAlreadySharedException) Code() string {
+func (s *DirectoryAlreadySharedException) Code() string {
 	return "DirectoryAlreadySharedException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryAlreadySharedException) Message() string {
+func (s *DirectoryAlreadySharedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8853,21 +8853,21 @@ func (s DirectoryAlreadySharedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryAlreadySharedException) OrigErr() error {
+func (s *DirectoryAlreadySharedException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryAlreadySharedException) Error() string {
+func (s *DirectoryAlreadySharedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryAlreadySharedException) StatusCode() int {
+func (s *DirectoryAlreadySharedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryAlreadySharedException) RequestID() string {
+func (s *DirectoryAlreadySharedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9311,12 +9311,12 @@ func newErrorDirectoryDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DirectoryDoesNotExistException) Code() string {
+func (s *DirectoryDoesNotExistException) Code() string {
 	return "DirectoryDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryDoesNotExistException) Message() string {
+func (s *DirectoryDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9324,21 +9324,21 @@ func (s DirectoryDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryDoesNotExistException) OrigErr() error {
+func (s *DirectoryDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryDoesNotExistException) Error() string {
+func (s *DirectoryDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryDoesNotExistException) StatusCode() int {
+func (s *DirectoryDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryDoesNotExistException) RequestID() string {
+func (s *DirectoryDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9373,12 +9373,12 @@ func newErrorDirectoryLimitExceededException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s DirectoryLimitExceededException) Code() string {
+func (s *DirectoryLimitExceededException) Code() string {
 	return "DirectoryLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryLimitExceededException) Message() string {
+func (s *DirectoryLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9386,21 +9386,21 @@ func (s DirectoryLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryLimitExceededException) OrigErr() error {
+func (s *DirectoryLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryLimitExceededException) Error() string {
+func (s *DirectoryLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryLimitExceededException) StatusCode() int {
+func (s *DirectoryLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryLimitExceededException) RequestID() string {
+func (s *DirectoryLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9530,12 +9530,12 @@ func newErrorDirectoryNotSharedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DirectoryNotSharedException) Code() string {
+func (s *DirectoryNotSharedException) Code() string {
 	return "DirectoryNotSharedException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryNotSharedException) Message() string {
+func (s *DirectoryNotSharedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9543,21 +9543,21 @@ func (s DirectoryNotSharedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryNotSharedException) OrigErr() error {
+func (s *DirectoryNotSharedException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryNotSharedException) Error() string {
+func (s *DirectoryNotSharedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryNotSharedException) StatusCode() int {
+func (s *DirectoryNotSharedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryNotSharedException) RequestID() string {
+func (s *DirectoryNotSharedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9590,12 +9590,12 @@ func newErrorDirectoryUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DirectoryUnavailableException) Code() string {
+func (s *DirectoryUnavailableException) Code() string {
 	return "DirectoryUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryUnavailableException) Message() string {
+func (s *DirectoryUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9603,21 +9603,21 @@ func (s DirectoryUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryUnavailableException) OrigErr() error {
+func (s *DirectoryUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryUnavailableException) Error() string {
+func (s *DirectoryUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryUnavailableException) StatusCode() int {
+func (s *DirectoryUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryUnavailableException) RequestID() string {
+func (s *DirectoryUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10070,12 +10070,12 @@ func newErrorDomainControllerLimitExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s DomainControllerLimitExceededException) Code() string {
+func (s *DomainControllerLimitExceededException) Code() string {
 	return "DomainControllerLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s DomainControllerLimitExceededException) Message() string {
+func (s *DomainControllerLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10083,21 +10083,21 @@ func (s DomainControllerLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DomainControllerLimitExceededException) OrigErr() error {
+func (s *DomainControllerLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s DomainControllerLimitExceededException) Error() string {
+func (s *DomainControllerLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DomainControllerLimitExceededException) StatusCode() int {
+func (s *DomainControllerLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DomainControllerLimitExceededException) RequestID() string {
+func (s *DomainControllerLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10357,12 +10357,12 @@ func newErrorEntityAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EntityAlreadyExistsException) Code() string {
+func (s *EntityAlreadyExistsException) Code() string {
 	return "EntityAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s EntityAlreadyExistsException) Message() string {
+func (s *EntityAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10370,21 +10370,21 @@ func (s EntityAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EntityAlreadyExistsException) OrigErr() error {
+func (s *EntityAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s EntityAlreadyExistsException) Error() string {
+func (s *EntityAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EntityAlreadyExistsException) StatusCode() int {
+func (s *EntityAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EntityAlreadyExistsException) RequestID() string {
+func (s *EntityAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10417,12 +10417,12 @@ func newErrorEntityDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EntityDoesNotExistException) Code() string {
+func (s *EntityDoesNotExistException) Code() string {
 	return "EntityDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s EntityDoesNotExistException) Message() string {
+func (s *EntityDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10430,21 +10430,21 @@ func (s EntityDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EntityDoesNotExistException) OrigErr() error {
+func (s *EntityDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s EntityDoesNotExistException) Error() string {
+func (s *EntityDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EntityDoesNotExistException) StatusCode() int {
+func (s *EntityDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EntityDoesNotExistException) RequestID() string {
+func (s *EntityDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10642,12 +10642,12 @@ func newErrorInsufficientPermissionsException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InsufficientPermissionsException) Code() string {
+func (s *InsufficientPermissionsException) Code() string {
 	return "InsufficientPermissionsException"
 }
 
 // Message returns the exception's message.
-func (s InsufficientPermissionsException) Message() string {
+func (s *InsufficientPermissionsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10655,21 +10655,21 @@ func (s InsufficientPermissionsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientPermissionsException) OrigErr() error {
+func (s *InsufficientPermissionsException) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientPermissionsException) Error() string {
+func (s *InsufficientPermissionsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientPermissionsException) StatusCode() int {
+func (s *InsufficientPermissionsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientPermissionsException) RequestID() string {
+func (s *InsufficientPermissionsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10702,12 +10702,12 @@ func newErrorInvalidCertificateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidCertificateException) Code() string {
+func (s *InvalidCertificateException) Code() string {
 	return "InvalidCertificateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCertificateException) Message() string {
+func (s *InvalidCertificateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10715,21 +10715,21 @@ func (s InvalidCertificateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCertificateException) OrigErr() error {
+func (s *InvalidCertificateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCertificateException) Error() string {
+func (s *InvalidCertificateException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCertificateException) StatusCode() int {
+func (s *InvalidCertificateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCertificateException) RequestID() string {
+func (s *InvalidCertificateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10763,12 +10763,12 @@ func newErrorInvalidLDAPSStatusException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidLDAPSStatusException) Code() string {
+func (s *InvalidLDAPSStatusException) Code() string {
 	return "InvalidLDAPSStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLDAPSStatusException) Message() string {
+func (s *InvalidLDAPSStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10776,21 +10776,21 @@ func (s InvalidLDAPSStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLDAPSStatusException) OrigErr() error {
+func (s *InvalidLDAPSStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLDAPSStatusException) Error() string {
+func (s *InvalidLDAPSStatusException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLDAPSStatusException) StatusCode() int {
+func (s *InvalidLDAPSStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLDAPSStatusException) RequestID() string {
+func (s *InvalidLDAPSStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10823,12 +10823,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10836,21 +10836,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10883,12 +10883,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10896,21 +10896,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10944,12 +10944,12 @@ func newErrorInvalidPasswordException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPasswordException) Code() string {
+func (s *InvalidPasswordException) Code() string {
 	return "InvalidPasswordException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPasswordException) Message() string {
+func (s *InvalidPasswordException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10957,21 +10957,21 @@ func (s InvalidPasswordException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPasswordException) OrigErr() error {
+func (s *InvalidPasswordException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPasswordException) Error() string {
+func (s *InvalidPasswordException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPasswordException) StatusCode() int {
+func (s *InvalidPasswordException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPasswordException) RequestID() string {
+func (s *InvalidPasswordException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11004,12 +11004,12 @@ func newErrorInvalidTargetException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTargetException) Code() string {
+func (s *InvalidTargetException) Code() string {
 	return "InvalidTargetException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTargetException) Message() string {
+func (s *InvalidTargetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11017,21 +11017,21 @@ func (s InvalidTargetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTargetException) OrigErr() error {
+func (s *InvalidTargetException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTargetException) Error() string {
+func (s *InvalidTargetException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTargetException) StatusCode() int {
+func (s *InvalidTargetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTargetException) RequestID() string {
+func (s *InvalidTargetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11170,12 +11170,12 @@ func newErrorIpRouteLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IpRouteLimitExceededException) Code() string {
+func (s *IpRouteLimitExceededException) Code() string {
 	return "IpRouteLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s IpRouteLimitExceededException) Message() string {
+func (s *IpRouteLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11183,21 +11183,21 @@ func (s IpRouteLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IpRouteLimitExceededException) OrigErr() error {
+func (s *IpRouteLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s IpRouteLimitExceededException) Error() string {
+func (s *IpRouteLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IpRouteLimitExceededException) StatusCode() int {
+func (s *IpRouteLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IpRouteLimitExceededException) RequestID() string {
+func (s *IpRouteLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11761,12 +11761,12 @@ func newErrorNoAvailableCertificateException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s NoAvailableCertificateException) Code() string {
+func (s *NoAvailableCertificateException) Code() string {
 	return "NoAvailableCertificateException"
 }
 
 // Message returns the exception's message.
-func (s NoAvailableCertificateException) Message() string {
+func (s *NoAvailableCertificateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11774,21 +11774,21 @@ func (s NoAvailableCertificateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoAvailableCertificateException) OrigErr() error {
+func (s *NoAvailableCertificateException) OrigErr() error {
 	return nil
 }
 
-func (s NoAvailableCertificateException) Error() string {
+func (s *NoAvailableCertificateException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoAvailableCertificateException) StatusCode() int {
+func (s *NoAvailableCertificateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoAvailableCertificateException) RequestID() string {
+func (s *NoAvailableCertificateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11821,12 +11821,12 @@ func newErrorOrganizationsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OrganizationsException) Code() string {
+func (s *OrganizationsException) Code() string {
 	return "OrganizationsException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationsException) Message() string {
+func (s *OrganizationsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11834,21 +11834,21 @@ func (s OrganizationsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationsException) OrigErr() error {
+func (s *OrganizationsException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationsException) Error() string {
+func (s *OrganizationsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationsException) StatusCode() int {
+func (s *OrganizationsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationsException) RequestID() string {
+func (s *OrganizationsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12630,12 +12630,12 @@ func newErrorServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceException) Code() string {
+func (s *ServiceException) Code() string {
 	return "ServiceException"
 }
 
 // Message returns the exception's message.
-func (s ServiceException) Message() string {
+func (s *ServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12643,21 +12643,21 @@ func (s ServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceException) OrigErr() error {
+func (s *ServiceException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceException) Error() string {
+func (s *ServiceException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceException) StatusCode() int {
+func (s *ServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceException) RequestID() string {
+func (s *ServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12801,12 +12801,12 @@ func newErrorShareLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ShareLimitExceededException) Code() string {
+func (s *ShareLimitExceededException) Code() string {
 	return "ShareLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ShareLimitExceededException) Message() string {
+func (s *ShareLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12814,21 +12814,21 @@ func (s ShareLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ShareLimitExceededException) OrigErr() error {
+func (s *ShareLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ShareLimitExceededException) Error() string {
+func (s *ShareLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ShareLimitExceededException) StatusCode() int {
+func (s *ShareLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ShareLimitExceededException) RequestID() string {
+func (s *ShareLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13092,12 +13092,12 @@ func newErrorSnapshotLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SnapshotLimitExceededException) Code() string {
+func (s *SnapshotLimitExceededException) Code() string {
 	return "SnapshotLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s SnapshotLimitExceededException) Message() string {
+func (s *SnapshotLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13105,21 +13105,21 @@ func (s SnapshotLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SnapshotLimitExceededException) OrigErr() error {
+func (s *SnapshotLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s SnapshotLimitExceededException) Error() string {
+func (s *SnapshotLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SnapshotLimitExceededException) StatusCode() int {
+func (s *SnapshotLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SnapshotLimitExceededException) RequestID() string {
+func (s *SnapshotLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13364,12 +13364,12 @@ func newErrorTagLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagLimitExceededException) Code() string {
+func (s *TagLimitExceededException) Code() string {
 	return "TagLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TagLimitExceededException) Message() string {
+func (s *TagLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13377,21 +13377,21 @@ func (s TagLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagLimitExceededException) OrigErr() error {
+func (s *TagLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TagLimitExceededException) Error() string {
+func (s *TagLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagLimitExceededException) StatusCode() int {
+func (s *TagLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagLimitExceededException) RequestID() string {
+func (s *TagLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13680,12 +13680,12 @@ func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedOperationException) Code() string {
+func (s *UnsupportedOperationException) Code() string {
 	return "UnsupportedOperationException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedOperationException) Message() string {
+func (s *UnsupportedOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13693,21 +13693,21 @@ func (s UnsupportedOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedOperationException) OrigErr() error {
+func (s *UnsupportedOperationException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedOperationException) Error() string {
+func (s *UnsupportedOperationException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedOperationException) StatusCode() int {
+func (s *UnsupportedOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedOperationException) RequestID() string {
+func (s *UnsupportedOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14047,12 +14047,12 @@ func newErrorUserDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UserDoesNotExistException) Code() string {
+func (s *UserDoesNotExistException) Code() string {
 	return "UserDoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s UserDoesNotExistException) Message() string {
+func (s *UserDoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14060,21 +14060,21 @@ func (s UserDoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserDoesNotExistException) OrigErr() error {
+func (s *UserDoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s UserDoesNotExistException) Error() string {
+func (s *UserDoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserDoesNotExistException) StatusCode() int {
+func (s *UserDoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserDoesNotExistException) RequestID() string {
+func (s *UserDoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/dlm/api.go
+++ b/service/dlm/api.go
@@ -1362,12 +1362,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1375,21 +1375,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1426,12 +1426,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1439,21 +1439,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1644,12 +1644,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1657,21 +1657,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1899,12 +1899,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1912,21 +1912,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -6831,12 +6831,12 @@ func newErrorBackupInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BackupInUseException) Code() string {
+func (s *BackupInUseException) Code() string {
 	return "BackupInUseException"
 }
 
 // Message returns the exception's message.
-func (s BackupInUseException) Message() string {
+func (s *BackupInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6844,21 +6844,21 @@ func (s BackupInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BackupInUseException) OrigErr() error {
+func (s *BackupInUseException) OrigErr() error {
 	return nil
 }
 
-func (s BackupInUseException) Error() string {
+func (s *BackupInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BackupInUseException) StatusCode() int {
+func (s *BackupInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BackupInUseException) RequestID() string {
+func (s *BackupInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6887,12 +6887,12 @@ func newErrorBackupNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BackupNotFoundException) Code() string {
+func (s *BackupNotFoundException) Code() string {
 	return "BackupNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s BackupNotFoundException) Message() string {
+func (s *BackupNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6900,21 +6900,21 @@ func (s BackupNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BackupNotFoundException) OrigErr() error {
+func (s *BackupNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s BackupNotFoundException) Error() string {
+func (s *BackupNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BackupNotFoundException) StatusCode() int {
+func (s *BackupNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BackupNotFoundException) RequestID() string {
+func (s *BackupNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7842,12 +7842,12 @@ func newErrorConditionalCheckFailedException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConditionalCheckFailedException) Code() string {
+func (s *ConditionalCheckFailedException) Code() string {
 	return "ConditionalCheckFailedException"
 }
 
 // Message returns the exception's message.
-func (s ConditionalCheckFailedException) Message() string {
+func (s *ConditionalCheckFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7855,21 +7855,21 @@ func (s ConditionalCheckFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConditionalCheckFailedException) OrigErr() error {
+func (s *ConditionalCheckFailedException) OrigErr() error {
 	return nil
 }
 
-func (s ConditionalCheckFailedException) Error() string {
+func (s *ConditionalCheckFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConditionalCheckFailedException) StatusCode() int {
+func (s *ConditionalCheckFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConditionalCheckFailedException) RequestID() string {
+func (s *ConditionalCheckFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8017,12 +8017,12 @@ func newErrorContinuousBackupsUnavailableException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s ContinuousBackupsUnavailableException) Code() string {
+func (s *ContinuousBackupsUnavailableException) Code() string {
 	return "ContinuousBackupsUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ContinuousBackupsUnavailableException) Message() string {
+func (s *ContinuousBackupsUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8030,21 +8030,21 @@ func (s ContinuousBackupsUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ContinuousBackupsUnavailableException) OrigErr() error {
+func (s *ContinuousBackupsUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ContinuousBackupsUnavailableException) Error() string {
+func (s *ContinuousBackupsUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ContinuousBackupsUnavailableException) StatusCode() int {
+func (s *ContinuousBackupsUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ContinuousBackupsUnavailableException) RequestID() string {
+func (s *ContinuousBackupsUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11296,12 +11296,12 @@ func newErrorGlobalTableAlreadyExistsException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s GlobalTableAlreadyExistsException) Code() string {
+func (s *GlobalTableAlreadyExistsException) Code() string {
 	return "GlobalTableAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s GlobalTableAlreadyExistsException) Message() string {
+func (s *GlobalTableAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11309,21 +11309,21 @@ func (s GlobalTableAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GlobalTableAlreadyExistsException) OrigErr() error {
+func (s *GlobalTableAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s GlobalTableAlreadyExistsException) Error() string {
+func (s *GlobalTableAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GlobalTableAlreadyExistsException) StatusCode() int {
+func (s *GlobalTableAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GlobalTableAlreadyExistsException) RequestID() string {
+func (s *GlobalTableAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11492,12 +11492,12 @@ func newErrorGlobalTableNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s GlobalTableNotFoundException) Code() string {
+func (s *GlobalTableNotFoundException) Code() string {
 	return "GlobalTableNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s GlobalTableNotFoundException) Message() string {
+func (s *GlobalTableNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11505,21 +11505,21 @@ func (s GlobalTableNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GlobalTableNotFoundException) OrigErr() error {
+func (s *GlobalTableNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s GlobalTableNotFoundException) Error() string {
+func (s *GlobalTableNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GlobalTableNotFoundException) StatusCode() int {
+func (s *GlobalTableNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GlobalTableNotFoundException) RequestID() string {
+func (s *GlobalTableNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11549,12 +11549,12 @@ func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatchException) Code() string {
+func (s *IdempotentParameterMismatchException) Code() string {
 	return "IdempotentParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatchException) Message() string {
+func (s *IdempotentParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11562,21 +11562,21 @@ func (s IdempotentParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatchException) OrigErr() error {
+func (s *IdempotentParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatchException) Error() string {
+func (s *IdempotentParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatchException) StatusCode() int {
+func (s *IdempotentParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatchException) RequestID() string {
+func (s *IdempotentParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11605,12 +11605,12 @@ func newErrorIndexNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IndexNotFoundException) Code() string {
+func (s *IndexNotFoundException) Code() string {
 	return "IndexNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s IndexNotFoundException) Message() string {
+func (s *IndexNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11618,21 +11618,21 @@ func (s IndexNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IndexNotFoundException) OrigErr() error {
+func (s *IndexNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s IndexNotFoundException) Error() string {
+func (s *IndexNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IndexNotFoundException) StatusCode() int {
+func (s *IndexNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IndexNotFoundException) RequestID() string {
+func (s *IndexNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11662,12 +11662,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11675,21 +11675,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11719,12 +11719,12 @@ func newErrorInvalidRestoreTimeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRestoreTimeException) Code() string {
+func (s *InvalidRestoreTimeException) Code() string {
 	return "InvalidRestoreTimeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRestoreTimeException) Message() string {
+func (s *InvalidRestoreTimeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11732,21 +11732,21 @@ func (s InvalidRestoreTimeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRestoreTimeException) OrigErr() error {
+func (s *InvalidRestoreTimeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRestoreTimeException) Error() string {
+func (s *InvalidRestoreTimeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRestoreTimeException) StatusCode() int {
+func (s *InvalidRestoreTimeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRestoreTimeException) RequestID() string {
+func (s *InvalidRestoreTimeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11823,12 +11823,12 @@ func newErrorItemCollectionSizeLimitExceededException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s ItemCollectionSizeLimitExceededException) Code() string {
+func (s *ItemCollectionSizeLimitExceededException) Code() string {
 	return "ItemCollectionSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ItemCollectionSizeLimitExceededException) Message() string {
+func (s *ItemCollectionSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11836,21 +11836,21 @@ func (s ItemCollectionSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ItemCollectionSizeLimitExceededException) OrigErr() error {
+func (s *ItemCollectionSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ItemCollectionSizeLimitExceededException) Error() string {
+func (s *ItemCollectionSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ItemCollectionSizeLimitExceededException) StatusCode() int {
+func (s *ItemCollectionSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ItemCollectionSizeLimitExceededException) RequestID() string {
+func (s *ItemCollectionSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12128,12 +12128,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12141,21 +12141,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13029,12 +13029,12 @@ func newErrorPointInTimeRecoveryUnavailableException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s PointInTimeRecoveryUnavailableException) Code() string {
+func (s *PointInTimeRecoveryUnavailableException) Code() string {
 	return "PointInTimeRecoveryUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s PointInTimeRecoveryUnavailableException) Message() string {
+func (s *PointInTimeRecoveryUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13042,21 +13042,21 @@ func (s PointInTimeRecoveryUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PointInTimeRecoveryUnavailableException) OrigErr() error {
+func (s *PointInTimeRecoveryUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s PointInTimeRecoveryUnavailableException) Error() string {
+func (s *PointInTimeRecoveryUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PointInTimeRecoveryUnavailableException) StatusCode() int {
+func (s *PointInTimeRecoveryUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PointInTimeRecoveryUnavailableException) RequestID() string {
+func (s *PointInTimeRecoveryUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13293,12 +13293,12 @@ func newErrorProvisionedThroughputExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s ProvisionedThroughputExceededException) Code() string {
+func (s *ProvisionedThroughputExceededException) Code() string {
 	return "ProvisionedThroughputExceededException"
 }
 
 // Message returns the exception's message.
-func (s ProvisionedThroughputExceededException) Message() string {
+func (s *ProvisionedThroughputExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13306,21 +13306,21 @@ func (s ProvisionedThroughputExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProvisionedThroughputExceededException) OrigErr() error {
+func (s *ProvisionedThroughputExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ProvisionedThroughputExceededException) Error() string {
+func (s *ProvisionedThroughputExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProvisionedThroughputExceededException) StatusCode() int {
+func (s *ProvisionedThroughputExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProvisionedThroughputExceededException) RequestID() string {
+func (s *ProvisionedThroughputExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14383,12 +14383,12 @@ func newErrorReplicaAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ReplicaAlreadyExistsException) Code() string {
+func (s *ReplicaAlreadyExistsException) Code() string {
 	return "ReplicaAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ReplicaAlreadyExistsException) Message() string {
+func (s *ReplicaAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14396,21 +14396,21 @@ func (s ReplicaAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReplicaAlreadyExistsException) OrigErr() error {
+func (s *ReplicaAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ReplicaAlreadyExistsException) Error() string {
+func (s *ReplicaAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReplicaAlreadyExistsException) StatusCode() int {
+func (s *ReplicaAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReplicaAlreadyExistsException) RequestID() string {
+func (s *ReplicaAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15033,12 +15033,12 @@ func newErrorReplicaNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ReplicaNotFoundException) Code() string {
+func (s *ReplicaNotFoundException) Code() string {
 	return "ReplicaNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ReplicaNotFoundException) Message() string {
+func (s *ReplicaNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15046,21 +15046,21 @@ func (s ReplicaNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReplicaNotFoundException) OrigErr() error {
+func (s *ReplicaNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ReplicaNotFoundException) Error() string {
+func (s *ReplicaNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReplicaNotFoundException) StatusCode() int {
+func (s *ReplicaNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReplicaNotFoundException) RequestID() string {
+func (s *ReplicaNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15423,12 +15423,12 @@ func newErrorRequestLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestLimitExceeded) Code() string {
+func (s *RequestLimitExceeded) Code() string {
 	return "RequestLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s RequestLimitExceeded) Message() string {
+func (s *RequestLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15436,21 +15436,21 @@ func (s RequestLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestLimitExceeded) OrigErr() error {
+func (s *RequestLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s RequestLimitExceeded) Error() string {
+func (s *RequestLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestLimitExceeded) StatusCode() int {
+func (s *RequestLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestLimitExceeded) RequestID() string {
+func (s *RequestLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15482,12 +15482,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15495,21 +15495,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15540,12 +15540,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15553,21 +15553,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16815,12 +16815,12 @@ func newErrorTableAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TableAlreadyExistsException) Code() string {
+func (s *TableAlreadyExistsException) Code() string {
 	return "TableAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s TableAlreadyExistsException) Message() string {
+func (s *TableAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16828,21 +16828,21 @@ func (s TableAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TableAlreadyExistsException) OrigErr() error {
+func (s *TableAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s TableAlreadyExistsException) Error() string {
+func (s *TableAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TableAlreadyExistsException) StatusCode() int {
+func (s *TableAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TableAlreadyExistsException) RequestID() string {
+func (s *TableAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17269,12 +17269,12 @@ func newErrorTableInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TableInUseException) Code() string {
+func (s *TableInUseException) Code() string {
 	return "TableInUseException"
 }
 
 // Message returns the exception's message.
-func (s TableInUseException) Message() string {
+func (s *TableInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17282,21 +17282,21 @@ func (s TableInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TableInUseException) OrigErr() error {
+func (s *TableInUseException) OrigErr() error {
 	return nil
 }
 
-func (s TableInUseException) Error() string {
+func (s *TableInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TableInUseException) StatusCode() int {
+func (s *TableInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TableInUseException) RequestID() string {
+func (s *TableInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17326,12 +17326,12 @@ func newErrorTableNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TableNotFoundException) Code() string {
+func (s *TableNotFoundException) Code() string {
 	return "TableNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s TableNotFoundException) Message() string {
+func (s *TableNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17339,21 +17339,21 @@ func (s TableNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TableNotFoundException) OrigErr() error {
+func (s *TableNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s TableNotFoundException) Error() string {
+func (s *TableNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TableNotFoundException) StatusCode() int {
+func (s *TableNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TableNotFoundException) RequestID() string {
+func (s *TableNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18096,12 +18096,12 @@ func newErrorTransactionCanceledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TransactionCanceledException) Code() string {
+func (s *TransactionCanceledException) Code() string {
 	return "TransactionCanceledException"
 }
 
 // Message returns the exception's message.
-func (s TransactionCanceledException) Message() string {
+func (s *TransactionCanceledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18109,21 +18109,21 @@ func (s TransactionCanceledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TransactionCanceledException) OrigErr() error {
+func (s *TransactionCanceledException) OrigErr() error {
 	return nil
 }
 
-func (s TransactionCanceledException) Error() string {
+func (s *TransactionCanceledException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TransactionCanceledException) StatusCode() int {
+func (s *TransactionCanceledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TransactionCanceledException) RequestID() string {
+func (s *TransactionCanceledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18152,12 +18152,12 @@ func newErrorTransactionConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TransactionConflictException) Code() string {
+func (s *TransactionConflictException) Code() string {
 	return "TransactionConflictException"
 }
 
 // Message returns the exception's message.
-func (s TransactionConflictException) Message() string {
+func (s *TransactionConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18165,21 +18165,21 @@ func (s TransactionConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TransactionConflictException) OrigErr() error {
+func (s *TransactionConflictException) OrigErr() error {
 	return nil
 }
 
-func (s TransactionConflictException) Error() string {
+func (s *TransactionConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TransactionConflictException) StatusCode() int {
+func (s *TransactionConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TransactionConflictException) RequestID() string {
+func (s *TransactionConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18208,12 +18208,12 @@ func newErrorTransactionInProgressException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TransactionInProgressException) Code() string {
+func (s *TransactionInProgressException) Code() string {
 	return "TransactionInProgressException"
 }
 
 // Message returns the exception's message.
-func (s TransactionInProgressException) Message() string {
+func (s *TransactionInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18221,21 +18221,21 @@ func (s TransactionInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TransactionInProgressException) OrigErr() error {
+func (s *TransactionInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s TransactionInProgressException) Error() string {
+func (s *TransactionInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TransactionInProgressException) StatusCode() int {
+func (s *TransactionInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TransactionInProgressException) RequestID() string {
+func (s *TransactionInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/dynamodbstreams/api.go
+++ b/service/dynamodbstreams/api.go
@@ -532,12 +532,12 @@ func newErrorExpiredIteratorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExpiredIteratorException) Code() string {
+func (s *ExpiredIteratorException) Code() string {
 	return "ExpiredIteratorException"
 }
 
 // Message returns the exception's message.
-func (s ExpiredIteratorException) Message() string {
+func (s *ExpiredIteratorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -545,21 +545,21 @@ func (s ExpiredIteratorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExpiredIteratorException) OrigErr() error {
+func (s *ExpiredIteratorException) OrigErr() error {
 	return nil
 }
 
-func (s ExpiredIteratorException) Error() string {
+func (s *ExpiredIteratorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExpiredIteratorException) StatusCode() int {
+func (s *ExpiredIteratorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExpiredIteratorException) RequestID() string {
+func (s *ExpiredIteratorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -841,12 +841,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -854,21 +854,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -903,12 +903,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -916,21 +916,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1163,12 +1163,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1176,21 +1176,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1585,12 +1585,12 @@ func newErrorTrimmedDataAccessException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TrimmedDataAccessException) Code() string {
+func (s *TrimmedDataAccessException) Code() string {
 	return "TrimmedDataAccessException"
 }
 
 // Message returns the exception's message.
-func (s TrimmedDataAccessException) Message() string {
+func (s *TrimmedDataAccessException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1598,21 +1598,21 @@ func (s TrimmedDataAccessException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TrimmedDataAccessException) OrigErr() error {
+func (s *TrimmedDataAccessException) OrigErr() error {
 	return nil
 }
 
-func (s TrimmedDataAccessException) Error() string {
+func (s *TrimmedDataAccessException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TrimmedDataAccessException) StatusCode() int {
+func (s *TrimmedDataAccessException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TrimmedDataAccessException) RequestID() string {
+func (s *TrimmedDataAccessException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/ebs/api.go
+++ b/service/ebs/api.go
@@ -891,12 +891,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -904,21 +904,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -950,12 +950,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -963,21 +963,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/ec2instanceconnect/api.go
+++ b/service/ec2instanceconnect/api.go
@@ -135,12 +135,12 @@ func newErrorAuthException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AuthException) Code() string {
+func (s *AuthException) Code() string {
 	return "AuthException"
 }
 
 // Message returns the exception's message.
-func (s AuthException) Message() string {
+func (s *AuthException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -148,21 +148,21 @@ func (s AuthException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AuthException) OrigErr() error {
+func (s *AuthException) OrigErr() error {
 	return nil
 }
 
-func (s AuthException) Error() string {
+func (s *AuthException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AuthException) StatusCode() int {
+func (s *AuthException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AuthException) RequestID() string {
+func (s *AuthException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -192,12 +192,12 @@ func newErrorEC2InstanceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EC2InstanceNotFoundException) Code() string {
+func (s *EC2InstanceNotFoundException) Code() string {
 	return "EC2InstanceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s EC2InstanceNotFoundException) Message() string {
+func (s *EC2InstanceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -205,21 +205,21 @@ func (s EC2InstanceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EC2InstanceNotFoundException) OrigErr() error {
+func (s *EC2InstanceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s EC2InstanceNotFoundException) Error() string {
+func (s *EC2InstanceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EC2InstanceNotFoundException) StatusCode() int {
+func (s *EC2InstanceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EC2InstanceNotFoundException) RequestID() string {
+func (s *EC2InstanceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -249,12 +249,12 @@ func newErrorInvalidArgsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgsException) Code() string {
+func (s *InvalidArgsException) Code() string {
 	return "InvalidArgsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgsException) Message() string {
+func (s *InvalidArgsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -262,21 +262,21 @@ func (s InvalidArgsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgsException) OrigErr() error {
+func (s *InvalidArgsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgsException) Error() string {
+func (s *InvalidArgsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgsException) StatusCode() int {
+func (s *InvalidArgsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgsException) RequestID() string {
+func (s *InvalidArgsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -433,12 +433,12 @@ func newErrorServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceException) Code() string {
+func (s *ServiceException) Code() string {
 	return "ServiceException"
 }
 
 // Message returns the exception's message.
-func (s ServiceException) Message() string {
+func (s *ServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -446,21 +446,21 @@ func (s ServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceException) OrigErr() error {
+func (s *ServiceException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceException) Error() string {
+func (s *ServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceException) StatusCode() int {
+func (s *ServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceException) RequestID() string {
+func (s *ServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -491,12 +491,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -504,20 +504,20 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }

--- a/service/ecr/api.go
+++ b/service/ecr/api.go
@@ -4481,12 +4481,12 @@ func newErrorEmptyUploadException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EmptyUploadException) Code() string {
+func (s *EmptyUploadException) Code() string {
 	return "EmptyUploadException"
 }
 
 // Message returns the exception's message.
-func (s EmptyUploadException) Message() string {
+func (s *EmptyUploadException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4494,21 +4494,21 @@ func (s EmptyUploadException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EmptyUploadException) OrigErr() error {
+func (s *EmptyUploadException) OrigErr() error {
 	return nil
 }
 
-func (s EmptyUploadException) Error() string {
+func (s *EmptyUploadException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EmptyUploadException) StatusCode() int {
+func (s *EmptyUploadException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EmptyUploadException) RequestID() string {
+func (s *EmptyUploadException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5138,12 +5138,12 @@ func newErrorImageAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ImageAlreadyExistsException) Code() string {
+func (s *ImageAlreadyExistsException) Code() string {
 	return "ImageAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ImageAlreadyExistsException) Message() string {
+func (s *ImageAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5151,21 +5151,21 @@ func (s ImageAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ImageAlreadyExistsException) OrigErr() error {
+func (s *ImageAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ImageAlreadyExistsException) Error() string {
+func (s *ImageAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ImageAlreadyExistsException) StatusCode() int {
+func (s *ImageAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ImageAlreadyExistsException) RequestID() string {
+func (s *ImageAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5375,12 +5375,12 @@ func newErrorImageNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ImageNotFoundException) Code() string {
+func (s *ImageNotFoundException) Code() string {
 	return "ImageNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ImageNotFoundException) Message() string {
+func (s *ImageNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5388,21 +5388,21 @@ func (s ImageNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ImageNotFoundException) OrigErr() error {
+func (s *ImageNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ImageNotFoundException) Error() string {
+func (s *ImageNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ImageNotFoundException) StatusCode() int {
+func (s *ImageNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ImageNotFoundException) RequestID() string {
+func (s *ImageNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5646,12 +5646,12 @@ func newErrorImageTagAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ImageTagAlreadyExistsException) Code() string {
+func (s *ImageTagAlreadyExistsException) Code() string {
 	return "ImageTagAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ImageTagAlreadyExistsException) Message() string {
+func (s *ImageTagAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5659,21 +5659,21 @@ func (s ImageTagAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ImageTagAlreadyExistsException) OrigErr() error {
+func (s *ImageTagAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ImageTagAlreadyExistsException) Error() string {
+func (s *ImageTagAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ImageTagAlreadyExistsException) StatusCode() int {
+func (s *ImageTagAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ImageTagAlreadyExistsException) RequestID() string {
+func (s *ImageTagAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5789,12 +5789,12 @@ func newErrorInvalidLayerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidLayerException) Code() string {
+func (s *InvalidLayerException) Code() string {
 	return "InvalidLayerException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLayerException) Message() string {
+func (s *InvalidLayerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5802,21 +5802,21 @@ func (s InvalidLayerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLayerException) OrigErr() error {
+func (s *InvalidLayerException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLayerException) Error() string {
+func (s *InvalidLayerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLayerException) StatusCode() int {
+func (s *InvalidLayerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLayerException) RequestID() string {
+func (s *InvalidLayerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5860,12 +5860,12 @@ func newErrorInvalidLayerPartException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidLayerPartException) Code() string {
+func (s *InvalidLayerPartException) Code() string {
 	return "InvalidLayerPartException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLayerPartException) Message() string {
+func (s *InvalidLayerPartException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5873,21 +5873,21 @@ func (s InvalidLayerPartException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLayerPartException) OrigErr() error {
+func (s *InvalidLayerPartException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLayerPartException) Error() string {
+func (s *InvalidLayerPartException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLayerPartException) StatusCode() int {
+func (s *InvalidLayerPartException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLayerPartException) RequestID() string {
+func (s *InvalidLayerPartException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5918,12 +5918,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5931,21 +5931,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5976,12 +5976,12 @@ func newErrorInvalidTagParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagParameterException) Code() string {
+func (s *InvalidTagParameterException) Code() string {
 	return "InvalidTagParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagParameterException) Message() string {
+func (s *InvalidTagParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5989,21 +5989,21 @@ func (s InvalidTagParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagParameterException) OrigErr() error {
+func (s *InvalidTagParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagParameterException) Error() string {
+func (s *InvalidTagParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagParameterException) StatusCode() int {
+func (s *InvalidTagParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagParameterException) RequestID() string {
+func (s *InvalidTagParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6085,12 +6085,12 @@ func newErrorLayerAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LayerAlreadyExistsException) Code() string {
+func (s *LayerAlreadyExistsException) Code() string {
 	return "LayerAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s LayerAlreadyExistsException) Message() string {
+func (s *LayerAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6098,21 +6098,21 @@ func (s LayerAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LayerAlreadyExistsException) OrigErr() error {
+func (s *LayerAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s LayerAlreadyExistsException) Error() string {
+func (s *LayerAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LayerAlreadyExistsException) StatusCode() int {
+func (s *LayerAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LayerAlreadyExistsException) RequestID() string {
+func (s *LayerAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6185,12 +6185,12 @@ func newErrorLayerInaccessibleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LayerInaccessibleException) Code() string {
+func (s *LayerInaccessibleException) Code() string {
 	return "LayerInaccessibleException"
 }
 
 // Message returns the exception's message.
-func (s LayerInaccessibleException) Message() string {
+func (s *LayerInaccessibleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6198,21 +6198,21 @@ func (s LayerInaccessibleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LayerInaccessibleException) OrigErr() error {
+func (s *LayerInaccessibleException) OrigErr() error {
 	return nil
 }
 
-func (s LayerInaccessibleException) Error() string {
+func (s *LayerInaccessibleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LayerInaccessibleException) StatusCode() int {
+func (s *LayerInaccessibleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LayerInaccessibleException) RequestID() string {
+func (s *LayerInaccessibleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6242,12 +6242,12 @@ func newErrorLayerPartTooSmallException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LayerPartTooSmallException) Code() string {
+func (s *LayerPartTooSmallException) Code() string {
 	return "LayerPartTooSmallException"
 }
 
 // Message returns the exception's message.
-func (s LayerPartTooSmallException) Message() string {
+func (s *LayerPartTooSmallException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6255,21 +6255,21 @@ func (s LayerPartTooSmallException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LayerPartTooSmallException) OrigErr() error {
+func (s *LayerPartTooSmallException) OrigErr() error {
 	return nil
 }
 
-func (s LayerPartTooSmallException) Error() string {
+func (s *LayerPartTooSmallException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LayerPartTooSmallException) StatusCode() int {
+func (s *LayerPartTooSmallException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LayerPartTooSmallException) RequestID() string {
+func (s *LayerPartTooSmallException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6300,12 +6300,12 @@ func newErrorLayersNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LayersNotFoundException) Code() string {
+func (s *LayersNotFoundException) Code() string {
 	return "LayersNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s LayersNotFoundException) Message() string {
+func (s *LayersNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6313,21 +6313,21 @@ func (s LayersNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LayersNotFoundException) OrigErr() error {
+func (s *LayersNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s LayersNotFoundException) Error() string {
+func (s *LayersNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LayersNotFoundException) StatusCode() int {
+func (s *LayersNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LayersNotFoundException) RequestID() string {
+func (s *LayersNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6356,12 +6356,12 @@ func newErrorLifecyclePolicyNotFoundException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s LifecyclePolicyNotFoundException) Code() string {
+func (s *LifecyclePolicyNotFoundException) Code() string {
 	return "LifecyclePolicyNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s LifecyclePolicyNotFoundException) Message() string {
+func (s *LifecyclePolicyNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6369,21 +6369,21 @@ func (s LifecyclePolicyNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LifecyclePolicyNotFoundException) OrigErr() error {
+func (s *LifecyclePolicyNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s LifecyclePolicyNotFoundException) Error() string {
+func (s *LifecyclePolicyNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LifecyclePolicyNotFoundException) StatusCode() int {
+func (s *LifecyclePolicyNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LifecyclePolicyNotFoundException) RequestID() string {
+func (s *LifecyclePolicyNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6437,12 +6437,12 @@ func newErrorLifecyclePolicyPreviewInProgressException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s LifecyclePolicyPreviewInProgressException) Code() string {
+func (s *LifecyclePolicyPreviewInProgressException) Code() string {
 	return "LifecyclePolicyPreviewInProgressException"
 }
 
 // Message returns the exception's message.
-func (s LifecyclePolicyPreviewInProgressException) Message() string {
+func (s *LifecyclePolicyPreviewInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6450,21 +6450,21 @@ func (s LifecyclePolicyPreviewInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LifecyclePolicyPreviewInProgressException) OrigErr() error {
+func (s *LifecyclePolicyPreviewInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s LifecyclePolicyPreviewInProgressException) Error() string {
+func (s *LifecyclePolicyPreviewInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LifecyclePolicyPreviewInProgressException) StatusCode() int {
+func (s *LifecyclePolicyPreviewInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LifecyclePolicyPreviewInProgressException) RequestID() string {
+func (s *LifecyclePolicyPreviewInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6493,12 +6493,12 @@ func newErrorLifecyclePolicyPreviewNotFoundException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s LifecyclePolicyPreviewNotFoundException) Code() string {
+func (s *LifecyclePolicyPreviewNotFoundException) Code() string {
 	return "LifecyclePolicyPreviewNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s LifecyclePolicyPreviewNotFoundException) Message() string {
+func (s *LifecyclePolicyPreviewNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6506,21 +6506,21 @@ func (s LifecyclePolicyPreviewNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LifecyclePolicyPreviewNotFoundException) OrigErr() error {
+func (s *LifecyclePolicyPreviewNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s LifecyclePolicyPreviewNotFoundException) Error() string {
+func (s *LifecyclePolicyPreviewNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LifecyclePolicyPreviewNotFoundException) StatusCode() int {
+func (s *LifecyclePolicyPreviewNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LifecyclePolicyPreviewNotFoundException) RequestID() string {
+func (s *LifecyclePolicyPreviewNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6662,12 +6662,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6675,21 +6675,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7450,12 +7450,12 @@ func newErrorRepositoryAlreadyExistsException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s RepositoryAlreadyExistsException) Code() string {
+func (s *RepositoryAlreadyExistsException) Code() string {
 	return "RepositoryAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryAlreadyExistsException) Message() string {
+func (s *RepositoryAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7463,21 +7463,21 @@ func (s RepositoryAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryAlreadyExistsException) OrigErr() error {
+func (s *RepositoryAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryAlreadyExistsException) Error() string {
+func (s *RepositoryAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryAlreadyExistsException) StatusCode() int {
+func (s *RepositoryAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryAlreadyExistsException) RequestID() string {
+func (s *RepositoryAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7508,12 +7508,12 @@ func newErrorRepositoryNotEmptyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RepositoryNotEmptyException) Code() string {
+func (s *RepositoryNotEmptyException) Code() string {
 	return "RepositoryNotEmptyException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryNotEmptyException) Message() string {
+func (s *RepositoryNotEmptyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7521,21 +7521,21 @@ func (s RepositoryNotEmptyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryNotEmptyException) OrigErr() error {
+func (s *RepositoryNotEmptyException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryNotEmptyException) Error() string {
+func (s *RepositoryNotEmptyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryNotEmptyException) StatusCode() int {
+func (s *RepositoryNotEmptyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryNotEmptyException) RequestID() string {
+func (s *RepositoryNotEmptyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7566,12 +7566,12 @@ func newErrorRepositoryNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RepositoryNotFoundException) Code() string {
+func (s *RepositoryNotFoundException) Code() string {
 	return "RepositoryNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryNotFoundException) Message() string {
+func (s *RepositoryNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7579,21 +7579,21 @@ func (s RepositoryNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryNotFoundException) OrigErr() error {
+func (s *RepositoryNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryNotFoundException) Error() string {
+func (s *RepositoryNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryNotFoundException) StatusCode() int {
+func (s *RepositoryNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryNotFoundException) RequestID() string {
+func (s *RepositoryNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7624,12 +7624,12 @@ func newErrorRepositoryPolicyNotFoundException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s RepositoryPolicyNotFoundException) Code() string {
+func (s *RepositoryPolicyNotFoundException) Code() string {
 	return "RepositoryPolicyNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s RepositoryPolicyNotFoundException) Message() string {
+func (s *RepositoryPolicyNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7637,21 +7637,21 @@ func (s RepositoryPolicyNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RepositoryPolicyNotFoundException) OrigErr() error {
+func (s *RepositoryPolicyNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s RepositoryPolicyNotFoundException) Error() string {
+func (s *RepositoryPolicyNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RepositoryPolicyNotFoundException) StatusCode() int {
+func (s *RepositoryPolicyNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RepositoryPolicyNotFoundException) RequestID() string {
+func (s *RepositoryPolicyNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7681,12 +7681,12 @@ func newErrorScanNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ScanNotFoundException) Code() string {
+func (s *ScanNotFoundException) Code() string {
 	return "ScanNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ScanNotFoundException) Message() string {
+func (s *ScanNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7694,21 +7694,21 @@ func (s ScanNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ScanNotFoundException) OrigErr() error {
+func (s *ScanNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ScanNotFoundException) Error() string {
+func (s *ScanNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ScanNotFoundException) StatusCode() int {
+func (s *ScanNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ScanNotFoundException) RequestID() string {
+func (s *ScanNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7738,12 +7738,12 @@ func newErrorServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServerException) Code() string {
+func (s *ServerException) Code() string {
 	return "ServerException"
 }
 
 // Message returns the exception's message.
-func (s ServerException) Message() string {
+func (s *ServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7751,21 +7751,21 @@ func (s ServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServerException) OrigErr() error {
+func (s *ServerException) OrigErr() error {
 	return nil
 }
 
-func (s ServerException) Error() string {
+func (s *ServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServerException) StatusCode() int {
+func (s *ServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServerException) RequestID() string {
+func (s *ServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8256,12 +8256,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8269,21 +8269,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8541,12 +8541,12 @@ func newErrorUploadNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UploadNotFoundException) Code() string {
+func (s *UploadNotFoundException) Code() string {
 	return "UploadNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s UploadNotFoundException) Message() string {
+func (s *UploadNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8554,21 +8554,21 @@ func (s UploadNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UploadNotFoundException) OrigErr() error {
+func (s *UploadNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s UploadNotFoundException) Error() string {
+func (s *UploadNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UploadNotFoundException) StatusCode() int {
+func (s *UploadNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UploadNotFoundException) RequestID() string {
+func (s *UploadNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -5539,12 +5539,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5552,21 +5552,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5779,12 +5779,12 @@ func newErrorAttributeLimitExceededException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s AttributeLimitExceededException) Code() string {
+func (s *AttributeLimitExceededException) Code() string {
 	return "AttributeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s AttributeLimitExceededException) Message() string {
+func (s *AttributeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5792,21 +5792,21 @@ func (s AttributeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AttributeLimitExceededException) OrigErr() error {
+func (s *AttributeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s AttributeLimitExceededException) Error() string {
+func (s *AttributeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AttributeLimitExceededException) StatusCode() int {
+func (s *AttributeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AttributeLimitExceededException) RequestID() string {
+func (s *AttributeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5978,12 +5978,12 @@ func newErrorBlockedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BlockedException) Code() string {
+func (s *BlockedException) Code() string {
 	return "BlockedException"
 }
 
 // Message returns the exception's message.
-func (s BlockedException) Message() string {
+func (s *BlockedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5991,21 +5991,21 @@ func (s BlockedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BlockedException) OrigErr() error {
+func (s *BlockedException) OrigErr() error {
 	return nil
 }
 
-func (s BlockedException) Error() string {
+func (s *BlockedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BlockedException) StatusCode() int {
+func (s *BlockedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BlockedException) RequestID() string {
+func (s *BlockedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6189,12 +6189,12 @@ func newErrorClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientException) Code() string {
+func (s *ClientException) Code() string {
 	return "ClientException"
 }
 
 // Message returns the exception's message.
-func (s ClientException) Message() string {
+func (s *ClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6202,21 +6202,21 @@ func (s ClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientException) OrigErr() error {
+func (s *ClientException) OrigErr() error {
 	return nil
 }
 
-func (s ClientException) Error() string {
+func (s *ClientException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientException) StatusCode() int {
+func (s *ClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientException) RequestID() string {
+func (s *ClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6485,12 +6485,12 @@ func newErrorClusterContainsContainerInstancesException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s ClusterContainsContainerInstancesException) Code() string {
+func (s *ClusterContainsContainerInstancesException) Code() string {
 	return "ClusterContainsContainerInstancesException"
 }
 
 // Message returns the exception's message.
-func (s ClusterContainsContainerInstancesException) Message() string {
+func (s *ClusterContainsContainerInstancesException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6498,21 +6498,21 @@ func (s ClusterContainsContainerInstancesException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClusterContainsContainerInstancesException) OrigErr() error {
+func (s *ClusterContainsContainerInstancesException) OrigErr() error {
 	return nil
 }
 
-func (s ClusterContainsContainerInstancesException) Error() string {
+func (s *ClusterContainsContainerInstancesException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClusterContainsContainerInstancesException) StatusCode() int {
+func (s *ClusterContainsContainerInstancesException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClusterContainsContainerInstancesException) RequestID() string {
+func (s *ClusterContainsContainerInstancesException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6543,12 +6543,12 @@ func newErrorClusterContainsServicesException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s ClusterContainsServicesException) Code() string {
+func (s *ClusterContainsServicesException) Code() string {
 	return "ClusterContainsServicesException"
 }
 
 // Message returns the exception's message.
-func (s ClusterContainsServicesException) Message() string {
+func (s *ClusterContainsServicesException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6556,21 +6556,21 @@ func (s ClusterContainsServicesException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClusterContainsServicesException) OrigErr() error {
+func (s *ClusterContainsServicesException) OrigErr() error {
 	return nil
 }
 
-func (s ClusterContainsServicesException) Error() string {
+func (s *ClusterContainsServicesException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClusterContainsServicesException) StatusCode() int {
+func (s *ClusterContainsServicesException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClusterContainsServicesException) RequestID() string {
+func (s *ClusterContainsServicesException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6599,12 +6599,12 @@ func newErrorClusterContainsTasksException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClusterContainsTasksException) Code() string {
+func (s *ClusterContainsTasksException) Code() string {
 	return "ClusterContainsTasksException"
 }
 
 // Message returns the exception's message.
-func (s ClusterContainsTasksException) Message() string {
+func (s *ClusterContainsTasksException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6612,21 +6612,21 @@ func (s ClusterContainsTasksException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClusterContainsTasksException) OrigErr() error {
+func (s *ClusterContainsTasksException) OrigErr() error {
 	return nil
 }
 
-func (s ClusterContainsTasksException) Error() string {
+func (s *ClusterContainsTasksException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClusterContainsTasksException) StatusCode() int {
+func (s *ClusterContainsTasksException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClusterContainsTasksException) RequestID() string {
+func (s *ClusterContainsTasksException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6656,12 +6656,12 @@ func newErrorClusterNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClusterNotFoundException) Code() string {
+func (s *ClusterNotFoundException) Code() string {
 	return "ClusterNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ClusterNotFoundException) Message() string {
+func (s *ClusterNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6669,21 +6669,21 @@ func (s ClusterNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClusterNotFoundException) OrigErr() error {
+func (s *ClusterNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ClusterNotFoundException) Error() string {
+func (s *ClusterNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClusterNotFoundException) StatusCode() int {
+func (s *ClusterNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClusterNotFoundException) RequestID() string {
+func (s *ClusterNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11550,12 +11550,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11563,21 +11563,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11709,12 +11709,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11722,21 +11722,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13229,12 +13229,12 @@ func newErrorMissingVersionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MissingVersionException) Code() string {
+func (s *MissingVersionException) Code() string {
 	return "MissingVersionException"
 }
 
 // Message returns the exception's message.
-func (s MissingVersionException) Message() string {
+func (s *MissingVersionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13242,21 +13242,21 @@ func (s MissingVersionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MissingVersionException) OrigErr() error {
+func (s *MissingVersionException) OrigErr() error {
 	return nil
 }
 
-func (s MissingVersionException) Error() string {
+func (s *MissingVersionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MissingVersionException) StatusCode() int {
+func (s *MissingVersionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MissingVersionException) RequestID() string {
+func (s *MissingVersionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13470,12 +13470,12 @@ func newErrorNoUpdateAvailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoUpdateAvailableException) Code() string {
+func (s *NoUpdateAvailableException) Code() string {
 	return "NoUpdateAvailableException"
 }
 
 // Message returns the exception's message.
-func (s NoUpdateAvailableException) Message() string {
+func (s *NoUpdateAvailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13483,21 +13483,21 @@ func (s NoUpdateAvailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoUpdateAvailableException) OrigErr() error {
+func (s *NoUpdateAvailableException) OrigErr() error {
 	return nil
 }
 
-func (s NoUpdateAvailableException) Error() string {
+func (s *NoUpdateAvailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoUpdateAvailableException) StatusCode() int {
+func (s *NoUpdateAvailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoUpdateAvailableException) RequestID() string {
+func (s *NoUpdateAvailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13673,12 +13673,12 @@ func newErrorPlatformTaskDefinitionIncompatibilityException(v protocol.ResponseM
 }
 
 // Code returns the exception type name.
-func (s PlatformTaskDefinitionIncompatibilityException) Code() string {
+func (s *PlatformTaskDefinitionIncompatibilityException) Code() string {
 	return "PlatformTaskDefinitionIncompatibilityException"
 }
 
 // Message returns the exception's message.
-func (s PlatformTaskDefinitionIncompatibilityException) Message() string {
+func (s *PlatformTaskDefinitionIncompatibilityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13686,21 +13686,21 @@ func (s PlatformTaskDefinitionIncompatibilityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PlatformTaskDefinitionIncompatibilityException) OrigErr() error {
+func (s *PlatformTaskDefinitionIncompatibilityException) OrigErr() error {
 	return nil
 }
 
-func (s PlatformTaskDefinitionIncompatibilityException) Error() string {
+func (s *PlatformTaskDefinitionIncompatibilityException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PlatformTaskDefinitionIncompatibilityException) StatusCode() int {
+func (s *PlatformTaskDefinitionIncompatibilityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PlatformTaskDefinitionIncompatibilityException) RequestID() string {
+func (s *PlatformTaskDefinitionIncompatibilityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13729,12 +13729,12 @@ func newErrorPlatformUnknownException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PlatformUnknownException) Code() string {
+func (s *PlatformUnknownException) Code() string {
 	return "PlatformUnknownException"
 }
 
 // Message returns the exception's message.
-func (s PlatformUnknownException) Message() string {
+func (s *PlatformUnknownException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13742,21 +13742,21 @@ func (s PlatformUnknownException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PlatformUnknownException) OrigErr() error {
+func (s *PlatformUnknownException) OrigErr() error {
 	return nil
 }
 
-func (s PlatformUnknownException) Error() string {
+func (s *PlatformUnknownException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PlatformUnknownException) StatusCode() int {
+func (s *PlatformUnknownException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PlatformUnknownException) RequestID() string {
+func (s *PlatformUnknownException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15103,12 +15103,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15116,21 +15116,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15159,12 +15159,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15172,21 +15172,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15714,12 +15714,12 @@ func newErrorServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServerException) Code() string {
+func (s *ServerException) Code() string {
 	return "ServerException"
 }
 
 // Message returns the exception's message.
-func (s ServerException) Message() string {
+func (s *ServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15727,21 +15727,21 @@ func (s ServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServerException) OrigErr() error {
+func (s *ServerException) OrigErr() error {
 	return nil
 }
 
-func (s ServerException) Error() string {
+func (s *ServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServerException) StatusCode() int {
+func (s *ServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServerException) RequestID() string {
+func (s *ServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16161,12 +16161,12 @@ func newErrorServiceNotActiveException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceNotActiveException) Code() string {
+func (s *ServiceNotActiveException) Code() string {
 	return "ServiceNotActiveException"
 }
 
 // Message returns the exception's message.
-func (s ServiceNotActiveException) Message() string {
+func (s *ServiceNotActiveException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16174,21 +16174,21 @@ func (s ServiceNotActiveException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceNotActiveException) OrigErr() error {
+func (s *ServiceNotActiveException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceNotActiveException) Error() string {
+func (s *ServiceNotActiveException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceNotActiveException) StatusCode() int {
+func (s *ServiceNotActiveException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceNotActiveException) RequestID() string {
+func (s *ServiceNotActiveException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16218,12 +16218,12 @@ func newErrorServiceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceNotFoundException) Code() string {
+func (s *ServiceNotFoundException) Code() string {
 	return "ServiceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ServiceNotFoundException) Message() string {
+func (s *ServiceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16231,21 +16231,21 @@ func (s ServiceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceNotFoundException) OrigErr() error {
+func (s *ServiceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceNotFoundException) Error() string {
+func (s *ServiceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceNotFoundException) StatusCode() int {
+func (s *ServiceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceNotFoundException) RequestID() string {
+func (s *ServiceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17261,12 +17261,12 @@ func newErrorTargetNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TargetNotFoundException) Code() string {
+func (s *TargetNotFoundException) Code() string {
 	return "TargetNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s TargetNotFoundException) Message() string {
+func (s *TargetNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17274,21 +17274,21 @@ func (s TargetNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TargetNotFoundException) OrigErr() error {
+func (s *TargetNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s TargetNotFoundException) Error() string {
+func (s *TargetNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TargetNotFoundException) StatusCode() int {
+func (s *TargetNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TargetNotFoundException) RequestID() string {
+func (s *TargetNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18528,12 +18528,12 @@ func newErrorTaskSetNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TaskSetNotFoundException) Code() string {
+func (s *TaskSetNotFoundException) Code() string {
 	return "TaskSetNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s TaskSetNotFoundException) Message() string {
+func (s *TaskSetNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18541,21 +18541,21 @@ func (s TaskSetNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TaskSetNotFoundException) OrigErr() error {
+func (s *TaskSetNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s TaskSetNotFoundException) Error() string {
+func (s *TaskSetNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TaskSetNotFoundException) StatusCode() int {
+func (s *TaskSetNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TaskSetNotFoundException) RequestID() string {
+func (s *TaskSetNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18720,12 +18720,12 @@ func newErrorUnsupportedFeatureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedFeatureException) Code() string {
+func (s *UnsupportedFeatureException) Code() string {
 	return "UnsupportedFeatureException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedFeatureException) Message() string {
+func (s *UnsupportedFeatureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18733,21 +18733,21 @@ func (s UnsupportedFeatureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedFeatureException) OrigErr() error {
+func (s *UnsupportedFeatureException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedFeatureException) Error() string {
+func (s *UnsupportedFeatureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedFeatureException) StatusCode() int {
+func (s *UnsupportedFeatureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedFeatureException) RequestID() string {
+func (s *UnsupportedFeatureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19102,12 +19102,12 @@ func newErrorUpdateInProgressException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UpdateInProgressException) Code() string {
+func (s *UpdateInProgressException) Code() string {
 	return "UpdateInProgressException"
 }
 
 // Message returns the exception's message.
-func (s UpdateInProgressException) Message() string {
+func (s *UpdateInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19115,21 +19115,21 @@ func (s UpdateInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UpdateInProgressException) OrigErr() error {
+func (s *UpdateInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s UpdateInProgressException) Error() string {
+func (s *UpdateInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UpdateInProgressException) StatusCode() int {
+func (s *UpdateInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UpdateInProgressException) RequestID() string {
+func (s *UpdateInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -2778,12 +2778,12 @@ func newErrorAccessPointAlreadyExists(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessPointAlreadyExists) Code() string {
+func (s *AccessPointAlreadyExists) Code() string {
 	return "AccessPointAlreadyExists"
 }
 
 // Message returns the exception's message.
-func (s AccessPointAlreadyExists) Message() string {
+func (s *AccessPointAlreadyExists) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2791,21 +2791,21 @@ func (s AccessPointAlreadyExists) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessPointAlreadyExists) OrigErr() error {
+func (s *AccessPointAlreadyExists) OrigErr() error {
 	return nil
 }
 
-func (s AccessPointAlreadyExists) Error() string {
+func (s *AccessPointAlreadyExists) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessPointAlreadyExists) StatusCode() int {
+func (s *AccessPointAlreadyExists) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessPointAlreadyExists) RequestID() string {
+func (s *AccessPointAlreadyExists) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2946,12 +2946,12 @@ func newErrorAccessPointLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessPointLimitExceeded) Code() string {
+func (s *AccessPointLimitExceeded) Code() string {
 	return "AccessPointLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s AccessPointLimitExceeded) Message() string {
+func (s *AccessPointLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2959,21 +2959,21 @@ func (s AccessPointLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessPointLimitExceeded) OrigErr() error {
+func (s *AccessPointLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s AccessPointLimitExceeded) Error() string {
+func (s *AccessPointLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessPointLimitExceeded) StatusCode() int {
+func (s *AccessPointLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessPointLimitExceeded) RequestID() string {
+func (s *AccessPointLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3006,12 +3006,12 @@ func newErrorAccessPointNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessPointNotFound) Code() string {
+func (s *AccessPointNotFound) Code() string {
 	return "AccessPointNotFound"
 }
 
 // Message returns the exception's message.
-func (s AccessPointNotFound) Message() string {
+func (s *AccessPointNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3019,21 +3019,21 @@ func (s AccessPointNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessPointNotFound) OrigErr() error {
+func (s *AccessPointNotFound) OrigErr() error {
 	return nil
 }
 
-func (s AccessPointNotFound) Error() string {
+func (s *AccessPointNotFound) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessPointNotFound) StatusCode() int {
+func (s *AccessPointNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessPointNotFound) RequestID() string {
+func (s *AccessPointNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3066,12 +3066,12 @@ func newErrorBadRequest(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequest) Code() string {
+func (s *BadRequest) Code() string {
 	return "BadRequest"
 }
 
 // Message returns the exception's message.
-func (s BadRequest) Message() string {
+func (s *BadRequest) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3079,21 +3079,21 @@ func (s BadRequest) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequest) OrigErr() error {
+func (s *BadRequest) OrigErr() error {
 	return nil
 }
 
-func (s BadRequest) Error() string {
+func (s *BadRequest) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequest) StatusCode() int {
+func (s *BadRequest) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequest) RequestID() string {
+func (s *BadRequest) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4006,12 +4006,12 @@ func newErrorDependencyTimeout(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DependencyTimeout) Code() string {
+func (s *DependencyTimeout) Code() string {
 	return "DependencyTimeout"
 }
 
 // Message returns the exception's message.
-func (s DependencyTimeout) Message() string {
+func (s *DependencyTimeout) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4019,21 +4019,21 @@ func (s DependencyTimeout) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DependencyTimeout) OrigErr() error {
+func (s *DependencyTimeout) OrigErr() error {
 	return nil
 }
 
-func (s DependencyTimeout) Error() string {
+func (s *DependencyTimeout) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DependencyTimeout) StatusCode() int {
+func (s *DependencyTimeout) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DependencyTimeout) RequestID() string {
+func (s *DependencyTimeout) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4731,12 +4731,12 @@ func newErrorFileSystemAlreadyExists(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileSystemAlreadyExists) Code() string {
+func (s *FileSystemAlreadyExists) Code() string {
 	return "FileSystemAlreadyExists"
 }
 
 // Message returns the exception's message.
-func (s FileSystemAlreadyExists) Message() string {
+func (s *FileSystemAlreadyExists) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4744,21 +4744,21 @@ func (s FileSystemAlreadyExists) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileSystemAlreadyExists) OrigErr() error {
+func (s *FileSystemAlreadyExists) OrigErr() error {
 	return nil
 }
 
-func (s FileSystemAlreadyExists) Error() string {
+func (s *FileSystemAlreadyExists) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileSystemAlreadyExists) StatusCode() int {
+func (s *FileSystemAlreadyExists) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileSystemAlreadyExists) RequestID() string {
+func (s *FileSystemAlreadyExists) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4972,12 +4972,12 @@ func newErrorFileSystemInUse(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileSystemInUse) Code() string {
+func (s *FileSystemInUse) Code() string {
 	return "FileSystemInUse"
 }
 
 // Message returns the exception's message.
-func (s FileSystemInUse) Message() string {
+func (s *FileSystemInUse) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4985,21 +4985,21 @@ func (s FileSystemInUse) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileSystemInUse) OrigErr() error {
+func (s *FileSystemInUse) OrigErr() error {
 	return nil
 }
 
-func (s FileSystemInUse) Error() string {
+func (s *FileSystemInUse) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileSystemInUse) StatusCode() int {
+func (s *FileSystemInUse) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileSystemInUse) RequestID() string {
+func (s *FileSystemInUse) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5032,12 +5032,12 @@ func newErrorFileSystemLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileSystemLimitExceeded) Code() string {
+func (s *FileSystemLimitExceeded) Code() string {
 	return "FileSystemLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s FileSystemLimitExceeded) Message() string {
+func (s *FileSystemLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5045,21 +5045,21 @@ func (s FileSystemLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileSystemLimitExceeded) OrigErr() error {
+func (s *FileSystemLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s FileSystemLimitExceeded) Error() string {
+func (s *FileSystemLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileSystemLimitExceeded) StatusCode() int {
+func (s *FileSystemLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileSystemLimitExceeded) RequestID() string {
+func (s *FileSystemLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5092,12 +5092,12 @@ func newErrorFileSystemNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileSystemNotFound) Code() string {
+func (s *FileSystemNotFound) Code() string {
 	return "FileSystemNotFound"
 }
 
 // Message returns the exception's message.
-func (s FileSystemNotFound) Message() string {
+func (s *FileSystemNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5105,21 +5105,21 @@ func (s FileSystemNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileSystemNotFound) OrigErr() error {
+func (s *FileSystemNotFound) OrigErr() error {
 	return nil
 }
 
-func (s FileSystemNotFound) Error() string {
+func (s *FileSystemNotFound) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileSystemNotFound) StatusCode() int {
+func (s *FileSystemNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileSystemNotFound) RequestID() string {
+func (s *FileSystemNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5214,12 +5214,12 @@ func newErrorIncorrectFileSystemLifeCycleState(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s IncorrectFileSystemLifeCycleState) Code() string {
+func (s *IncorrectFileSystemLifeCycleState) Code() string {
 	return "IncorrectFileSystemLifeCycleState"
 }
 
 // Message returns the exception's message.
-func (s IncorrectFileSystemLifeCycleState) Message() string {
+func (s *IncorrectFileSystemLifeCycleState) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5227,21 +5227,21 @@ func (s IncorrectFileSystemLifeCycleState) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncorrectFileSystemLifeCycleState) OrigErr() error {
+func (s *IncorrectFileSystemLifeCycleState) OrigErr() error {
 	return nil
 }
 
-func (s IncorrectFileSystemLifeCycleState) Error() string {
+func (s *IncorrectFileSystemLifeCycleState) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncorrectFileSystemLifeCycleState) StatusCode() int {
+func (s *IncorrectFileSystemLifeCycleState) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncorrectFileSystemLifeCycleState) RequestID() string {
+func (s *IncorrectFileSystemLifeCycleState) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5273,12 +5273,12 @@ func newErrorIncorrectMountTargetState(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncorrectMountTargetState) Code() string {
+func (s *IncorrectMountTargetState) Code() string {
 	return "IncorrectMountTargetState"
 }
 
 // Message returns the exception's message.
-func (s IncorrectMountTargetState) Message() string {
+func (s *IncorrectMountTargetState) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5286,21 +5286,21 @@ func (s IncorrectMountTargetState) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncorrectMountTargetState) OrigErr() error {
+func (s *IncorrectMountTargetState) OrigErr() error {
 	return nil
 }
 
-func (s IncorrectMountTargetState) Error() string {
+func (s *IncorrectMountTargetState) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncorrectMountTargetState) StatusCode() int {
+func (s *IncorrectMountTargetState) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncorrectMountTargetState) RequestID() string {
+func (s *IncorrectMountTargetState) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5336,12 +5336,12 @@ func newErrorInsufficientThroughputCapacity(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InsufficientThroughputCapacity) Code() string {
+func (s *InsufficientThroughputCapacity) Code() string {
 	return "InsufficientThroughputCapacity"
 }
 
 // Message returns the exception's message.
-func (s InsufficientThroughputCapacity) Message() string {
+func (s *InsufficientThroughputCapacity) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5349,21 +5349,21 @@ func (s InsufficientThroughputCapacity) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientThroughputCapacity) OrigErr() error {
+func (s *InsufficientThroughputCapacity) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientThroughputCapacity) Error() string {
+func (s *InsufficientThroughputCapacity) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientThroughputCapacity) StatusCode() int {
+func (s *InsufficientThroughputCapacity) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientThroughputCapacity) RequestID() string {
+func (s *InsufficientThroughputCapacity) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5395,12 +5395,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5408,21 +5408,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5455,12 +5455,12 @@ func newErrorInvalidPolicyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPolicyException) Code() string {
+func (s *InvalidPolicyException) Code() string {
 	return "InvalidPolicyException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPolicyException) Message() string {
+func (s *InvalidPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5468,21 +5468,21 @@ func (s InvalidPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPolicyException) OrigErr() error {
+func (s *InvalidPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPolicyException) Error() string {
+func (s *InvalidPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPolicyException) StatusCode() int {
+func (s *InvalidPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPolicyException) RequestID() string {
+func (s *InvalidPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5515,12 +5515,12 @@ func newErrorIpAddressInUse(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IpAddressInUse) Code() string {
+func (s *IpAddressInUse) Code() string {
 	return "IpAddressInUse"
 }
 
 // Message returns the exception's message.
-func (s IpAddressInUse) Message() string {
+func (s *IpAddressInUse) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5528,21 +5528,21 @@ func (s IpAddressInUse) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IpAddressInUse) OrigErr() error {
+func (s *IpAddressInUse) OrigErr() error {
 	return nil
 }
 
-func (s IpAddressInUse) Error() string {
+func (s *IpAddressInUse) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IpAddressInUse) StatusCode() int {
+func (s *IpAddressInUse) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IpAddressInUse) RequestID() string {
+func (s *IpAddressInUse) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5764,12 +5764,12 @@ func newErrorMountTargetConflict(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MountTargetConflict) Code() string {
+func (s *MountTargetConflict) Code() string {
 	return "MountTargetConflict"
 }
 
 // Message returns the exception's message.
-func (s MountTargetConflict) Message() string {
+func (s *MountTargetConflict) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5777,21 +5777,21 @@ func (s MountTargetConflict) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MountTargetConflict) OrigErr() error {
+func (s *MountTargetConflict) OrigErr() error {
 	return nil
 }
 
-func (s MountTargetConflict) Error() string {
+func (s *MountTargetConflict) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MountTargetConflict) StatusCode() int {
+func (s *MountTargetConflict) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MountTargetConflict) RequestID() string {
+func (s *MountTargetConflict) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5934,12 +5934,12 @@ func newErrorMountTargetNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MountTargetNotFound) Code() string {
+func (s *MountTargetNotFound) Code() string {
 	return "MountTargetNotFound"
 }
 
 // Message returns the exception's message.
-func (s MountTargetNotFound) Message() string {
+func (s *MountTargetNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5947,21 +5947,21 @@ func (s MountTargetNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MountTargetNotFound) OrigErr() error {
+func (s *MountTargetNotFound) OrigErr() error {
 	return nil
 }
 
-func (s MountTargetNotFound) Error() string {
+func (s *MountTargetNotFound) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MountTargetNotFound) StatusCode() int {
+func (s *MountTargetNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MountTargetNotFound) RequestID() string {
+func (s *MountTargetNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5998,12 +5998,12 @@ func newErrorNetworkInterfaceLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NetworkInterfaceLimitExceeded) Code() string {
+func (s *NetworkInterfaceLimitExceeded) Code() string {
 	return "NetworkInterfaceLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s NetworkInterfaceLimitExceeded) Message() string {
+func (s *NetworkInterfaceLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6011,21 +6011,21 @@ func (s NetworkInterfaceLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NetworkInterfaceLimitExceeded) OrigErr() error {
+func (s *NetworkInterfaceLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s NetworkInterfaceLimitExceeded) Error() string {
+func (s *NetworkInterfaceLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NetworkInterfaceLimitExceeded) StatusCode() int {
+func (s *NetworkInterfaceLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NetworkInterfaceLimitExceeded) RequestID() string {
+func (s *NetworkInterfaceLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6058,12 +6058,12 @@ func newErrorNoFreeAddressesInSubnet(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoFreeAddressesInSubnet) Code() string {
+func (s *NoFreeAddressesInSubnet) Code() string {
 	return "NoFreeAddressesInSubnet"
 }
 
 // Message returns the exception's message.
-func (s NoFreeAddressesInSubnet) Message() string {
+func (s *NoFreeAddressesInSubnet) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6071,21 +6071,21 @@ func (s NoFreeAddressesInSubnet) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoFreeAddressesInSubnet) OrigErr() error {
+func (s *NoFreeAddressesInSubnet) OrigErr() error {
 	return nil
 }
 
-func (s NoFreeAddressesInSubnet) Error() string {
+func (s *NoFreeAddressesInSubnet) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoFreeAddressesInSubnet) StatusCode() int {
+func (s *NoFreeAddressesInSubnet) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoFreeAddressesInSubnet) RequestID() string {
+func (s *NoFreeAddressesInSubnet) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6117,12 +6117,12 @@ func newErrorPolicyNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyNotFound) Code() string {
+func (s *PolicyNotFound) Code() string {
 	return "PolicyNotFound"
 }
 
 // Message returns the exception's message.
-func (s PolicyNotFound) Message() string {
+func (s *PolicyNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6130,21 +6130,21 @@ func (s PolicyNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyNotFound) OrigErr() error {
+func (s *PolicyNotFound) OrigErr() error {
 	return nil
 }
 
-func (s PolicyNotFound) Error() string {
+func (s *PolicyNotFound) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyNotFound) StatusCode() int {
+func (s *PolicyNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyNotFound) RequestID() string {
+func (s *PolicyNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6497,12 +6497,12 @@ func newErrorSecurityGroupLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SecurityGroupLimitExceeded) Code() string {
+func (s *SecurityGroupLimitExceeded) Code() string {
 	return "SecurityGroupLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s SecurityGroupLimitExceeded) Message() string {
+func (s *SecurityGroupLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6510,21 +6510,21 @@ func (s SecurityGroupLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SecurityGroupLimitExceeded) OrigErr() error {
+func (s *SecurityGroupLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s SecurityGroupLimitExceeded) Error() string {
+func (s *SecurityGroupLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SecurityGroupLimitExceeded) StatusCode() int {
+func (s *SecurityGroupLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SecurityGroupLimitExceeded) RequestID() string {
+func (s *SecurityGroupLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6557,12 +6557,12 @@ func newErrorSecurityGroupNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SecurityGroupNotFound) Code() string {
+func (s *SecurityGroupNotFound) Code() string {
 	return "SecurityGroupNotFound"
 }
 
 // Message returns the exception's message.
-func (s SecurityGroupNotFound) Message() string {
+func (s *SecurityGroupNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6570,21 +6570,21 @@ func (s SecurityGroupNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SecurityGroupNotFound) OrigErr() error {
+func (s *SecurityGroupNotFound) OrigErr() error {
 	return nil
 }
 
-func (s SecurityGroupNotFound) Error() string {
+func (s *SecurityGroupNotFound) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SecurityGroupNotFound) StatusCode() int {
+func (s *SecurityGroupNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SecurityGroupNotFound) RequestID() string {
+func (s *SecurityGroupNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6616,12 +6616,12 @@ func newErrorSubnetNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SubnetNotFound) Code() string {
+func (s *SubnetNotFound) Code() string {
 	return "SubnetNotFound"
 }
 
 // Message returns the exception's message.
-func (s SubnetNotFound) Message() string {
+func (s *SubnetNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6629,21 +6629,21 @@ func (s SubnetNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubnetNotFound) OrigErr() error {
+func (s *SubnetNotFound) OrigErr() error {
 	return nil
 }
 
-func (s SubnetNotFound) Error() string {
+func (s *SubnetNotFound) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubnetNotFound) StatusCode() int {
+func (s *SubnetNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubnetNotFound) RequestID() string {
+func (s *SubnetNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6811,12 +6811,12 @@ func newErrorThroughputLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThroughputLimitExceeded) Code() string {
+func (s *ThroughputLimitExceeded) Code() string {
 	return "ThroughputLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ThroughputLimitExceeded) Message() string {
+func (s *ThroughputLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6824,21 +6824,21 @@ func (s ThroughputLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThroughputLimitExceeded) OrigErr() error {
+func (s *ThroughputLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ThroughputLimitExceeded) Error() string {
+func (s *ThroughputLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThroughputLimitExceeded) StatusCode() int {
+func (s *ThroughputLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThroughputLimitExceeded) RequestID() string {
+func (s *ThroughputLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6871,12 +6871,12 @@ func newErrorTooManyRequests(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequests) Code() string {
+func (s *TooManyRequests) Code() string {
 	return "TooManyRequests"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequests) Message() string {
+func (s *TooManyRequests) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6884,21 +6884,21 @@ func (s TooManyRequests) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequests) OrigErr() error {
+func (s *TooManyRequests) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequests) Error() string {
+func (s *TooManyRequests) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequests) StatusCode() int {
+func (s *TooManyRequests) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequests) RequestID() string {
+func (s *TooManyRequests) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6929,12 +6929,12 @@ func newErrorUnsupportedAvailabilityZone(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedAvailabilityZone) Code() string {
+func (s *UnsupportedAvailabilityZone) Code() string {
 	return "UnsupportedAvailabilityZone"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedAvailabilityZone) Message() string {
+func (s *UnsupportedAvailabilityZone) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6942,21 +6942,21 @@ func (s UnsupportedAvailabilityZone) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedAvailabilityZone) OrigErr() error {
+func (s *UnsupportedAvailabilityZone) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedAvailabilityZone) Error() string {
+func (s *UnsupportedAvailabilityZone) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedAvailabilityZone) StatusCode() int {
+func (s *UnsupportedAvailabilityZone) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedAvailabilityZone) RequestID() string {
+func (s *UnsupportedAvailabilityZone) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/eks/api.go
+++ b/service/eks/api.go
@@ -2474,12 +2474,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2487,21 +2487,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2564,12 +2564,12 @@ func newErrorClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientException) Code() string {
+func (s *ClientException) Code() string {
 	return "ClientException"
 }
 
 // Message returns the exception's message.
-func (s ClientException) Message() string {
+func (s *ClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2577,21 +2577,21 @@ func (s ClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientException) OrigErr() error {
+func (s *ClientException) OrigErr() error {
 	return nil
 }
 
-func (s ClientException) Error() string {
+func (s *ClientException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientException) StatusCode() int {
+func (s *ClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientException) RequestID() string {
+func (s *ClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4130,12 +4130,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4143,21 +4143,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4193,12 +4193,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4206,21 +4206,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5223,12 +5223,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5236,21 +5236,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5382,12 +5382,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5395,21 +5395,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5444,12 +5444,12 @@ func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceededException) Code() string {
+func (s *ResourceLimitExceededException) Code() string {
 	return "ResourceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceededException) Message() string {
+func (s *ResourceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5457,21 +5457,21 @@ func (s ResourceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceededException) OrigErr() error {
+func (s *ResourceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceededException) Error() string {
+func (s *ResourceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceededException) StatusCode() int {
+func (s *ResourceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceededException) RequestID() string {
+func (s *ResourceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5511,12 +5511,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5524,21 +5524,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5573,12 +5573,12 @@ func newErrorServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServerException) Code() string {
+func (s *ServerException) Code() string {
 	return "ServerException"
 }
 
 // Message returns the exception's message.
-func (s ServerException) Message() string {
+func (s *ServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5586,21 +5586,21 @@ func (s ServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServerException) OrigErr() error {
+func (s *ServerException) OrigErr() error {
 	return nil
 }
 
-func (s ServerException) Error() string {
+func (s *ServerException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServerException) StatusCode() int {
+func (s *ServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServerException) RequestID() string {
+func (s *ServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5629,12 +5629,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5642,21 +5642,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5771,12 +5771,12 @@ func newErrorUnsupportedAvailabilityZoneException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s UnsupportedAvailabilityZoneException) Code() string {
+func (s *UnsupportedAvailabilityZoneException) Code() string {
 	return "UnsupportedAvailabilityZoneException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedAvailabilityZoneException) Message() string {
+func (s *UnsupportedAvailabilityZoneException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5784,21 +5784,21 @@ func (s UnsupportedAvailabilityZoneException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedAvailabilityZoneException) OrigErr() error {
+func (s *UnsupportedAvailabilityZoneException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedAvailabilityZoneException) Error() string {
+func (s *UnsupportedAvailabilityZoneException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedAvailabilityZoneException) StatusCode() int {
+func (s *UnsupportedAvailabilityZoneException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedAvailabilityZoneException) RequestID() string {
+func (s *UnsupportedAvailabilityZoneException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/elasticinference/api.go
+++ b/service/elasticinference/api.go
@@ -294,12 +294,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -307,21 +307,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -350,12 +350,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -363,21 +363,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -470,12 +470,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -483,21 +483,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -3287,12 +3287,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3300,21 +3300,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3767,12 +3767,12 @@ func newErrorBaseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BaseException) Code() string {
+func (s *BaseException) Code() string {
 	return "BaseException"
 }
 
 // Message returns the exception's message.
-func (s BaseException) Message() string {
+func (s *BaseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3780,21 +3780,21 @@ func (s BaseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BaseException) OrigErr() error {
+func (s *BaseException) OrigErr() error {
 	return nil
 }
 
-func (s BaseException) Error() string {
+func (s *BaseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BaseException) StatusCode() int {
+func (s *BaseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BaseException) RequestID() string {
+func (s *BaseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4038,12 +4038,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4051,21 +4051,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5157,12 +5157,12 @@ func newErrorDisabledOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DisabledOperationException) Code() string {
+func (s *DisabledOperationException) Code() string {
 	return "DisabledOperationException"
 }
 
 // Message returns the exception's message.
-func (s DisabledOperationException) Message() string {
+func (s *DisabledOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5170,21 +5170,21 @@ func (s DisabledOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DisabledOperationException) OrigErr() error {
+func (s *DisabledOperationException) OrigErr() error {
 	return nil
 }
 
-func (s DisabledOperationException) Error() string {
+func (s *DisabledOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DisabledOperationException) StatusCode() int {
+func (s *DisabledOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DisabledOperationException) RequestID() string {
+func (s *DisabledOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6591,12 +6591,12 @@ func newErrorInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalException) Code() string {
+func (s *InternalException) Code() string {
 	return "InternalException"
 }
 
 // Message returns the exception's message.
-func (s InternalException) Message() string {
+func (s *InternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6604,21 +6604,21 @@ func (s InternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalException) OrigErr() error {
+func (s *InternalException) OrigErr() error {
 	return nil
 }
 
-func (s InternalException) Error() string {
+func (s *InternalException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalException) StatusCode() int {
+func (s *InternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalException) RequestID() string {
+func (s *InternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6648,12 +6648,12 @@ func newErrorInvalidTypeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTypeException) Code() string {
+func (s *InvalidTypeException) Code() string {
 	return "InvalidTypeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTypeException) Message() string {
+func (s *InvalidTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6661,21 +6661,21 @@ func (s InvalidTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTypeException) OrigErr() error {
+func (s *InvalidTypeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTypeException) Error() string {
+func (s *InvalidTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTypeException) StatusCode() int {
+func (s *InvalidTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTypeException) RequestID() string {
+func (s *InvalidTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6705,12 +6705,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6718,21 +6718,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8112,12 +8112,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8125,21 +8125,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8169,12 +8169,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8182,21 +8182,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9137,12 +9137,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9150,21 +9150,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -1888,12 +1888,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1901,21 +1901,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4118,12 +4118,12 @@ func newErrorIncompatibleVersionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncompatibleVersionException) Code() string {
+func (s *IncompatibleVersionException) Code() string {
 	return "IncompatibleVersionException"
 }
 
 // Message returns the exception's message.
-func (s IncompatibleVersionException) Message() string {
+func (s *IncompatibleVersionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4131,21 +4131,21 @@ func (s IncompatibleVersionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncompatibleVersionException) OrigErr() error {
+func (s *IncompatibleVersionException) OrigErr() error {
 	return nil
 }
 
-func (s IncompatibleVersionException) Error() string {
+func (s *IncompatibleVersionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncompatibleVersionException) StatusCode() int {
+func (s *IncompatibleVersionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncompatibleVersionException) RequestID() string {
+func (s *IncompatibleVersionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4247,12 +4247,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4260,21 +4260,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5154,12 +5154,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5167,21 +5167,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6786,12 +6786,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6799,21 +6799,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6844,12 +6844,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6857,21 +6857,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7731,12 +7731,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7744,21 +7744,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -7415,12 +7415,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7428,21 +7428,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7472,12 +7472,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7485,21 +7485,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7532,12 +7532,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7545,21 +7545,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/eventbridge/api.go
+++ b/service/eventbridge/api.go
@@ -3265,12 +3265,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3278,21 +3278,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4731,12 +4731,12 @@ func newErrorInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalException) Code() string {
+func (s *InternalException) Code() string {
 	return "InternalException"
 }
 
 // Message returns the exception's message.
-func (s InternalException) Message() string {
+func (s *InternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4744,21 +4744,21 @@ func (s InternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalException) OrigErr() error {
+func (s *InternalException) OrigErr() error {
 	return nil
 }
 
-func (s InternalException) Error() string {
+func (s *InternalException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalException) StatusCode() int {
+func (s *InternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalException) RequestID() string {
+func (s *InternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4787,12 +4787,12 @@ func newErrorInvalidEventPatternException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidEventPatternException) Code() string {
+func (s *InvalidEventPatternException) Code() string {
 	return "InvalidEventPatternException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEventPatternException) Message() string {
+func (s *InvalidEventPatternException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4800,21 +4800,21 @@ func (s InvalidEventPatternException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEventPatternException) OrigErr() error {
+func (s *InvalidEventPatternException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEventPatternException) Error() string {
+func (s *InvalidEventPatternException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEventPatternException) StatusCode() int {
+func (s *InvalidEventPatternException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEventPatternException) RequestID() string {
+func (s *InvalidEventPatternException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4843,12 +4843,12 @@ func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidStateException) Code() string {
+func (s *InvalidStateException) Code() string {
 	return "InvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateException) Message() string {
+func (s *InvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4856,21 +4856,21 @@ func (s InvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateException) OrigErr() error {
+func (s *InvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateException) Error() string {
+func (s *InvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateException) StatusCode() int {
+func (s *InvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateException) RequestID() string {
+func (s *InvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4943,12 +4943,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4956,21 +4956,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5791,12 +5791,12 @@ func newErrorManagedRuleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ManagedRuleException) Code() string {
+func (s *ManagedRuleException) Code() string {
 	return "ManagedRuleException"
 }
 
 // Message returns the exception's message.
-func (s ManagedRuleException) Message() string {
+func (s *ManagedRuleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5804,21 +5804,21 @@ func (s ManagedRuleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ManagedRuleException) OrigErr() error {
+func (s *ManagedRuleException) OrigErr() error {
 	return nil
 }
 
-func (s ManagedRuleException) Error() string {
+func (s *ManagedRuleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ManagedRuleException) StatusCode() int {
+func (s *ManagedRuleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ManagedRuleException) RequestID() string {
+func (s *ManagedRuleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5979,12 +5979,12 @@ func newErrorPolicyLengthExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyLengthExceededException) Code() string {
+func (s *PolicyLengthExceededException) Code() string {
 	return "PolicyLengthExceededException"
 }
 
 // Message returns the exception's message.
-func (s PolicyLengthExceededException) Message() string {
+func (s *PolicyLengthExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5992,21 +5992,21 @@ func (s PolicyLengthExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyLengthExceededException) OrigErr() error {
+func (s *PolicyLengthExceededException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyLengthExceededException) Error() string {
+func (s *PolicyLengthExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyLengthExceededException) StatusCode() int {
+func (s *PolicyLengthExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyLengthExceededException) RequestID() string {
+func (s *PolicyLengthExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7119,12 +7119,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7132,21 +7132,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7175,12 +7175,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7188,21 +7188,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -1494,12 +1494,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1507,21 +1507,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3717,12 +3717,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3730,21 +3730,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3778,12 +3778,12 @@ func newErrorInvalidKMSResourceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidKMSResourceException) Code() string {
+func (s *InvalidKMSResourceException) Code() string {
 	return "InvalidKMSResourceException"
 }
 
 // Message returns the exception's message.
-func (s InvalidKMSResourceException) Message() string {
+func (s *InvalidKMSResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3791,21 +3791,21 @@ func (s InvalidKMSResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidKMSResourceException) OrigErr() error {
+func (s *InvalidKMSResourceException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidKMSResourceException) Error() string {
+func (s *InvalidKMSResourceException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidKMSResourceException) StatusCode() int {
+func (s *InvalidKMSResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidKMSResourceException) RequestID() string {
+func (s *InvalidKMSResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3988,12 +3988,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4001,21 +4001,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5564,12 +5564,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5577,21 +5577,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5621,12 +5621,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5634,21 +5634,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6185,12 +6185,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6198,21 +6198,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/fms/api.go
+++ b/service/fms/api.go
@@ -2511,12 +2511,12 @@ func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalErrorException) Code() string {
+func (s *InternalErrorException) Code() string {
 	return "InternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalErrorException) Message() string {
+func (s *InternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2524,21 +2524,21 @@ func (s InternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalErrorException) OrigErr() error {
+func (s *InternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalErrorException) Error() string {
+func (s *InternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalErrorException) StatusCode() int {
+func (s *InternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalErrorException) RequestID() string {
+func (s *InternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2567,12 +2567,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2580,21 +2580,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2625,12 +2625,12 @@ func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOperationException) Code() string {
+func (s *InvalidOperationException) Code() string {
 	return "InvalidOperationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOperationException) Message() string {
+func (s *InvalidOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2638,21 +2638,21 @@ func (s InvalidOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOperationException) OrigErr() error {
+func (s *InvalidOperationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOperationException) Error() string {
+func (s *InvalidOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOperationException) StatusCode() int {
+func (s *InvalidOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOperationException) RequestID() string {
+func (s *InvalidOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2681,12 +2681,12 @@ func newErrorInvalidTypeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTypeException) Code() string {
+func (s *InvalidTypeException) Code() string {
 	return "InvalidTypeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTypeException) Message() string {
+func (s *InvalidTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2694,21 +2694,21 @@ func (s InvalidTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTypeException) OrigErr() error {
+func (s *InvalidTypeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTypeException) Error() string {
+func (s *InvalidTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTypeException) StatusCode() int {
+func (s *InvalidTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTypeException) RequestID() string {
+func (s *InvalidTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2740,12 +2740,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2753,21 +2753,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3772,12 +3772,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3785,21 +3785,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/forecastqueryservice/api.go
+++ b/service/forecastqueryservice/api.go
@@ -208,12 +208,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -221,21 +221,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -264,12 +264,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -277,21 +277,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -320,12 +320,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -333,21 +333,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -495,12 +495,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -508,21 +508,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -552,12 +552,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -565,20 +565,20 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }

--- a/service/forecastservice/api.go
+++ b/service/forecastservice/api.go
@@ -6492,12 +6492,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6505,21 +6505,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6548,12 +6548,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6561,21 +6561,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6604,12 +6604,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6617,21 +6617,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7598,12 +7598,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7611,21 +7611,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7654,12 +7654,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7667,21 +7667,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7711,12 +7711,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7724,21 +7724,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/frauddetector/api.go
+++ b/service/frauddetector/api.go
@@ -5332,12 +5332,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5345,21 +5345,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6458,12 +6458,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6471,21 +6471,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6739,12 +6739,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6752,21 +6752,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7566,12 +7566,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7579,21 +7579,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/fsx/api.go
+++ b/service/fsx/api.go
@@ -1804,12 +1804,12 @@ func newErrorActiveDirectoryError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ActiveDirectoryError) Code() string {
+func (s *ActiveDirectoryError) Code() string {
 	return "ActiveDirectoryError"
 }
 
 // Message returns the exception's message.
-func (s ActiveDirectoryError) Message() string {
+func (s *ActiveDirectoryError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1817,21 +1817,21 @@ func (s ActiveDirectoryError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ActiveDirectoryError) OrigErr() error {
+func (s *ActiveDirectoryError) OrigErr() error {
 	return nil
 }
 
-func (s ActiveDirectoryError) Error() string {
+func (s *ActiveDirectoryError) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ActiveDirectoryError) StatusCode() int {
+func (s *ActiveDirectoryError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ActiveDirectoryError) RequestID() string {
+func (s *ActiveDirectoryError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2015,12 +2015,12 @@ func newErrorBackupInProgress(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BackupInProgress) Code() string {
+func (s *BackupInProgress) Code() string {
 	return "BackupInProgress"
 }
 
 // Message returns the exception's message.
-func (s BackupInProgress) Message() string {
+func (s *BackupInProgress) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2028,21 +2028,21 @@ func (s BackupInProgress) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BackupInProgress) OrigErr() error {
+func (s *BackupInProgress) OrigErr() error {
 	return nil
 }
 
-func (s BackupInProgress) Error() string {
+func (s *BackupInProgress) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BackupInProgress) StatusCode() int {
+func (s *BackupInProgress) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BackupInProgress) RequestID() string {
+func (s *BackupInProgress) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2072,12 +2072,12 @@ func newErrorBackupNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BackupNotFound) Code() string {
+func (s *BackupNotFound) Code() string {
 	return "BackupNotFound"
 }
 
 // Message returns the exception's message.
-func (s BackupNotFound) Message() string {
+func (s *BackupNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2085,21 +2085,21 @@ func (s BackupNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BackupNotFound) OrigErr() error {
+func (s *BackupNotFound) OrigErr() error {
 	return nil
 }
 
-func (s BackupNotFound) Error() string {
+func (s *BackupNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BackupNotFound) StatusCode() int {
+func (s *BackupNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BackupNotFound) RequestID() string {
+func (s *BackupNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2132,12 +2132,12 @@ func newErrorBackupRestoring(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BackupRestoring) Code() string {
+func (s *BackupRestoring) Code() string {
 	return "BackupRestoring"
 }
 
 // Message returns the exception's message.
-func (s BackupRestoring) Message() string {
+func (s *BackupRestoring) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2145,21 +2145,21 @@ func (s BackupRestoring) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BackupRestoring) OrigErr() error {
+func (s *BackupRestoring) OrigErr() error {
 	return nil
 }
 
-func (s BackupRestoring) Error() string {
+func (s *BackupRestoring) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BackupRestoring) StatusCode() int {
+func (s *BackupRestoring) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BackupRestoring) RequestID() string {
+func (s *BackupRestoring) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2189,12 +2189,12 @@ func newErrorBadRequest(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequest) Code() string {
+func (s *BadRequest) Code() string {
 	return "BadRequest"
 }
 
 // Message returns the exception's message.
-func (s BadRequest) Message() string {
+func (s *BadRequest) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2202,21 +2202,21 @@ func (s BadRequest) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequest) OrigErr() error {
+func (s *BadRequest) OrigErr() error {
 	return nil
 }
 
-func (s BadRequest) Error() string {
+func (s *BadRequest) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequest) StatusCode() int {
+func (s *BadRequest) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequest) RequestID() string {
+func (s *BadRequest) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3623,12 +3623,12 @@ func newErrorDataRepositoryTaskEnded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DataRepositoryTaskEnded) Code() string {
+func (s *DataRepositoryTaskEnded) Code() string {
 	return "DataRepositoryTaskEnded"
 }
 
 // Message returns the exception's message.
-func (s DataRepositoryTaskEnded) Message() string {
+func (s *DataRepositoryTaskEnded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3636,21 +3636,21 @@ func (s DataRepositoryTaskEnded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DataRepositoryTaskEnded) OrigErr() error {
+func (s *DataRepositoryTaskEnded) OrigErr() error {
 	return nil
 }
 
-func (s DataRepositoryTaskEnded) Error() string {
+func (s *DataRepositoryTaskEnded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DataRepositoryTaskEnded) StatusCode() int {
+func (s *DataRepositoryTaskEnded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DataRepositoryTaskEnded) RequestID() string {
+func (s *DataRepositoryTaskEnded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3681,12 +3681,12 @@ func newErrorDataRepositoryTaskExecuting(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DataRepositoryTaskExecuting) Code() string {
+func (s *DataRepositoryTaskExecuting) Code() string {
 	return "DataRepositoryTaskExecuting"
 }
 
 // Message returns the exception's message.
-func (s DataRepositoryTaskExecuting) Message() string {
+func (s *DataRepositoryTaskExecuting) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3694,21 +3694,21 @@ func (s DataRepositoryTaskExecuting) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DataRepositoryTaskExecuting) OrigErr() error {
+func (s *DataRepositoryTaskExecuting) OrigErr() error {
 	return nil
 }
 
-func (s DataRepositoryTaskExecuting) Error() string {
+func (s *DataRepositoryTaskExecuting) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DataRepositoryTaskExecuting) StatusCode() int {
+func (s *DataRepositoryTaskExecuting) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DataRepositoryTaskExecuting) RequestID() string {
+func (s *DataRepositoryTaskExecuting) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3808,12 +3808,12 @@ func newErrorDataRepositoryTaskNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DataRepositoryTaskNotFound) Code() string {
+func (s *DataRepositoryTaskNotFound) Code() string {
 	return "DataRepositoryTaskNotFound"
 }
 
 // Message returns the exception's message.
-func (s DataRepositoryTaskNotFound) Message() string {
+func (s *DataRepositoryTaskNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3821,21 +3821,21 @@ func (s DataRepositoryTaskNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DataRepositoryTaskNotFound) OrigErr() error {
+func (s *DataRepositoryTaskNotFound) OrigErr() error {
 	return nil
 }
 
-func (s DataRepositoryTaskNotFound) Error() string {
+func (s *DataRepositoryTaskNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DataRepositoryTaskNotFound) StatusCode() int {
+func (s *DataRepositoryTaskNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DataRepositoryTaskNotFound) RequestID() string {
+func (s *DataRepositoryTaskNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4769,12 +4769,12 @@ func newErrorFileSystemNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FileSystemNotFound) Code() string {
+func (s *FileSystemNotFound) Code() string {
 	return "FileSystemNotFound"
 }
 
 // Message returns the exception's message.
-func (s FileSystemNotFound) Message() string {
+func (s *FileSystemNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4782,21 +4782,21 @@ func (s FileSystemNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FileSystemNotFound) OrigErr() error {
+func (s *FileSystemNotFound) OrigErr() error {
 	return nil
 }
 
-func (s FileSystemNotFound) Error() string {
+func (s *FileSystemNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FileSystemNotFound) StatusCode() int {
+func (s *FileSystemNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FileSystemNotFound) RequestID() string {
+func (s *FileSystemNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4868,12 +4868,12 @@ func newErrorIncompatibleParameterError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncompatibleParameterError) Code() string {
+func (s *IncompatibleParameterError) Code() string {
 	return "IncompatibleParameterError"
 }
 
 // Message returns the exception's message.
-func (s IncompatibleParameterError) Message() string {
+func (s *IncompatibleParameterError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4881,21 +4881,21 @@ func (s IncompatibleParameterError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncompatibleParameterError) OrigErr() error {
+func (s *IncompatibleParameterError) OrigErr() error {
 	return nil
 }
 
-func (s IncompatibleParameterError) Error() string {
+func (s *IncompatibleParameterError) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncompatibleParameterError) StatusCode() int {
+func (s *IncompatibleParameterError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncompatibleParameterError) RequestID() string {
+func (s *IncompatibleParameterError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4925,12 +4925,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4938,21 +4938,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4982,12 +4982,12 @@ func newErrorInvalidExportPath(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidExportPath) Code() string {
+func (s *InvalidExportPath) Code() string {
 	return "InvalidExportPath"
 }
 
 // Message returns the exception's message.
-func (s InvalidExportPath) Message() string {
+func (s *InvalidExportPath) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4995,21 +4995,21 @@ func (s InvalidExportPath) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidExportPath) OrigErr() error {
+func (s *InvalidExportPath) OrigErr() error {
 	return nil
 }
 
-func (s InvalidExportPath) Error() string {
+func (s *InvalidExportPath) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidExportPath) StatusCode() int {
+func (s *InvalidExportPath) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidExportPath) RequestID() string {
+func (s *InvalidExportPath) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5039,12 +5039,12 @@ func newErrorInvalidImportPath(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidImportPath) Code() string {
+func (s *InvalidImportPath) Code() string {
 	return "InvalidImportPath"
 }
 
 // Message returns the exception's message.
-func (s InvalidImportPath) Message() string {
+func (s *InvalidImportPath) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5052,21 +5052,21 @@ func (s InvalidImportPath) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidImportPath) OrigErr() error {
+func (s *InvalidImportPath) OrigErr() error {
 	return nil
 }
 
-func (s InvalidImportPath) Error() string {
+func (s *InvalidImportPath) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidImportPath) StatusCode() int {
+func (s *InvalidImportPath) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidImportPath) RequestID() string {
+func (s *InvalidImportPath) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5113,12 +5113,12 @@ func newErrorInvalidNetworkSettings(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNetworkSettings) Code() string {
+func (s *InvalidNetworkSettings) Code() string {
 	return "InvalidNetworkSettings"
 }
 
 // Message returns the exception's message.
-func (s InvalidNetworkSettings) Message() string {
+func (s *InvalidNetworkSettings) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5126,21 +5126,21 @@ func (s InvalidNetworkSettings) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNetworkSettings) OrigErr() error {
+func (s *InvalidNetworkSettings) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNetworkSettings) Error() string {
+func (s *InvalidNetworkSettings) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNetworkSettings) StatusCode() int {
+func (s *InvalidNetworkSettings) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNetworkSettings) RequestID() string {
+func (s *InvalidNetworkSettings) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5171,12 +5171,12 @@ func newErrorInvalidPerUnitStorageThroughput(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidPerUnitStorageThroughput) Code() string {
+func (s *InvalidPerUnitStorageThroughput) Code() string {
 	return "InvalidPerUnitStorageThroughput"
 }
 
 // Message returns the exception's message.
-func (s InvalidPerUnitStorageThroughput) Message() string {
+func (s *InvalidPerUnitStorageThroughput) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5184,21 +5184,21 @@ func (s InvalidPerUnitStorageThroughput) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPerUnitStorageThroughput) OrigErr() error {
+func (s *InvalidPerUnitStorageThroughput) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPerUnitStorageThroughput) Error() string {
+func (s *InvalidPerUnitStorageThroughput) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPerUnitStorageThroughput) StatusCode() int {
+func (s *InvalidPerUnitStorageThroughput) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPerUnitStorageThroughput) RequestID() string {
+func (s *InvalidPerUnitStorageThroughput) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5402,12 +5402,12 @@ func newErrorMissingFileSystemConfiguration(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MissingFileSystemConfiguration) Code() string {
+func (s *MissingFileSystemConfiguration) Code() string {
 	return "MissingFileSystemConfiguration"
 }
 
 // Message returns the exception's message.
-func (s MissingFileSystemConfiguration) Message() string {
+func (s *MissingFileSystemConfiguration) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5415,21 +5415,21 @@ func (s MissingFileSystemConfiguration) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MissingFileSystemConfiguration) OrigErr() error {
+func (s *MissingFileSystemConfiguration) OrigErr() error {
 	return nil
 }
 
-func (s MissingFileSystemConfiguration) Error() string {
+func (s *MissingFileSystemConfiguration) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MissingFileSystemConfiguration) StatusCode() int {
+func (s *MissingFileSystemConfiguration) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MissingFileSystemConfiguration) RequestID() string {
+func (s *MissingFileSystemConfiguration) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5465,12 +5465,12 @@ func newErrorNotServiceResourceError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotServiceResourceError) Code() string {
+func (s *NotServiceResourceError) Code() string {
 	return "NotServiceResourceError"
 }
 
 // Message returns the exception's message.
-func (s NotServiceResourceError) Message() string {
+func (s *NotServiceResourceError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5478,21 +5478,21 @@ func (s NotServiceResourceError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotServiceResourceError) OrigErr() error {
+func (s *NotServiceResourceError) OrigErr() error {
 	return nil
 }
 
-func (s NotServiceResourceError) Error() string {
+func (s *NotServiceResourceError) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotServiceResourceError) StatusCode() int {
+func (s *NotServiceResourceError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotServiceResourceError) RequestID() string {
+func (s *NotServiceResourceError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5527,12 +5527,12 @@ func newErrorResourceDoesNotSupportTagging(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceDoesNotSupportTagging) Code() string {
+func (s *ResourceDoesNotSupportTagging) Code() string {
 	return "ResourceDoesNotSupportTagging"
 }
 
 // Message returns the exception's message.
-func (s ResourceDoesNotSupportTagging) Message() string {
+func (s *ResourceDoesNotSupportTagging) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5540,21 +5540,21 @@ func (s ResourceDoesNotSupportTagging) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceDoesNotSupportTagging) OrigErr() error {
+func (s *ResourceDoesNotSupportTagging) OrigErr() error {
 	return nil
 }
 
-func (s ResourceDoesNotSupportTagging) Error() string {
+func (s *ResourceDoesNotSupportTagging) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceDoesNotSupportTagging) StatusCode() int {
+func (s *ResourceDoesNotSupportTagging) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceDoesNotSupportTagging) RequestID() string {
+func (s *ResourceDoesNotSupportTagging) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5589,12 +5589,12 @@ func newErrorResourceNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFound) Code() string {
+func (s *ResourceNotFound) Code() string {
 	return "ResourceNotFound"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFound) Message() string {
+func (s *ResourceNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5602,21 +5602,21 @@ func (s ResourceNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFound) OrigErr() error {
+func (s *ResourceNotFound) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFound) Error() string {
+func (s *ResourceNotFound) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFound) StatusCode() int {
+func (s *ResourceNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFound) RequestID() string {
+func (s *ResourceNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5934,12 +5934,12 @@ func newErrorServiceLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceLimitExceeded) Code() string {
+func (s *ServiceLimitExceeded) Code() string {
 	return "ServiceLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ServiceLimitExceeded) Message() string {
+func (s *ServiceLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5947,21 +5947,21 @@ func (s ServiceLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceLimitExceeded) OrigErr() error {
+func (s *ServiceLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ServiceLimitExceeded) Error() string {
+func (s *ServiceLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceLimitExceeded) StatusCode() int {
+func (s *ServiceLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceLimitExceeded) RequestID() string {
+func (s *ServiceLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6127,12 +6127,12 @@ func newErrorUnsupportedOperation(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedOperation) Code() string {
+func (s *UnsupportedOperation) Code() string {
 	return "UnsupportedOperation"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedOperation) Message() string {
+func (s *UnsupportedOperation) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6140,21 +6140,21 @@ func (s UnsupportedOperation) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedOperation) OrigErr() error {
+func (s *UnsupportedOperation) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedOperation) Error() string {
+func (s *UnsupportedOperation) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedOperation) StatusCode() int {
+func (s *UnsupportedOperation) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedOperation) RequestID() string {
+func (s *UnsupportedOperation) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/gamelift/api.go
+++ b/service/gamelift/api.go
@@ -9822,12 +9822,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9835,21 +9835,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15074,12 +15074,12 @@ func newErrorFleetCapacityExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FleetCapacityExceededException) Code() string {
+func (s *FleetCapacityExceededException) Code() string {
 	return "FleetCapacityExceededException"
 }
 
 // Message returns the exception's message.
-func (s FleetCapacityExceededException) Message() string {
+func (s *FleetCapacityExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15087,21 +15087,21 @@ func (s FleetCapacityExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FleetCapacityExceededException) OrigErr() error {
+func (s *FleetCapacityExceededException) OrigErr() error {
 	return nil
 }
 
-func (s FleetCapacityExceededException) Error() string {
+func (s *FleetCapacityExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FleetCapacityExceededException) StatusCode() int {
+func (s *FleetCapacityExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FleetCapacityExceededException) RequestID() string {
+func (s *FleetCapacityExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15618,12 +15618,12 @@ func newErrorGameSessionFullException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s GameSessionFullException) Code() string {
+func (s *GameSessionFullException) Code() string {
 	return "GameSessionFullException"
 }
 
 // Message returns the exception's message.
-func (s GameSessionFullException) Message() string {
+func (s *GameSessionFullException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15631,21 +15631,21 @@ func (s GameSessionFullException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GameSessionFullException) OrigErr() error {
+func (s *GameSessionFullException) OrigErr() error {
 	return nil
 }
 
-func (s GameSessionFullException) Error() string {
+func (s *GameSessionFullException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GameSessionFullException) StatusCode() int {
+func (s *GameSessionFullException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GameSessionFullException) RequestID() string {
+func (s *GameSessionFullException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16215,12 +16215,12 @@ func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatchException) Code() string {
+func (s *IdempotentParameterMismatchException) Code() string {
 	return "IdempotentParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatchException) Message() string {
+func (s *IdempotentParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16228,21 +16228,21 @@ func (s IdempotentParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatchException) OrigErr() error {
+func (s *IdempotentParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatchException) Error() string {
+func (s *IdempotentParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatchException) StatusCode() int {
+func (s *IdempotentParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatchException) RequestID() string {
+func (s *IdempotentParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16481,12 +16481,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16494,21 +16494,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16539,12 +16539,12 @@ func newErrorInvalidFleetStatusException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFleetStatusException) Code() string {
+func (s *InvalidFleetStatusException) Code() string {
 	return "InvalidFleetStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidFleetStatusException) Message() string {
+func (s *InvalidFleetStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16552,21 +16552,21 @@ func (s InvalidFleetStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFleetStatusException) OrigErr() error {
+func (s *InvalidFleetStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFleetStatusException) Error() string {
+func (s *InvalidFleetStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFleetStatusException) StatusCode() int {
+func (s *InvalidFleetStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFleetStatusException) RequestID() string {
+func (s *InvalidFleetStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16597,12 +16597,12 @@ func newErrorInvalidGameSessionStatusException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s InvalidGameSessionStatusException) Code() string {
+func (s *InvalidGameSessionStatusException) Code() string {
 	return "InvalidGameSessionStatusException"
 }
 
 // Message returns the exception's message.
-func (s InvalidGameSessionStatusException) Message() string {
+func (s *InvalidGameSessionStatusException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16610,21 +16610,21 @@ func (s InvalidGameSessionStatusException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidGameSessionStatusException) OrigErr() error {
+func (s *InvalidGameSessionStatusException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidGameSessionStatusException) Error() string {
+func (s *InvalidGameSessionStatusException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidGameSessionStatusException) StatusCode() int {
+func (s *InvalidGameSessionStatusException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidGameSessionStatusException) RequestID() string {
+func (s *InvalidGameSessionStatusException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16654,12 +16654,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16667,21 +16667,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16807,12 +16807,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16820,21 +16820,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17840,12 +17840,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17853,21 +17853,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20396,12 +20396,12 @@ func newErrorTaggingFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TaggingFailedException) Code() string {
+func (s *TaggingFailedException) Code() string {
 	return "TaggingFailedException"
 }
 
 // Message returns the exception's message.
-func (s TaggingFailedException) Message() string {
+func (s *TaggingFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20409,21 +20409,21 @@ func (s TaggingFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TaggingFailedException) OrigErr() error {
+func (s *TaggingFailedException) OrigErr() error {
 	return nil
 }
 
-func (s TaggingFailedException) Error() string {
+func (s *TaggingFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TaggingFailedException) StatusCode() int {
+func (s *TaggingFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TaggingFailedException) RequestID() string {
+func (s *TaggingFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20515,12 +20515,12 @@ func newErrorTerminalRoutingStrategyException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s TerminalRoutingStrategyException) Code() string {
+func (s *TerminalRoutingStrategyException) Code() string {
 	return "TerminalRoutingStrategyException"
 }
 
 // Message returns the exception's message.
-func (s TerminalRoutingStrategyException) Message() string {
+func (s *TerminalRoutingStrategyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20528,21 +20528,21 @@ func (s TerminalRoutingStrategyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TerminalRoutingStrategyException) OrigErr() error {
+func (s *TerminalRoutingStrategyException) OrigErr() error {
 	return nil
 }
 
-func (s TerminalRoutingStrategyException) Error() string {
+func (s *TerminalRoutingStrategyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TerminalRoutingStrategyException) StatusCode() int {
+func (s *TerminalRoutingStrategyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TerminalRoutingStrategyException) RequestID() string {
+func (s *TerminalRoutingStrategyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20571,12 +20571,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20584,21 +20584,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20627,12 +20627,12 @@ func newErrorUnsupportedRegionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedRegionException) Code() string {
+func (s *UnsupportedRegionException) Code() string {
 	return "UnsupportedRegionException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedRegionException) Message() string {
+func (s *UnsupportedRegionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20640,21 +20640,21 @@ func (s UnsupportedRegionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedRegionException) OrigErr() error {
+func (s *UnsupportedRegionException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedRegionException) Error() string {
+func (s *UnsupportedRegionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedRegionException) StatusCode() int {
+func (s *UnsupportedRegionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedRegionException) RequestID() string {
+func (s *UnsupportedRegionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -6206,12 +6206,12 @@ func newErrorInsufficientCapacityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InsufficientCapacityException) Code() string {
+func (s *InsufficientCapacityException) Code() string {
 	return "InsufficientCapacityException"
 }
 
 // Message returns the exception's message.
-func (s InsufficientCapacityException) Message() string {
+func (s *InsufficientCapacityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6219,21 +6219,21 @@ func (s InsufficientCapacityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InsufficientCapacityException) OrigErr() error {
+func (s *InsufficientCapacityException) OrigErr() error {
 	return nil
 }
 
-func (s InsufficientCapacityException) Error() string {
+func (s *InsufficientCapacityException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InsufficientCapacityException) StatusCode() int {
+func (s *InsufficientCapacityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InsufficientCapacityException) RequestID() string {
+func (s *InsufficientCapacityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6269,12 +6269,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6282,21 +6282,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6845,12 +6845,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6858,21 +6858,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7618,12 +7618,12 @@ func newErrorMissingParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MissingParameterValueException) Code() string {
+func (s *MissingParameterValueException) Code() string {
 	return "MissingParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s MissingParameterValueException) Message() string {
+func (s *MissingParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7631,21 +7631,21 @@ func (s MissingParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MissingParameterValueException) OrigErr() error {
+func (s *MissingParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s MissingParameterValueException) Error() string {
+func (s *MissingParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MissingParameterValueException) StatusCode() int {
+func (s *MissingParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MissingParameterValueException) RequestID() string {
+func (s *MissingParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7780,12 +7780,12 @@ func newErrorPolicyEnforcedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyEnforcedException) Code() string {
+func (s *PolicyEnforcedException) Code() string {
 	return "PolicyEnforcedException"
 }
 
 // Message returns the exception's message.
-func (s PolicyEnforcedException) Message() string {
+func (s *PolicyEnforcedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7793,21 +7793,21 @@ func (s PolicyEnforcedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyEnforcedException) OrigErr() error {
+func (s *PolicyEnforcedException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyEnforcedException) Error() string {
+func (s *PolicyEnforcedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyEnforcedException) StatusCode() int {
+func (s *PolicyEnforcedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyEnforcedException) RequestID() string {
+func (s *PolicyEnforcedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8043,12 +8043,12 @@ func newErrorRequestTimeoutException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestTimeoutException) Code() string {
+func (s *RequestTimeoutException) Code() string {
 	return "RequestTimeoutException"
 }
 
 // Message returns the exception's message.
-func (s RequestTimeoutException) Message() string {
+func (s *RequestTimeoutException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8056,21 +8056,21 @@ func (s RequestTimeoutException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestTimeoutException) OrigErr() error {
+func (s *RequestTimeoutException) OrigErr() error {
 	return nil
 }
 
-func (s RequestTimeoutException) Error() string {
+func (s *RequestTimeoutException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestTimeoutException) StatusCode() int {
+func (s *RequestTimeoutException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestTimeoutException) RequestID() string {
+func (s *RequestTimeoutException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8108,12 +8108,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8121,21 +8121,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8331,12 +8331,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8344,21 +8344,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/globalaccelerator/api.go
+++ b/service/globalaccelerator/api.go
@@ -2530,12 +2530,12 @@ func newErrorAcceleratorNotDisabledException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s AcceleratorNotDisabledException) Code() string {
+func (s *AcceleratorNotDisabledException) Code() string {
 	return "AcceleratorNotDisabledException"
 }
 
 // Message returns the exception's message.
-func (s AcceleratorNotDisabledException) Message() string {
+func (s *AcceleratorNotDisabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2543,21 +2543,21 @@ func (s AcceleratorNotDisabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AcceleratorNotDisabledException) OrigErr() error {
+func (s *AcceleratorNotDisabledException) OrigErr() error {
 	return nil
 }
 
-func (s AcceleratorNotDisabledException) Error() string {
+func (s *AcceleratorNotDisabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AcceleratorNotDisabledException) StatusCode() int {
+func (s *AcceleratorNotDisabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AcceleratorNotDisabledException) RequestID() string {
+func (s *AcceleratorNotDisabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2586,12 +2586,12 @@ func newErrorAcceleratorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AcceleratorNotFoundException) Code() string {
+func (s *AcceleratorNotFoundException) Code() string {
 	return "AcceleratorNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s AcceleratorNotFoundException) Message() string {
+func (s *AcceleratorNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2599,21 +2599,21 @@ func (s AcceleratorNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AcceleratorNotFoundException) OrigErr() error {
+func (s *AcceleratorNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s AcceleratorNotFoundException) Error() string {
+func (s *AcceleratorNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AcceleratorNotFoundException) StatusCode() int {
+func (s *AcceleratorNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AcceleratorNotFoundException) RequestID() string {
+func (s *AcceleratorNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2642,12 +2642,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2655,21 +2655,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2762,12 +2762,12 @@ func newErrorAssociatedEndpointGroupFoundException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s AssociatedEndpointGroupFoundException) Code() string {
+func (s *AssociatedEndpointGroupFoundException) Code() string {
 	return "AssociatedEndpointGroupFoundException"
 }
 
 // Message returns the exception's message.
-func (s AssociatedEndpointGroupFoundException) Message() string {
+func (s *AssociatedEndpointGroupFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2775,21 +2775,21 @@ func (s AssociatedEndpointGroupFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AssociatedEndpointGroupFoundException) OrigErr() error {
+func (s *AssociatedEndpointGroupFoundException) OrigErr() error {
 	return nil
 }
 
-func (s AssociatedEndpointGroupFoundException) Error() string {
+func (s *AssociatedEndpointGroupFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AssociatedEndpointGroupFoundException) StatusCode() int {
+func (s *AssociatedEndpointGroupFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AssociatedEndpointGroupFoundException) RequestID() string {
+func (s *AssociatedEndpointGroupFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2820,12 +2820,12 @@ func newErrorAssociatedListenerFoundException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s AssociatedListenerFoundException) Code() string {
+func (s *AssociatedListenerFoundException) Code() string {
 	return "AssociatedListenerFoundException"
 }
 
 // Message returns the exception's message.
-func (s AssociatedListenerFoundException) Message() string {
+func (s *AssociatedListenerFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2833,21 +2833,21 @@ func (s AssociatedListenerFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AssociatedListenerFoundException) OrigErr() error {
+func (s *AssociatedListenerFoundException) OrigErr() error {
 	return nil
 }
 
-func (s AssociatedListenerFoundException) Error() string {
+func (s *AssociatedListenerFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AssociatedListenerFoundException) StatusCode() int {
+func (s *AssociatedListenerFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AssociatedListenerFoundException) RequestID() string {
+func (s *AssociatedListenerFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3003,12 +3003,12 @@ func newErrorByoipCidrNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ByoipCidrNotFoundException) Code() string {
+func (s *ByoipCidrNotFoundException) Code() string {
 	return "ByoipCidrNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ByoipCidrNotFoundException) Message() string {
+func (s *ByoipCidrNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3016,21 +3016,21 @@ func (s ByoipCidrNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ByoipCidrNotFoundException) OrigErr() error {
+func (s *ByoipCidrNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ByoipCidrNotFoundException) Error() string {
+func (s *ByoipCidrNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ByoipCidrNotFoundException) StatusCode() int {
+func (s *ByoipCidrNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ByoipCidrNotFoundException) RequestID() string {
+func (s *ByoipCidrNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4310,12 +4310,12 @@ func newErrorEndpointGroupAlreadyExistsException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s EndpointGroupAlreadyExistsException) Code() string {
+func (s *EndpointGroupAlreadyExistsException) Code() string {
 	return "EndpointGroupAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s EndpointGroupAlreadyExistsException) Message() string {
+func (s *EndpointGroupAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4323,21 +4323,21 @@ func (s EndpointGroupAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EndpointGroupAlreadyExistsException) OrigErr() error {
+func (s *EndpointGroupAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s EndpointGroupAlreadyExistsException) Error() string {
+func (s *EndpointGroupAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EndpointGroupAlreadyExistsException) StatusCode() int {
+func (s *EndpointGroupAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EndpointGroupAlreadyExistsException) RequestID() string {
+func (s *EndpointGroupAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4366,12 +4366,12 @@ func newErrorEndpointGroupNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EndpointGroupNotFoundException) Code() string {
+func (s *EndpointGroupNotFoundException) Code() string {
 	return "EndpointGroupNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s EndpointGroupNotFoundException) Message() string {
+func (s *EndpointGroupNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4379,21 +4379,21 @@ func (s EndpointGroupNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EndpointGroupNotFoundException) OrigErr() error {
+func (s *EndpointGroupNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s EndpointGroupNotFoundException) Error() string {
+func (s *EndpointGroupNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EndpointGroupNotFoundException) StatusCode() int {
+func (s *EndpointGroupNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EndpointGroupNotFoundException) RequestID() string {
+func (s *EndpointGroupNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4423,12 +4423,12 @@ func newErrorIncorrectCidrStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncorrectCidrStateException) Code() string {
+func (s *IncorrectCidrStateException) Code() string {
 	return "IncorrectCidrStateException"
 }
 
 // Message returns the exception's message.
-func (s IncorrectCidrStateException) Message() string {
+func (s *IncorrectCidrStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4436,21 +4436,21 @@ func (s IncorrectCidrStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncorrectCidrStateException) OrigErr() error {
+func (s *IncorrectCidrStateException) OrigErr() error {
 	return nil
 }
 
-func (s IncorrectCidrStateException) Error() string {
+func (s *IncorrectCidrStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncorrectCidrStateException) StatusCode() int {
+func (s *IncorrectCidrStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncorrectCidrStateException) RequestID() string {
+func (s *IncorrectCidrStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4479,12 +4479,12 @@ func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceErrorException) Code() string {
+func (s *InternalServiceErrorException) Code() string {
 	return "InternalServiceErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceErrorException) Message() string {
+func (s *InternalServiceErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4492,21 +4492,21 @@ func (s InternalServiceErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceErrorException) OrigErr() error {
+func (s *InternalServiceErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceErrorException) Error() string {
+func (s *InternalServiceErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceErrorException) StatusCode() int {
+func (s *InternalServiceErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceErrorException) RequestID() string {
+func (s *InternalServiceErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4535,12 +4535,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4548,21 +4548,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4591,12 +4591,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4604,21 +4604,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4648,12 +4648,12 @@ func newErrorInvalidPortRangeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPortRangeException) Code() string {
+func (s *InvalidPortRangeException) Code() string {
 	return "InvalidPortRangeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPortRangeException) Message() string {
+func (s *InvalidPortRangeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4661,21 +4661,21 @@ func (s InvalidPortRangeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPortRangeException) OrigErr() error {
+func (s *InvalidPortRangeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPortRangeException) Error() string {
+func (s *InvalidPortRangeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPortRangeException) StatusCode() int {
+func (s *InvalidPortRangeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPortRangeException) RequestID() string {
+func (s *InvalidPortRangeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4739,12 +4739,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4752,21 +4752,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5277,12 +5277,12 @@ func newErrorListenerNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ListenerNotFoundException) Code() string {
+func (s *ListenerNotFoundException) Code() string {
 	return "ListenerNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ListenerNotFoundException) Message() string {
+func (s *ListenerNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5290,21 +5290,21 @@ func (s ListenerNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ListenerNotFoundException) OrigErr() error {
+func (s *ListenerNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ListenerNotFoundException) Error() string {
+func (s *ListenerNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ListenerNotFoundException) StatusCode() int {
+func (s *ListenerNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ListenerNotFoundException) RequestID() string {
+func (s *ListenerNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/glue/api.go
+++ b/service/glue/api.go
@@ -12687,12 +12687,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12700,21 +12700,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12855,12 +12855,12 @@ func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyExistsException) Code() string {
+func (s *AlreadyExistsException) Code() string {
 	return "AlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyExistsException) Message() string {
+func (s *AlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12868,21 +12868,21 @@ func (s AlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyExistsException) OrigErr() error {
+func (s *AlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyExistsException) Error() string {
+func (s *AlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyExistsException) StatusCode() int {
+func (s *AlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyExistsException) RequestID() string {
+func (s *AlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14738,12 +14738,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14751,21 +14751,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14795,12 +14795,12 @@ func newErrorConcurrentRunsExceededException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentRunsExceededException) Code() string {
+func (s *ConcurrentRunsExceededException) Code() string {
 	return "ConcurrentRunsExceededException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentRunsExceededException) Message() string {
+func (s *ConcurrentRunsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14808,21 +14808,21 @@ func (s ConcurrentRunsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentRunsExceededException) OrigErr() error {
+func (s *ConcurrentRunsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentRunsExceededException) Error() string {
+func (s *ConcurrentRunsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentRunsExceededException) StatusCode() int {
+func (s *ConcurrentRunsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentRunsExceededException) RequestID() string {
+func (s *ConcurrentRunsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14930,12 +14930,12 @@ func newErrorConditionCheckFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConditionCheckFailureException) Code() string {
+func (s *ConditionCheckFailureException) Code() string {
 	return "ConditionCheckFailureException"
 }
 
 // Message returns the exception's message.
-func (s ConditionCheckFailureException) Message() string {
+func (s *ConditionCheckFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14943,21 +14943,21 @@ func (s ConditionCheckFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConditionCheckFailureException) OrigErr() error {
+func (s *ConditionCheckFailureException) OrigErr() error {
 	return nil
 }
 
-func (s ConditionCheckFailureException) Error() string {
+func (s *ConditionCheckFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConditionCheckFailureException) StatusCode() int {
+func (s *ConditionCheckFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConditionCheckFailureException) RequestID() string {
+func (s *ConditionCheckFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15754,12 +15754,12 @@ func newErrorCrawlerNotRunningException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CrawlerNotRunningException) Code() string {
+func (s *CrawlerNotRunningException) Code() string {
 	return "CrawlerNotRunningException"
 }
 
 // Message returns the exception's message.
-func (s CrawlerNotRunningException) Message() string {
+func (s *CrawlerNotRunningException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15767,21 +15767,21 @@ func (s CrawlerNotRunningException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CrawlerNotRunningException) OrigErr() error {
+func (s *CrawlerNotRunningException) OrigErr() error {
 	return nil
 }
 
-func (s CrawlerNotRunningException) Error() string {
+func (s *CrawlerNotRunningException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CrawlerNotRunningException) StatusCode() int {
+func (s *CrawlerNotRunningException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CrawlerNotRunningException) RequestID() string {
+func (s *CrawlerNotRunningException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15811,12 +15811,12 @@ func newErrorCrawlerRunningException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CrawlerRunningException) Code() string {
+func (s *CrawlerRunningException) Code() string {
 	return "CrawlerRunningException"
 }
 
 // Message returns the exception's message.
-func (s CrawlerRunningException) Message() string {
+func (s *CrawlerRunningException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15824,21 +15824,21 @@ func (s CrawlerRunningException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CrawlerRunningException) OrigErr() error {
+func (s *CrawlerRunningException) OrigErr() error {
 	return nil
 }
 
-func (s CrawlerRunningException) Error() string {
+func (s *CrawlerRunningException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CrawlerRunningException) StatusCode() int {
+func (s *CrawlerRunningException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CrawlerRunningException) RequestID() string {
+func (s *CrawlerRunningException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15868,12 +15868,12 @@ func newErrorCrawlerStoppingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CrawlerStoppingException) Code() string {
+func (s *CrawlerStoppingException) Code() string {
 	return "CrawlerStoppingException"
 }
 
 // Message returns the exception's message.
-func (s CrawlerStoppingException) Message() string {
+func (s *CrawlerStoppingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15881,21 +15881,21 @@ func (s CrawlerStoppingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CrawlerStoppingException) OrigErr() error {
+func (s *CrawlerStoppingException) OrigErr() error {
 	return nil
 }
 
-func (s CrawlerStoppingException) Error() string {
+func (s *CrawlerStoppingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CrawlerStoppingException) StatusCode() int {
+func (s *CrawlerStoppingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CrawlerStoppingException) RequestID() string {
+func (s *CrawlerStoppingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20375,12 +20375,12 @@ func newErrorEncryptionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EncryptionException) Code() string {
+func (s *EncryptionException) Code() string {
 	return "GlueEncryptionException"
 }
 
 // Message returns the exception's message.
-func (s EncryptionException) Message() string {
+func (s *EncryptionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20388,21 +20388,21 @@ func (s EncryptionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EncryptionException) OrigErr() error {
+func (s *EncryptionException) OrigErr() error {
 	return nil
 }
 
-func (s EncryptionException) Error() string {
+func (s *EncryptionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EncryptionException) StatusCode() int {
+func (s *EncryptionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EncryptionException) RequestID() string {
+func (s *EncryptionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20432,12 +20432,12 @@ func newErrorEntityNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EntityNotFoundException) Code() string {
+func (s *EntityNotFoundException) Code() string {
 	return "EntityNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s EntityNotFoundException) Message() string {
+func (s *EntityNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20445,21 +20445,21 @@ func (s EntityNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EntityNotFoundException) OrigErr() error {
+func (s *EntityNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s EntityNotFoundException) Error() string {
+func (s *EntityNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EntityNotFoundException) StatusCode() int {
+func (s *EntityNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EntityNotFoundException) RequestID() string {
+func (s *EntityNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25054,12 +25054,12 @@ func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatchException) Code() string {
+func (s *IdempotentParameterMismatchException) Code() string {
 	return "IdempotentParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatchException) Message() string {
+func (s *IdempotentParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25067,21 +25067,21 @@ func (s IdempotentParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatchException) OrigErr() error {
+func (s *IdempotentParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatchException) Error() string {
+func (s *IdempotentParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatchException) StatusCode() int {
+func (s *IdempotentParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatchException) RequestID() string {
+func (s *IdempotentParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25196,12 +25196,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25209,21 +25209,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25253,12 +25253,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25266,21 +25266,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27372,12 +27372,12 @@ func newErrorMLTransformNotReadyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MLTransformNotReadyException) Code() string {
+func (s *MLTransformNotReadyException) Code() string {
 	return "MLTransformNotReadyException"
 }
 
 // Message returns the exception's message.
-func (s MLTransformNotReadyException) Message() string {
+func (s *MLTransformNotReadyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27385,21 +27385,21 @@ func (s MLTransformNotReadyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MLTransformNotReadyException) OrigErr() error {
+func (s *MLTransformNotReadyException) OrigErr() error {
 	return nil
 }
 
-func (s MLTransformNotReadyException) Error() string {
+func (s *MLTransformNotReadyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MLTransformNotReadyException) StatusCode() int {
+func (s *MLTransformNotReadyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MLTransformNotReadyException) RequestID() string {
+func (s *MLTransformNotReadyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27498,12 +27498,12 @@ func newErrorNoScheduleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoScheduleException) Code() string {
+func (s *NoScheduleException) Code() string {
 	return "NoScheduleException"
 }
 
 // Message returns the exception's message.
-func (s NoScheduleException) Message() string {
+func (s *NoScheduleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27511,21 +27511,21 @@ func (s NoScheduleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoScheduleException) OrigErr() error {
+func (s *NoScheduleException) OrigErr() error {
 	return nil
 }
 
-func (s NoScheduleException) Error() string {
+func (s *NoScheduleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoScheduleException) StatusCode() int {
+func (s *NoScheduleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoScheduleException) RequestID() string {
+func (s *NoScheduleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27663,12 +27663,12 @@ func newErrorOperationTimeoutException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationTimeoutException) Code() string {
+func (s *OperationTimeoutException) Code() string {
 	return "OperationTimeoutException"
 }
 
 // Message returns the exception's message.
-func (s OperationTimeoutException) Message() string {
+func (s *OperationTimeoutException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27676,21 +27676,21 @@ func (s OperationTimeoutException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationTimeoutException) OrigErr() error {
+func (s *OperationTimeoutException) OrigErr() error {
 	return nil
 }
 
-func (s OperationTimeoutException) Error() string {
+func (s *OperationTimeoutException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationTimeoutException) StatusCode() int {
+func (s *OperationTimeoutException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationTimeoutException) RequestID() string {
+func (s *OperationTimeoutException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28571,12 +28571,12 @@ func newErrorResourceNumberLimitExceededException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s ResourceNumberLimitExceededException) Code() string {
+func (s *ResourceNumberLimitExceededException) Code() string {
 	return "ResourceNumberLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNumberLimitExceededException) Message() string {
+func (s *ResourceNumberLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28584,21 +28584,21 @@ func (s ResourceNumberLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNumberLimitExceededException) OrigErr() error {
+func (s *ResourceNumberLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNumberLimitExceededException) Error() string {
+func (s *ResourceNumberLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNumberLimitExceededException) StatusCode() int {
+func (s *ResourceNumberLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNumberLimitExceededException) RequestID() string {
+func (s *ResourceNumberLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28777,12 +28777,12 @@ func newErrorSchedulerNotRunningException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SchedulerNotRunningException) Code() string {
+func (s *SchedulerNotRunningException) Code() string {
 	return "SchedulerNotRunningException"
 }
 
 // Message returns the exception's message.
-func (s SchedulerNotRunningException) Message() string {
+func (s *SchedulerNotRunningException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28790,21 +28790,21 @@ func (s SchedulerNotRunningException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SchedulerNotRunningException) OrigErr() error {
+func (s *SchedulerNotRunningException) OrigErr() error {
 	return nil
 }
 
-func (s SchedulerNotRunningException) Error() string {
+func (s *SchedulerNotRunningException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SchedulerNotRunningException) StatusCode() int {
+func (s *SchedulerNotRunningException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SchedulerNotRunningException) RequestID() string {
+func (s *SchedulerNotRunningException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28834,12 +28834,12 @@ func newErrorSchedulerRunningException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SchedulerRunningException) Code() string {
+func (s *SchedulerRunningException) Code() string {
 	return "SchedulerRunningException"
 }
 
 // Message returns the exception's message.
-func (s SchedulerRunningException) Message() string {
+func (s *SchedulerRunningException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28847,21 +28847,21 @@ func (s SchedulerRunningException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SchedulerRunningException) OrigErr() error {
+func (s *SchedulerRunningException) OrigErr() error {
 	return nil
 }
 
-func (s SchedulerRunningException) Error() string {
+func (s *SchedulerRunningException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SchedulerRunningException) StatusCode() int {
+func (s *SchedulerRunningException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SchedulerRunningException) RequestID() string {
+func (s *SchedulerRunningException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28891,12 +28891,12 @@ func newErrorSchedulerTransitioningException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s SchedulerTransitioningException) Code() string {
+func (s *SchedulerTransitioningException) Code() string {
 	return "SchedulerTransitioningException"
 }
 
 // Message returns the exception's message.
-func (s SchedulerTransitioningException) Message() string {
+func (s *SchedulerTransitioningException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28904,21 +28904,21 @@ func (s SchedulerTransitioningException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SchedulerTransitioningException) OrigErr() error {
+func (s *SchedulerTransitioningException) OrigErr() error {
 	return nil
 }
 
-func (s SchedulerTransitioningException) Error() string {
+func (s *SchedulerTransitioningException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SchedulerTransitioningException) StatusCode() int {
+func (s *SchedulerTransitioningException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SchedulerTransitioningException) RequestID() string {
+func (s *SchedulerTransitioningException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -33735,12 +33735,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -33748,21 +33748,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -33792,12 +33792,12 @@ func newErrorVersionMismatchException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s VersionMismatchException) Code() string {
+func (s *VersionMismatchException) Code() string {
 	return "VersionMismatchException"
 }
 
 // Message returns the exception's message.
-func (s VersionMismatchException) Message() string {
+func (s *VersionMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -33805,21 +33805,21 @@ func (s VersionMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s VersionMismatchException) OrigErr() error {
+func (s *VersionMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s VersionMismatchException) Error() string {
+func (s *VersionMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s VersionMismatchException) StatusCode() int {
+func (s *VersionMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s VersionMismatchException) RequestID() string {
+func (s *VersionMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/greengrass/api.go
+++ b/service/greengrass/api.go
@@ -7354,12 +7354,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7367,21 +7367,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14232,12 +14232,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14245,21 +14245,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/groundstation/api.go
+++ b/service/groundstation/api.go
@@ -3930,12 +3930,12 @@ func newErrorDependencyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DependencyException) Code() string {
+func (s *DependencyException) Code() string {
 	return "DependencyException"
 }
 
 // Message returns the exception's message.
-func (s DependencyException) Message() string {
+func (s *DependencyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3943,21 +3943,21 @@ func (s DependencyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DependencyException) OrigErr() error {
+func (s *DependencyException) OrigErr() error {
 	return nil
 }
 
-func (s DependencyException) Error() string {
+func (s *DependencyException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DependencyException) StatusCode() int {
+func (s *DependencyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DependencyException) RequestID() string {
+func (s *DependencyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4990,12 +4990,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5003,21 +5003,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5773,12 +5773,12 @@ func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceededException) Code() string {
+func (s *ResourceLimitExceededException) Code() string {
 	return "ResourceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceededException) Message() string {
+func (s *ResourceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5786,21 +5786,21 @@ func (s ResourceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceededException) OrigErr() error {
+func (s *ResourceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceededException) Error() string {
+func (s *ResourceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceededException) StatusCode() int {
+func (s *ResourceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceededException) RequestID() string {
+func (s *ResourceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5829,12 +5829,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5842,21 +5842,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/guardduty/api.go
+++ b/service/guardduty/api.go
@@ -5046,12 +5046,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5059,21 +5059,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8423,12 +8423,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8436,21 +8436,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/health/api.go
+++ b/service/health/api.go
@@ -1652,12 +1652,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1665,21 +1665,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3641,12 +3641,12 @@ func newErrorInvalidPaginationToken(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPaginationToken) Code() string {
+func (s *InvalidPaginationToken) Code() string {
 	return "InvalidPaginationToken"
 }
 
 // Message returns the exception's message.
-func (s InvalidPaginationToken) Message() string {
+func (s *InvalidPaginationToken) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3654,21 +3654,21 @@ func (s InvalidPaginationToken) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPaginationToken) OrigErr() error {
+func (s *InvalidPaginationToken) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPaginationToken) Error() string {
+func (s *InvalidPaginationToken) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPaginationToken) StatusCode() int {
+func (s *InvalidPaginationToken) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPaginationToken) RequestID() string {
+func (s *InvalidPaginationToken) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4123,12 +4123,12 @@ func newErrorUnsupportedLocale(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedLocale) Code() string {
+func (s *UnsupportedLocale) Code() string {
 	return "UnsupportedLocale"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedLocale) Message() string {
+func (s *UnsupportedLocale) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4136,21 +4136,21 @@ func (s UnsupportedLocale) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedLocale) OrigErr() error {
+func (s *UnsupportedLocale) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedLocale) Error() string {
+func (s *UnsupportedLocale) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedLocale) StatusCode() int {
+func (s *UnsupportedLocale) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedLocale) RequestID() string {
+func (s *UnsupportedLocale) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/imagebuilder/api.go
+++ b/service/imagebuilder/api.go
@@ -4906,12 +4906,12 @@ func newErrorCallRateLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CallRateLimitExceededException) Code() string {
+func (s *CallRateLimitExceededException) Code() string {
 	return "CallRateLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s CallRateLimitExceededException) Message() string {
+func (s *CallRateLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4919,21 +4919,21 @@ func (s CallRateLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CallRateLimitExceededException) OrigErr() error {
+func (s *CallRateLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s CallRateLimitExceededException) Error() string {
+func (s *CallRateLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CallRateLimitExceededException) StatusCode() int {
+func (s *CallRateLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CallRateLimitExceededException) RequestID() string {
+func (s *CallRateLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5055,12 +5055,12 @@ func newErrorClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientException) Code() string {
+func (s *ClientException) Code() string {
 	return "ClientException"
 }
 
 // Message returns the exception's message.
-func (s ClientException) Message() string {
+func (s *ClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5068,21 +5068,21 @@ func (s ClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientException) OrigErr() error {
+func (s *ClientException) OrigErr() error {
 	return nil
 }
 
-func (s ClientException) Error() string {
+func (s *ClientException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientException) StatusCode() int {
+func (s *ClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientException) RequestID() string {
+func (s *ClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7351,12 +7351,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7364,21 +7364,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8045,12 +8045,12 @@ func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatchException) Code() string {
+func (s *IdempotentParameterMismatchException) Code() string {
 	return "IdempotentParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatchException) Message() string {
+func (s *IdempotentParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8058,21 +8058,21 @@ func (s IdempotentParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatchException) OrigErr() error {
+func (s *IdempotentParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatchException) Error() string {
+func (s *IdempotentParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatchException) StatusCode() int {
+func (s *IdempotentParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatchException) RequestID() string {
+func (s *IdempotentParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9338,12 +9338,12 @@ func newErrorInvalidPaginationTokenException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidPaginationTokenException) Code() string {
+func (s *InvalidPaginationTokenException) Code() string {
 	return "InvalidPaginationTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPaginationTokenException) Message() string {
+func (s *InvalidPaginationTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9351,21 +9351,21 @@ func (s InvalidPaginationTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPaginationTokenException) OrigErr() error {
+func (s *InvalidPaginationTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPaginationTokenException) Error() string {
+func (s *InvalidPaginationTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPaginationTokenException) StatusCode() int {
+func (s *InvalidPaginationTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPaginationTokenException) RequestID() string {
+func (s *InvalidPaginationTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9395,12 +9395,12 @@ func newErrorInvalidParameterCombinationException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterCombinationException) Code() string {
+func (s *InvalidParameterCombinationException) Code() string {
 	return "InvalidParameterCombinationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterCombinationException) Message() string {
+func (s *InvalidParameterCombinationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9408,21 +9408,21 @@ func (s InvalidParameterCombinationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterCombinationException) OrigErr() error {
+func (s *InvalidParameterCombinationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterCombinationException) Error() string {
+func (s *InvalidParameterCombinationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterCombinationException) StatusCode() int {
+func (s *InvalidParameterCombinationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterCombinationException) RequestID() string {
+func (s *InvalidParameterCombinationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9452,12 +9452,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9465,21 +9465,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9508,12 +9508,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9521,21 +9521,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9564,12 +9564,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9577,21 +9577,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9620,12 +9620,12 @@ func newErrorInvalidVersionNumberException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidVersionNumberException) Code() string {
+func (s *InvalidVersionNumberException) Code() string {
 	return "InvalidVersionNumberException"
 }
 
 // Message returns the exception's message.
-func (s InvalidVersionNumberException) Message() string {
+func (s *InvalidVersionNumberException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9633,21 +9633,21 @@ func (s InvalidVersionNumberException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidVersionNumberException) OrigErr() error {
+func (s *InvalidVersionNumberException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidVersionNumberException) Error() string {
+func (s *InvalidVersionNumberException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidVersionNumberException) StatusCode() int {
+func (s *InvalidVersionNumberException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidVersionNumberException) RequestID() string {
+func (s *InvalidVersionNumberException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11191,12 +11191,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11204,21 +11204,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11248,12 +11248,12 @@ func newErrorResourceDependencyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceDependencyException) Code() string {
+func (s *ResourceDependencyException) Code() string {
 	return "ResourceDependencyException"
 }
 
 // Message returns the exception's message.
-func (s ResourceDependencyException) Message() string {
+func (s *ResourceDependencyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11261,21 +11261,21 @@ func (s ResourceDependencyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceDependencyException) OrigErr() error {
+func (s *ResourceDependencyException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceDependencyException) Error() string {
+func (s *ResourceDependencyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceDependencyException) StatusCode() int {
+func (s *ResourceDependencyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceDependencyException) RequestID() string {
+func (s *ResourceDependencyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11305,12 +11305,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11318,21 +11318,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11361,12 +11361,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11374,21 +11374,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11517,12 +11517,12 @@ func newErrorServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceException) Code() string {
+func (s *ServiceException) Code() string {
 	return "ServiceException"
 }
 
 // Message returns the exception's message.
-func (s ServiceException) Message() string {
+func (s *ServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11530,21 +11530,21 @@ func (s ServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceException) OrigErr() error {
+func (s *ServiceException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceException) Error() string {
+func (s *ServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceException) StatusCode() int {
+func (s *ServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceException) RequestID() string {
+func (s *ServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11573,12 +11573,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11586,21 +11586,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/inspector/api.go
+++ b/service/inspector/api.go
@@ -4061,12 +4061,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4074,21 +4074,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4408,12 +4408,12 @@ func newErrorAgentsAlreadyRunningAssessmentException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s AgentsAlreadyRunningAssessmentException) Code() string {
+func (s *AgentsAlreadyRunningAssessmentException) Code() string {
 	return "AgentsAlreadyRunningAssessmentException"
 }
 
 // Message returns the exception's message.
-func (s AgentsAlreadyRunningAssessmentException) Message() string {
+func (s *AgentsAlreadyRunningAssessmentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4421,21 +4421,21 @@ func (s AgentsAlreadyRunningAssessmentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AgentsAlreadyRunningAssessmentException) OrigErr() error {
+func (s *AgentsAlreadyRunningAssessmentException) OrigErr() error {
 	return nil
 }
 
-func (s AgentsAlreadyRunningAssessmentException) Error() string {
+func (s *AgentsAlreadyRunningAssessmentException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AgentsAlreadyRunningAssessmentException) StatusCode() int {
+func (s *AgentsAlreadyRunningAssessmentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AgentsAlreadyRunningAssessmentException) RequestID() string {
+func (s *AgentsAlreadyRunningAssessmentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4867,12 +4867,12 @@ func newErrorAssessmentRunInProgressException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s AssessmentRunInProgressException) Code() string {
+func (s *AssessmentRunInProgressException) Code() string {
 	return "AssessmentRunInProgressException"
 }
 
 // Message returns the exception's message.
-func (s AssessmentRunInProgressException) Message() string {
+func (s *AssessmentRunInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4880,21 +4880,21 @@ func (s AssessmentRunInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AssessmentRunInProgressException) OrigErr() error {
+func (s *AssessmentRunInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s AssessmentRunInProgressException) Error() string {
+func (s *AssessmentRunInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AssessmentRunInProgressException) StatusCode() int {
+func (s *AssessmentRunInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AssessmentRunInProgressException) RequestID() string {
+func (s *AssessmentRunInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7558,12 +7558,12 @@ func newErrorInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalException) Code() string {
+func (s *InternalException) Code() string {
 	return "InternalException"
 }
 
 // Message returns the exception's message.
-func (s InternalException) Message() string {
+func (s *InternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7571,21 +7571,21 @@ func (s InternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalException) OrigErr() error {
+func (s *InternalException) OrigErr() error {
 	return nil
 }
 
-func (s InternalException) Error() string {
+func (s *InternalException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalException) StatusCode() int {
+func (s *InternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalException) RequestID() string {
+func (s *InternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7626,12 +7626,12 @@ func newErrorInvalidCrossAccountRoleException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidCrossAccountRoleException) Code() string {
+func (s *InvalidCrossAccountRoleException) Code() string {
 	return "InvalidCrossAccountRoleException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCrossAccountRoleException) Message() string {
+func (s *InvalidCrossAccountRoleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7639,21 +7639,21 @@ func (s InvalidCrossAccountRoleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCrossAccountRoleException) OrigErr() error {
+func (s *InvalidCrossAccountRoleException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCrossAccountRoleException) Error() string {
+func (s *InvalidCrossAccountRoleException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCrossAccountRoleException) StatusCode() int {
+func (s *InvalidCrossAccountRoleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCrossAccountRoleException) RequestID() string {
+func (s *InvalidCrossAccountRoleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7694,12 +7694,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7707,21 +7707,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7762,12 +7762,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7775,21 +7775,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8868,12 +8868,12 @@ func newErrorNoSuchEntityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoSuchEntityException) Code() string {
+func (s *NoSuchEntityException) Code() string {
 	return "NoSuchEntityException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchEntityException) Message() string {
+func (s *NoSuchEntityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8881,21 +8881,21 @@ func (s NoSuchEntityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchEntityException) OrigErr() error {
+func (s *NoSuchEntityException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchEntityException) Error() string {
+func (s *NoSuchEntityException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchEntityException) StatusCode() int {
+func (s *NoSuchEntityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchEntityException) RequestID() string {
+func (s *NoSuchEntityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9028,12 +9028,12 @@ func newErrorPreviewGenerationInProgressException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s PreviewGenerationInProgressException) Code() string {
+func (s *PreviewGenerationInProgressException) Code() string {
 	return "PreviewGenerationInProgressException"
 }
 
 // Message returns the exception's message.
-func (s PreviewGenerationInProgressException) Message() string {
+func (s *PreviewGenerationInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9041,21 +9041,21 @@ func (s PreviewGenerationInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PreviewGenerationInProgressException) OrigErr() error {
+func (s *PreviewGenerationInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s PreviewGenerationInProgressException) Error() string {
+func (s *PreviewGenerationInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PreviewGenerationInProgressException) StatusCode() int {
+func (s *PreviewGenerationInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PreviewGenerationInProgressException) RequestID() string {
+func (s *PreviewGenerationInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9549,12 +9549,12 @@ func newErrorServiceTemporarilyUnavailableException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s ServiceTemporarilyUnavailableException) Code() string {
+func (s *ServiceTemporarilyUnavailableException) Code() string {
 	return "ServiceTemporarilyUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceTemporarilyUnavailableException) Message() string {
+func (s *ServiceTemporarilyUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9562,21 +9562,21 @@ func (s ServiceTemporarilyUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceTemporarilyUnavailableException) OrigErr() error {
+func (s *ServiceTemporarilyUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceTemporarilyUnavailableException) Error() string {
+func (s *ServiceTemporarilyUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceTemporarilyUnavailableException) StatusCode() int {
+func (s *ServiceTemporarilyUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceTemporarilyUnavailableException) RequestID() string {
+func (s *ServiceTemporarilyUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10197,12 +10197,12 @@ func newErrorUnsupportedFeatureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedFeatureException) Code() string {
+func (s *UnsupportedFeatureException) Code() string {
 	return "UnsupportedFeatureException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedFeatureException) Message() string {
+func (s *UnsupportedFeatureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10210,21 +10210,21 @@ func (s UnsupportedFeatureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedFeatureException) OrigErr() error {
+func (s *UnsupportedFeatureException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedFeatureException) Error() string {
+func (s *UnsupportedFeatureException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedFeatureException) StatusCode() int {
+func (s *UnsupportedFeatureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedFeatureException) RequestID() string {
+func (s *UnsupportedFeatureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -21432,12 +21432,12 @@ func newErrorCertificateConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CertificateConflictException) Code() string {
+func (s *CertificateConflictException) Code() string {
 	return "CertificateConflictException"
 }
 
 // Message returns the exception's message.
-func (s CertificateConflictException) Message() string {
+func (s *CertificateConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21445,21 +21445,21 @@ func (s CertificateConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CertificateConflictException) OrigErr() error {
+func (s *CertificateConflictException) OrigErr() error {
 	return nil
 }
 
-func (s CertificateConflictException) Error() string {
+func (s *CertificateConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CertificateConflictException) StatusCode() int {
+func (s *CertificateConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CertificateConflictException) RequestID() string {
+func (s *CertificateConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21621,12 +21621,12 @@ func newErrorCertificateStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CertificateStateException) Code() string {
+func (s *CertificateStateException) Code() string {
 	return "CertificateStateException"
 }
 
 // Message returns the exception's message.
-func (s CertificateStateException) Message() string {
+func (s *CertificateStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21634,21 +21634,21 @@ func (s CertificateStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CertificateStateException) OrigErr() error {
+func (s *CertificateStateException) OrigErr() error {
 	return nil
 }
 
-func (s CertificateStateException) Error() string {
+func (s *CertificateStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CertificateStateException) StatusCode() int {
+func (s *CertificateStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CertificateStateException) RequestID() string {
+func (s *CertificateStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21678,12 +21678,12 @@ func newErrorCertificateValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CertificateValidationException) Code() string {
+func (s *CertificateValidationException) Code() string {
 	return "CertificateValidationException"
 }
 
 // Message returns the exception's message.
-func (s CertificateValidationException) Message() string {
+func (s *CertificateValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21691,21 +21691,21 @@ func (s CertificateValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CertificateValidationException) OrigErr() error {
+func (s *CertificateValidationException) OrigErr() error {
 	return nil
 }
 
-func (s CertificateValidationException) Error() string {
+func (s *CertificateValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CertificateValidationException) StatusCode() int {
+func (s *CertificateValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CertificateValidationException) RequestID() string {
+func (s *CertificateValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22232,12 +22232,12 @@ func newErrorConflictingResourceUpdateException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s ConflictingResourceUpdateException) Code() string {
+func (s *ConflictingResourceUpdateException) Code() string {
 	return "ConflictingResourceUpdateException"
 }
 
 // Message returns the exception's message.
-func (s ConflictingResourceUpdateException) Message() string {
+func (s *ConflictingResourceUpdateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22245,21 +22245,21 @@ func (s ConflictingResourceUpdateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictingResourceUpdateException) OrigErr() error {
+func (s *ConflictingResourceUpdateException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictingResourceUpdateException) Error() string {
+func (s *ConflictingResourceUpdateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictingResourceUpdateException) StatusCode() int {
+func (s *ConflictingResourceUpdateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictingResourceUpdateException) RequestID() string {
+func (s *ConflictingResourceUpdateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -25503,12 +25503,12 @@ func newErrorDeleteConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DeleteConflictException) Code() string {
+func (s *DeleteConflictException) Code() string {
 	return "DeleteConflictException"
 }
 
 // Message returns the exception's message.
-func (s DeleteConflictException) Message() string {
+func (s *DeleteConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -25516,21 +25516,21 @@ func (s DeleteConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeleteConflictException) OrigErr() error {
+func (s *DeleteConflictException) OrigErr() error {
 	return nil
 }
 
-func (s DeleteConflictException) Error() string {
+func (s *DeleteConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeleteConflictException) StatusCode() int {
+func (s *DeleteConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeleteConflictException) RequestID() string {
+func (s *DeleteConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -32154,12 +32154,12 @@ func newErrorIndexNotReadyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IndexNotReadyException) Code() string {
+func (s *IndexNotReadyException) Code() string {
 	return "IndexNotReadyException"
 }
 
 // Message returns the exception's message.
-func (s IndexNotReadyException) Message() string {
+func (s *IndexNotReadyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -32167,21 +32167,21 @@ func (s IndexNotReadyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IndexNotReadyException) OrigErr() error {
+func (s *IndexNotReadyException) OrigErr() error {
 	return nil
 }
 
-func (s IndexNotReadyException) Error() string {
+func (s *IndexNotReadyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IndexNotReadyException) StatusCode() int {
+func (s *IndexNotReadyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IndexNotReadyException) RequestID() string {
+func (s *IndexNotReadyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -32211,12 +32211,12 @@ func newErrorInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalException) Code() string {
+func (s *InternalException) Code() string {
 	return "InternalException"
 }
 
 // Message returns the exception's message.
-func (s InternalException) Message() string {
+func (s *InternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -32224,21 +32224,21 @@ func (s InternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalException) OrigErr() error {
+func (s *InternalException) OrigErr() error {
 	return nil
 }
 
-func (s InternalException) Error() string {
+func (s *InternalException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalException) StatusCode() int {
+func (s *InternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalException) RequestID() string {
+func (s *InternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -32268,12 +32268,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -32281,21 +32281,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -32324,12 +32324,12 @@ func newErrorInvalidAggregationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAggregationException) Code() string {
+func (s *InvalidAggregationException) Code() string {
 	return "InvalidAggregationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAggregationException) Message() string {
+func (s *InvalidAggregationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -32337,21 +32337,21 @@ func (s InvalidAggregationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAggregationException) OrigErr() error {
+func (s *InvalidAggregationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAggregationException) Error() string {
+func (s *InvalidAggregationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAggregationException) StatusCode() int {
+func (s *InvalidAggregationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAggregationException) RequestID() string {
+func (s *InvalidAggregationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -32381,12 +32381,12 @@ func newErrorInvalidQueryException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidQueryException) Code() string {
+func (s *InvalidQueryException) Code() string {
 	return "InvalidQueryException"
 }
 
 // Message returns the exception's message.
-func (s InvalidQueryException) Message() string {
+func (s *InvalidQueryException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -32394,21 +32394,21 @@ func (s InvalidQueryException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidQueryException) OrigErr() error {
+func (s *InvalidQueryException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidQueryException) Error() string {
+func (s *InvalidQueryException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidQueryException) StatusCode() int {
+func (s *InvalidQueryException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidQueryException) RequestID() string {
+func (s *InvalidQueryException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -32438,12 +32438,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -32451,21 +32451,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -32495,12 +32495,12 @@ func newErrorInvalidResponseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResponseException) Code() string {
+func (s *InvalidResponseException) Code() string {
 	return "InvalidResponseException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResponseException) Message() string {
+func (s *InvalidResponseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -32508,21 +32508,21 @@ func (s InvalidResponseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResponseException) OrigErr() error {
+func (s *InvalidResponseException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResponseException) Error() string {
+func (s *InvalidResponseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResponseException) StatusCode() int {
+func (s *InvalidResponseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResponseException) RequestID() string {
+func (s *InvalidResponseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -32554,12 +32554,12 @@ func newErrorInvalidStateTransitionException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidStateTransitionException) Code() string {
+func (s *InvalidStateTransitionException) Code() string {
 	return "InvalidStateTransitionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateTransitionException) Message() string {
+func (s *InvalidStateTransitionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -32567,21 +32567,21 @@ func (s InvalidStateTransitionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateTransitionException) OrigErr() error {
+func (s *InvalidStateTransitionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateTransitionException) Error() string {
+func (s *InvalidStateTransitionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateTransitionException) StatusCode() int {
+func (s *InvalidStateTransitionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateTransitionException) RequestID() string {
+func (s *InvalidStateTransitionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -33624,12 +33624,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -33637,21 +33637,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -38382,12 +38382,12 @@ func newErrorMalformedPolicyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MalformedPolicyException) Code() string {
+func (s *MalformedPolicyException) Code() string {
 	return "MalformedPolicyException"
 }
 
 // Message returns the exception's message.
-func (s MalformedPolicyException) Message() string {
+func (s *MalformedPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -38395,21 +38395,21 @@ func (s MalformedPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MalformedPolicyException) OrigErr() error {
+func (s *MalformedPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s MalformedPolicyException) Error() string {
+func (s *MalformedPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MalformedPolicyException) StatusCode() int {
+func (s *MalformedPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MalformedPolicyException) RequestID() string {
+func (s *MalformedPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -38802,12 +38802,12 @@ func newErrorNotConfiguredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotConfiguredException) Code() string {
+func (s *NotConfiguredException) Code() string {
 	return "NotConfiguredException"
 }
 
 // Message returns the exception's message.
-func (s NotConfiguredException) Message() string {
+func (s *NotConfiguredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -38815,21 +38815,21 @@ func (s NotConfiguredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotConfiguredException) OrigErr() error {
+func (s *NotConfiguredException) OrigErr() error {
 	return nil
 }
 
-func (s NotConfiguredException) Error() string {
+func (s *NotConfiguredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotConfiguredException) StatusCode() int {
+func (s *NotConfiguredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotConfiguredException) RequestID() string {
+func (s *NotConfiguredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -40080,12 +40080,12 @@ func newErrorRegistrationCodeValidationException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s RegistrationCodeValidationException) Code() string {
+func (s *RegistrationCodeValidationException) Code() string {
 	return "RegistrationCodeValidationException"
 }
 
 // Message returns the exception's message.
-func (s RegistrationCodeValidationException) Message() string {
+func (s *RegistrationCodeValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -40093,21 +40093,21 @@ func (s RegistrationCodeValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RegistrationCodeValidationException) OrigErr() error {
+func (s *RegistrationCodeValidationException) OrigErr() error {
 	return nil
 }
 
-func (s RegistrationCodeValidationException) Error() string {
+func (s *RegistrationCodeValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RegistrationCodeValidationException) StatusCode() int {
+func (s *RegistrationCodeValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RegistrationCodeValidationException) RequestID() string {
+func (s *RegistrationCodeValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -40635,12 +40635,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -40648,21 +40648,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -40809,12 +40809,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -40822,21 +40822,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -40866,12 +40866,12 @@ func newErrorResourceRegistrationFailureException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s ResourceRegistrationFailureException) Code() string {
+func (s *ResourceRegistrationFailureException) Code() string {
 	return "ResourceRegistrationFailureException"
 }
 
 // Message returns the exception's message.
-func (s ResourceRegistrationFailureException) Message() string {
+func (s *ResourceRegistrationFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -40879,21 +40879,21 @@ func (s ResourceRegistrationFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceRegistrationFailureException) OrigErr() error {
+func (s *ResourceRegistrationFailureException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceRegistrationFailureException) Error() string {
+func (s *ResourceRegistrationFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceRegistrationFailureException) StatusCode() int {
+func (s *ResourceRegistrationFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceRegistrationFailureException) RequestID() string {
+func (s *ResourceRegistrationFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -41568,12 +41568,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -41581,21 +41581,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42131,12 +42131,12 @@ func newErrorSqlParseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SqlParseException) Code() string {
+func (s *SqlParseException) Code() string {
 	return "SqlParseException"
 }
 
 // Message returns the exception's message.
-func (s SqlParseException) Message() string {
+func (s *SqlParseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42144,21 +42144,21 @@ func (s SqlParseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SqlParseException) OrigErr() error {
+func (s *SqlParseException) OrigErr() error {
 	return nil
 }
 
-func (s SqlParseException) Error() string {
+func (s *SqlParseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SqlParseException) StatusCode() int {
+func (s *SqlParseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SqlParseException) RequestID() string {
+func (s *SqlParseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -43173,12 +43173,12 @@ func newErrorTaskAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TaskAlreadyExistsException) Code() string {
+func (s *TaskAlreadyExistsException) Code() string {
 	return "TaskAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s TaskAlreadyExistsException) Message() string {
+func (s *TaskAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -43186,21 +43186,21 @@ func (s TaskAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TaskAlreadyExistsException) OrigErr() error {
+func (s *TaskAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s TaskAlreadyExistsException) Error() string {
+func (s *TaskAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TaskAlreadyExistsException) StatusCode() int {
+func (s *TaskAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TaskAlreadyExistsException) RequestID() string {
+func (s *TaskAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -44234,12 +44234,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -44247,21 +44247,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -44807,12 +44807,12 @@ func newErrorTransferAlreadyCompletedException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s TransferAlreadyCompletedException) Code() string {
+func (s *TransferAlreadyCompletedException) Code() string {
 	return "TransferAlreadyCompletedException"
 }
 
 // Message returns the exception's message.
-func (s TransferAlreadyCompletedException) Message() string {
+func (s *TransferAlreadyCompletedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -44820,21 +44820,21 @@ func (s TransferAlreadyCompletedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TransferAlreadyCompletedException) OrigErr() error {
+func (s *TransferAlreadyCompletedException) OrigErr() error {
 	return nil
 }
 
-func (s TransferAlreadyCompletedException) Error() string {
+func (s *TransferAlreadyCompletedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TransferAlreadyCompletedException) StatusCode() int {
+func (s *TransferAlreadyCompletedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TransferAlreadyCompletedException) RequestID() string {
+func (s *TransferAlreadyCompletedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -44958,12 +44958,12 @@ func newErrorTransferConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TransferConflictException) Code() string {
+func (s *TransferConflictException) Code() string {
 	return "TransferConflictException"
 }
 
 // Message returns the exception's message.
-func (s TransferConflictException) Message() string {
+func (s *TransferConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -44971,21 +44971,21 @@ func (s TransferConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TransferConflictException) OrigErr() error {
+func (s *TransferConflictException) OrigErr() error {
 	return nil
 }
 
-func (s TransferConflictException) Error() string {
+func (s *TransferConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TransferConflictException) StatusCode() int {
+func (s *TransferConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TransferConflictException) RequestID() string {
+func (s *TransferConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -45075,12 +45075,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -45088,21 +45088,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -47451,12 +47451,12 @@ func newErrorVersionConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s VersionConflictException) Code() string {
+func (s *VersionConflictException) Code() string {
 	return "VersionConflictException"
 }
 
 // Message returns the exception's message.
-func (s VersionConflictException) Message() string {
+func (s *VersionConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -47464,21 +47464,21 @@ func (s VersionConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s VersionConflictException) OrigErr() error {
+func (s *VersionConflictException) OrigErr() error {
 	return nil
 }
 
-func (s VersionConflictException) Error() string {
+func (s *VersionConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s VersionConflictException) StatusCode() int {
+func (s *VersionConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s VersionConflictException) RequestID() string {
+func (s *VersionConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -47508,12 +47508,12 @@ func newErrorVersionsLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s VersionsLimitExceededException) Code() string {
+func (s *VersionsLimitExceededException) Code() string {
 	return "VersionsLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s VersionsLimitExceededException) Message() string {
+func (s *VersionsLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -47521,21 +47521,21 @@ func (s VersionsLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s VersionsLimitExceededException) OrigErr() error {
+func (s *VersionsLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s VersionsLimitExceededException) Error() string {
+func (s *VersionsLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s VersionsLimitExceededException) StatusCode() int {
+func (s *VersionsLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s VersionsLimitExceededException) RequestID() string {
+func (s *VersionsLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/iot1clickdevicesservice/api.go
+++ b/service/iot1clickdevicesservice/api.go
@@ -1538,12 +1538,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1551,21 +1551,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1720,12 +1720,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1733,21 +1733,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1779,12 +1779,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1792,21 +1792,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2174,12 +2174,12 @@ func newErrorPreconditionFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PreconditionFailedException) Code() string {
+func (s *PreconditionFailedException) Code() string {
 	return "PreconditionFailedException"
 }
 
 // Message returns the exception's message.
-func (s PreconditionFailedException) Message() string {
+func (s *PreconditionFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2187,21 +2187,21 @@ func (s PreconditionFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PreconditionFailedException) OrigErr() error {
+func (s *PreconditionFailedException) OrigErr() error {
 	return nil
 }
 
-func (s PreconditionFailedException) Error() string {
+func (s *PreconditionFailedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PreconditionFailedException) StatusCode() int {
+func (s *PreconditionFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PreconditionFailedException) RequestID() string {
+func (s *PreconditionFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2233,12 +2233,12 @@ func newErrorRangeNotSatisfiableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RangeNotSatisfiableException) Code() string {
+func (s *RangeNotSatisfiableException) Code() string {
 	return "RangeNotSatisfiableException"
 }
 
 // Message returns the exception's message.
-func (s RangeNotSatisfiableException) Message() string {
+func (s *RangeNotSatisfiableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2246,21 +2246,21 @@ func (s RangeNotSatisfiableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RangeNotSatisfiableException) OrigErr() error {
+func (s *RangeNotSatisfiableException) OrigErr() error {
 	return nil
 }
 
-func (s RangeNotSatisfiableException) Error() string {
+func (s *RangeNotSatisfiableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RangeNotSatisfiableException) StatusCode() int {
+func (s *RangeNotSatisfiableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RangeNotSatisfiableException) RequestID() string {
+func (s *RangeNotSatisfiableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2292,12 +2292,12 @@ func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceConflictException) Code() string {
+func (s *ResourceConflictException) Code() string {
 	return "ResourceConflictException"
 }
 
 // Message returns the exception's message.
-func (s ResourceConflictException) Message() string {
+func (s *ResourceConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2305,21 +2305,21 @@ func (s ResourceConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceConflictException) OrigErr() error {
+func (s *ResourceConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceConflictException) Error() string {
+func (s *ResourceConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceConflictException) StatusCode() int {
+func (s *ResourceConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceConflictException) RequestID() string {
+func (s *ResourceConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2351,12 +2351,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2364,21 +2364,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/iot1clickprojects/api.go
+++ b/service/iot1clickprojects/api.go
@@ -2267,12 +2267,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2280,21 +2280,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2324,12 +2324,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2337,21 +2337,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2952,12 +2952,12 @@ func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceConflictException) Code() string {
+func (s *ResourceConflictException) Code() string {
 	return "ResourceConflictException"
 }
 
 // Message returns the exception's message.
-func (s ResourceConflictException) Message() string {
+func (s *ResourceConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2965,21 +2965,21 @@ func (s ResourceConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceConflictException) OrigErr() error {
+func (s *ResourceConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceConflictException) Error() string {
+func (s *ResourceConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceConflictException) StatusCode() int {
+func (s *ResourceConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceConflictException) RequestID() string {
+func (s *ResourceConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3009,12 +3009,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3022,21 +3022,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3140,12 +3140,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3153,21 +3153,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/iotanalytics/api.go
+++ b/service/iotanalytics/api.go
@@ -7214,12 +7214,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7227,21 +7227,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7270,12 +7270,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7283,21 +7283,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7477,12 +7477,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7490,21 +7490,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8799,12 +8799,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8812,21 +8812,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8913,12 +8913,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8926,21 +8926,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9470,12 +9470,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9483,21 +9483,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9807,12 +9807,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9820,21 +9820,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -430,12 +430,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -443,21 +443,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -621,12 +621,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -634,21 +634,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -678,12 +678,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -691,21 +691,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -735,12 +735,12 @@ func newErrorMethodNotAllowedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MethodNotAllowedException) Code() string {
+func (s *MethodNotAllowedException) Code() string {
 	return "MethodNotAllowedException"
 }
 
 // Message returns the exception's message.
-func (s MethodNotAllowedException) Message() string {
+func (s *MethodNotAllowedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -748,21 +748,21 @@ func (s MethodNotAllowedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MethodNotAllowedException) OrigErr() error {
+func (s *MethodNotAllowedException) OrigErr() error {
 	return nil
 }
 
-func (s MethodNotAllowedException) Error() string {
+func (s *MethodNotAllowedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MethodNotAllowedException) StatusCode() int {
+func (s *MethodNotAllowedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MethodNotAllowedException) RequestID() string {
+func (s *MethodNotAllowedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -866,12 +866,12 @@ func newErrorRequestEntityTooLargeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestEntityTooLargeException) Code() string {
+func (s *RequestEntityTooLargeException) Code() string {
 	return "RequestEntityTooLargeException"
 }
 
 // Message returns the exception's message.
-func (s RequestEntityTooLargeException) Message() string {
+func (s *RequestEntityTooLargeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -879,21 +879,21 @@ func (s RequestEntityTooLargeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestEntityTooLargeException) OrigErr() error {
+func (s *RequestEntityTooLargeException) OrigErr() error {
 	return nil
 }
 
-func (s RequestEntityTooLargeException) Error() string {
+func (s *RequestEntityTooLargeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestEntityTooLargeException) StatusCode() int {
+func (s *RequestEntityTooLargeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestEntityTooLargeException) RequestID() string {
+func (s *RequestEntityTooLargeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -923,12 +923,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -936,21 +936,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -980,12 +980,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -993,21 +993,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1037,12 +1037,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1050,21 +1050,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1094,12 +1094,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1107,21 +1107,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1151,12 +1151,12 @@ func newErrorUnsupportedDocumentEncodingException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s UnsupportedDocumentEncodingException) Code() string {
+func (s *UnsupportedDocumentEncodingException) Code() string {
 	return "UnsupportedDocumentEncodingException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedDocumentEncodingException) Message() string {
+func (s *UnsupportedDocumentEncodingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1164,21 +1164,21 @@ func (s UnsupportedDocumentEncodingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedDocumentEncodingException) OrigErr() error {
+func (s *UnsupportedDocumentEncodingException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedDocumentEncodingException) Error() string {
+func (s *UnsupportedDocumentEncodingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedDocumentEncodingException) StatusCode() int {
+func (s *UnsupportedDocumentEncodingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedDocumentEncodingException) RequestID() string {
+func (s *UnsupportedDocumentEncodingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/iotevents/api.go
+++ b/service/iotevents/api.go
@@ -3149,12 +3149,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3162,21 +3162,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3206,12 +3206,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3219,21 +3219,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3351,12 +3351,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3364,21 +3364,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4077,12 +4077,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4090,21 +4090,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4134,12 +4134,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4147,21 +4147,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4191,12 +4191,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4204,21 +4204,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4290,12 +4290,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4303,21 +4303,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4751,12 +4751,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4764,21 +4764,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4899,12 +4899,12 @@ func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedOperationException) Code() string {
+func (s *UnsupportedOperationException) Code() string {
 	return "UnsupportedOperationException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedOperationException) Message() string {
+func (s *UnsupportedOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4912,21 +4912,21 @@ func (s UnsupportedOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedOperationException) OrigErr() error {
+func (s *UnsupportedOperationException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedOperationException) Error() string {
+func (s *UnsupportedOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedOperationException) StatusCode() int {
+func (s *UnsupportedOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedOperationException) RequestID() string {
+func (s *UnsupportedOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/ioteventsdata/api.go
+++ b/service/ioteventsdata/api.go
@@ -1020,12 +1020,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1033,21 +1033,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1077,12 +1077,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1090,21 +1090,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1319,12 +1319,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1332,21 +1332,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1376,12 +1376,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1389,21 +1389,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1433,12 +1433,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1446,21 +1446,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/iotjobsdataplane/api.go
+++ b/service/iotjobsdataplane/api.go
@@ -419,12 +419,12 @@ func newErrorCertificateValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CertificateValidationException) Code() string {
+func (s *CertificateValidationException) Code() string {
 	return "CertificateValidationException"
 }
 
 // Message returns the exception's message.
-func (s CertificateValidationException) Message() string {
+func (s *CertificateValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -432,21 +432,21 @@ func (s CertificateValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CertificateValidationException) OrigErr() error {
+func (s *CertificateValidationException) OrigErr() error {
 	return nil
 }
 
-func (s CertificateValidationException) Error() string {
+func (s *CertificateValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CertificateValidationException) StatusCode() int {
+func (s *CertificateValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CertificateValidationException) RequestID() string {
+func (s *CertificateValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -652,12 +652,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -665,21 +665,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -711,12 +711,12 @@ func newErrorInvalidStateTransitionException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidStateTransitionException) Code() string {
+func (s *InvalidStateTransitionException) Code() string {
 	return "InvalidStateTransitionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateTransitionException) Message() string {
+func (s *InvalidStateTransitionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -724,21 +724,21 @@ func (s InvalidStateTransitionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateTransitionException) OrigErr() error {
+func (s *InvalidStateTransitionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateTransitionException) Error() string {
+func (s *InvalidStateTransitionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateTransitionException) StatusCode() int {
+func (s *InvalidStateTransitionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateTransitionException) RequestID() string {
+func (s *InvalidStateTransitionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1002,12 +1002,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1015,21 +1015,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1059,12 +1059,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1072,21 +1072,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1205,12 +1205,12 @@ func newErrorTerminalStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TerminalStateException) Code() string {
+func (s *TerminalStateException) Code() string {
 	return "TerminalStateException"
 }
 
 // Message returns the exception's message.
-func (s TerminalStateException) Message() string {
+func (s *TerminalStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1218,21 +1218,21 @@ func (s TerminalStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TerminalStateException) OrigErr() error {
+func (s *TerminalStateException) OrigErr() error {
 	return nil
 }
 
-func (s TerminalStateException) Error() string {
+func (s *TerminalStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TerminalStateException) StatusCode() int {
+func (s *TerminalStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TerminalStateException) RequestID() string {
+func (s *TerminalStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1267,12 +1267,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1280,21 +1280,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/iotsecuretunneling/api.go
+++ b/service/iotsecuretunneling/api.go
@@ -869,12 +869,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -882,21 +882,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1213,12 +1213,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1226,21 +1226,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/iotthingsgraph/api.go
+++ b/service/iotthingsgraph/api.go
@@ -5725,12 +5725,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5738,21 +5738,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5780,12 +5780,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5793,21 +5793,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5835,12 +5835,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5848,21 +5848,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6124,12 +6124,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6137,21 +6137,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6179,12 +6179,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6192,21 +6192,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6234,12 +6234,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6247,21 +6247,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7460,12 +7460,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7473,21 +7473,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kafka/api.go
+++ b/service/kafka/api.go
@@ -2300,12 +2300,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2313,21 +2313,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3218,12 +3218,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3231,21 +3231,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4311,12 +4311,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4324,21 +4324,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4443,12 +4443,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4456,21 +4456,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5433,12 +5433,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5446,21 +5446,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5704,12 +5704,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5717,21 +5717,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5893,12 +5893,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5906,21 +5906,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5951,12 +5951,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5964,21 +5964,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kendra/api.go
+++ b/service/kendra/api.go
@@ -2063,12 +2063,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2076,21 +2076,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2876,12 +2876,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2889,21 +2889,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5305,12 +5305,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5318,21 +5318,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6316,12 +6316,12 @@ func newErrorResourceAlreadyExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistException) Code() string {
+func (s *ResourceAlreadyExistException) Code() string {
 	return "ResourceAlreadyExistException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistException) Message() string {
+func (s *ResourceAlreadyExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6329,21 +6329,21 @@ func (s ResourceAlreadyExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistException) OrigErr() error {
+func (s *ResourceAlreadyExistException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistException) Error() string {
+func (s *ResourceAlreadyExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistException) StatusCode() int {
+func (s *ResourceAlreadyExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistException) RequestID() string {
+func (s *ResourceAlreadyExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6371,12 +6371,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6384,21 +6384,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6426,12 +6426,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6439,21 +6439,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6481,12 +6481,12 @@ func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceUnavailableException) Code() string {
+func (s *ResourceUnavailableException) Code() string {
 	return "ResourceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ResourceUnavailableException) Message() string {
+func (s *ResourceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6494,21 +6494,21 @@ func (s ResourceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceUnavailableException) OrigErr() error {
+func (s *ResourceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceUnavailableException) Error() string {
+func (s *ResourceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceUnavailableException) StatusCode() int {
+func (s *ResourceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceUnavailableException) RequestID() string {
+func (s *ResourceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6779,12 +6779,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6792,21 +6792,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7341,12 +7341,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7354,21 +7354,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7674,12 +7674,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7687,21 +7687,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -4627,12 +4627,12 @@ func newErrorExpiredIteratorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExpiredIteratorException) Code() string {
+func (s *ExpiredIteratorException) Code() string {
 	return "ExpiredIteratorException"
 }
 
 // Message returns the exception's message.
-func (s ExpiredIteratorException) Message() string {
+func (s *ExpiredIteratorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4640,21 +4640,21 @@ func (s ExpiredIteratorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExpiredIteratorException) OrigErr() error {
+func (s *ExpiredIteratorException) OrigErr() error {
 	return nil
 }
 
-func (s ExpiredIteratorException) Error() string {
+func (s *ExpiredIteratorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExpiredIteratorException) StatusCode() int {
+func (s *ExpiredIteratorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExpiredIteratorException) RequestID() string {
+func (s *ExpiredIteratorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4683,12 +4683,12 @@ func newErrorExpiredNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExpiredNextTokenException) Code() string {
+func (s *ExpiredNextTokenException) Code() string {
 	return "ExpiredNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s ExpiredNextTokenException) Message() string {
+func (s *ExpiredNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4696,21 +4696,21 @@ func (s ExpiredNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExpiredNextTokenException) OrigErr() error {
+func (s *ExpiredNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s ExpiredNextTokenException) Error() string {
+func (s *ExpiredNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExpiredNextTokenException) StatusCode() int {
+func (s *ExpiredNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExpiredNextTokenException) RequestID() string {
+func (s *ExpiredNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5125,12 +5125,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5138,21 +5138,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5183,12 +5183,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5196,21 +5196,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5268,12 +5268,12 @@ func newErrorKMSAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSAccessDeniedException) Code() string {
+func (s *KMSAccessDeniedException) Code() string {
 	return "KMSAccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s KMSAccessDeniedException) Message() string {
+func (s *KMSAccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5281,21 +5281,21 @@ func (s KMSAccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSAccessDeniedException) OrigErr() error {
+func (s *KMSAccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s KMSAccessDeniedException) Error() string {
+func (s *KMSAccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSAccessDeniedException) StatusCode() int {
+func (s *KMSAccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSAccessDeniedException) RequestID() string {
+func (s *KMSAccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5353,12 +5353,12 @@ func newErrorKMSDisabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSDisabledException) Code() string {
+func (s *KMSDisabledException) Code() string {
 	return "KMSDisabledException"
 }
 
 // Message returns the exception's message.
-func (s KMSDisabledException) Message() string {
+func (s *KMSDisabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5366,21 +5366,21 @@ func (s KMSDisabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSDisabledException) OrigErr() error {
+func (s *KMSDisabledException) OrigErr() error {
 	return nil
 }
 
-func (s KMSDisabledException) Error() string {
+func (s *KMSDisabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSDisabledException) StatusCode() int {
+func (s *KMSDisabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSDisabledException) RequestID() string {
+func (s *KMSDisabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5440,12 +5440,12 @@ func newErrorKMSInvalidStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSInvalidStateException) Code() string {
+func (s *KMSInvalidStateException) Code() string {
 	return "KMSInvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s KMSInvalidStateException) Message() string {
+func (s *KMSInvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5453,21 +5453,21 @@ func (s KMSInvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSInvalidStateException) OrigErr() error {
+func (s *KMSInvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s KMSInvalidStateException) Error() string {
+func (s *KMSInvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSInvalidStateException) StatusCode() int {
+func (s *KMSInvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSInvalidStateException) RequestID() string {
+func (s *KMSInvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5525,12 +5525,12 @@ func newErrorKMSNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSNotFoundException) Code() string {
+func (s *KMSNotFoundException) Code() string {
 	return "KMSNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s KMSNotFoundException) Message() string {
+func (s *KMSNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5538,21 +5538,21 @@ func (s KMSNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSNotFoundException) OrigErr() error {
+func (s *KMSNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s KMSNotFoundException) Error() string {
+func (s *KMSNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSNotFoundException) StatusCode() int {
+func (s *KMSNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSNotFoundException) RequestID() string {
+func (s *KMSNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5609,12 +5609,12 @@ func newErrorKMSOptInRequired(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSOptInRequired) Code() string {
+func (s *KMSOptInRequired) Code() string {
 	return "KMSOptInRequired"
 }
 
 // Message returns the exception's message.
-func (s KMSOptInRequired) Message() string {
+func (s *KMSOptInRequired) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5622,21 +5622,21 @@ func (s KMSOptInRequired) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSOptInRequired) OrigErr() error {
+func (s *KMSOptInRequired) OrigErr() error {
 	return nil
 }
 
-func (s KMSOptInRequired) Error() string {
+func (s *KMSOptInRequired) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSOptInRequired) StatusCode() int {
+func (s *KMSOptInRequired) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSOptInRequired) RequestID() string {
+func (s *KMSOptInRequired) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5695,12 +5695,12 @@ func newErrorKMSThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSThrottlingException) Code() string {
+func (s *KMSThrottlingException) Code() string {
 	return "KMSThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s KMSThrottlingException) Message() string {
+func (s *KMSThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5708,21 +5708,21 @@ func (s KMSThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSThrottlingException) OrigErr() error {
+func (s *KMSThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s KMSThrottlingException) Error() string {
+func (s *KMSThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSThrottlingException) StatusCode() int {
+func (s *KMSThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSThrottlingException) RequestID() string {
+func (s *KMSThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5753,12 +5753,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5766,21 +5766,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6411,12 +6411,12 @@ func newErrorProvisionedThroughputExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s ProvisionedThroughputExceededException) Code() string {
+func (s *ProvisionedThroughputExceededException) Code() string {
 	return "ProvisionedThroughputExceededException"
 }
 
 // Message returns the exception's message.
-func (s ProvisionedThroughputExceededException) Message() string {
+func (s *ProvisionedThroughputExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6424,21 +6424,21 @@ func (s ProvisionedThroughputExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProvisionedThroughputExceededException) OrigErr() error {
+func (s *ProvisionedThroughputExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ProvisionedThroughputExceededException) Error() string {
+func (s *ProvisionedThroughputExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProvisionedThroughputExceededException) StatusCode() int {
+func (s *ProvisionedThroughputExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProvisionedThroughputExceededException) RequestID() string {
+func (s *ProvisionedThroughputExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7158,12 +7158,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7171,21 +7171,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7243,12 +7243,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7256,21 +7256,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kinesisanalytics/api.go
+++ b/service/kinesisanalytics/api.go
@@ -3221,12 +3221,12 @@ func newErrorCodeValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CodeValidationException) Code() string {
+func (s *CodeValidationException) Code() string {
 	return "CodeValidationException"
 }
 
 // Message returns the exception's message.
-func (s CodeValidationException) Message() string {
+func (s *CodeValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3234,21 +3234,21 @@ func (s CodeValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CodeValidationException) OrigErr() error {
+func (s *CodeValidationException) OrigErr() error {
 	return nil
 }
 
-func (s CodeValidationException) Error() string {
+func (s *CodeValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CodeValidationException) StatusCode() int {
+func (s *CodeValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CodeValidationException) RequestID() string {
+func (s *CodeValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3279,12 +3279,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3292,21 +3292,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5149,12 +5149,12 @@ func newErrorInvalidApplicationConfigurationException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s InvalidApplicationConfigurationException) Code() string {
+func (s *InvalidApplicationConfigurationException) Code() string {
 	return "InvalidApplicationConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApplicationConfigurationException) Message() string {
+func (s *InvalidApplicationConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5162,21 +5162,21 @@ func (s InvalidApplicationConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApplicationConfigurationException) OrigErr() error {
+func (s *InvalidApplicationConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApplicationConfigurationException) Error() string {
+func (s *InvalidApplicationConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApplicationConfigurationException) StatusCode() int {
+func (s *InvalidApplicationConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApplicationConfigurationException) RequestID() string {
+func (s *InvalidApplicationConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5205,12 +5205,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5218,21 +5218,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6070,12 +6070,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6083,21 +6083,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6999,12 +6999,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7012,21 +7012,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7055,12 +7055,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7068,21 +7068,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7114,12 +7114,12 @@ func newErrorResourceProvisionedThroughputExceededException(v protocol.ResponseM
 }
 
 // Code returns the exception type name.
-func (s ResourceProvisionedThroughputExceededException) Code() string {
+func (s *ResourceProvisionedThroughputExceededException) Code() string {
 	return "ResourceProvisionedThroughputExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceProvisionedThroughputExceededException) Message() string {
+func (s *ResourceProvisionedThroughputExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7127,21 +7127,21 @@ func (s ResourceProvisionedThroughputExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceProvisionedThroughputExceededException) OrigErr() error {
+func (s *ResourceProvisionedThroughputExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceProvisionedThroughputExceededException) Error() string {
+func (s *ResourceProvisionedThroughputExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceProvisionedThroughputExceededException) StatusCode() int {
+func (s *ResourceProvisionedThroughputExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceProvisionedThroughputExceededException) RequestID() string {
+func (s *ResourceProvisionedThroughputExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7448,12 +7448,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7461,21 +7461,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7862,12 +7862,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7875,21 +7875,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7923,12 +7923,12 @@ func newErrorUnableToDetectSchemaException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnableToDetectSchemaException) Code() string {
+func (s *UnableToDetectSchemaException) Code() string {
 	return "UnableToDetectSchemaException"
 }
 
 // Message returns the exception's message.
-func (s UnableToDetectSchemaException) Message() string {
+func (s *UnableToDetectSchemaException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7936,21 +7936,21 @@ func (s UnableToDetectSchemaException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnableToDetectSchemaException) OrigErr() error {
+func (s *UnableToDetectSchemaException) OrigErr() error {
 	return nil
 }
 
-func (s UnableToDetectSchemaException) Error() string {
+func (s *UnableToDetectSchemaException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnableToDetectSchemaException) StatusCode() int {
+func (s *UnableToDetectSchemaException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnableToDetectSchemaException) RequestID() string {
+func (s *UnableToDetectSchemaException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7980,12 +7980,12 @@ func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedOperationException) Code() string {
+func (s *UnsupportedOperationException) Code() string {
 	return "UnsupportedOperationException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedOperationException) Message() string {
+func (s *UnsupportedOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7993,21 +7993,21 @@ func (s UnsupportedOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedOperationException) OrigErr() error {
+func (s *UnsupportedOperationException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedOperationException) Error() string {
+func (s *UnsupportedOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedOperationException) StatusCode() int {
+func (s *UnsupportedOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedOperationException) RequestID() string {
+func (s *UnsupportedOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kinesisanalyticsv2/api.go
+++ b/service/kinesisanalyticsv2/api.go
@@ -4774,12 +4774,12 @@ func newErrorCodeValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CodeValidationException) Code() string {
+func (s *CodeValidationException) Code() string {
 	return "CodeValidationException"
 }
 
 // Message returns the exception's message.
-func (s CodeValidationException) Message() string {
+func (s *CodeValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4787,21 +4787,21 @@ func (s CodeValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CodeValidationException) OrigErr() error {
+func (s *CodeValidationException) OrigErr() error {
 	return nil
 }
 
-func (s CodeValidationException) Error() string {
+func (s *CodeValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CodeValidationException) StatusCode() int {
+func (s *CodeValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CodeValidationException) RequestID() string {
+func (s *CodeValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4832,12 +4832,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4845,21 +4845,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7362,12 +7362,12 @@ func newErrorInvalidApplicationConfigurationException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s InvalidApplicationConfigurationException) Code() string {
+func (s *InvalidApplicationConfigurationException) Code() string {
 	return "InvalidApplicationConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidApplicationConfigurationException) Message() string {
+func (s *InvalidApplicationConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7375,21 +7375,21 @@ func (s InvalidApplicationConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidApplicationConfigurationException) OrigErr() error {
+func (s *InvalidApplicationConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidApplicationConfigurationException) Error() string {
+func (s *InvalidApplicationConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidApplicationConfigurationException) StatusCode() int {
+func (s *InvalidApplicationConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidApplicationConfigurationException) RequestID() string {
+func (s *InvalidApplicationConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7418,12 +7418,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7431,21 +7431,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7474,12 +7474,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7487,21 +7487,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8229,12 +8229,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8242,21 +8242,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9715,12 +9715,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9728,21 +9728,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9771,12 +9771,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9784,21 +9784,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9830,12 +9830,12 @@ func newErrorResourceProvisionedThroughputExceededException(v protocol.ResponseM
 }
 
 // Code returns the exception type name.
-func (s ResourceProvisionedThroughputExceededException) Code() string {
+func (s *ResourceProvisionedThroughputExceededException) Code() string {
 	return "ResourceProvisionedThroughputExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceProvisionedThroughputExceededException) Message() string {
+func (s *ResourceProvisionedThroughputExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9843,21 +9843,21 @@ func (s ResourceProvisionedThroughputExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceProvisionedThroughputExceededException) OrigErr() error {
+func (s *ResourceProvisionedThroughputExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceProvisionedThroughputExceededException) Error() string {
+func (s *ResourceProvisionedThroughputExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceProvisionedThroughputExceededException) StatusCode() int {
+func (s *ResourceProvisionedThroughputExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceProvisionedThroughputExceededException) RequestID() string {
+func (s *ResourceProvisionedThroughputExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10428,12 +10428,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10441,21 +10441,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11169,12 +11169,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11182,21 +11182,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11233,12 +11233,12 @@ func newErrorUnableToDetectSchemaException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnableToDetectSchemaException) Code() string {
+func (s *UnableToDetectSchemaException) Code() string {
 	return "UnableToDetectSchemaException"
 }
 
 // Message returns the exception's message.
-func (s UnableToDetectSchemaException) Message() string {
+func (s *UnableToDetectSchemaException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11246,21 +11246,21 @@ func (s UnableToDetectSchemaException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnableToDetectSchemaException) OrigErr() error {
+func (s *UnableToDetectSchemaException) OrigErr() error {
 	return nil
 }
 
-func (s UnableToDetectSchemaException) Error() string {
+func (s *UnableToDetectSchemaException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnableToDetectSchemaException) StatusCode() int {
+func (s *UnableToDetectSchemaException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnableToDetectSchemaException) RequestID() string {
+func (s *UnableToDetectSchemaException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11290,12 +11290,12 @@ func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedOperationException) Code() string {
+func (s *UnsupportedOperationException) Code() string {
 	return "UnsupportedOperationException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedOperationException) Message() string {
+func (s *UnsupportedOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11303,21 +11303,21 @@ func (s UnsupportedOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedOperationException) OrigErr() error {
+func (s *UnsupportedOperationException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedOperationException) Error() string {
+func (s *UnsupportedOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedOperationException) StatusCode() int {
+func (s *UnsupportedOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedOperationException) RequestID() string {
+func (s *UnsupportedOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kinesisvideo/api.go
+++ b/service/kinesisvideo/api.go
@@ -2029,12 +2029,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2042,21 +2042,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2086,12 +2086,12 @@ func newErrorAccountChannelLimitExceededException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s AccountChannelLimitExceededException) Code() string {
+func (s *AccountChannelLimitExceededException) Code() string {
 	return "AccountChannelLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s AccountChannelLimitExceededException) Message() string {
+func (s *AccountChannelLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2099,21 +2099,21 @@ func (s AccountChannelLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountChannelLimitExceededException) OrigErr() error {
+func (s *AccountChannelLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s AccountChannelLimitExceededException) Error() string {
+func (s *AccountChannelLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountChannelLimitExceededException) StatusCode() int {
+func (s *AccountChannelLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountChannelLimitExceededException) RequestID() string {
+func (s *AccountChannelLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2142,12 +2142,12 @@ func newErrorAccountStreamLimitExceededException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s AccountStreamLimitExceededException) Code() string {
+func (s *AccountStreamLimitExceededException) Code() string {
 	return "AccountStreamLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s AccountStreamLimitExceededException) Message() string {
+func (s *AccountStreamLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2155,21 +2155,21 @@ func (s AccountStreamLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountStreamLimitExceededException) OrigErr() error {
+func (s *AccountStreamLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s AccountStreamLimitExceededException) Error() string {
+func (s *AccountStreamLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountStreamLimitExceededException) StatusCode() int {
+func (s *AccountStreamLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountStreamLimitExceededException) RequestID() string {
+func (s *AccountStreamLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2327,12 +2327,12 @@ func newErrorClientLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientLimitExceededException) Code() string {
+func (s *ClientLimitExceededException) Code() string {
 	return "ClientLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ClientLimitExceededException) Message() string {
+func (s *ClientLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2340,21 +2340,21 @@ func (s ClientLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientLimitExceededException) OrigErr() error {
+func (s *ClientLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ClientLimitExceededException) Error() string {
+func (s *ClientLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientLimitExceededException) StatusCode() int {
+func (s *ClientLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientLimitExceededException) RequestID() string {
+func (s *ClientLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2925,12 +2925,12 @@ func newErrorDeviceStreamLimitExceededException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s DeviceStreamLimitExceededException) Code() string {
+func (s *DeviceStreamLimitExceededException) Code() string {
 	return "DeviceStreamLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s DeviceStreamLimitExceededException) Message() string {
+func (s *DeviceStreamLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2938,21 +2938,21 @@ func (s DeviceStreamLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeviceStreamLimitExceededException) OrigErr() error {
+func (s *DeviceStreamLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s DeviceStreamLimitExceededException) Error() string {
+func (s *DeviceStreamLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeviceStreamLimitExceededException) StatusCode() int {
+func (s *DeviceStreamLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeviceStreamLimitExceededException) RequestID() string {
+func (s *DeviceStreamLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3148,12 +3148,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3161,21 +3161,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3204,12 +3204,12 @@ func newErrorInvalidDeviceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDeviceException) Code() string {
+func (s *InvalidDeviceException) Code() string {
 	return "InvalidDeviceException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeviceException) Message() string {
+func (s *InvalidDeviceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3217,21 +3217,21 @@ func (s InvalidDeviceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeviceException) OrigErr() error {
+func (s *InvalidDeviceException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeviceException) Error() string {
+func (s *InvalidDeviceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeviceException) StatusCode() int {
+func (s *InvalidDeviceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeviceException) RequestID() string {
+func (s *InvalidDeviceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3260,12 +3260,12 @@ func newErrorInvalidResourceFormatException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceFormatException) Code() string {
+func (s *InvalidResourceFormatException) Code() string {
 	return "InvalidResourceFormatException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceFormatException) Message() string {
+func (s *InvalidResourceFormatException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3273,21 +3273,21 @@ func (s InvalidResourceFormatException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceFormatException) OrigErr() error {
+func (s *InvalidResourceFormatException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceFormatException) Error() string {
+func (s *InvalidResourceFormatException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceFormatException) StatusCode() int {
+func (s *InvalidResourceFormatException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceFormatException) RequestID() string {
+func (s *InvalidResourceFormatException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3685,12 +3685,12 @@ func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotAuthorizedException) Code() string {
+func (s *NotAuthorizedException) Code() string {
 	return "NotAuthorizedException"
 }
 
 // Message returns the exception's message.
-func (s NotAuthorizedException) Message() string {
+func (s *NotAuthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3698,21 +3698,21 @@ func (s NotAuthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotAuthorizedException) OrigErr() error {
+func (s *NotAuthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s NotAuthorizedException) Error() string {
+func (s *NotAuthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotAuthorizedException) StatusCode() int {
+func (s *NotAuthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotAuthorizedException) RequestID() string {
+func (s *NotAuthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3777,12 +3777,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3790,21 +3790,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3833,12 +3833,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3846,21 +3846,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4350,12 +4350,12 @@ func newErrorTagsPerResourceExceededLimitException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s TagsPerResourceExceededLimitException) Code() string {
+func (s *TagsPerResourceExceededLimitException) Code() string {
 	return "TagsPerResourceExceededLimitException"
 }
 
 // Message returns the exception's message.
-func (s TagsPerResourceExceededLimitException) Message() string {
+func (s *TagsPerResourceExceededLimitException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4363,21 +4363,21 @@ func (s TagsPerResourceExceededLimitException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagsPerResourceExceededLimitException) OrigErr() error {
+func (s *TagsPerResourceExceededLimitException) OrigErr() error {
 	return nil
 }
 
-func (s TagsPerResourceExceededLimitException) Error() string {
+func (s *TagsPerResourceExceededLimitException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagsPerResourceExceededLimitException) StatusCode() int {
+func (s *TagsPerResourceExceededLimitException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagsPerResourceExceededLimitException) RequestID() string {
+func (s *TagsPerResourceExceededLimitException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4874,12 +4874,12 @@ func newErrorVersionMismatchException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s VersionMismatchException) Code() string {
+func (s *VersionMismatchException) Code() string {
 	return "VersionMismatchException"
 }
 
 // Message returns the exception's message.
-func (s VersionMismatchException) Message() string {
+func (s *VersionMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4887,21 +4887,21 @@ func (s VersionMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s VersionMismatchException) OrigErr() error {
+func (s *VersionMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s VersionMismatchException) Error() string {
+func (s *VersionMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s VersionMismatchException) StatusCode() int {
+func (s *VersionMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s VersionMismatchException) RequestID() string {
+func (s *VersionMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kinesisvideoarchivedmedia/api.go
+++ b/service/kinesisvideoarchivedmedia/api.go
@@ -853,12 +853,12 @@ func newErrorClientLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientLimitExceededException) Code() string {
+func (s *ClientLimitExceededException) Code() string {
 	return "ClientLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ClientLimitExceededException) Message() string {
+func (s *ClientLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -866,21 +866,21 @@ func (s ClientLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientLimitExceededException) OrigErr() error {
+func (s *ClientLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ClientLimitExceededException) Error() string {
+func (s *ClientLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientLimitExceededException) StatusCode() int {
+func (s *ClientLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientLimitExceededException) RequestID() string {
+func (s *ClientLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1897,12 +1897,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1910,21 +1910,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1954,12 +1954,12 @@ func newErrorInvalidCodecPrivateDataException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidCodecPrivateDataException) Code() string {
+func (s *InvalidCodecPrivateDataException) Code() string {
 	return "InvalidCodecPrivateDataException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCodecPrivateDataException) Message() string {
+func (s *InvalidCodecPrivateDataException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1967,21 +1967,21 @@ func (s InvalidCodecPrivateDataException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCodecPrivateDataException) OrigErr() error {
+func (s *InvalidCodecPrivateDataException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCodecPrivateDataException) Error() string {
+func (s *InvalidCodecPrivateDataException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCodecPrivateDataException) StatusCode() int {
+func (s *InvalidCodecPrivateDataException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCodecPrivateDataException) RequestID() string {
+func (s *InvalidCodecPrivateDataException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2128,12 +2128,12 @@ func newErrorMissingCodecPrivateDataException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s MissingCodecPrivateDataException) Code() string {
+func (s *MissingCodecPrivateDataException) Code() string {
 	return "MissingCodecPrivateDataException"
 }
 
 // Message returns the exception's message.
-func (s MissingCodecPrivateDataException) Message() string {
+func (s *MissingCodecPrivateDataException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2141,21 +2141,21 @@ func (s MissingCodecPrivateDataException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MissingCodecPrivateDataException) OrigErr() error {
+func (s *MissingCodecPrivateDataException) OrigErr() error {
 	return nil
 }
 
-func (s MissingCodecPrivateDataException) Error() string {
+func (s *MissingCodecPrivateDataException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MissingCodecPrivateDataException) StatusCode() int {
+func (s *MissingCodecPrivateDataException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MissingCodecPrivateDataException) RequestID() string {
+func (s *MissingCodecPrivateDataException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2185,12 +2185,12 @@ func newErrorNoDataRetentionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoDataRetentionException) Code() string {
+func (s *NoDataRetentionException) Code() string {
 	return "NoDataRetentionException"
 }
 
 // Message returns the exception's message.
-func (s NoDataRetentionException) Message() string {
+func (s *NoDataRetentionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2198,21 +2198,21 @@ func (s NoDataRetentionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoDataRetentionException) OrigErr() error {
+func (s *NoDataRetentionException) OrigErr() error {
 	return nil
 }
 
-func (s NoDataRetentionException) Error() string {
+func (s *NoDataRetentionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoDataRetentionException) StatusCode() int {
+func (s *NoDataRetentionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoDataRetentionException) RequestID() string {
+func (s *NoDataRetentionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2242,12 +2242,12 @@ func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotAuthorizedException) Code() string {
+func (s *NotAuthorizedException) Code() string {
 	return "NotAuthorizedException"
 }
 
 // Message returns the exception's message.
-func (s NotAuthorizedException) Message() string {
+func (s *NotAuthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2255,21 +2255,21 @@ func (s NotAuthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotAuthorizedException) OrigErr() error {
+func (s *NotAuthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s NotAuthorizedException) Error() string {
+func (s *NotAuthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotAuthorizedException) StatusCode() int {
+func (s *NotAuthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotAuthorizedException) RequestID() string {
+func (s *NotAuthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2305,12 +2305,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2318,21 +2318,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2417,12 +2417,12 @@ func newErrorUnsupportedStreamMediaTypeException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s UnsupportedStreamMediaTypeException) Code() string {
+func (s *UnsupportedStreamMediaTypeException) Code() string {
 	return "UnsupportedStreamMediaTypeException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedStreamMediaTypeException) Message() string {
+func (s *UnsupportedStreamMediaTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2430,21 +2430,21 @@ func (s UnsupportedStreamMediaTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedStreamMediaTypeException) OrigErr() error {
+func (s *UnsupportedStreamMediaTypeException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedStreamMediaTypeException) Error() string {
+func (s *UnsupportedStreamMediaTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedStreamMediaTypeException) StatusCode() int {
+func (s *UnsupportedStreamMediaTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedStreamMediaTypeException) RequestID() string {
+func (s *UnsupportedStreamMediaTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kinesisvideomedia/api.go
+++ b/service/kinesisvideomedia/api.go
@@ -178,12 +178,12 @@ func newErrorClientLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientLimitExceededException) Code() string {
+func (s *ClientLimitExceededException) Code() string {
 	return "ClientLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ClientLimitExceededException) Message() string {
+func (s *ClientLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -191,21 +191,21 @@ func (s ClientLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientLimitExceededException) OrigErr() error {
+func (s *ClientLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ClientLimitExceededException) Error() string {
+func (s *ClientLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientLimitExceededException) StatusCode() int {
+func (s *ClientLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientLimitExceededException) RequestID() string {
+func (s *ClientLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -235,12 +235,12 @@ func newErrorConnectionLimitExceededException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s ConnectionLimitExceededException) Code() string {
+func (s *ConnectionLimitExceededException) Code() string {
 	return "ConnectionLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ConnectionLimitExceededException) Message() string {
+func (s *ConnectionLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -248,21 +248,21 @@ func (s ConnectionLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConnectionLimitExceededException) OrigErr() error {
+func (s *ConnectionLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ConnectionLimitExceededException) Error() string {
+func (s *ConnectionLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConnectionLimitExceededException) StatusCode() int {
+func (s *ConnectionLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConnectionLimitExceededException) RequestID() string {
+func (s *ConnectionLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -438,12 +438,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -451,21 +451,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -497,12 +497,12 @@ func newErrorInvalidEndpointException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidEndpointException) Code() string {
+func (s *InvalidEndpointException) Code() string {
 	return "InvalidEndpointException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEndpointException) Message() string {
+func (s *InvalidEndpointException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -510,21 +510,21 @@ func (s InvalidEndpointException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEndpointException) OrigErr() error {
+func (s *InvalidEndpointException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEndpointException) Error() string {
+func (s *InvalidEndpointException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEndpointException) StatusCode() int {
+func (s *InvalidEndpointException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEndpointException) RequestID() string {
+func (s *InvalidEndpointException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -554,12 +554,12 @@ func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotAuthorizedException) Code() string {
+func (s *NotAuthorizedException) Code() string {
 	return "NotAuthorizedException"
 }
 
 // Message returns the exception's message.
-func (s NotAuthorizedException) Message() string {
+func (s *NotAuthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -567,21 +567,21 @@ func (s NotAuthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotAuthorizedException) OrigErr() error {
+func (s *NotAuthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s NotAuthorizedException) Error() string {
+func (s *NotAuthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotAuthorizedException) StatusCode() int {
+func (s *NotAuthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotAuthorizedException) RequestID() string {
+func (s *NotAuthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -610,12 +610,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -623,21 +623,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kinesisvideosignalingchannels/api.go
+++ b/service/kinesisvideosignalingchannels/api.go
@@ -243,12 +243,12 @@ func newErrorClientLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClientLimitExceededException) Code() string {
+func (s *ClientLimitExceededException) Code() string {
 	return "ClientLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ClientLimitExceededException) Message() string {
+func (s *ClientLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -256,21 +256,21 @@ func (s ClientLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClientLimitExceededException) OrigErr() error {
+func (s *ClientLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ClientLimitExceededException) Error() string {
+func (s *ClientLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClientLimitExceededException) StatusCode() int {
+func (s *ClientLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClientLimitExceededException) RequestID() string {
+func (s *ClientLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -452,12 +452,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -465,21 +465,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -508,12 +508,12 @@ func newErrorInvalidClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidClientException) Code() string {
+func (s *InvalidClientException) Code() string {
 	return "InvalidClientException"
 }
 
 // Message returns the exception's message.
-func (s InvalidClientException) Message() string {
+func (s *InvalidClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -521,21 +521,21 @@ func (s InvalidClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidClientException) OrigErr() error {
+func (s *InvalidClientException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidClientException) Error() string {
+func (s *InvalidClientException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidClientException) StatusCode() int {
+func (s *InvalidClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidClientException) RequestID() string {
+func (s *InvalidClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -564,12 +564,12 @@ func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotAuthorizedException) Code() string {
+func (s *NotAuthorizedException) Code() string {
 	return "NotAuthorizedException"
 }
 
 // Message returns the exception's message.
-func (s NotAuthorizedException) Message() string {
+func (s *NotAuthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -577,21 +577,21 @@ func (s NotAuthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotAuthorizedException) OrigErr() error {
+func (s *NotAuthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s NotAuthorizedException) Error() string {
+func (s *NotAuthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotAuthorizedException) StatusCode() int {
+func (s *NotAuthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotAuthorizedException) RequestID() string {
+func (s *NotAuthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -620,12 +620,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -633,21 +633,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -776,12 +776,12 @@ func newErrorSessionExpiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SessionExpiredException) Code() string {
+func (s *SessionExpiredException) Code() string {
 	return "SessionExpiredException"
 }
 
 // Message returns the exception's message.
-func (s SessionExpiredException) Message() string {
+func (s *SessionExpiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -789,21 +789,21 @@ func (s SessionExpiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SessionExpiredException) OrigErr() error {
+func (s *SessionExpiredException) OrigErr() error {
 	return nil
 }
 
-func (s SessionExpiredException) Error() string {
+func (s *SessionExpiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SessionExpiredException) StatusCode() int {
+func (s *SessionExpiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SessionExpiredException) RequestID() string {
+func (s *SessionExpiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -6556,12 +6556,12 @@ func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyExistsException) Code() string {
+func (s *AlreadyExistsException) Code() string {
 	return "AlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyExistsException) Message() string {
+func (s *AlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6569,21 +6569,21 @@ func (s AlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyExistsException) OrigErr() error {
+func (s *AlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyExistsException) Error() string {
+func (s *AlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyExistsException) StatusCode() int {
+func (s *AlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyExistsException) RequestID() string {
+func (s *AlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6694,12 +6694,12 @@ func newErrorCloudHsmClusterInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CloudHsmClusterInUseException) Code() string {
+func (s *CloudHsmClusterInUseException) Code() string {
 	return "CloudHsmClusterInUseException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmClusterInUseException) Message() string {
+func (s *CloudHsmClusterInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6707,21 +6707,21 @@ func (s CloudHsmClusterInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmClusterInUseException) OrigErr() error {
+func (s *CloudHsmClusterInUseException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmClusterInUseException) Error() string {
+func (s *CloudHsmClusterInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmClusterInUseException) StatusCode() int {
+func (s *CloudHsmClusterInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmClusterInUseException) RequestID() string {
+func (s *CloudHsmClusterInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6779,12 +6779,12 @@ func newErrorCloudHsmClusterInvalidConfigurationException(v protocol.ResponseMet
 }
 
 // Code returns the exception type name.
-func (s CloudHsmClusterInvalidConfigurationException) Code() string {
+func (s *CloudHsmClusterInvalidConfigurationException) Code() string {
 	return "CloudHsmClusterInvalidConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmClusterInvalidConfigurationException) Message() string {
+func (s *CloudHsmClusterInvalidConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6792,21 +6792,21 @@ func (s CloudHsmClusterInvalidConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmClusterInvalidConfigurationException) OrigErr() error {
+func (s *CloudHsmClusterInvalidConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmClusterInvalidConfigurationException) Error() string {
+func (s *CloudHsmClusterInvalidConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmClusterInvalidConfigurationException) StatusCode() int {
+func (s *CloudHsmClusterInvalidConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmClusterInvalidConfigurationException) RequestID() string {
+func (s *CloudHsmClusterInvalidConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6839,12 +6839,12 @@ func newErrorCloudHsmClusterNotActiveException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s CloudHsmClusterNotActiveException) Code() string {
+func (s *CloudHsmClusterNotActiveException) Code() string {
 	return "CloudHsmClusterNotActiveException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmClusterNotActiveException) Message() string {
+func (s *CloudHsmClusterNotActiveException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6852,21 +6852,21 @@ func (s CloudHsmClusterNotActiveException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmClusterNotActiveException) OrigErr() error {
+func (s *CloudHsmClusterNotActiveException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmClusterNotActiveException) Error() string {
+func (s *CloudHsmClusterNotActiveException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmClusterNotActiveException) StatusCode() int {
+func (s *CloudHsmClusterNotActiveException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmClusterNotActiveException) RequestID() string {
+func (s *CloudHsmClusterNotActiveException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6897,12 +6897,12 @@ func newErrorCloudHsmClusterNotFoundException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s CloudHsmClusterNotFoundException) Code() string {
+func (s *CloudHsmClusterNotFoundException) Code() string {
 	return "CloudHsmClusterNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmClusterNotFoundException) Message() string {
+func (s *CloudHsmClusterNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6910,21 +6910,21 @@ func (s CloudHsmClusterNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmClusterNotFoundException) OrigErr() error {
+func (s *CloudHsmClusterNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmClusterNotFoundException) Error() string {
+func (s *CloudHsmClusterNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmClusterNotFoundException) StatusCode() int {
+func (s *CloudHsmClusterNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmClusterNotFoundException) RequestID() string {
+func (s *CloudHsmClusterNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6964,12 +6964,12 @@ func newErrorCloudHsmClusterNotRelatedException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s CloudHsmClusterNotRelatedException) Code() string {
+func (s *CloudHsmClusterNotRelatedException) Code() string {
 	return "CloudHsmClusterNotRelatedException"
 }
 
 // Message returns the exception's message.
-func (s CloudHsmClusterNotRelatedException) Message() string {
+func (s *CloudHsmClusterNotRelatedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6977,21 +6977,21 @@ func (s CloudHsmClusterNotRelatedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CloudHsmClusterNotRelatedException) OrigErr() error {
+func (s *CloudHsmClusterNotRelatedException) OrigErr() error {
 	return nil
 }
 
-func (s CloudHsmClusterNotRelatedException) Error() string {
+func (s *CloudHsmClusterNotRelatedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CloudHsmClusterNotRelatedException) StatusCode() int {
+func (s *CloudHsmClusterNotRelatedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CloudHsmClusterNotRelatedException) RequestID() string {
+func (s *CloudHsmClusterNotRelatedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7737,12 +7737,12 @@ func newErrorCustomKeyStoreHasCMKsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CustomKeyStoreHasCMKsException) Code() string {
+func (s *CustomKeyStoreHasCMKsException) Code() string {
 	return "CustomKeyStoreHasCMKsException"
 }
 
 // Message returns the exception's message.
-func (s CustomKeyStoreHasCMKsException) Message() string {
+func (s *CustomKeyStoreHasCMKsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7750,21 +7750,21 @@ func (s CustomKeyStoreHasCMKsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CustomKeyStoreHasCMKsException) OrigErr() error {
+func (s *CustomKeyStoreHasCMKsException) OrigErr() error {
 	return nil
 }
 
-func (s CustomKeyStoreHasCMKsException) Error() string {
+func (s *CustomKeyStoreHasCMKsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CustomKeyStoreHasCMKsException) StatusCode() int {
+func (s *CustomKeyStoreHasCMKsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CustomKeyStoreHasCMKsException) RequestID() string {
+func (s *CustomKeyStoreHasCMKsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7809,12 +7809,12 @@ func newErrorCustomKeyStoreInvalidStateException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s CustomKeyStoreInvalidStateException) Code() string {
+func (s *CustomKeyStoreInvalidStateException) Code() string {
 	return "CustomKeyStoreInvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s CustomKeyStoreInvalidStateException) Message() string {
+func (s *CustomKeyStoreInvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7822,21 +7822,21 @@ func (s CustomKeyStoreInvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CustomKeyStoreInvalidStateException) OrigErr() error {
+func (s *CustomKeyStoreInvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s CustomKeyStoreInvalidStateException) Error() string {
+func (s *CustomKeyStoreInvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CustomKeyStoreInvalidStateException) StatusCode() int {
+func (s *CustomKeyStoreInvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CustomKeyStoreInvalidStateException) RequestID() string {
+func (s *CustomKeyStoreInvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7867,12 +7867,12 @@ func newErrorCustomKeyStoreNameInUseException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s CustomKeyStoreNameInUseException) Code() string {
+func (s *CustomKeyStoreNameInUseException) Code() string {
 	return "CustomKeyStoreNameInUseException"
 }
 
 // Message returns the exception's message.
-func (s CustomKeyStoreNameInUseException) Message() string {
+func (s *CustomKeyStoreNameInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7880,21 +7880,21 @@ func (s CustomKeyStoreNameInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CustomKeyStoreNameInUseException) OrigErr() error {
+func (s *CustomKeyStoreNameInUseException) OrigErr() error {
 	return nil
 }
 
-func (s CustomKeyStoreNameInUseException) Error() string {
+func (s *CustomKeyStoreNameInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CustomKeyStoreNameInUseException) StatusCode() int {
+func (s *CustomKeyStoreNameInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CustomKeyStoreNameInUseException) RequestID() string {
+func (s *CustomKeyStoreNameInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7924,12 +7924,12 @@ func newErrorCustomKeyStoreNotFoundException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s CustomKeyStoreNotFoundException) Code() string {
+func (s *CustomKeyStoreNotFoundException) Code() string {
 	return "CustomKeyStoreNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s CustomKeyStoreNotFoundException) Message() string {
+func (s *CustomKeyStoreNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7937,21 +7937,21 @@ func (s CustomKeyStoreNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CustomKeyStoreNotFoundException) OrigErr() error {
+func (s *CustomKeyStoreNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s CustomKeyStoreNotFoundException) Error() string {
+func (s *CustomKeyStoreNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CustomKeyStoreNotFoundException) StatusCode() int {
+func (s *CustomKeyStoreNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CustomKeyStoreNotFoundException) RequestID() string {
+func (s *CustomKeyStoreNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8483,12 +8483,12 @@ func newErrorDependencyTimeoutException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DependencyTimeoutException) Code() string {
+func (s *DependencyTimeoutException) Code() string {
 	return "DependencyTimeoutException"
 }
 
 // Message returns the exception's message.
-func (s DependencyTimeoutException) Message() string {
+func (s *DependencyTimeoutException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8496,21 +8496,21 @@ func (s DependencyTimeoutException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DependencyTimeoutException) OrigErr() error {
+func (s *DependencyTimeoutException) OrigErr() error {
 	return nil
 }
 
-func (s DependencyTimeoutException) Error() string {
+func (s *DependencyTimeoutException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DependencyTimeoutException) StatusCode() int {
+func (s *DependencyTimeoutException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DependencyTimeoutException) RequestID() string {
+func (s *DependencyTimeoutException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8902,12 +8902,12 @@ func newErrorDisabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DisabledException) Code() string {
+func (s *DisabledException) Code() string {
 	return "DisabledException"
 }
 
 // Message returns the exception's message.
-func (s DisabledException) Message() string {
+func (s *DisabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8915,21 +8915,21 @@ func (s DisabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DisabledException) OrigErr() error {
+func (s *DisabledException) OrigErr() error {
 	return nil
 }
 
-func (s DisabledException) Error() string {
+func (s *DisabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DisabledException) StatusCode() int {
+func (s *DisabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DisabledException) RequestID() string {
+func (s *DisabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9316,12 +9316,12 @@ func newErrorExpiredImportTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExpiredImportTokenException) Code() string {
+func (s *ExpiredImportTokenException) Code() string {
 	return "ExpiredImportTokenException"
 }
 
 // Message returns the exception's message.
-func (s ExpiredImportTokenException) Message() string {
+func (s *ExpiredImportTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9329,21 +9329,21 @@ func (s ExpiredImportTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExpiredImportTokenException) OrigErr() error {
+func (s *ExpiredImportTokenException) OrigErr() error {
 	return nil
 }
 
-func (s ExpiredImportTokenException) Error() string {
+func (s *ExpiredImportTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExpiredImportTokenException) StatusCode() int {
+func (s *ExpiredImportTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExpiredImportTokenException) RequestID() string {
+func (s *ExpiredImportTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10896,12 +10896,12 @@ func newErrorIncorrectKeyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncorrectKeyException) Code() string {
+func (s *IncorrectKeyException) Code() string {
 	return "IncorrectKeyException"
 }
 
 // Message returns the exception's message.
-func (s IncorrectKeyException) Message() string {
+func (s *IncorrectKeyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10909,21 +10909,21 @@ func (s IncorrectKeyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncorrectKeyException) OrigErr() error {
+func (s *IncorrectKeyException) OrigErr() error {
 	return nil
 }
 
-func (s IncorrectKeyException) Error() string {
+func (s *IncorrectKeyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncorrectKeyException) StatusCode() int {
+func (s *IncorrectKeyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncorrectKeyException) RequestID() string {
+func (s *IncorrectKeyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10954,12 +10954,12 @@ func newErrorIncorrectKeyMaterialException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncorrectKeyMaterialException) Code() string {
+func (s *IncorrectKeyMaterialException) Code() string {
 	return "IncorrectKeyMaterialException"
 }
 
 // Message returns the exception's message.
-func (s IncorrectKeyMaterialException) Message() string {
+func (s *IncorrectKeyMaterialException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10967,21 +10967,21 @@ func (s IncorrectKeyMaterialException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncorrectKeyMaterialException) OrigErr() error {
+func (s *IncorrectKeyMaterialException) OrigErr() error {
 	return nil
 }
 
-func (s IncorrectKeyMaterialException) Error() string {
+func (s *IncorrectKeyMaterialException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncorrectKeyMaterialException) StatusCode() int {
+func (s *IncorrectKeyMaterialException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncorrectKeyMaterialException) RequestID() string {
+func (s *IncorrectKeyMaterialException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11015,12 +11015,12 @@ func newErrorIncorrectTrustAnchorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncorrectTrustAnchorException) Code() string {
+func (s *IncorrectTrustAnchorException) Code() string {
 	return "IncorrectTrustAnchorException"
 }
 
 // Message returns the exception's message.
-func (s IncorrectTrustAnchorException) Message() string {
+func (s *IncorrectTrustAnchorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11028,21 +11028,21 @@ func (s IncorrectTrustAnchorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncorrectTrustAnchorException) OrigErr() error {
+func (s *IncorrectTrustAnchorException) OrigErr() error {
 	return nil
 }
 
-func (s IncorrectTrustAnchorException) Error() string {
+func (s *IncorrectTrustAnchorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncorrectTrustAnchorException) StatusCode() int {
+func (s *IncorrectTrustAnchorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncorrectTrustAnchorException) RequestID() string {
+func (s *IncorrectTrustAnchorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11072,12 +11072,12 @@ func newErrorInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalException) Code() string {
+func (s *InternalException) Code() string {
 	return "KMSInternalException"
 }
 
 // Message returns the exception's message.
-func (s InternalException) Message() string {
+func (s *InternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11085,21 +11085,21 @@ func (s InternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalException) OrigErr() error {
+func (s *InternalException) OrigErr() error {
 	return nil
 }
 
-func (s InternalException) Error() string {
+func (s *InternalException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalException) StatusCode() int {
+func (s *InternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalException) RequestID() string {
+func (s *InternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11128,12 +11128,12 @@ func newErrorInvalidAliasNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAliasNameException) Code() string {
+func (s *InvalidAliasNameException) Code() string {
 	return "InvalidAliasNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAliasNameException) Message() string {
+func (s *InvalidAliasNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11141,21 +11141,21 @@ func (s InvalidAliasNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAliasNameException) OrigErr() error {
+func (s *InvalidAliasNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAliasNameException) Error() string {
+func (s *InvalidAliasNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAliasNameException) StatusCode() int {
+func (s *InvalidAliasNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAliasNameException) RequestID() string {
+func (s *InvalidAliasNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11185,12 +11185,12 @@ func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArnException) Code() string {
+func (s *InvalidArnException) Code() string {
 	return "InvalidArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArnException) Message() string {
+func (s *InvalidArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11198,21 +11198,21 @@ func (s InvalidArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArnException) OrigErr() error {
+func (s *InvalidArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArnException) Error() string {
+func (s *InvalidArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArnException) StatusCode() int {
+func (s *InvalidArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArnException) RequestID() string {
+func (s *InvalidArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11247,12 +11247,12 @@ func newErrorInvalidCiphertextException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidCiphertextException) Code() string {
+func (s *InvalidCiphertextException) Code() string {
 	return "InvalidCiphertextException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCiphertextException) Message() string {
+func (s *InvalidCiphertextException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11260,21 +11260,21 @@ func (s InvalidCiphertextException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCiphertextException) OrigErr() error {
+func (s *InvalidCiphertextException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCiphertextException) Error() string {
+func (s *InvalidCiphertextException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCiphertextException) StatusCode() int {
+func (s *InvalidCiphertextException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCiphertextException) RequestID() string {
+func (s *InvalidCiphertextException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11303,12 +11303,12 @@ func newErrorInvalidGrantIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidGrantIdException) Code() string {
+func (s *InvalidGrantIdException) Code() string {
 	return "InvalidGrantIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidGrantIdException) Message() string {
+func (s *InvalidGrantIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11316,21 +11316,21 @@ func (s InvalidGrantIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidGrantIdException) OrigErr() error {
+func (s *InvalidGrantIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidGrantIdException) Error() string {
+func (s *InvalidGrantIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidGrantIdException) StatusCode() int {
+func (s *InvalidGrantIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidGrantIdException) RequestID() string {
+func (s *InvalidGrantIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11359,12 +11359,12 @@ func newErrorInvalidGrantTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidGrantTokenException) Code() string {
+func (s *InvalidGrantTokenException) Code() string {
 	return "InvalidGrantTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidGrantTokenException) Message() string {
+func (s *InvalidGrantTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11372,21 +11372,21 @@ func (s InvalidGrantTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidGrantTokenException) OrigErr() error {
+func (s *InvalidGrantTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidGrantTokenException) Error() string {
+func (s *InvalidGrantTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidGrantTokenException) StatusCode() int {
+func (s *InvalidGrantTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidGrantTokenException) RequestID() string {
+func (s *InvalidGrantTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11416,12 +11416,12 @@ func newErrorInvalidImportTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidImportTokenException) Code() string {
+func (s *InvalidImportTokenException) Code() string {
 	return "InvalidImportTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidImportTokenException) Message() string {
+func (s *InvalidImportTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11429,21 +11429,21 @@ func (s InvalidImportTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidImportTokenException) OrigErr() error {
+func (s *InvalidImportTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidImportTokenException) Error() string {
+func (s *InvalidImportTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidImportTokenException) StatusCode() int {
+func (s *InvalidImportTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidImportTokenException) RequestID() string {
+func (s *InvalidImportTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11484,12 +11484,12 @@ func newErrorInvalidKeyUsageException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidKeyUsageException) Code() string {
+func (s *InvalidKeyUsageException) Code() string {
 	return "InvalidKeyUsageException"
 }
 
 // Message returns the exception's message.
-func (s InvalidKeyUsageException) Message() string {
+func (s *InvalidKeyUsageException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11497,21 +11497,21 @@ func (s InvalidKeyUsageException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidKeyUsageException) OrigErr() error {
+func (s *InvalidKeyUsageException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidKeyUsageException) Error() string {
+func (s *InvalidKeyUsageException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidKeyUsageException) StatusCode() int {
+func (s *InvalidKeyUsageException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidKeyUsageException) RequestID() string {
+func (s *InvalidKeyUsageException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11541,12 +11541,12 @@ func newErrorInvalidMarkerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidMarkerException) Code() string {
+func (s *InvalidMarkerException) Code() string {
 	return "InvalidMarkerException"
 }
 
 // Message returns the exception's message.
-func (s InvalidMarkerException) Message() string {
+func (s *InvalidMarkerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11554,21 +11554,21 @@ func (s InvalidMarkerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidMarkerException) OrigErr() error {
+func (s *InvalidMarkerException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidMarkerException) Error() string {
+func (s *InvalidMarkerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidMarkerException) StatusCode() int {
+func (s *InvalidMarkerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidMarkerException) RequestID() string {
+func (s *InvalidMarkerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11602,12 +11602,12 @@ func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidStateException) Code() string {
+func (s *InvalidStateException) Code() string {
 	return "KMSInvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateException) Message() string {
+func (s *InvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11615,21 +11615,21 @@ func (s InvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateException) OrigErr() error {
+func (s *InvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateException) Error() string {
+func (s *InvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateException) StatusCode() int {
+func (s *InvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateException) RequestID() string {
+func (s *InvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11660,12 +11660,12 @@ func newErrorKMSInvalidSignatureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSInvalidSignatureException) Code() string {
+func (s *KMSInvalidSignatureException) Code() string {
 	return "KMSInvalidSignatureException"
 }
 
 // Message returns the exception's message.
-func (s KMSInvalidSignatureException) Message() string {
+func (s *KMSInvalidSignatureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11673,21 +11673,21 @@ func (s KMSInvalidSignatureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSInvalidSignatureException) OrigErr() error {
+func (s *KMSInvalidSignatureException) OrigErr() error {
 	return nil
 }
 
-func (s KMSInvalidSignatureException) Error() string {
+func (s *KMSInvalidSignatureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSInvalidSignatureException) StatusCode() int {
+func (s *KMSInvalidSignatureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSInvalidSignatureException) RequestID() string {
+func (s *KMSInvalidSignatureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11963,12 +11963,12 @@ func newErrorKeyUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KeyUnavailableException) Code() string {
+func (s *KeyUnavailableException) Code() string {
 	return "KeyUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s KeyUnavailableException) Message() string {
+func (s *KeyUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11976,21 +11976,21 @@ func (s KeyUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KeyUnavailableException) OrigErr() error {
+func (s *KeyUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s KeyUnavailableException) Error() string {
+func (s *KeyUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KeyUnavailableException) StatusCode() int {
+func (s *KeyUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KeyUnavailableException) RequestID() string {
+func (s *KeyUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12021,12 +12021,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12034,21 +12034,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12763,12 +12763,12 @@ func newErrorMalformedPolicyDocumentException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s MalformedPolicyDocumentException) Code() string {
+func (s *MalformedPolicyDocumentException) Code() string {
 	return "MalformedPolicyDocumentException"
 }
 
 // Message returns the exception's message.
-func (s MalformedPolicyDocumentException) Message() string {
+func (s *MalformedPolicyDocumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12776,21 +12776,21 @@ func (s MalformedPolicyDocumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MalformedPolicyDocumentException) OrigErr() error {
+func (s *MalformedPolicyDocumentException) OrigErr() error {
 	return nil
 }
 
-func (s MalformedPolicyDocumentException) Error() string {
+func (s *MalformedPolicyDocumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MalformedPolicyDocumentException) StatusCode() int {
+func (s *MalformedPolicyDocumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MalformedPolicyDocumentException) RequestID() string {
+func (s *MalformedPolicyDocumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12820,12 +12820,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12833,21 +12833,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13783,12 +13783,12 @@ func newErrorTagException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagException) Code() string {
+func (s *TagException) Code() string {
 	return "TagException"
 }
 
 // Message returns the exception's message.
-func (s TagException) Message() string {
+func (s *TagException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13796,21 +13796,21 @@ func (s TagException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagException) OrigErr() error {
+func (s *TagException) OrigErr() error {
 	return nil
 }
 
-func (s TagException) Error() string {
+func (s *TagException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagException) StatusCode() int {
+func (s *TagException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagException) RequestID() string {
+func (s *TagException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13929,12 +13929,12 @@ func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedOperationException) Code() string {
+func (s *UnsupportedOperationException) Code() string {
 	return "UnsupportedOperationException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedOperationException) Message() string {
+func (s *UnsupportedOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13942,21 +13942,21 @@ func (s UnsupportedOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedOperationException) OrigErr() error {
+func (s *UnsupportedOperationException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedOperationException) Error() string {
+func (s *UnsupportedOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedOperationException) StatusCode() int {
+func (s *UnsupportedOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedOperationException) RequestID() string {
+func (s *UnsupportedOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/lakeformation/api.go
+++ b/service/lakeformation/api.go
@@ -1357,12 +1357,12 @@ func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyExistsException) Code() string {
+func (s *AlreadyExistsException) Code() string {
 	return "AlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyExistsException) Message() string {
+func (s *AlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1370,21 +1370,21 @@ func (s AlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyExistsException) OrigErr() error {
+func (s *AlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyExistsException) Error() string {
+func (s *AlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyExistsException) StatusCode() int {
+func (s *AlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyExistsException) RequestID() string {
+func (s *AlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1749,12 +1749,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1762,21 +1762,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2122,12 +2122,12 @@ func newErrorEntityNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EntityNotFoundException) Code() string {
+func (s *EntityNotFoundException) Code() string {
 	return "EntityNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s EntityNotFoundException) Message() string {
+func (s *EntityNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2135,21 +2135,21 @@ func (s EntityNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EntityNotFoundException) OrigErr() error {
+func (s *EntityNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s EntityNotFoundException) Error() string {
+func (s *EntityNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EntityNotFoundException) StatusCode() int {
+func (s *EntityNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EntityNotFoundException) RequestID() string {
+func (s *EntityNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2552,12 +2552,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2565,21 +2565,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2609,12 +2609,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2622,21 +2622,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2890,12 +2890,12 @@ func newErrorOperationTimeoutException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationTimeoutException) Code() string {
+func (s *OperationTimeoutException) Code() string {
 	return "OperationTimeoutException"
 }
 
 // Message returns the exception's message.
-func (s OperationTimeoutException) Message() string {
+func (s *OperationTimeoutException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2903,21 +2903,21 @@ func (s OperationTimeoutException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationTimeoutException) OrigErr() error {
+func (s *OperationTimeoutException) OrigErr() error {
 	return nil
 }
 
-func (s OperationTimeoutException) Error() string {
+func (s *OperationTimeoutException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationTimeoutException) StatusCode() int {
+func (s *OperationTimeoutException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationTimeoutException) RequestID() string {
+func (s *OperationTimeoutException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -5806,12 +5806,12 @@ func newErrorCodeStorageExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CodeStorageExceededException) Code() string {
+func (s *CodeStorageExceededException) Code() string {
 	return "CodeStorageExceededException"
 }
 
 // Message returns the exception's message.
-func (s CodeStorageExceededException) Message() string {
+func (s *CodeStorageExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5819,21 +5819,21 @@ func (s CodeStorageExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CodeStorageExceededException) OrigErr() error {
+func (s *CodeStorageExceededException) OrigErr() error {
 	return nil
 }
 
-func (s CodeStorageExceededException) Error() string {
+func (s *CodeStorageExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CodeStorageExceededException) StatusCode() int {
+func (s *CodeStorageExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CodeStorageExceededException) RequestID() string {
+func (s *CodeStorageExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6949,12 +6949,12 @@ func newErrorEC2AccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EC2AccessDeniedException) Code() string {
+func (s *EC2AccessDeniedException) Code() string {
 	return "EC2AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s EC2AccessDeniedException) Message() string {
+func (s *EC2AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6962,21 +6962,21 @@ func (s EC2AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EC2AccessDeniedException) OrigErr() error {
+func (s *EC2AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s EC2AccessDeniedException) Error() string {
+func (s *EC2AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EC2AccessDeniedException) StatusCode() int {
+func (s *EC2AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EC2AccessDeniedException) RequestID() string {
+func (s *EC2AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7008,12 +7008,12 @@ func newErrorEC2ThrottledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EC2ThrottledException) Code() string {
+func (s *EC2ThrottledException) Code() string {
 	return "EC2ThrottledException"
 }
 
 // Message returns the exception's message.
-func (s EC2ThrottledException) Message() string {
+func (s *EC2ThrottledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7021,21 +7021,21 @@ func (s EC2ThrottledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EC2ThrottledException) OrigErr() error {
+func (s *EC2ThrottledException) OrigErr() error {
 	return nil
 }
 
-func (s EC2ThrottledException) Error() string {
+func (s *EC2ThrottledException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EC2ThrottledException) StatusCode() int {
+func (s *EC2ThrottledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EC2ThrottledException) RequestID() string {
+func (s *EC2ThrottledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7069,12 +7069,12 @@ func newErrorEC2UnexpectedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EC2UnexpectedException) Code() string {
+func (s *EC2UnexpectedException) Code() string {
 	return "EC2UnexpectedException"
 }
 
 // Message returns the exception's message.
-func (s EC2UnexpectedException) Message() string {
+func (s *EC2UnexpectedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7082,21 +7082,21 @@ func (s EC2UnexpectedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EC2UnexpectedException) OrigErr() error {
+func (s *EC2UnexpectedException) OrigErr() error {
 	return nil
 }
 
-func (s EC2UnexpectedException) Error() string {
+func (s *EC2UnexpectedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EC2UnexpectedException) StatusCode() int {
+func (s *EC2UnexpectedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EC2UnexpectedException) RequestID() string {
+func (s *EC2UnexpectedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7129,12 +7129,12 @@ func newErrorENILimitReachedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ENILimitReachedException) Code() string {
+func (s *ENILimitReachedException) Code() string {
 	return "ENILimitReachedException"
 }
 
 // Message returns the exception's message.
-func (s ENILimitReachedException) Message() string {
+func (s *ENILimitReachedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7142,21 +7142,21 @@ func (s ENILimitReachedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ENILimitReachedException) OrigErr() error {
+func (s *ENILimitReachedException) OrigErr() error {
 	return nil
 }
 
-func (s ENILimitReachedException) Error() string {
+func (s *ENILimitReachedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ENILimitReachedException) StatusCode() int {
+func (s *ENILimitReachedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ENILimitReachedException) RequestID() string {
+func (s *ENILimitReachedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9000,12 +9000,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9013,21 +9013,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9060,12 +9060,12 @@ func newErrorInvalidRequestContentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestContentException) Code() string {
+func (s *InvalidRequestContentException) Code() string {
 	return "InvalidRequestContentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestContentException) Message() string {
+func (s *InvalidRequestContentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9073,21 +9073,21 @@ func (s InvalidRequestContentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestContentException) OrigErr() error {
+func (s *InvalidRequestContentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestContentException) Error() string {
+func (s *InvalidRequestContentException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestContentException) StatusCode() int {
+func (s *InvalidRequestContentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestContentException) RequestID() string {
+func (s *InvalidRequestContentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9118,12 +9118,12 @@ func newErrorInvalidRuntimeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRuntimeException) Code() string {
+func (s *InvalidRuntimeException) Code() string {
 	return "InvalidRuntimeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRuntimeException) Message() string {
+func (s *InvalidRuntimeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9131,21 +9131,21 @@ func (s InvalidRuntimeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRuntimeException) OrigErr() error {
+func (s *InvalidRuntimeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRuntimeException) Error() string {
+func (s *InvalidRuntimeException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRuntimeException) StatusCode() int {
+func (s *InvalidRuntimeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRuntimeException) RequestID() string {
+func (s *InvalidRuntimeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9177,12 +9177,12 @@ func newErrorInvalidSecurityGroupIDException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidSecurityGroupIDException) Code() string {
+func (s *InvalidSecurityGroupIDException) Code() string {
 	return "InvalidSecurityGroupIDException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSecurityGroupIDException) Message() string {
+func (s *InvalidSecurityGroupIDException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9190,21 +9190,21 @@ func (s InvalidSecurityGroupIDException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSecurityGroupIDException) OrigErr() error {
+func (s *InvalidSecurityGroupIDException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSecurityGroupIDException) Error() string {
+func (s *InvalidSecurityGroupIDException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSecurityGroupIDException) StatusCode() int {
+func (s *InvalidSecurityGroupIDException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSecurityGroupIDException) RequestID() string {
+func (s *InvalidSecurityGroupIDException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9235,12 +9235,12 @@ func newErrorInvalidSubnetIDException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSubnetIDException) Code() string {
+func (s *InvalidSubnetIDException) Code() string {
 	return "InvalidSubnetIDException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSubnetIDException) Message() string {
+func (s *InvalidSubnetIDException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9248,21 +9248,21 @@ func (s InvalidSubnetIDException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSubnetIDException) OrigErr() error {
+func (s *InvalidSubnetIDException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSubnetIDException) Error() string {
+func (s *InvalidSubnetIDException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSubnetIDException) StatusCode() int {
+func (s *InvalidSubnetIDException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSubnetIDException) RequestID() string {
+func (s *InvalidSubnetIDException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9293,12 +9293,12 @@ func newErrorInvalidZipFileException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidZipFileException) Code() string {
+func (s *InvalidZipFileException) Code() string {
 	return "InvalidZipFileException"
 }
 
 // Message returns the exception's message.
-func (s InvalidZipFileException) Message() string {
+func (s *InvalidZipFileException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9306,21 +9306,21 @@ func (s InvalidZipFileException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidZipFileException) OrigErr() error {
+func (s *InvalidZipFileException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidZipFileException) Error() string {
+func (s *InvalidZipFileException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidZipFileException) StatusCode() int {
+func (s *InvalidZipFileException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidZipFileException) RequestID() string {
+func (s *InvalidZipFileException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9623,12 +9623,12 @@ func newErrorKMSAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSAccessDeniedException) Code() string {
+func (s *KMSAccessDeniedException) Code() string {
 	return "KMSAccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s KMSAccessDeniedException) Message() string {
+func (s *KMSAccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9636,21 +9636,21 @@ func (s KMSAccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSAccessDeniedException) OrigErr() error {
+func (s *KMSAccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s KMSAccessDeniedException) Error() string {
+func (s *KMSAccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSAccessDeniedException) StatusCode() int {
+func (s *KMSAccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSAccessDeniedException) RequestID() string {
+func (s *KMSAccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9682,12 +9682,12 @@ func newErrorKMSDisabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSDisabledException) Code() string {
+func (s *KMSDisabledException) Code() string {
 	return "KMSDisabledException"
 }
 
 // Message returns the exception's message.
-func (s KMSDisabledException) Message() string {
+func (s *KMSDisabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9695,21 +9695,21 @@ func (s KMSDisabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSDisabledException) OrigErr() error {
+func (s *KMSDisabledException) OrigErr() error {
 	return nil
 }
 
-func (s KMSDisabledException) Error() string {
+func (s *KMSDisabledException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSDisabledException) StatusCode() int {
+func (s *KMSDisabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSDisabledException) RequestID() string {
+func (s *KMSDisabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9741,12 +9741,12 @@ func newErrorKMSInvalidStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSInvalidStateException) Code() string {
+func (s *KMSInvalidStateException) Code() string {
 	return "KMSInvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s KMSInvalidStateException) Message() string {
+func (s *KMSInvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9754,21 +9754,21 @@ func (s KMSInvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSInvalidStateException) OrigErr() error {
+func (s *KMSInvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s KMSInvalidStateException) Error() string {
+func (s *KMSInvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSInvalidStateException) StatusCode() int {
+func (s *KMSInvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSInvalidStateException) RequestID() string {
+func (s *KMSInvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9800,12 +9800,12 @@ func newErrorKMSNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSNotFoundException) Code() string {
+func (s *KMSNotFoundException) Code() string {
 	return "KMSNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s KMSNotFoundException) Message() string {
+func (s *KMSNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9813,21 +9813,21 @@ func (s KMSNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSNotFoundException) OrigErr() error {
+func (s *KMSNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s KMSNotFoundException) Error() string {
+func (s *KMSNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSNotFoundException) StatusCode() int {
+func (s *KMSNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSNotFoundException) RequestID() string {
+func (s *KMSNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11073,12 +11073,12 @@ func newErrorPolicyLengthExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyLengthExceededException) Code() string {
+func (s *PolicyLengthExceededException) Code() string {
 	return "PolicyLengthExceededException"
 }
 
 // Message returns the exception's message.
-func (s PolicyLengthExceededException) Message() string {
+func (s *PolicyLengthExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11086,21 +11086,21 @@ func (s PolicyLengthExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyLengthExceededException) OrigErr() error {
+func (s *PolicyLengthExceededException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyLengthExceededException) Error() string {
+func (s *PolicyLengthExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyLengthExceededException) StatusCode() int {
+func (s *PolicyLengthExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyLengthExceededException) RequestID() string {
+func (s *PolicyLengthExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11135,12 +11135,12 @@ func newErrorPreconditionFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PreconditionFailedException) Code() string {
+func (s *PreconditionFailedException) Code() string {
 	return "PreconditionFailedException"
 }
 
 // Message returns the exception's message.
-func (s PreconditionFailedException) Message() string {
+func (s *PreconditionFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11148,21 +11148,21 @@ func (s PreconditionFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PreconditionFailedException) OrigErr() error {
+func (s *PreconditionFailedException) OrigErr() error {
 	return nil
 }
 
-func (s PreconditionFailedException) Error() string {
+func (s *PreconditionFailedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PreconditionFailedException) StatusCode() int {
+func (s *PreconditionFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PreconditionFailedException) RequestID() string {
+func (s *PreconditionFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11274,12 +11274,12 @@ func newErrorProvisionedConcurrencyConfigNotFoundException(v protocol.ResponseMe
 }
 
 // Code returns the exception type name.
-func (s ProvisionedConcurrencyConfigNotFoundException) Code() string {
+func (s *ProvisionedConcurrencyConfigNotFoundException) Code() string {
 	return "ProvisionedConcurrencyConfigNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ProvisionedConcurrencyConfigNotFoundException) Message() string {
+func (s *ProvisionedConcurrencyConfigNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11287,21 +11287,21 @@ func (s ProvisionedConcurrencyConfigNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProvisionedConcurrencyConfigNotFoundException) OrigErr() error {
+func (s *ProvisionedConcurrencyConfigNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ProvisionedConcurrencyConfigNotFoundException) Error() string {
+func (s *ProvisionedConcurrencyConfigNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProvisionedConcurrencyConfigNotFoundException) StatusCode() int {
+func (s *ProvisionedConcurrencyConfigNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProvisionedConcurrencyConfigNotFoundException) RequestID() string {
+func (s *ProvisionedConcurrencyConfigNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12224,12 +12224,12 @@ func newErrorRequestTooLargeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestTooLargeException) Code() string {
+func (s *RequestTooLargeException) Code() string {
 	return "RequestTooLargeException"
 }
 
 // Message returns the exception's message.
-func (s RequestTooLargeException) Message() string {
+func (s *RequestTooLargeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12237,21 +12237,21 @@ func (s RequestTooLargeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestTooLargeException) OrigErr() error {
+func (s *RequestTooLargeException) OrigErr() error {
 	return nil
 }
 
-func (s RequestTooLargeException) Error() string {
+func (s *RequestTooLargeException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestTooLargeException) StatusCode() int {
+func (s *RequestTooLargeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestTooLargeException) RequestID() string {
+func (s *RequestTooLargeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12284,12 +12284,12 @@ func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceConflictException) Code() string {
+func (s *ResourceConflictException) Code() string {
 	return "ResourceConflictException"
 }
 
 // Message returns the exception's message.
-func (s ResourceConflictException) Message() string {
+func (s *ResourceConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12297,21 +12297,21 @@ func (s ResourceConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceConflictException) OrigErr() error {
+func (s *ResourceConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceConflictException) Error() string {
+func (s *ResourceConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceConflictException) StatusCode() int {
+func (s *ResourceConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceConflictException) RequestID() string {
+func (s *ResourceConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12344,12 +12344,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12357,21 +12357,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12402,12 +12402,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12415,21 +12415,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12463,12 +12463,12 @@ func newErrorResourceNotReadyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotReadyException) Code() string {
+func (s *ResourceNotReadyException) Code() string {
 	return "ResourceNotReadyException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotReadyException) Message() string {
+func (s *ResourceNotReadyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12476,21 +12476,21 @@ func (s ResourceNotReadyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotReadyException) OrigErr() error {
+func (s *ResourceNotReadyException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotReadyException) Error() string {
+func (s *ResourceNotReadyException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotReadyException) StatusCode() int {
+func (s *ResourceNotReadyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotReadyException) RequestID() string {
+func (s *ResourceNotReadyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12521,12 +12521,12 @@ func newErrorServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceException) Code() string {
+func (s *ServiceException) Code() string {
 	return "ServiceException"
 }
 
 // Message returns the exception's message.
-func (s ServiceException) Message() string {
+func (s *ServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12534,21 +12534,21 @@ func (s ServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceException) OrigErr() error {
+func (s *ServiceException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceException) Error() string {
+func (s *ServiceException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceException) StatusCode() int {
+func (s *ServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceException) RequestID() string {
+func (s *ServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12580,12 +12580,12 @@ func newErrorSubnetIPAddressLimitReachedException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s SubnetIPAddressLimitReachedException) Code() string {
+func (s *SubnetIPAddressLimitReachedException) Code() string {
 	return "SubnetIPAddressLimitReachedException"
 }
 
 // Message returns the exception's message.
-func (s SubnetIPAddressLimitReachedException) Message() string {
+func (s *SubnetIPAddressLimitReachedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12593,21 +12593,21 @@ func (s SubnetIPAddressLimitReachedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubnetIPAddressLimitReachedException) OrigErr() error {
+func (s *SubnetIPAddressLimitReachedException) OrigErr() error {
 	return nil
 }
 
-func (s SubnetIPAddressLimitReachedException) Error() string {
+func (s *SubnetIPAddressLimitReachedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubnetIPAddressLimitReachedException) StatusCode() int {
+func (s *SubnetIPAddressLimitReachedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubnetIPAddressLimitReachedException) RequestID() string {
+func (s *SubnetIPAddressLimitReachedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12712,12 +12712,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12725,21 +12725,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12819,12 +12819,12 @@ func newErrorUnsupportedMediaTypeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedMediaTypeException) Code() string {
+func (s *UnsupportedMediaTypeException) Code() string {
 	return "UnsupportedMediaTypeException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedMediaTypeException) Message() string {
+func (s *UnsupportedMediaTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12832,21 +12832,21 @@ func (s UnsupportedMediaTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedMediaTypeException) OrigErr() error {
+func (s *UnsupportedMediaTypeException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedMediaTypeException) Error() string {
+func (s *UnsupportedMediaTypeException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedMediaTypeException) StatusCode() int {
+func (s *UnsupportedMediaTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedMediaTypeException) RequestID() string {
+func (s *UnsupportedMediaTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/lexmodelbuildingservice/api.go
+++ b/service/lexmodelbuildingservice/api.go
@@ -4568,12 +4568,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4581,21 +4581,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5048,12 +5048,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5061,21 +5061,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9265,12 +9265,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9278,21 +9278,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9323,12 +9323,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9336,21 +9336,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9666,12 +9666,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9679,21 +9679,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9723,12 +9723,12 @@ func newErrorPreconditionFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PreconditionFailedException) Code() string {
+func (s *PreconditionFailedException) Code() string {
 	return "PreconditionFailedException"
 }
 
 // Message returns the exception's message.
-func (s PreconditionFailedException) Message() string {
+func (s *PreconditionFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9736,21 +9736,21 @@ func (s PreconditionFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PreconditionFailedException) OrigErr() error {
+func (s *PreconditionFailedException) OrigErr() error {
 	return nil
 }
 
-func (s PreconditionFailedException) Error() string {
+func (s *PreconditionFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PreconditionFailedException) StatusCode() int {
+func (s *PreconditionFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PreconditionFailedException) RequestID() string {
+func (s *PreconditionFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11372,12 +11372,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11385,21 +11385,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -661,12 +661,12 @@ func newErrorBadGatewayException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadGatewayException) Code() string {
+func (s *BadGatewayException) Code() string {
 	return "BadGatewayException"
 }
 
 // Message returns the exception's message.
-func (s BadGatewayException) Message() string {
+func (s *BadGatewayException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -674,21 +674,21 @@ func (s BadGatewayException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadGatewayException) OrigErr() error {
+func (s *BadGatewayException) OrigErr() error {
 	return nil
 }
 
-func (s BadGatewayException) Error() string {
+func (s *BadGatewayException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadGatewayException) StatusCode() int {
+func (s *BadGatewayException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadGatewayException) RequestID() string {
+func (s *BadGatewayException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -718,12 +718,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -731,21 +731,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -814,12 +814,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -827,21 +827,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1004,12 +1004,12 @@ func newErrorDependencyFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DependencyFailedException) Code() string {
+func (s *DependencyFailedException) Code() string {
 	return "DependencyFailedException"
 }
 
 // Message returns the exception's message.
-func (s DependencyFailedException) Message() string {
+func (s *DependencyFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1017,21 +1017,21 @@ func (s DependencyFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DependencyFailedException) OrigErr() error {
+func (s *DependencyFailedException) OrigErr() error {
 	return nil
 }
 
-func (s DependencyFailedException) Error() string {
+func (s *DependencyFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DependencyFailedException) StatusCode() int {
+func (s *DependencyFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DependencyFailedException) RequestID() string {
+func (s *DependencyFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1541,12 +1541,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1554,21 +1554,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1599,12 +1599,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1612,21 +1612,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1655,12 +1655,12 @@ func newErrorLoopDetectedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LoopDetectedException) Code() string {
+func (s *LoopDetectedException) Code() string {
 	return "LoopDetectedException"
 }
 
 // Message returns the exception's message.
-func (s LoopDetectedException) Message() string {
+func (s *LoopDetectedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1668,21 +1668,21 @@ func (s LoopDetectedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LoopDetectedException) OrigErr() error {
+func (s *LoopDetectedException) OrigErr() error {
 	return nil
 }
 
-func (s LoopDetectedException) Error() string {
+func (s *LoopDetectedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LoopDetectedException) StatusCode() int {
+func (s *LoopDetectedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LoopDetectedException) RequestID() string {
+func (s *LoopDetectedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1711,12 +1711,12 @@ func newErrorNotAcceptableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotAcceptableException) Code() string {
+func (s *NotAcceptableException) Code() string {
 	return "NotAcceptableException"
 }
 
 // Message returns the exception's message.
-func (s NotAcceptableException) Message() string {
+func (s *NotAcceptableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1724,21 +1724,21 @@ func (s NotAcceptableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotAcceptableException) OrigErr() error {
+func (s *NotAcceptableException) OrigErr() error {
 	return nil
 }
 
-func (s NotAcceptableException) Error() string {
+func (s *NotAcceptableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotAcceptableException) StatusCode() int {
+func (s *NotAcceptableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotAcceptableException) RequestID() string {
+func (s *NotAcceptableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1768,12 +1768,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1781,21 +1781,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2861,12 +2861,12 @@ func newErrorRequestTimeoutException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestTimeoutException) Code() string {
+func (s *RequestTimeoutException) Code() string {
 	return "RequestTimeoutException"
 }
 
 // Message returns the exception's message.
-func (s RequestTimeoutException) Message() string {
+func (s *RequestTimeoutException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2874,21 +2874,21 @@ func (s RequestTimeoutException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestTimeoutException) OrigErr() error {
+func (s *RequestTimeoutException) OrigErr() error {
 	return nil
 }
 
-func (s RequestTimeoutException) Error() string {
+func (s *RequestTimeoutException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestTimeoutException) StatusCode() int {
+func (s *RequestTimeoutException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestTimeoutException) RequestID() string {
+func (s *RequestTimeoutException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2999,12 +2999,12 @@ func newErrorUnsupportedMediaTypeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedMediaTypeException) Code() string {
+func (s *UnsupportedMediaTypeException) Code() string {
 	return "UnsupportedMediaTypeException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedMediaTypeException) Message() string {
+func (s *UnsupportedMediaTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3012,21 +3012,21 @@ func (s UnsupportedMediaTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedMediaTypeException) OrigErr() error {
+func (s *UnsupportedMediaTypeException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedMediaTypeException) Error() string {
+func (s *UnsupportedMediaTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedMediaTypeException) StatusCode() int {
+func (s *UnsupportedMediaTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedMediaTypeException) RequestID() string {
+func (s *UnsupportedMediaTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/licensemanager/api.go
+++ b/service/licensemanager/api.go
@@ -1568,12 +1568,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1581,21 +1581,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1625,12 +1625,12 @@ func newErrorAuthorizationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AuthorizationException) Code() string {
+func (s *AuthorizationException) Code() string {
 	return "AuthorizationException"
 }
 
 // Message returns the exception's message.
-func (s AuthorizationException) Message() string {
+func (s *AuthorizationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1638,21 +1638,21 @@ func (s AuthorizationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AuthorizationException) OrigErr() error {
+func (s *AuthorizationException) OrigErr() error {
 	return nil
 }
 
-func (s AuthorizationException) Error() string {
+func (s *AuthorizationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AuthorizationException) StatusCode() int {
+func (s *AuthorizationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AuthorizationException) RequestID() string {
+func (s *AuthorizationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1941,12 +1941,12 @@ func newErrorFailedDependencyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FailedDependencyException) Code() string {
+func (s *FailedDependencyException) Code() string {
 	return "FailedDependencyException"
 }
 
 // Message returns the exception's message.
-func (s FailedDependencyException) Message() string {
+func (s *FailedDependencyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1954,21 +1954,21 @@ func (s FailedDependencyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FailedDependencyException) OrigErr() error {
+func (s *FailedDependencyException) OrigErr() error {
 	return nil
 }
 
-func (s FailedDependencyException) Error() string {
+func (s *FailedDependencyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FailedDependencyException) StatusCode() int {
+func (s *FailedDependencyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FailedDependencyException) RequestID() string {
+func (s *FailedDependencyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2032,12 +2032,12 @@ func newErrorFilterLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FilterLimitExceededException) Code() string {
+func (s *FilterLimitExceededException) Code() string {
 	return "FilterLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s FilterLimitExceededException) Message() string {
+func (s *FilterLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2045,21 +2045,21 @@ func (s FilterLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FilterLimitExceededException) OrigErr() error {
+func (s *FilterLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s FilterLimitExceededException) Error() string {
+func (s *FilterLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FilterLimitExceededException) StatusCode() int {
+func (s *FilterLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FilterLimitExceededException) RequestID() string {
+func (s *FilterLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2360,12 +2360,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2373,21 +2373,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2419,12 +2419,12 @@ func newErrorInvalidResourceStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceStateException) Code() string {
+func (s *InvalidResourceStateException) Code() string {
 	return "InvalidResourceStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceStateException) Message() string {
+func (s *InvalidResourceStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2432,21 +2432,21 @@ func (s InvalidResourceStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceStateException) OrigErr() error {
+func (s *InvalidResourceStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceStateException) Error() string {
+func (s *InvalidResourceStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceStateException) StatusCode() int {
+func (s *InvalidResourceStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceStateException) RequestID() string {
+func (s *InvalidResourceStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2938,12 +2938,12 @@ func newErrorLicenseUsageException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LicenseUsageException) Code() string {
+func (s *LicenseUsageException) Code() string {
 	return "LicenseUsageException"
 }
 
 // Message returns the exception's message.
-func (s LicenseUsageException) Message() string {
+func (s *LicenseUsageException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2951,21 +2951,21 @@ func (s LicenseUsageException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LicenseUsageException) OrigErr() error {
+func (s *LicenseUsageException) OrigErr() error {
 	return nil
 }
 
-func (s LicenseUsageException) Error() string {
+func (s *LicenseUsageException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LicenseUsageException) StatusCode() int {
+func (s *LicenseUsageException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LicenseUsageException) RequestID() string {
+func (s *LicenseUsageException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3881,12 +3881,12 @@ func newErrorRateLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RateLimitExceededException) Code() string {
+func (s *RateLimitExceededException) Code() string {
 	return "RateLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s RateLimitExceededException) Message() string {
+func (s *RateLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3894,21 +3894,21 @@ func (s RateLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RateLimitExceededException) OrigErr() error {
+func (s *RateLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s RateLimitExceededException) Error() string {
+func (s *RateLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RateLimitExceededException) StatusCode() int {
+func (s *RateLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RateLimitExceededException) RequestID() string {
+func (s *RateLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4006,12 +4006,12 @@ func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceededException) Code() string {
+func (s *ResourceLimitExceededException) Code() string {
 	return "ResourceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceededException) Message() string {
+func (s *ResourceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4019,21 +4019,21 @@ func (s ResourceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceededException) OrigErr() error {
+func (s *ResourceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceededException) Error() string {
+func (s *ResourceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceededException) StatusCode() int {
+func (s *ResourceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceededException) RequestID() string {
+func (s *ResourceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4062,12 +4062,12 @@ func newErrorServerInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServerInternalException) Code() string {
+func (s *ServerInternalException) Code() string {
 	return "ServerInternalException"
 }
 
 // Message returns the exception's message.
-func (s ServerInternalException) Message() string {
+func (s *ServerInternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4075,21 +4075,21 @@ func (s ServerInternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServerInternalException) OrigErr() error {
+func (s *ServerInternalException) OrigErr() error {
 	return nil
 }
 
-func (s ServerInternalException) Error() string {
+func (s *ServerInternalException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServerInternalException) StatusCode() int {
+func (s *ServerInternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServerInternalException) RequestID() string {
+func (s *ServerInternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/lightsail/api.go
+++ b/service/lightsail/api.go
@@ -12195,12 +12195,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12208,21 +12208,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12258,12 +12258,12 @@ func newErrorAccountSetupInProgressException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s AccountSetupInProgressException) Code() string {
+func (s *AccountSetupInProgressException) Code() string {
 	return "AccountSetupInProgressException"
 }
 
 // Message returns the exception's message.
-func (s AccountSetupInProgressException) Message() string {
+func (s *AccountSetupInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12271,21 +12271,21 @@ func (s AccountSetupInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountSetupInProgressException) OrigErr() error {
+func (s *AccountSetupInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s AccountSetupInProgressException) Error() string {
+func (s *AccountSetupInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountSetupInProgressException) StatusCode() int {
+func (s *AccountSetupInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountSetupInProgressException) RequestID() string {
+func (s *AccountSetupInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23459,12 +23459,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23472,21 +23472,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24443,12 +24443,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24456,21 +24456,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24705,12 +24705,12 @@ func newErrorOperationFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationFailureException) Code() string {
+func (s *OperationFailureException) Code() string {
 	return "OperationFailureException"
 }
 
 // Message returns the exception's message.
-func (s OperationFailureException) Message() string {
+func (s *OperationFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24718,21 +24718,21 @@ func (s OperationFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationFailureException) OrigErr() error {
+func (s *OperationFailureException) OrigErr() error {
 	return nil
 }
 
-func (s OperationFailureException) Error() string {
+func (s *OperationFailureException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationFailureException) StatusCode() int {
+func (s *OperationFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationFailureException) RequestID() string {
+func (s *OperationFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26484,12 +26484,12 @@ func newErrorServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceException) Code() string {
+func (s *ServiceException) Code() string {
 	return "ServiceException"
 }
 
 // Message returns the exception's message.
-func (s ServiceException) Message() string {
+func (s *ServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26497,21 +26497,21 @@ func (s ServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceException) OrigErr() error {
+func (s *ServiceException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceException) Error() string {
+func (s *ServiceException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceException) StatusCode() int {
+func (s *ServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceException) RequestID() string {
+func (s *ServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27136,12 +27136,12 @@ func newErrorUnauthenticatedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthenticatedException) Code() string {
+func (s *UnauthenticatedException) Code() string {
 	return "UnauthenticatedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthenticatedException) Message() string {
+func (s *UnauthenticatedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27149,21 +27149,21 @@ func (s UnauthenticatedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthenticatedException) OrigErr() error {
+func (s *UnauthenticatedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthenticatedException) Error() string {
+func (s *UnauthenticatedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthenticatedException) StatusCode() int {
+func (s *UnauthenticatedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthenticatedException) RequestID() string {
+func (s *UnauthenticatedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -6871,12 +6871,12 @@ func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatchException) Code() string {
+func (s *IdempotentParameterMismatchException) Code() string {
 	return "IdempotentParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatchException) Message() string {
+func (s *IdempotentParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6884,21 +6884,21 @@ func (s IdempotentParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatchException) OrigErr() error {
+func (s *IdempotentParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatchException) Error() string {
+func (s *IdempotentParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatchException) StatusCode() int {
+func (s *IdempotentParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatchException) RequestID() string {
+func (s *IdempotentParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6929,12 +6929,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6942,21 +6942,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6988,12 +6988,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7001,21 +7001,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7043,12 +7043,12 @@ func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagException) Code() string {
+func (s *InvalidTagException) Code() string {
 	return "InvalidTagException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagException) Message() string {
+func (s *InvalidTagException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7056,21 +7056,21 @@ func (s InvalidTagException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagException) OrigErr() error {
+func (s *InvalidTagException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagException) Error() string {
+func (s *InvalidTagException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagException) StatusCode() int {
+func (s *InvalidTagException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagException) RequestID() string {
+func (s *InvalidTagException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7102,12 +7102,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7115,21 +7115,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7611,12 +7611,12 @@ func newErrorPredictorNotMountedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PredictorNotMountedException) Code() string {
+func (s *PredictorNotMountedException) Code() string {
 	return "PredictorNotMountedException"
 }
 
 // Message returns the exception's message.
-func (s PredictorNotMountedException) Message() string {
+func (s *PredictorNotMountedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7624,21 +7624,21 @@ func (s PredictorNotMountedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PredictorNotMountedException) OrigErr() error {
+func (s *PredictorNotMountedException) OrigErr() error {
 	return nil
 }
 
-func (s PredictorNotMountedException) Error() string {
+func (s *PredictorNotMountedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PredictorNotMountedException) StatusCode() int {
+func (s *PredictorNotMountedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PredictorNotMountedException) RequestID() string {
+func (s *PredictorNotMountedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8602,12 +8602,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8615,21 +8615,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8859,12 +8859,12 @@ func newErrorTagLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagLimitExceededException) Code() string {
+func (s *TagLimitExceededException) Code() string {
 	return "TagLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TagLimitExceededException) Message() string {
+func (s *TagLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8872,21 +8872,21 @@ func (s TagLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagLimitExceededException) OrigErr() error {
+func (s *TagLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TagLimitExceededException) Error() string {
+func (s *TagLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagLimitExceededException) StatusCode() int {
+func (s *TagLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagLimitExceededException) RequestID() string {
+func (s *TagLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/macie/api.go
+++ b/service/macie/api.go
@@ -775,12 +775,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -788,21 +788,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1242,12 +1242,12 @@ func newErrorInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalException) Code() string {
+func (s *InternalException) Code() string {
 	return "InternalException"
 }
 
 // Message returns the exception's message.
-func (s InternalException) Message() string {
+func (s *InternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1255,21 +1255,21 @@ func (s InternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalException) OrigErr() error {
+func (s *InternalException) OrigErr() error {
 	return nil
 }
 
-func (s InternalException) Error() string {
+func (s *InternalException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalException) StatusCode() int {
+func (s *InternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalException) RequestID() string {
+func (s *InternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1305,12 +1305,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1318,21 +1318,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1368,12 +1368,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1381,21 +1381,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/managedblockchain/api.go
+++ b/service/managedblockchain/api.go
@@ -2380,12 +2380,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2393,21 +2393,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3532,12 +3532,12 @@ func newErrorIllegalActionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IllegalActionException) Code() string {
+func (s *IllegalActionException) Code() string {
 	return "IllegalActionException"
 }
 
 // Message returns the exception's message.
-func (s IllegalActionException) Message() string {
+func (s *IllegalActionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3545,21 +3545,21 @@ func (s IllegalActionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IllegalActionException) OrigErr() error {
+func (s *IllegalActionException) OrigErr() error {
 	return nil
 }
 
-func (s IllegalActionException) Error() string {
+func (s *IllegalActionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IllegalActionException) StatusCode() int {
+func (s *IllegalActionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IllegalActionException) RequestID() string {
+func (s *IllegalActionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3589,12 +3589,12 @@ func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceErrorException) Code() string {
+func (s *InternalServiceErrorException) Code() string {
 	return "InternalServiceErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceErrorException) Message() string {
+func (s *InternalServiceErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3602,21 +3602,21 @@ func (s InternalServiceErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceErrorException) OrigErr() error {
+func (s *InternalServiceErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceErrorException) Error() string {
+func (s *InternalServiceErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceErrorException) StatusCode() int {
+func (s *InternalServiceErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceErrorException) RequestID() string {
+func (s *InternalServiceErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3646,12 +3646,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3659,21 +3659,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6079,12 +6079,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6092,21 +6092,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6137,12 +6137,12 @@ func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceededException) Code() string {
+func (s *ResourceLimitExceededException) Code() string {
 	return "ResourceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceededException) Message() string {
+func (s *ResourceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6150,21 +6150,21 @@ func (s ResourceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceededException) OrigErr() error {
+func (s *ResourceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceededException) Error() string {
+func (s *ResourceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceededException) StatusCode() int {
+func (s *ResourceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceededException) RequestID() string {
+func (s *ResourceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6194,12 +6194,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6207,21 +6207,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6251,12 +6251,12 @@ func newErrorResourceNotReadyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotReadyException) Code() string {
+func (s *ResourceNotReadyException) Code() string {
 	return "ResourceNotReadyException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotReadyException) Message() string {
+func (s *ResourceNotReadyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6264,21 +6264,21 @@ func (s ResourceNotReadyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotReadyException) OrigErr() error {
+func (s *ResourceNotReadyException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotReadyException) Error() string {
+func (s *ResourceNotReadyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotReadyException) StatusCode() int {
+func (s *ResourceNotReadyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotReadyException) RequestID() string {
+func (s *ResourceNotReadyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6310,12 +6310,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6323,21 +6323,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/marketplacecatalog/api.go
+++ b/service/marketplacecatalog/api.go
@@ -716,12 +716,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -729,21 +729,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1577,12 +1577,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1590,21 +1590,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1921,12 +1921,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1934,21 +1934,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1977,12 +1977,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1990,21 +1990,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2033,12 +2033,12 @@ func newErrorResourceNotSupportedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotSupportedException) Code() string {
+func (s *ResourceNotSupportedException) Code() string {
 	return "ResourceNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotSupportedException) Message() string {
+func (s *ResourceNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2046,21 +2046,21 @@ func (s ResourceNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotSupportedException) OrigErr() error {
+func (s *ResourceNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotSupportedException) Error() string {
+func (s *ResourceNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotSupportedException) StatusCode() int {
+func (s *ResourceNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotSupportedException) RequestID() string {
+func (s *ResourceNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2089,12 +2089,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2102,21 +2102,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2319,12 +2319,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2332,21 +2332,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2375,12 +2375,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2388,21 +2388,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/marketplacecommerceanalytics/api.go
+++ b/service/marketplacecommerceanalytics/api.go
@@ -215,12 +215,12 @@ func newErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s Exception) Code() string {
+func (s *Exception) Code() string {
 	return "MarketplaceCommerceAnalyticsException"
 }
 
 // Message returns the exception's message.
-func (s Exception) Message() string {
+func (s *Exception) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -228,21 +228,21 @@ func (s Exception) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s Exception) OrigErr() error {
+func (s *Exception) OrigErr() error {
 	return nil
 }
 
-func (s Exception) Error() string {
+func (s *Exception) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s Exception) StatusCode() int {
+func (s *Exception) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s Exception) RequestID() string {
+func (s *Exception) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/marketplaceentitlementservice/api.go
+++ b/service/marketplaceentitlementservice/api.go
@@ -366,12 +366,12 @@ func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceErrorException) Code() string {
+func (s *InternalServiceErrorException) Code() string {
 	return "InternalServiceErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceErrorException) Message() string {
+func (s *InternalServiceErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -379,21 +379,21 @@ func (s InternalServiceErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceErrorException) OrigErr() error {
+func (s *InternalServiceErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceErrorException) Error() string {
+func (s *InternalServiceErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceErrorException) StatusCode() int {
+func (s *InternalServiceErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceErrorException) RequestID() string {
+func (s *InternalServiceErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -422,12 +422,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -435,21 +435,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -478,12 +478,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -491,21 +491,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/marketplacemetering/api.go
+++ b/service/marketplacemetering/api.go
@@ -601,12 +601,12 @@ func newErrorCustomerNotEntitledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CustomerNotEntitledException) Code() string {
+func (s *CustomerNotEntitledException) Code() string {
 	return "CustomerNotEntitledException"
 }
 
 // Message returns the exception's message.
-func (s CustomerNotEntitledException) Message() string {
+func (s *CustomerNotEntitledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -614,21 +614,21 @@ func (s CustomerNotEntitledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CustomerNotEntitledException) OrigErr() error {
+func (s *CustomerNotEntitledException) OrigErr() error {
 	return nil
 }
 
-func (s CustomerNotEntitledException) Error() string {
+func (s *CustomerNotEntitledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CustomerNotEntitledException) StatusCode() int {
+func (s *CustomerNotEntitledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CustomerNotEntitledException) RequestID() string {
+func (s *CustomerNotEntitledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -657,12 +657,12 @@ func newErrorDisabledApiException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DisabledApiException) Code() string {
+func (s *DisabledApiException) Code() string {
 	return "DisabledApiException"
 }
 
 // Message returns the exception's message.
-func (s DisabledApiException) Message() string {
+func (s *DisabledApiException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -670,21 +670,21 @@ func (s DisabledApiException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DisabledApiException) OrigErr() error {
+func (s *DisabledApiException) OrigErr() error {
 	return nil
 }
 
-func (s DisabledApiException) Error() string {
+func (s *DisabledApiException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DisabledApiException) StatusCode() int {
+func (s *DisabledApiException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DisabledApiException) RequestID() string {
+func (s *DisabledApiException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -715,12 +715,12 @@ func newErrorDuplicateRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateRequestException) Code() string {
+func (s *DuplicateRequestException) Code() string {
 	return "DuplicateRequestException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateRequestException) Message() string {
+func (s *DuplicateRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -728,21 +728,21 @@ func (s DuplicateRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateRequestException) OrigErr() error {
+func (s *DuplicateRequestException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateRequestException) Error() string {
+func (s *DuplicateRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateRequestException) StatusCode() int {
+func (s *DuplicateRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateRequestException) RequestID() string {
+func (s *DuplicateRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -775,12 +775,12 @@ func newErrorExpiredTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExpiredTokenException) Code() string {
+func (s *ExpiredTokenException) Code() string {
 	return "ExpiredTokenException"
 }
 
 // Message returns the exception's message.
-func (s ExpiredTokenException) Message() string {
+func (s *ExpiredTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -788,21 +788,21 @@ func (s ExpiredTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExpiredTokenException) OrigErr() error {
+func (s *ExpiredTokenException) OrigErr() error {
 	return nil
 }
 
-func (s ExpiredTokenException) Error() string {
+func (s *ExpiredTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExpiredTokenException) StatusCode() int {
+func (s *ExpiredTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExpiredTokenException) RequestID() string {
+func (s *ExpiredTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -832,12 +832,12 @@ func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceErrorException) Code() string {
+func (s *InternalServiceErrorException) Code() string {
 	return "InternalServiceErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceErrorException) Message() string {
+func (s *InternalServiceErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -845,21 +845,21 @@ func (s InternalServiceErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceErrorException) OrigErr() error {
+func (s *InternalServiceErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceErrorException) Error() string {
+func (s *InternalServiceErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceErrorException) StatusCode() int {
+func (s *InternalServiceErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceErrorException) RequestID() string {
+func (s *InternalServiceErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -888,12 +888,12 @@ func newErrorInvalidCustomerIdentifierException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s InvalidCustomerIdentifierException) Code() string {
+func (s *InvalidCustomerIdentifierException) Code() string {
 	return "InvalidCustomerIdentifierException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCustomerIdentifierException) Message() string {
+func (s *InvalidCustomerIdentifierException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -901,21 +901,21 @@ func (s InvalidCustomerIdentifierException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCustomerIdentifierException) OrigErr() error {
+func (s *InvalidCustomerIdentifierException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCustomerIdentifierException) Error() string {
+func (s *InvalidCustomerIdentifierException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCustomerIdentifierException) StatusCode() int {
+func (s *InvalidCustomerIdentifierException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCustomerIdentifierException) RequestID() string {
+func (s *InvalidCustomerIdentifierException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -946,12 +946,12 @@ func newErrorInvalidEndpointRegionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidEndpointRegionException) Code() string {
+func (s *InvalidEndpointRegionException) Code() string {
 	return "InvalidEndpointRegionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidEndpointRegionException) Message() string {
+func (s *InvalidEndpointRegionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -959,21 +959,21 @@ func (s InvalidEndpointRegionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidEndpointRegionException) OrigErr() error {
+func (s *InvalidEndpointRegionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidEndpointRegionException) Error() string {
+func (s *InvalidEndpointRegionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidEndpointRegionException) StatusCode() int {
+func (s *InvalidEndpointRegionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidEndpointRegionException) RequestID() string {
+func (s *InvalidEndpointRegionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1003,12 +1003,12 @@ func newErrorInvalidProductCodeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidProductCodeException) Code() string {
+func (s *InvalidProductCodeException) Code() string {
 	return "InvalidProductCodeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidProductCodeException) Message() string {
+func (s *InvalidProductCodeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1016,21 +1016,21 @@ func (s InvalidProductCodeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidProductCodeException) OrigErr() error {
+func (s *InvalidProductCodeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidProductCodeException) Error() string {
+func (s *InvalidProductCodeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidProductCodeException) StatusCode() int {
+func (s *InvalidProductCodeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidProductCodeException) RequestID() string {
+func (s *InvalidProductCodeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1059,12 +1059,12 @@ func newErrorInvalidPublicKeyVersionException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidPublicKeyVersionException) Code() string {
+func (s *InvalidPublicKeyVersionException) Code() string {
 	return "InvalidPublicKeyVersionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPublicKeyVersionException) Message() string {
+func (s *InvalidPublicKeyVersionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1072,21 +1072,21 @@ func (s InvalidPublicKeyVersionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPublicKeyVersionException) OrigErr() error {
+func (s *InvalidPublicKeyVersionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPublicKeyVersionException) Error() string {
+func (s *InvalidPublicKeyVersionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPublicKeyVersionException) StatusCode() int {
+func (s *InvalidPublicKeyVersionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPublicKeyVersionException) RequestID() string {
+func (s *InvalidPublicKeyVersionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1117,12 +1117,12 @@ func newErrorInvalidRegionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRegionException) Code() string {
+func (s *InvalidRegionException) Code() string {
 	return "InvalidRegionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRegionException) Message() string {
+func (s *InvalidRegionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1130,21 +1130,21 @@ func (s InvalidRegionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRegionException) OrigErr() error {
+func (s *InvalidRegionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRegionException) Error() string {
+func (s *InvalidRegionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRegionException) StatusCode() int {
+func (s *InvalidRegionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRegionException) RequestID() string {
+func (s *InvalidRegionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1173,12 +1173,12 @@ func newErrorInvalidTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTokenException) Code() string {
+func (s *InvalidTokenException) Code() string {
 	return "InvalidTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTokenException) Message() string {
+func (s *InvalidTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1186,21 +1186,21 @@ func (s InvalidTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTokenException) OrigErr() error {
+func (s *InvalidTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTokenException) Error() string {
+func (s *InvalidTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTokenException) StatusCode() int {
+func (s *InvalidTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTokenException) RequestID() string {
+func (s *InvalidTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1230,12 +1230,12 @@ func newErrorInvalidUsageDimensionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidUsageDimensionException) Code() string {
+func (s *InvalidUsageDimensionException) Code() string {
 	return "InvalidUsageDimensionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidUsageDimensionException) Message() string {
+func (s *InvalidUsageDimensionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1243,21 +1243,21 @@ func (s InvalidUsageDimensionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidUsageDimensionException) OrigErr() error {
+func (s *InvalidUsageDimensionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidUsageDimensionException) Error() string {
+func (s *InvalidUsageDimensionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidUsageDimensionException) StatusCode() int {
+func (s *InvalidUsageDimensionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidUsageDimensionException) RequestID() string {
+func (s *InvalidUsageDimensionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1407,12 +1407,12 @@ func newErrorPlatformNotSupportedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PlatformNotSupportedException) Code() string {
+func (s *PlatformNotSupportedException) Code() string {
 	return "PlatformNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s PlatformNotSupportedException) Message() string {
+func (s *PlatformNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1420,21 +1420,21 @@ func (s PlatformNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PlatformNotSupportedException) OrigErr() error {
+func (s *PlatformNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s PlatformNotSupportedException) Error() string {
+func (s *PlatformNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PlatformNotSupportedException) StatusCode() int {
+func (s *PlatformNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PlatformNotSupportedException) RequestID() string {
+func (s *PlatformNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1644,12 +1644,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1657,21 +1657,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1700,12 +1700,12 @@ func newErrorTimestampOutOfBoundsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TimestampOutOfBoundsException) Code() string {
+func (s *TimestampOutOfBoundsException) Code() string {
 	return "TimestampOutOfBoundsException"
 }
 
 // Message returns the exception's message.
-func (s TimestampOutOfBoundsException) Message() string {
+func (s *TimestampOutOfBoundsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1713,21 +1713,21 @@ func (s TimestampOutOfBoundsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TimestampOutOfBoundsException) OrigErr() error {
+func (s *TimestampOutOfBoundsException) OrigErr() error {
 	return nil
 }
 
-func (s TimestampOutOfBoundsException) Error() string {
+func (s *TimestampOutOfBoundsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TimestampOutOfBoundsException) StatusCode() int {
+func (s *TimestampOutOfBoundsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TimestampOutOfBoundsException) RequestID() string {
+func (s *TimestampOutOfBoundsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mediaconnect/api.go
+++ b/service/mediaconnect/api.go
@@ -2238,12 +2238,12 @@ func newErrorAddFlowOutputs420Exception(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AddFlowOutputs420Exception) Code() string {
+func (s *AddFlowOutputs420Exception) Code() string {
 	return "AddFlowOutputs420Exception"
 }
 
 // Message returns the exception's message.
-func (s AddFlowOutputs420Exception) Message() string {
+func (s *AddFlowOutputs420Exception) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2251,21 +2251,21 @@ func (s AddFlowOutputs420Exception) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AddFlowOutputs420Exception) OrigErr() error {
+func (s *AddFlowOutputs420Exception) OrigErr() error {
 	return nil
 }
 
-func (s AddFlowOutputs420Exception) Error() string {
+func (s *AddFlowOutputs420Exception) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AddFlowOutputs420Exception) StatusCode() int {
+func (s *AddFlowOutputs420Exception) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AddFlowOutputs420Exception) RequestID() string {
+func (s *AddFlowOutputs420Exception) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2631,12 +2631,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2644,21 +2644,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2689,12 +2689,12 @@ func newErrorCreateFlow420Exception(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CreateFlow420Exception) Code() string {
+func (s *CreateFlow420Exception) Code() string {
 	return "CreateFlow420Exception"
 }
 
 // Message returns the exception's message.
-func (s CreateFlow420Exception) Message() string {
+func (s *CreateFlow420Exception) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2702,21 +2702,21 @@ func (s CreateFlow420Exception) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CreateFlow420Exception) OrigErr() error {
+func (s *CreateFlow420Exception) OrigErr() error {
 	return nil
 }
 
-func (s CreateFlow420Exception) Error() string {
+func (s *CreateFlow420Exception) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CreateFlow420Exception) StatusCode() int {
+func (s *CreateFlow420Exception) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CreateFlow420Exception) RequestID() string {
+func (s *CreateFlow420Exception) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3415,12 +3415,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3428,21 +3428,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3559,12 +3559,12 @@ func newErrorGrantFlowEntitlements420Exception(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s GrantFlowEntitlements420Exception) Code() string {
+func (s *GrantFlowEntitlements420Exception) Code() string {
 	return "GrantFlowEntitlements420Exception"
 }
 
 // Message returns the exception's message.
-func (s GrantFlowEntitlements420Exception) Message() string {
+func (s *GrantFlowEntitlements420Exception) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3572,21 +3572,21 @@ func (s GrantFlowEntitlements420Exception) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GrantFlowEntitlements420Exception) OrigErr() error {
+func (s *GrantFlowEntitlements420Exception) OrigErr() error {
 	return nil
 }
 
-func (s GrantFlowEntitlements420Exception) Error() string {
+func (s *GrantFlowEntitlements420Exception) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GrantFlowEntitlements420Exception) StatusCode() int {
+func (s *GrantFlowEntitlements420Exception) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GrantFlowEntitlements420Exception) RequestID() string {
+func (s *GrantFlowEntitlements420Exception) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3714,12 +3714,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3727,21 +3727,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4156,12 +4156,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4169,21 +4169,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4591,12 +4591,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4604,21 +4604,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5104,12 +5104,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5117,21 +5117,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -3930,12 +3930,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3943,21 +3943,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5370,12 +5370,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5383,21 +5383,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8238,12 +8238,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8251,21 +8251,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11545,12 +11545,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11558,21 +11558,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14982,12 +14982,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14995,21 +14995,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16992,12 +16992,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17005,21 +17005,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/medialive/api.go
+++ b/service/medialive/api.go
@@ -5538,12 +5538,12 @@ func newErrorBadGatewayException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadGatewayException) Code() string {
+func (s *BadGatewayException) Code() string {
 	return "BadGatewayException"
 }
 
 // Message returns the exception's message.
-func (s BadGatewayException) Message() string {
+func (s *BadGatewayException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5551,21 +5551,21 @@ func (s BadGatewayException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadGatewayException) OrigErr() error {
+func (s *BadGatewayException) OrigErr() error {
 	return nil
 }
 
-func (s BadGatewayException) Error() string {
+func (s *BadGatewayException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadGatewayException) StatusCode() int {
+func (s *BadGatewayException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadGatewayException) RequestID() string {
+func (s *BadGatewayException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5593,12 +5593,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5606,21 +5606,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7007,12 +7007,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7020,21 +7020,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10800,12 +10800,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10813,21 +10813,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10977,12 +10977,12 @@ func newErrorGatewayTimeoutException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s GatewayTimeoutException) Code() string {
+func (s *GatewayTimeoutException) Code() string {
 	return "GatewayTimeoutException"
 }
 
 // Message returns the exception's message.
-func (s GatewayTimeoutException) Message() string {
+func (s *GatewayTimeoutException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10990,21 +10990,21 @@ func (s GatewayTimeoutException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GatewayTimeoutException) OrigErr() error {
+func (s *GatewayTimeoutException) OrigErr() error {
 	return nil
 }
 
-func (s GatewayTimeoutException) Error() string {
+func (s *GatewayTimeoutException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GatewayTimeoutException) StatusCode() int {
+func (s *GatewayTimeoutException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GatewayTimeoutException) RequestID() string {
+func (s *GatewayTimeoutException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14246,12 +14246,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14259,21 +14259,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17213,12 +17213,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17226,21 +17226,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20837,12 +20837,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20850,21 +20850,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -21092,12 +21092,12 @@ func newErrorUnprocessableEntityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnprocessableEntityException) Code() string {
+func (s *UnprocessableEntityException) Code() string {
 	return "UnprocessableEntityException"
 }
 
 // Message returns the exception's message.
-func (s UnprocessableEntityException) Message() string {
+func (s *UnprocessableEntityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21105,21 +21105,21 @@ func (s UnprocessableEntityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnprocessableEntityException) OrigErr() error {
+func (s *UnprocessableEntityException) OrigErr() error {
 	return nil
 }
 
-func (s UnprocessableEntityException) Error() string {
+func (s *UnprocessableEntityException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnprocessableEntityException) StatusCode() int {
+func (s *UnprocessableEntityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnprocessableEntityException) RequestID() string {
+func (s *UnprocessableEntityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mediapackage/api.go
+++ b/service/mediapackage/api.go
@@ -3435,12 +3435,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3448,21 +3448,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4143,12 +4143,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4156,21 +4156,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4613,12 +4613,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4626,21 +4626,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5109,12 +5109,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5122,21 +5122,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5365,12 +5365,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5378,21 +5378,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5420,12 +5420,12 @@ func newErrorUnprocessableEntityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnprocessableEntityException) Code() string {
+func (s *UnprocessableEntityException) Code() string {
 	return "UnprocessableEntityException"
 }
 
 // Message returns the exception's message.
-func (s UnprocessableEntityException) Message() string {
+func (s *UnprocessableEntityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5433,21 +5433,21 @@ func (s UnprocessableEntityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnprocessableEntityException) OrigErr() error {
+func (s *UnprocessableEntityException) OrigErr() error {
 	return nil
 }
 
-func (s UnprocessableEntityException) Error() string {
+func (s *UnprocessableEntityException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnprocessableEntityException) StatusCode() int {
+func (s *UnprocessableEntityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnprocessableEntityException) RequestID() string {
+func (s *UnprocessableEntityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mediapackagevod/api.go
+++ b/service/mediapackagevod/api.go
@@ -2564,12 +2564,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2577,21 +2577,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2835,12 +2835,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2848,21 +2848,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3265,12 +3265,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3278,21 +3278,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3440,12 +3440,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3453,21 +3453,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3606,12 +3606,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3619,21 +3619,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3661,12 +3661,12 @@ func newErrorUnprocessableEntityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnprocessableEntityException) Code() string {
+func (s *UnprocessableEntityException) Code() string {
 	return "UnprocessableEntityException"
 }
 
 // Message returns the exception's message.
-func (s UnprocessableEntityException) Message() string {
+func (s *UnprocessableEntityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3674,21 +3674,21 @@ func (s UnprocessableEntityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnprocessableEntityException) OrigErr() error {
+func (s *UnprocessableEntityException) OrigErr() error {
 	return nil
 }
 
-func (s UnprocessableEntityException) Error() string {
+func (s *UnprocessableEntityException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnprocessableEntityException) StatusCode() int {
+func (s *UnprocessableEntityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnprocessableEntityException) RequestID() string {
+func (s *UnprocessableEntityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mediastore/api.go
+++ b/service/mediastore/api.go
@@ -1813,12 +1813,12 @@ func newErrorContainerInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ContainerInUseException) Code() string {
+func (s *ContainerInUseException) Code() string {
 	return "ContainerInUseException"
 }
 
 // Message returns the exception's message.
-func (s ContainerInUseException) Message() string {
+func (s *ContainerInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1826,21 +1826,21 @@ func (s ContainerInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ContainerInUseException) OrigErr() error {
+func (s *ContainerInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ContainerInUseException) Error() string {
+func (s *ContainerInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ContainerInUseException) StatusCode() int {
+func (s *ContainerInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ContainerInUseException) RequestID() string {
+func (s *ContainerInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1869,12 +1869,12 @@ func newErrorContainerNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ContainerNotFoundException) Code() string {
+func (s *ContainerNotFoundException) Code() string {
 	return "ContainerNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ContainerNotFoundException) Message() string {
+func (s *ContainerNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1882,21 +1882,21 @@ func (s ContainerNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ContainerNotFoundException) OrigErr() error {
+func (s *ContainerNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ContainerNotFoundException) Error() string {
+func (s *ContainerNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ContainerNotFoundException) StatusCode() int {
+func (s *ContainerNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ContainerNotFoundException) RequestID() string {
+func (s *ContainerNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1925,12 +1925,12 @@ func newErrorCorsPolicyNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CorsPolicyNotFoundException) Code() string {
+func (s *CorsPolicyNotFoundException) Code() string {
 	return "CorsPolicyNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s CorsPolicyNotFoundException) Message() string {
+func (s *CorsPolicyNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1938,21 +1938,21 @@ func (s CorsPolicyNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CorsPolicyNotFoundException) OrigErr() error {
+func (s *CorsPolicyNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s CorsPolicyNotFoundException) Error() string {
+func (s *CorsPolicyNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CorsPolicyNotFoundException) StatusCode() int {
+func (s *CorsPolicyNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CorsPolicyNotFoundException) RequestID() string {
+func (s *CorsPolicyNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2673,12 +2673,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2686,21 +2686,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2729,12 +2729,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2742,21 +2742,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2937,12 +2937,12 @@ func newErrorPolicyNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyNotFoundException) Code() string {
+func (s *PolicyNotFoundException) Code() string {
 	return "PolicyNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s PolicyNotFoundException) Message() string {
+func (s *PolicyNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2950,21 +2950,21 @@ func (s PolicyNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyNotFoundException) OrigErr() error {
+func (s *PolicyNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyNotFoundException) Error() string {
+func (s *PolicyNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyNotFoundException) StatusCode() int {
+func (s *PolicyNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyNotFoundException) RequestID() string {
+func (s *PolicyNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mediastoredata/api.go
+++ b/service/mediastoredata/api.go
@@ -528,12 +528,12 @@ func newErrorContainerNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ContainerNotFoundException) Code() string {
+func (s *ContainerNotFoundException) Code() string {
 	return "ContainerNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ContainerNotFoundException) Message() string {
+func (s *ContainerNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -541,21 +541,21 @@ func (s ContainerNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ContainerNotFoundException) OrigErr() error {
+func (s *ContainerNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ContainerNotFoundException) Error() string {
+func (s *ContainerNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ContainerNotFoundException) StatusCode() int {
+func (s *ContainerNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ContainerNotFoundException) RequestID() string {
+func (s *ContainerNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -915,12 +915,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -928,21 +928,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1145,12 +1145,12 @@ func newErrorObjectNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ObjectNotFoundException) Code() string {
+func (s *ObjectNotFoundException) Code() string {
 	return "ObjectNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ObjectNotFoundException) Message() string {
+func (s *ObjectNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1158,21 +1158,21 @@ func (s ObjectNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ObjectNotFoundException) OrigErr() error {
+func (s *ObjectNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ObjectNotFoundException) Error() string {
+func (s *ObjectNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ObjectNotFoundException) StatusCode() int {
+func (s *ObjectNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ObjectNotFoundException) RequestID() string {
+func (s *ObjectNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1379,12 +1379,12 @@ func newErrorRequestedRangeNotSatisfiableException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s RequestedRangeNotSatisfiableException) Code() string {
+func (s *RequestedRangeNotSatisfiableException) Code() string {
 	return "RequestedRangeNotSatisfiableException"
 }
 
 // Message returns the exception's message.
-func (s RequestedRangeNotSatisfiableException) Message() string {
+func (s *RequestedRangeNotSatisfiableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1392,21 +1392,21 @@ func (s RequestedRangeNotSatisfiableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestedRangeNotSatisfiableException) OrigErr() error {
+func (s *RequestedRangeNotSatisfiableException) OrigErr() error {
 	return nil
 }
 
-func (s RequestedRangeNotSatisfiableException) Error() string {
+func (s *RequestedRangeNotSatisfiableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestedRangeNotSatisfiableException) StatusCode() int {
+func (s *RequestedRangeNotSatisfiableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestedRangeNotSatisfiableException) RequestID() string {
+func (s *RequestedRangeNotSatisfiableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mediatailor/api.go
+++ b/service/mediatailor/api.go
@@ -581,12 +581,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -594,21 +594,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/migrationhub/api.go
+++ b/service/migrationhub/api.go
@@ -2223,12 +2223,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2236,21 +2236,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3124,12 +3124,12 @@ func newErrorDryRunOperation(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DryRunOperation) Code() string {
+func (s *DryRunOperation) Code() string {
 	return "DryRunOperation"
 }
 
 // Message returns the exception's message.
-func (s DryRunOperation) Message() string {
+func (s *DryRunOperation) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3137,21 +3137,21 @@ func (s DryRunOperation) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DryRunOperation) OrigErr() error {
+func (s *DryRunOperation) OrigErr() error {
 	return nil
 }
 
-func (s DryRunOperation) Error() string {
+func (s *DryRunOperation) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DryRunOperation) StatusCode() int {
+func (s *DryRunOperation) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DryRunOperation) RequestID() string {
+func (s *DryRunOperation) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3180,12 +3180,12 @@ func newErrorHomeRegionNotSetException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s HomeRegionNotSetException) Code() string {
+func (s *HomeRegionNotSetException) Code() string {
 	return "HomeRegionNotSetException"
 }
 
 // Message returns the exception's message.
-func (s HomeRegionNotSetException) Message() string {
+func (s *HomeRegionNotSetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3193,21 +3193,21 @@ func (s HomeRegionNotSetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s HomeRegionNotSetException) OrigErr() error {
+func (s *HomeRegionNotSetException) OrigErr() error {
 	return nil
 }
 
-func (s HomeRegionNotSetException) Error() string {
+func (s *HomeRegionNotSetException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s HomeRegionNotSetException) StatusCode() int {
+func (s *HomeRegionNotSetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s HomeRegionNotSetException) RequestID() string {
+func (s *HomeRegionNotSetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3320,12 +3320,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3333,21 +3333,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3377,12 +3377,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3390,21 +3390,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4288,12 +4288,12 @@ func newErrorPolicyErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyErrorException) Code() string {
+func (s *PolicyErrorException) Code() string {
 	return "PolicyErrorException"
 }
 
 // Message returns the exception's message.
-func (s PolicyErrorException) Message() string {
+func (s *PolicyErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4301,21 +4301,21 @@ func (s PolicyErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyErrorException) OrigErr() error {
+func (s *PolicyErrorException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyErrorException) Error() string {
+func (s *PolicyErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyErrorException) StatusCode() int {
+func (s *PolicyErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyErrorException) RequestID() string {
+func (s *PolicyErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4579,12 +4579,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4592,21 +4592,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4636,12 +4636,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4649,21 +4649,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4752,12 +4752,12 @@ func newErrorUnauthorizedOperation(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedOperation) Code() string {
+func (s *UnauthorizedOperation) Code() string {
 	return "UnauthorizedOperation"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedOperation) Message() string {
+func (s *UnauthorizedOperation) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4765,21 +4765,21 @@ func (s UnauthorizedOperation) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedOperation) OrigErr() error {
+func (s *UnauthorizedOperation) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedOperation) Error() string {
+func (s *UnauthorizedOperation) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedOperation) StatusCode() int {
+func (s *UnauthorizedOperation) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedOperation) RequestID() string {
+func (s *UnauthorizedOperation) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/migrationhubconfig/api.go
+++ b/service/migrationhubconfig/api.go
@@ -377,12 +377,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -390,21 +390,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -650,12 +650,12 @@ func newErrorDryRunOperation(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DryRunOperation) Code() string {
+func (s *DryRunOperation) Code() string {
 	return "DryRunOperation"
 }
 
 // Message returns the exception's message.
-func (s DryRunOperation) Message() string {
+func (s *DryRunOperation) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -663,21 +663,21 @@ func (s DryRunOperation) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DryRunOperation) OrigErr() error {
+func (s *DryRunOperation) OrigErr() error {
 	return nil
 }
 
-func (s DryRunOperation) Error() string {
+func (s *DryRunOperation) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DryRunOperation) StatusCode() int {
+func (s *DryRunOperation) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DryRunOperation) RequestID() string {
+func (s *DryRunOperation) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -802,12 +802,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -815,21 +815,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -859,12 +859,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -872,21 +872,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -916,12 +916,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -929,21 +929,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mobile/api.go
+++ b/service/mobile/api.go
@@ -1044,12 +1044,12 @@ func newErrorAccountActionRequiredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccountActionRequiredException) Code() string {
+func (s *AccountActionRequiredException) Code() string {
 	return "AccountActionRequiredException"
 }
 
 // Message returns the exception's message.
-func (s AccountActionRequiredException) Message() string {
+func (s *AccountActionRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1057,21 +1057,21 @@ func (s AccountActionRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountActionRequiredException) OrigErr() error {
+func (s *AccountActionRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s AccountActionRequiredException) Error() string {
+func (s *AccountActionRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountActionRequiredException) StatusCode() int {
+func (s *AccountActionRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountActionRequiredException) RequestID() string {
+func (s *AccountActionRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1102,12 +1102,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1115,21 +1115,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1702,12 +1702,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1715,21 +1715,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1765,12 +1765,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1778,21 +1778,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1961,12 +1961,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1974,21 +1974,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2203,12 +2203,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2216,21 +2216,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2264,12 +2264,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2277,21 +2277,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2321,12 +2321,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2334,21 +2334,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -117,12 +117,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -130,21 +130,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mq/api.go
+++ b/service/mq/api.go
@@ -2010,12 +2010,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2023,21 +2023,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2510,12 +2510,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2523,21 +2523,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4080,12 +4080,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4093,21 +4093,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4138,12 +4138,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4151,21 +4151,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4716,12 +4716,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4729,21 +4729,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4904,12 +4904,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4917,21 +4917,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/mturk/api.go
+++ b/service/mturk/api.go
@@ -8661,12 +8661,12 @@ func newErrorRequestError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RequestError) Code() string {
+func (s *RequestError) Code() string {
 	return "RequestError"
 }
 
 // Message returns the exception's message.
-func (s RequestError) Message() string {
+func (s *RequestError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8674,21 +8674,21 @@ func (s RequestError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestError) OrigErr() error {
+func (s *RequestError) OrigErr() error {
 	return nil
 }
 
-func (s RequestError) Error() string {
+func (s *RequestError) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestError) StatusCode() int {
+func (s *RequestError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestError) RequestID() string {
+func (s *RequestError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9167,12 +9167,12 @@ func newErrorServiceFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceFault) Code() string {
+func (s *ServiceFault) Code() string {
 	return "ServiceFault"
 }
 
 // Message returns the exception's message.
-func (s ServiceFault) Message() string {
+func (s *ServiceFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9180,21 +9180,21 @@ func (s ServiceFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceFault) OrigErr() error {
+func (s *ServiceFault) OrigErr() error {
 	return nil
 }
 
-func (s ServiceFault) Error() string {
+func (s *ServiceFault) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceFault) StatusCode() int {
+func (s *ServiceFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceFault) RequestID() string {
+func (s *ServiceFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/networkmanager/api.go
+++ b/service/networkmanager/api.go
@@ -3137,12 +3137,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3150,21 +3150,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3431,12 +3431,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3444,21 +3444,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5505,12 +5505,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5518,21 +5518,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5921,12 +5921,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5934,21 +5934,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5994,12 +5994,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6007,21 +6007,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6246,12 +6246,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6259,21 +6259,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6909,12 +6909,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6922,21 +6922,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -14348,12 +14348,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14361,21 +14361,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17196,12 +17196,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17209,21 +17209,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/opsworkscm/api.go
+++ b/service/opsworkscm/api.go
@@ -3526,12 +3526,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3539,21 +3539,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3585,12 +3585,12 @@ func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidStateException) Code() string {
+func (s *InvalidStateException) Code() string {
 	return "InvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateException) Message() string {
+func (s *InvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3598,21 +3598,21 @@ func (s InvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateException) OrigErr() error {
+func (s *InvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateException) Error() string {
+func (s *InvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateException) StatusCode() int {
+func (s *InvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateException) RequestID() string {
+func (s *InvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3643,12 +3643,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3656,21 +3656,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3806,12 +3806,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3819,21 +3819,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3864,12 +3864,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3877,21 +3877,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4838,12 +4838,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4851,21 +4851,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/organizations/api.go
+++ b/service/organizations/api.go
@@ -12965,12 +12965,12 @@ func newErrorAWSOrganizationsNotInUseException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s AWSOrganizationsNotInUseException) Code() string {
+func (s *AWSOrganizationsNotInUseException) Code() string {
 	return "AWSOrganizationsNotInUseException"
 }
 
 // Message returns the exception's message.
-func (s AWSOrganizationsNotInUseException) Message() string {
+func (s *AWSOrganizationsNotInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12978,21 +12978,21 @@ func (s AWSOrganizationsNotInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AWSOrganizationsNotInUseException) OrigErr() error {
+func (s *AWSOrganizationsNotInUseException) OrigErr() error {
 	return nil
 }
 
-func (s AWSOrganizationsNotInUseException) Error() string {
+func (s *AWSOrganizationsNotInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AWSOrganizationsNotInUseException) StatusCode() int {
+func (s *AWSOrganizationsNotInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AWSOrganizationsNotInUseException) RequestID() string {
+func (s *AWSOrganizationsNotInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13089,12 +13089,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13102,21 +13102,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13149,12 +13149,12 @@ func newErrorAccessDeniedForDependencyException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedForDependencyException) Code() string {
+func (s *AccessDeniedForDependencyException) Code() string {
 	return "AccessDeniedForDependencyException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedForDependencyException) Message() string {
+func (s *AccessDeniedForDependencyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13162,21 +13162,21 @@ func (s AccessDeniedForDependencyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedForDependencyException) OrigErr() error {
+func (s *AccessDeniedForDependencyException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedForDependencyException) Error() string {
+func (s *AccessDeniedForDependencyException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedForDependencyException) StatusCode() int {
+func (s *AccessDeniedForDependencyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedForDependencyException) RequestID() string {
+func (s *AccessDeniedForDependencyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13297,12 +13297,12 @@ func newErrorAccountAlreadyRegisteredException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s AccountAlreadyRegisteredException) Code() string {
+func (s *AccountAlreadyRegisteredException) Code() string {
 	return "AccountAlreadyRegisteredException"
 }
 
 // Message returns the exception's message.
-func (s AccountAlreadyRegisteredException) Message() string {
+func (s *AccountAlreadyRegisteredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13310,21 +13310,21 @@ func (s AccountAlreadyRegisteredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountAlreadyRegisteredException) OrigErr() error {
+func (s *AccountAlreadyRegisteredException) OrigErr() error {
 	return nil
 }
 
-func (s AccountAlreadyRegisteredException) Error() string {
+func (s *AccountAlreadyRegisteredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountAlreadyRegisteredException) StatusCode() int {
+func (s *AccountAlreadyRegisteredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountAlreadyRegisteredException) RequestID() string {
+func (s *AccountAlreadyRegisteredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13355,12 +13355,12 @@ func newErrorAccountNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccountNotFoundException) Code() string {
+func (s *AccountNotFoundException) Code() string {
 	return "AccountNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s AccountNotFoundException) Message() string {
+func (s *AccountNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13368,21 +13368,21 @@ func (s AccountNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountNotFoundException) OrigErr() error {
+func (s *AccountNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s AccountNotFoundException) Error() string {
+func (s *AccountNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountNotFoundException) StatusCode() int {
+func (s *AccountNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountNotFoundException) RequestID() string {
+func (s *AccountNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13411,12 +13411,12 @@ func newErrorAccountNotRegisteredException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccountNotRegisteredException) Code() string {
+func (s *AccountNotRegisteredException) Code() string {
 	return "AccountNotRegisteredException"
 }
 
 // Message returns the exception's message.
-func (s AccountNotRegisteredException) Message() string {
+func (s *AccountNotRegisteredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13424,21 +13424,21 @@ func (s AccountNotRegisteredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountNotRegisteredException) OrigErr() error {
+func (s *AccountNotRegisteredException) OrigErr() error {
 	return nil
 }
 
-func (s AccountNotRegisteredException) Error() string {
+func (s *AccountNotRegisteredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountNotRegisteredException) StatusCode() int {
+func (s *AccountNotRegisteredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountNotRegisteredException) RequestID() string {
+func (s *AccountNotRegisteredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13470,12 +13470,12 @@ func newErrorAccountOwnerNotVerifiedException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s AccountOwnerNotVerifiedException) Code() string {
+func (s *AccountOwnerNotVerifiedException) Code() string {
 	return "AccountOwnerNotVerifiedException"
 }
 
 // Message returns the exception's message.
-func (s AccountOwnerNotVerifiedException) Message() string {
+func (s *AccountOwnerNotVerifiedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13483,21 +13483,21 @@ func (s AccountOwnerNotVerifiedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountOwnerNotVerifiedException) OrigErr() error {
+func (s *AccountOwnerNotVerifiedException) OrigErr() error {
 	return nil
 }
 
-func (s AccountOwnerNotVerifiedException) Error() string {
+func (s *AccountOwnerNotVerifiedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountOwnerNotVerifiedException) StatusCode() int {
+func (s *AccountOwnerNotVerifiedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountOwnerNotVerifiedException) RequestID() string {
+func (s *AccountOwnerNotVerifiedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13527,12 +13527,12 @@ func newErrorAlreadyInOrganizationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyInOrganizationException) Code() string {
+func (s *AlreadyInOrganizationException) Code() string {
 	return "AlreadyInOrganizationException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyInOrganizationException) Message() string {
+func (s *AlreadyInOrganizationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13540,21 +13540,21 @@ func (s AlreadyInOrganizationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyInOrganizationException) OrigErr() error {
+func (s *AlreadyInOrganizationException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyInOrganizationException) Error() string {
+func (s *AlreadyInOrganizationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyInOrganizationException) StatusCode() int {
+func (s *AlreadyInOrganizationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyInOrganizationException) RequestID() string {
+func (s *AlreadyInOrganizationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13778,12 +13778,12 @@ func newErrorChildNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ChildNotFoundException) Code() string {
+func (s *ChildNotFoundException) Code() string {
 	return "ChildNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ChildNotFoundException) Message() string {
+func (s *ChildNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13791,21 +13791,21 @@ func (s ChildNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ChildNotFoundException) OrigErr() error {
+func (s *ChildNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ChildNotFoundException) Error() string {
+func (s *ChildNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ChildNotFoundException) StatusCode() int {
+func (s *ChildNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ChildNotFoundException) RequestID() string {
+func (s *ChildNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13835,12 +13835,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13848,21 +13848,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14001,12 +14001,12 @@ func newErrorConstraintViolationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConstraintViolationException) Code() string {
+func (s *ConstraintViolationException) Code() string {
 	return "ConstraintViolationException"
 }
 
 // Message returns the exception's message.
-func (s ConstraintViolationException) Message() string {
+func (s *ConstraintViolationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14014,21 +14014,21 @@ func (s ConstraintViolationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConstraintViolationException) OrigErr() error {
+func (s *ConstraintViolationException) OrigErr() error {
 	return nil
 }
 
-func (s ConstraintViolationException) Error() string {
+func (s *ConstraintViolationException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConstraintViolationException) StatusCode() int {
+func (s *ConstraintViolationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConstraintViolationException) RequestID() string {
+func (s *ConstraintViolationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14317,12 +14317,12 @@ func newErrorCreateAccountStatusNotFoundException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s CreateAccountStatusNotFoundException) Code() string {
+func (s *CreateAccountStatusNotFoundException) Code() string {
 	return "CreateAccountStatusNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s CreateAccountStatusNotFoundException) Message() string {
+func (s *CreateAccountStatusNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14330,21 +14330,21 @@ func (s CreateAccountStatusNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CreateAccountStatusNotFoundException) OrigErr() error {
+func (s *CreateAccountStatusNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s CreateAccountStatusNotFoundException) Error() string {
+func (s *CreateAccountStatusNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CreateAccountStatusNotFoundException) StatusCode() int {
+func (s *CreateAccountStatusNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CreateAccountStatusNotFoundException) RequestID() string {
+func (s *CreateAccountStatusNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15629,12 +15629,12 @@ func newErrorDestinationParentNotFoundException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s DestinationParentNotFoundException) Code() string {
+func (s *DestinationParentNotFoundException) Code() string {
 	return "DestinationParentNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s DestinationParentNotFoundException) Message() string {
+func (s *DestinationParentNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15642,21 +15642,21 @@ func (s DestinationParentNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DestinationParentNotFoundException) OrigErr() error {
+func (s *DestinationParentNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s DestinationParentNotFoundException) Error() string {
+func (s *DestinationParentNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DestinationParentNotFoundException) StatusCode() int {
+func (s *DestinationParentNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DestinationParentNotFoundException) RequestID() string {
+func (s *DestinationParentNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15907,12 +15907,12 @@ func newErrorDuplicateAccountException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateAccountException) Code() string {
+func (s *DuplicateAccountException) Code() string {
 	return "DuplicateAccountException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateAccountException) Message() string {
+func (s *DuplicateAccountException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15920,21 +15920,21 @@ func (s DuplicateAccountException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateAccountException) OrigErr() error {
+func (s *DuplicateAccountException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateAccountException) Error() string {
+func (s *DuplicateAccountException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateAccountException) StatusCode() int {
+func (s *DuplicateAccountException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateAccountException) RequestID() string {
+func (s *DuplicateAccountException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15967,12 +15967,12 @@ func newErrorDuplicateHandshakeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateHandshakeException) Code() string {
+func (s *DuplicateHandshakeException) Code() string {
 	return "DuplicateHandshakeException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateHandshakeException) Message() string {
+func (s *DuplicateHandshakeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15980,21 +15980,21 @@ func (s DuplicateHandshakeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateHandshakeException) OrigErr() error {
+func (s *DuplicateHandshakeException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateHandshakeException) Error() string {
+func (s *DuplicateHandshakeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateHandshakeException) StatusCode() int {
+func (s *DuplicateHandshakeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateHandshakeException) RequestID() string {
+func (s *DuplicateHandshakeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16023,12 +16023,12 @@ func newErrorDuplicateOrganizationalUnitException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s DuplicateOrganizationalUnitException) Code() string {
+func (s *DuplicateOrganizationalUnitException) Code() string {
 	return "DuplicateOrganizationalUnitException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateOrganizationalUnitException) Message() string {
+func (s *DuplicateOrganizationalUnitException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16036,21 +16036,21 @@ func (s DuplicateOrganizationalUnitException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateOrganizationalUnitException) OrigErr() error {
+func (s *DuplicateOrganizationalUnitException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateOrganizationalUnitException) Error() string {
+func (s *DuplicateOrganizationalUnitException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateOrganizationalUnitException) StatusCode() int {
+func (s *DuplicateOrganizationalUnitException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateOrganizationalUnitException) RequestID() string {
+func (s *DuplicateOrganizationalUnitException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16079,12 +16079,12 @@ func newErrorDuplicatePolicyAttachmentException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s DuplicatePolicyAttachmentException) Code() string {
+func (s *DuplicatePolicyAttachmentException) Code() string {
 	return "DuplicatePolicyAttachmentException"
 }
 
 // Message returns the exception's message.
-func (s DuplicatePolicyAttachmentException) Message() string {
+func (s *DuplicatePolicyAttachmentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16092,21 +16092,21 @@ func (s DuplicatePolicyAttachmentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicatePolicyAttachmentException) OrigErr() error {
+func (s *DuplicatePolicyAttachmentException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicatePolicyAttachmentException) Error() string {
+func (s *DuplicatePolicyAttachmentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicatePolicyAttachmentException) StatusCode() int {
+func (s *DuplicatePolicyAttachmentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicatePolicyAttachmentException) RequestID() string {
+func (s *DuplicatePolicyAttachmentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16135,12 +16135,12 @@ func newErrorDuplicatePolicyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicatePolicyException) Code() string {
+func (s *DuplicatePolicyException) Code() string {
 	return "DuplicatePolicyException"
 }
 
 // Message returns the exception's message.
-func (s DuplicatePolicyException) Message() string {
+func (s *DuplicatePolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16148,21 +16148,21 @@ func (s DuplicatePolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicatePolicyException) OrigErr() error {
+func (s *DuplicatePolicyException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicatePolicyException) Error() string {
+func (s *DuplicatePolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicatePolicyException) StatusCode() int {
+func (s *DuplicatePolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicatePolicyException) RequestID() string {
+func (s *DuplicatePolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16247,12 +16247,12 @@ func newErrorEffectivePolicyNotFoundException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s EffectivePolicyNotFoundException) Code() string {
+func (s *EffectivePolicyNotFoundException) Code() string {
 	return "EffectivePolicyNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s EffectivePolicyNotFoundException) Message() string {
+func (s *EffectivePolicyNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16260,21 +16260,21 @@ func (s EffectivePolicyNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EffectivePolicyNotFoundException) OrigErr() error {
+func (s *EffectivePolicyNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s EffectivePolicyNotFoundException) Error() string {
+func (s *EffectivePolicyNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EffectivePolicyNotFoundException) StatusCode() int {
+func (s *EffectivePolicyNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EffectivePolicyNotFoundException) RequestID() string {
+func (s *EffectivePolicyNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16516,12 +16516,12 @@ func newErrorFinalizingOrganizationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s FinalizingOrganizationException) Code() string {
+func (s *FinalizingOrganizationException) Code() string {
 	return "FinalizingOrganizationException"
 }
 
 // Message returns the exception's message.
-func (s FinalizingOrganizationException) Message() string {
+func (s *FinalizingOrganizationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16529,21 +16529,21 @@ func (s FinalizingOrganizationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FinalizingOrganizationException) OrigErr() error {
+func (s *FinalizingOrganizationException) OrigErr() error {
 	return nil
 }
 
-func (s FinalizingOrganizationException) Error() string {
+func (s *FinalizingOrganizationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FinalizingOrganizationException) StatusCode() int {
+func (s *FinalizingOrganizationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FinalizingOrganizationException) RequestID() string {
+func (s *FinalizingOrganizationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16715,12 +16715,12 @@ func newErrorHandshakeAlreadyInStateException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s HandshakeAlreadyInStateException) Code() string {
+func (s *HandshakeAlreadyInStateException) Code() string {
 	return "HandshakeAlreadyInStateException"
 }
 
 // Message returns the exception's message.
-func (s HandshakeAlreadyInStateException) Message() string {
+func (s *HandshakeAlreadyInStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16728,21 +16728,21 @@ func (s HandshakeAlreadyInStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s HandshakeAlreadyInStateException) OrigErr() error {
+func (s *HandshakeAlreadyInStateException) OrigErr() error {
 	return nil
 }
 
-func (s HandshakeAlreadyInStateException) Error() string {
+func (s *HandshakeAlreadyInStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s HandshakeAlreadyInStateException) StatusCode() int {
+func (s *HandshakeAlreadyInStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s HandshakeAlreadyInStateException) RequestID() string {
+func (s *HandshakeAlreadyInStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16810,12 +16810,12 @@ func newErrorHandshakeConstraintViolationException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s HandshakeConstraintViolationException) Code() string {
+func (s *HandshakeConstraintViolationException) Code() string {
 	return "HandshakeConstraintViolationException"
 }
 
 // Message returns the exception's message.
-func (s HandshakeConstraintViolationException) Message() string {
+func (s *HandshakeConstraintViolationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16823,21 +16823,21 @@ func (s HandshakeConstraintViolationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s HandshakeConstraintViolationException) OrigErr() error {
+func (s *HandshakeConstraintViolationException) OrigErr() error {
 	return nil
 }
 
-func (s HandshakeConstraintViolationException) Error() string {
+func (s *HandshakeConstraintViolationException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s HandshakeConstraintViolationException) StatusCode() int {
+func (s *HandshakeConstraintViolationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s HandshakeConstraintViolationException) RequestID() string {
+func (s *HandshakeConstraintViolationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16907,12 +16907,12 @@ func newErrorHandshakeNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s HandshakeNotFoundException) Code() string {
+func (s *HandshakeNotFoundException) Code() string {
 	return "HandshakeNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s HandshakeNotFoundException) Message() string {
+func (s *HandshakeNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16920,21 +16920,21 @@ func (s HandshakeNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s HandshakeNotFoundException) OrigErr() error {
+func (s *HandshakeNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s HandshakeNotFoundException) Error() string {
+func (s *HandshakeNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s HandshakeNotFoundException) StatusCode() int {
+func (s *HandshakeNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s HandshakeNotFoundException) RequestID() string {
+func (s *HandshakeNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17084,12 +17084,12 @@ func newErrorInvalidHandshakeTransitionException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s InvalidHandshakeTransitionException) Code() string {
+func (s *InvalidHandshakeTransitionException) Code() string {
 	return "InvalidHandshakeTransitionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidHandshakeTransitionException) Message() string {
+func (s *InvalidHandshakeTransitionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17097,21 +17097,21 @@ func (s InvalidHandshakeTransitionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidHandshakeTransitionException) OrigErr() error {
+func (s *InvalidHandshakeTransitionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidHandshakeTransitionException) Error() string {
+func (s *InvalidHandshakeTransitionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidHandshakeTransitionException) StatusCode() int {
+func (s *InvalidHandshakeTransitionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidHandshakeTransitionException) RequestID() string {
+func (s *InvalidHandshakeTransitionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17203,12 +17203,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17216,21 +17216,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19088,12 +19088,12 @@ func newErrorMalformedPolicyDocumentException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s MalformedPolicyDocumentException) Code() string {
+func (s *MalformedPolicyDocumentException) Code() string {
 	return "MalformedPolicyDocumentException"
 }
 
 // Message returns the exception's message.
-func (s MalformedPolicyDocumentException) Message() string {
+func (s *MalformedPolicyDocumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19101,21 +19101,21 @@ func (s MalformedPolicyDocumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MalformedPolicyDocumentException) OrigErr() error {
+func (s *MalformedPolicyDocumentException) OrigErr() error {
 	return nil
 }
 
-func (s MalformedPolicyDocumentException) Error() string {
+func (s *MalformedPolicyDocumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MalformedPolicyDocumentException) StatusCode() int {
+func (s *MalformedPolicyDocumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MalformedPolicyDocumentException) RequestID() string {
+func (s *MalformedPolicyDocumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19146,12 +19146,12 @@ func newErrorMasterCannotLeaveOrganizationException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s MasterCannotLeaveOrganizationException) Code() string {
+func (s *MasterCannotLeaveOrganizationException) Code() string {
 	return "MasterCannotLeaveOrganizationException"
 }
 
 // Message returns the exception's message.
-func (s MasterCannotLeaveOrganizationException) Message() string {
+func (s *MasterCannotLeaveOrganizationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19159,21 +19159,21 @@ func (s MasterCannotLeaveOrganizationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MasterCannotLeaveOrganizationException) OrigErr() error {
+func (s *MasterCannotLeaveOrganizationException) OrigErr() error {
 	return nil
 }
 
-func (s MasterCannotLeaveOrganizationException) Error() string {
+func (s *MasterCannotLeaveOrganizationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MasterCannotLeaveOrganizationException) StatusCode() int {
+func (s *MasterCannotLeaveOrganizationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MasterCannotLeaveOrganizationException) RequestID() string {
+func (s *MasterCannotLeaveOrganizationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19419,12 +19419,12 @@ func newErrorOrganizationNotEmptyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OrganizationNotEmptyException) Code() string {
+func (s *OrganizationNotEmptyException) Code() string {
 	return "OrganizationNotEmptyException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationNotEmptyException) Message() string {
+func (s *OrganizationNotEmptyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19432,21 +19432,21 @@ func (s OrganizationNotEmptyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationNotEmptyException) OrigErr() error {
+func (s *OrganizationNotEmptyException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationNotEmptyException) Error() string {
+func (s *OrganizationNotEmptyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationNotEmptyException) StatusCode() int {
+func (s *OrganizationNotEmptyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationNotEmptyException) RequestID() string {
+func (s *OrganizationNotEmptyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19533,12 +19533,12 @@ func newErrorOrganizationalUnitNotEmptyException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s OrganizationalUnitNotEmptyException) Code() string {
+func (s *OrganizationalUnitNotEmptyException) Code() string {
 	return "OrganizationalUnitNotEmptyException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationalUnitNotEmptyException) Message() string {
+func (s *OrganizationalUnitNotEmptyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19546,21 +19546,21 @@ func (s OrganizationalUnitNotEmptyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationalUnitNotEmptyException) OrigErr() error {
+func (s *OrganizationalUnitNotEmptyException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationalUnitNotEmptyException) Error() string {
+func (s *OrganizationalUnitNotEmptyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationalUnitNotEmptyException) StatusCode() int {
+func (s *OrganizationalUnitNotEmptyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationalUnitNotEmptyException) RequestID() string {
+func (s *OrganizationalUnitNotEmptyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19589,12 +19589,12 @@ func newErrorOrganizationalUnitNotFoundException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s OrganizationalUnitNotFoundException) Code() string {
+func (s *OrganizationalUnitNotFoundException) Code() string {
 	return "OrganizationalUnitNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationalUnitNotFoundException) Message() string {
+func (s *OrganizationalUnitNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19602,21 +19602,21 @@ func (s OrganizationalUnitNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationalUnitNotFoundException) OrigErr() error {
+func (s *OrganizationalUnitNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationalUnitNotFoundException) Error() string {
+func (s *OrganizationalUnitNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationalUnitNotFoundException) StatusCode() int {
+func (s *OrganizationalUnitNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationalUnitNotFoundException) RequestID() string {
+func (s *OrganizationalUnitNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19690,12 +19690,12 @@ func newErrorParentNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ParentNotFoundException) Code() string {
+func (s *ParentNotFoundException) Code() string {
 	return "ParentNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ParentNotFoundException) Message() string {
+func (s *ParentNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19703,21 +19703,21 @@ func (s ParentNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParentNotFoundException) OrigErr() error {
+func (s *ParentNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ParentNotFoundException) Error() string {
+func (s *ParentNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParentNotFoundException) StatusCode() int {
+func (s *ParentNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParentNotFoundException) RequestID() string {
+func (s *ParentNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19782,12 +19782,12 @@ func newErrorPolicyChangesInProgressException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s PolicyChangesInProgressException) Code() string {
+func (s *PolicyChangesInProgressException) Code() string {
 	return "PolicyChangesInProgressException"
 }
 
 // Message returns the exception's message.
-func (s PolicyChangesInProgressException) Message() string {
+func (s *PolicyChangesInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19795,21 +19795,21 @@ func (s PolicyChangesInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyChangesInProgressException) OrigErr() error {
+func (s *PolicyChangesInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyChangesInProgressException) Error() string {
+func (s *PolicyChangesInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyChangesInProgressException) StatusCode() int {
+func (s *PolicyChangesInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyChangesInProgressException) RequestID() string {
+func (s *PolicyChangesInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19839,12 +19839,12 @@ func newErrorPolicyInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyInUseException) Code() string {
+func (s *PolicyInUseException) Code() string {
 	return "PolicyInUseException"
 }
 
 // Message returns the exception's message.
-func (s PolicyInUseException) Message() string {
+func (s *PolicyInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19852,21 +19852,21 @@ func (s PolicyInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyInUseException) OrigErr() error {
+func (s *PolicyInUseException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyInUseException) Error() string {
+func (s *PolicyInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyInUseException) StatusCode() int {
+func (s *PolicyInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyInUseException) RequestID() string {
+func (s *PolicyInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19895,12 +19895,12 @@ func newErrorPolicyNotAttachedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyNotAttachedException) Code() string {
+func (s *PolicyNotAttachedException) Code() string {
 	return "PolicyNotAttachedException"
 }
 
 // Message returns the exception's message.
-func (s PolicyNotAttachedException) Message() string {
+func (s *PolicyNotAttachedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19908,21 +19908,21 @@ func (s PolicyNotAttachedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyNotAttachedException) OrigErr() error {
+func (s *PolicyNotAttachedException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyNotAttachedException) Error() string {
+func (s *PolicyNotAttachedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyNotAttachedException) StatusCode() int {
+func (s *PolicyNotAttachedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyNotAttachedException) RequestID() string {
+func (s *PolicyNotAttachedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19951,12 +19951,12 @@ func newErrorPolicyNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyNotFoundException) Code() string {
+func (s *PolicyNotFoundException) Code() string {
 	return "PolicyNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s PolicyNotFoundException) Message() string {
+func (s *PolicyNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19964,21 +19964,21 @@ func (s PolicyNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyNotFoundException) OrigErr() error {
+func (s *PolicyNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyNotFoundException) Error() string {
+func (s *PolicyNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyNotFoundException) StatusCode() int {
+func (s *PolicyNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyNotFoundException) RequestID() string {
+func (s *PolicyNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20163,12 +20163,12 @@ func newErrorPolicyTypeAlreadyEnabledException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s PolicyTypeAlreadyEnabledException) Code() string {
+func (s *PolicyTypeAlreadyEnabledException) Code() string {
 	return "PolicyTypeAlreadyEnabledException"
 }
 
 // Message returns the exception's message.
-func (s PolicyTypeAlreadyEnabledException) Message() string {
+func (s *PolicyTypeAlreadyEnabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20176,21 +20176,21 @@ func (s PolicyTypeAlreadyEnabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyTypeAlreadyEnabledException) OrigErr() error {
+func (s *PolicyTypeAlreadyEnabledException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyTypeAlreadyEnabledException) Error() string {
+func (s *PolicyTypeAlreadyEnabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyTypeAlreadyEnabledException) StatusCode() int {
+func (s *PolicyTypeAlreadyEnabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyTypeAlreadyEnabledException) RequestID() string {
+func (s *PolicyTypeAlreadyEnabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20223,12 +20223,12 @@ func newErrorPolicyTypeNotAvailableForOrganizationException(v protocol.ResponseM
 }
 
 // Code returns the exception type name.
-func (s PolicyTypeNotAvailableForOrganizationException) Code() string {
+func (s *PolicyTypeNotAvailableForOrganizationException) Code() string {
 	return "PolicyTypeNotAvailableForOrganizationException"
 }
 
 // Message returns the exception's message.
-func (s PolicyTypeNotAvailableForOrganizationException) Message() string {
+func (s *PolicyTypeNotAvailableForOrganizationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20236,21 +20236,21 @@ func (s PolicyTypeNotAvailableForOrganizationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyTypeNotAvailableForOrganizationException) OrigErr() error {
+func (s *PolicyTypeNotAvailableForOrganizationException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyTypeNotAvailableForOrganizationException) Error() string {
+func (s *PolicyTypeNotAvailableForOrganizationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyTypeNotAvailableForOrganizationException) StatusCode() int {
+func (s *PolicyTypeNotAvailableForOrganizationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyTypeNotAvailableForOrganizationException) RequestID() string {
+func (s *PolicyTypeNotAvailableForOrganizationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20283,12 +20283,12 @@ func newErrorPolicyTypeNotEnabledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PolicyTypeNotEnabledException) Code() string {
+func (s *PolicyTypeNotEnabledException) Code() string {
 	return "PolicyTypeNotEnabledException"
 }
 
 // Message returns the exception's message.
-func (s PolicyTypeNotEnabledException) Message() string {
+func (s *PolicyTypeNotEnabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20296,21 +20296,21 @@ func (s PolicyTypeNotEnabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PolicyTypeNotEnabledException) OrigErr() error {
+func (s *PolicyTypeNotEnabledException) OrigErr() error {
 	return nil
 }
 
-func (s PolicyTypeNotEnabledException) Error() string {
+func (s *PolicyTypeNotEnabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PolicyTypeNotEnabledException) StatusCode() int {
+func (s *PolicyTypeNotEnabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PolicyTypeNotEnabledException) RequestID() string {
+func (s *PolicyTypeNotEnabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20574,12 +20574,12 @@ func newErrorRootNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RootNotFoundException) Code() string {
+func (s *RootNotFoundException) Code() string {
 	return "RootNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s RootNotFoundException) Message() string {
+func (s *RootNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20587,21 +20587,21 @@ func (s RootNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RootNotFoundException) OrigErr() error {
+func (s *RootNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s RootNotFoundException) Error() string {
+func (s *RootNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RootNotFoundException) StatusCode() int {
+func (s *RootNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RootNotFoundException) RequestID() string {
+func (s *RootNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20631,12 +20631,12 @@ func newErrorServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceException) Code() string {
+func (s *ServiceException) Code() string {
 	return "ServiceException"
 }
 
 // Message returns the exception's message.
-func (s ServiceException) Message() string {
+func (s *ServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20644,21 +20644,21 @@ func (s ServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceException) OrigErr() error {
+func (s *ServiceException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceException) Error() string {
+func (s *ServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceException) StatusCode() int {
+func (s *ServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceException) RequestID() string {
+func (s *ServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20687,12 +20687,12 @@ func newErrorSourceParentNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SourceParentNotFoundException) Code() string {
+func (s *SourceParentNotFoundException) Code() string {
 	return "SourceParentNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s SourceParentNotFoundException) Message() string {
+func (s *SourceParentNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20700,21 +20700,21 @@ func (s SourceParentNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SourceParentNotFoundException) OrigErr() error {
+func (s *SourceParentNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s SourceParentNotFoundException) Error() string {
+func (s *SourceParentNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SourceParentNotFoundException) StatusCode() int {
+func (s *SourceParentNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SourceParentNotFoundException) RequestID() string {
+func (s *SourceParentNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20880,12 +20880,12 @@ func newErrorTargetNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TargetNotFoundException) Code() string {
+func (s *TargetNotFoundException) Code() string {
 	return "TargetNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s TargetNotFoundException) Message() string {
+func (s *TargetNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20893,21 +20893,21 @@ func (s TargetNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TargetNotFoundException) OrigErr() error {
+func (s *TargetNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s TargetNotFoundException) Error() string {
+func (s *TargetNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TargetNotFoundException) StatusCode() int {
+func (s *TargetNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TargetNotFoundException) RequestID() string {
+func (s *TargetNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20943,12 +20943,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20956,21 +20956,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20999,12 +20999,12 @@ func newErrorUnsupportedAPIEndpointException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s UnsupportedAPIEndpointException) Code() string {
+func (s *UnsupportedAPIEndpointException) Code() string {
 	return "UnsupportedAPIEndpointException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedAPIEndpointException) Message() string {
+func (s *UnsupportedAPIEndpointException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -21012,21 +21012,21 @@ func (s UnsupportedAPIEndpointException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedAPIEndpointException) OrigErr() error {
+func (s *UnsupportedAPIEndpointException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedAPIEndpointException) Error() string {
+func (s *UnsupportedAPIEndpointException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedAPIEndpointException) StatusCode() int {
+func (s *UnsupportedAPIEndpointException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedAPIEndpointException) RequestID() string {
+func (s *UnsupportedAPIEndpointException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/outposts/api.go
+++ b/service/outposts/api.go
@@ -768,12 +768,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -781,21 +781,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1253,12 +1253,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1266,21 +1266,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1469,12 +1469,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1482,21 +1482,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1625,12 +1625,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1638,21 +1638,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1732,12 +1732,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1745,20 +1745,20 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }

--- a/service/personalize/api.go
+++ b/service/personalize/api.go
@@ -8539,12 +8539,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8552,21 +8552,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8595,12 +8595,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8608,21 +8608,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8651,12 +8651,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8664,21 +8664,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9731,12 +9731,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9744,21 +9744,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9787,12 +9787,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9800,21 +9800,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9843,12 +9843,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9856,21 +9856,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/personalizeevents/api.go
+++ b/service/personalizeevents/api.go
@@ -221,12 +221,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -234,21 +234,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/personalizeruntime/api.go
+++ b/service/personalizeruntime/api.go
@@ -422,12 +422,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -435,21 +435,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -504,12 +504,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -517,20 +517,20 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }

--- a/service/pi/api.go
+++ b/service/pi/api.go
@@ -919,12 +919,12 @@ func newErrorInternalServiceError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceError) Code() string {
+func (s *InternalServiceError) Code() string {
 	return "InternalServiceError"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceError) Message() string {
+func (s *InternalServiceError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -932,21 +932,21 @@ func (s InternalServiceError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceError) OrigErr() error {
+func (s *InternalServiceError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceError) Error() string {
+func (s *InternalServiceError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceError) StatusCode() int {
+func (s *InternalServiceError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceError) RequestID() string {
+func (s *InternalServiceError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -975,12 +975,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -988,21 +988,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1149,12 +1149,12 @@ func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotAuthorizedException) Code() string {
+func (s *NotAuthorizedException) Code() string {
 	return "NotAuthorizedException"
 }
 
 // Message returns the exception's message.
-func (s NotAuthorizedException) Message() string {
+func (s *NotAuthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1162,21 +1162,21 @@ func (s NotAuthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotAuthorizedException) OrigErr() error {
+func (s *NotAuthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s NotAuthorizedException) Error() string {
+func (s *NotAuthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotAuthorizedException) StatusCode() int {
+func (s *NotAuthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotAuthorizedException) RequestID() string {
+func (s *NotAuthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/pinpoint/api.go
+++ b/service/pinpoint/api.go
@@ -13418,12 +13418,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13431,21 +13431,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20259,12 +20259,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20272,21 +20272,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -24835,12 +24835,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -24848,21 +24848,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26443,12 +26443,12 @@ func newErrorMethodNotAllowedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MethodNotAllowedException) Code() string {
+func (s *MethodNotAllowedException) Code() string {
 	return "MethodNotAllowedException"
 }
 
 // Message returns the exception's message.
-func (s MethodNotAllowedException) Message() string {
+func (s *MethodNotAllowedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26456,21 +26456,21 @@ func (s MethodNotAllowedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MethodNotAllowedException) OrigErr() error {
+func (s *MethodNotAllowedException) OrigErr() error {
 	return nil
 }
 
-func (s MethodNotAllowedException) Error() string {
+func (s *MethodNotAllowedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MethodNotAllowedException) StatusCode() int {
+func (s *MethodNotAllowedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MethodNotAllowedException) RequestID() string {
+func (s *MethodNotAllowedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26673,12 +26673,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26686,21 +26686,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26918,12 +26918,12 @@ func newErrorPayloadTooLargeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PayloadTooLargeException) Code() string {
+func (s *PayloadTooLargeException) Code() string {
 	return "PayloadTooLargeException"
 }
 
 // Message returns the exception's message.
-func (s PayloadTooLargeException) Message() string {
+func (s *PayloadTooLargeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26931,21 +26931,21 @@ func (s PayloadTooLargeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PayloadTooLargeException) OrigErr() error {
+func (s *PayloadTooLargeException) OrigErr() error {
 	return nil
 }
 
-func (s PayloadTooLargeException) Error() string {
+func (s *PayloadTooLargeException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PayloadTooLargeException) StatusCode() int {
+func (s *PayloadTooLargeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PayloadTooLargeException) RequestID() string {
+func (s *PayloadTooLargeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30800,12 +30800,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30813,21 +30813,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/pinpointemail/api.go
+++ b/service/pinpointemail/api.go
@@ -4211,12 +4211,12 @@ func newErrorAccountSuspendedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccountSuspendedException) Code() string {
+func (s *AccountSuspendedException) Code() string {
 	return "AccountSuspendedException"
 }
 
 // Message returns the exception's message.
-func (s AccountSuspendedException) Message() string {
+func (s *AccountSuspendedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4224,21 +4224,21 @@ func (s AccountSuspendedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountSuspendedException) OrigErr() error {
+func (s *AccountSuspendedException) OrigErr() error {
 	return nil
 }
 
-func (s AccountSuspendedException) Error() string {
+func (s *AccountSuspendedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountSuspendedException) StatusCode() int {
+func (s *AccountSuspendedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountSuspendedException) RequestID() string {
+func (s *AccountSuspendedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4267,12 +4267,12 @@ func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyExistsException) Code() string {
+func (s *AlreadyExistsException) Code() string {
 	return "AlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyExistsException) Message() string {
+func (s *AlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4280,21 +4280,21 @@ func (s AlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyExistsException) OrigErr() error {
+func (s *AlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyExistsException) Error() string {
+func (s *AlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyExistsException) StatusCode() int {
+func (s *AlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyExistsException) RequestID() string {
+func (s *AlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4323,12 +4323,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4336,21 +4336,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4618,12 +4618,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4631,21 +4631,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7644,12 +7644,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7657,21 +7657,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8280,12 +8280,12 @@ func newErrorMailFromDomainNotVerifiedException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s MailFromDomainNotVerifiedException) Code() string {
+func (s *MailFromDomainNotVerifiedException) Code() string {
 	return "MailFromDomainNotVerifiedException"
 }
 
 // Message returns the exception's message.
-func (s MailFromDomainNotVerifiedException) Message() string {
+func (s *MailFromDomainNotVerifiedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8293,21 +8293,21 @@ func (s MailFromDomainNotVerifiedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MailFromDomainNotVerifiedException) OrigErr() error {
+func (s *MailFromDomainNotVerifiedException) OrigErr() error {
 	return nil
 }
 
-func (s MailFromDomainNotVerifiedException) Error() string {
+func (s *MailFromDomainNotVerifiedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MailFromDomainNotVerifiedException) StatusCode() int {
+func (s *MailFromDomainNotVerifiedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MailFromDomainNotVerifiedException) RequestID() string {
+func (s *MailFromDomainNotVerifiedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8403,12 +8403,12 @@ func newErrorMessageRejected(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MessageRejected) Code() string {
+func (s *MessageRejected) Code() string {
 	return "MessageRejected"
 }
 
 // Message returns the exception's message.
-func (s MessageRejected) Message() string {
+func (s *MessageRejected) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8416,21 +8416,21 @@ func (s MessageRejected) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MessageRejected) OrigErr() error {
+func (s *MessageRejected) OrigErr() error {
 	return nil
 }
 
-func (s MessageRejected) Error() string {
+func (s *MessageRejected) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MessageRejected) StatusCode() int {
+func (s *MessageRejected) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MessageRejected) RequestID() string {
+func (s *MessageRejected) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8525,12 +8525,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8538,21 +8538,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9887,12 +9887,12 @@ func newErrorSendingPausedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SendingPausedException) Code() string {
+func (s *SendingPausedException) Code() string {
 	return "SendingPausedException"
 }
 
 // Message returns the exception's message.
-func (s SendingPausedException) Message() string {
+func (s *SendingPausedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9900,21 +9900,21 @@ func (s SendingPausedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SendingPausedException) OrigErr() error {
+func (s *SendingPausedException) OrigErr() error {
 	return nil
 }
 
-func (s SendingPausedException) Error() string {
+func (s *SendingPausedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SendingPausedException) StatusCode() int {
+func (s *SendingPausedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SendingPausedException) RequestID() string {
+func (s *SendingPausedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10185,12 +10185,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10198,21 +10198,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/pinpointsmsvoice/api.go
+++ b/service/pinpointsmsvoice/api.go
@@ -772,12 +772,12 @@ func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyExistsException) Code() string {
+func (s *AlreadyExistsException) Code() string {
 	return "AlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyExistsException) Message() string {
+func (s *AlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -785,21 +785,21 @@ func (s AlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyExistsException) OrigErr() error {
+func (s *AlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyExistsException) Error() string {
+func (s *AlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyExistsException) StatusCode() int {
+func (s *AlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyExistsException) RequestID() string {
+func (s *AlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -828,12 +828,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -841,21 +841,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1388,12 +1388,12 @@ func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceErrorException) Code() string {
+func (s *InternalServiceErrorException) Code() string {
 	return "InternalServiceErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceErrorException) Message() string {
+func (s *InternalServiceErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1401,21 +1401,21 @@ func (s InternalServiceErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceErrorException) OrigErr() error {
+func (s *InternalServiceErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceErrorException) Error() string {
+func (s *InternalServiceErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceErrorException) StatusCode() int {
+func (s *InternalServiceErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceErrorException) RequestID() string {
+func (s *InternalServiceErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1480,12 +1480,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1493,21 +1493,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1602,12 +1602,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1615,21 +1615,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1863,12 +1863,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1876,21 +1876,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/polly/api.go
+++ b/service/polly/api.go
@@ -1144,12 +1144,12 @@ func newErrorEngineNotSupportedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EngineNotSupportedException) Code() string {
+func (s *EngineNotSupportedException) Code() string {
 	return "EngineNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s EngineNotSupportedException) Message() string {
+func (s *EngineNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1157,21 +1157,21 @@ func (s EngineNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EngineNotSupportedException) OrigErr() error {
+func (s *EngineNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s EngineNotSupportedException) Error() string {
+func (s *EngineNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EngineNotSupportedException) StatusCode() int {
+func (s *EngineNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EngineNotSupportedException) RequestID() string {
+func (s *EngineNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1341,12 +1341,12 @@ func newErrorInvalidLexiconException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidLexiconException) Code() string {
+func (s *InvalidLexiconException) Code() string {
 	return "InvalidLexiconException"
 }
 
 // Message returns the exception's message.
-func (s InvalidLexiconException) Message() string {
+func (s *InvalidLexiconException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1354,21 +1354,21 @@ func (s InvalidLexiconException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLexiconException) OrigErr() error {
+func (s *InvalidLexiconException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLexiconException) Error() string {
+func (s *InvalidLexiconException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLexiconException) StatusCode() int {
+func (s *InvalidLexiconException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLexiconException) RequestID() string {
+func (s *InvalidLexiconException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1398,12 +1398,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1411,21 +1411,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1455,12 +1455,12 @@ func newErrorInvalidS3BucketException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidS3BucketException) Code() string {
+func (s *InvalidS3BucketException) Code() string {
 	return "InvalidS3BucketException"
 }
 
 // Message returns the exception's message.
-func (s InvalidS3BucketException) Message() string {
+func (s *InvalidS3BucketException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1468,21 +1468,21 @@ func (s InvalidS3BucketException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidS3BucketException) OrigErr() error {
+func (s *InvalidS3BucketException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidS3BucketException) Error() string {
+func (s *InvalidS3BucketException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidS3BucketException) StatusCode() int {
+func (s *InvalidS3BucketException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidS3BucketException) RequestID() string {
+func (s *InvalidS3BucketException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1512,12 +1512,12 @@ func newErrorInvalidS3KeyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidS3KeyException) Code() string {
+func (s *InvalidS3KeyException) Code() string {
 	return "InvalidS3KeyException"
 }
 
 // Message returns the exception's message.
-func (s InvalidS3KeyException) Message() string {
+func (s *InvalidS3KeyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1525,21 +1525,21 @@ func (s InvalidS3KeyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidS3KeyException) OrigErr() error {
+func (s *InvalidS3KeyException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidS3KeyException) Error() string {
+func (s *InvalidS3KeyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidS3KeyException) StatusCode() int {
+func (s *InvalidS3KeyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidS3KeyException) RequestID() string {
+func (s *InvalidS3KeyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1568,12 +1568,12 @@ func newErrorInvalidSampleRateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSampleRateException) Code() string {
+func (s *InvalidSampleRateException) Code() string {
 	return "InvalidSampleRateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSampleRateException) Message() string {
+func (s *InvalidSampleRateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1581,21 +1581,21 @@ func (s InvalidSampleRateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSampleRateException) OrigErr() error {
+func (s *InvalidSampleRateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSampleRateException) Error() string {
+func (s *InvalidSampleRateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSampleRateException) StatusCode() int {
+func (s *InvalidSampleRateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSampleRateException) RequestID() string {
+func (s *InvalidSampleRateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1625,12 +1625,12 @@ func newErrorInvalidSnsTopicArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSnsTopicArnException) Code() string {
+func (s *InvalidSnsTopicArnException) Code() string {
 	return "InvalidSnsTopicArnException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSnsTopicArnException) Message() string {
+func (s *InvalidSnsTopicArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1638,21 +1638,21 @@ func (s InvalidSnsTopicArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSnsTopicArnException) OrigErr() error {
+func (s *InvalidSnsTopicArnException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSnsTopicArnException) Error() string {
+func (s *InvalidSnsTopicArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSnsTopicArnException) StatusCode() int {
+func (s *InvalidSnsTopicArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSnsTopicArnException) RequestID() string {
+func (s *InvalidSnsTopicArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1682,12 +1682,12 @@ func newErrorInvalidSsmlException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSsmlException) Code() string {
+func (s *InvalidSsmlException) Code() string {
 	return "InvalidSsmlException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSsmlException) Message() string {
+func (s *InvalidSsmlException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1695,21 +1695,21 @@ func (s InvalidSsmlException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSsmlException) OrigErr() error {
+func (s *InvalidSsmlException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSsmlException) Error() string {
+func (s *InvalidSsmlException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSsmlException) StatusCode() int {
+func (s *InvalidSsmlException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSsmlException) RequestID() string {
+func (s *InvalidSsmlException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1739,12 +1739,12 @@ func newErrorInvalidTaskIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTaskIdException) Code() string {
+func (s *InvalidTaskIdException) Code() string {
 	return "InvalidTaskIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTaskIdException) Message() string {
+func (s *InvalidTaskIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1752,21 +1752,21 @@ func (s InvalidTaskIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTaskIdException) OrigErr() error {
+func (s *InvalidTaskIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTaskIdException) Error() string {
+func (s *InvalidTaskIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTaskIdException) StatusCode() int {
+func (s *InvalidTaskIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTaskIdException) RequestID() string {
+func (s *InvalidTaskIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1796,12 +1796,12 @@ func newErrorLanguageNotSupportedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LanguageNotSupportedException) Code() string {
+func (s *LanguageNotSupportedException) Code() string {
 	return "LanguageNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s LanguageNotSupportedException) Message() string {
+func (s *LanguageNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1809,21 +1809,21 @@ func (s LanguageNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LanguageNotSupportedException) OrigErr() error {
+func (s *LanguageNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s LanguageNotSupportedException) Error() string {
+func (s *LanguageNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LanguageNotSupportedException) StatusCode() int {
+func (s *LanguageNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LanguageNotSupportedException) RequestID() string {
+func (s *LanguageNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1997,12 +1997,12 @@ func newErrorLexiconNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LexiconNotFoundException) Code() string {
+func (s *LexiconNotFoundException) Code() string {
 	return "LexiconNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s LexiconNotFoundException) Message() string {
+func (s *LexiconNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2010,21 +2010,21 @@ func (s LexiconNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LexiconNotFoundException) OrigErr() error {
+func (s *LexiconNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s LexiconNotFoundException) Error() string {
+func (s *LexiconNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LexiconNotFoundException) StatusCode() int {
+func (s *LexiconNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LexiconNotFoundException) RequestID() string {
+func (s *LexiconNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2053,12 +2053,12 @@ func newErrorLexiconSizeExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LexiconSizeExceededException) Code() string {
+func (s *LexiconSizeExceededException) Code() string {
 	return "LexiconSizeExceededException"
 }
 
 // Message returns the exception's message.
-func (s LexiconSizeExceededException) Message() string {
+func (s *LexiconSizeExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2066,21 +2066,21 @@ func (s LexiconSizeExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LexiconSizeExceededException) OrigErr() error {
+func (s *LexiconSizeExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LexiconSizeExceededException) Error() string {
+func (s *LexiconSizeExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LexiconSizeExceededException) StatusCode() int {
+func (s *LexiconSizeExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LexiconSizeExceededException) RequestID() string {
+func (s *LexiconSizeExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2257,12 +2257,12 @@ func newErrorMarksNotSupportedForFormatException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s MarksNotSupportedForFormatException) Code() string {
+func (s *MarksNotSupportedForFormatException) Code() string {
 	return "MarksNotSupportedForFormatException"
 }
 
 // Message returns the exception's message.
-func (s MarksNotSupportedForFormatException) Message() string {
+func (s *MarksNotSupportedForFormatException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2270,21 +2270,21 @@ func (s MarksNotSupportedForFormatException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MarksNotSupportedForFormatException) OrigErr() error {
+func (s *MarksNotSupportedForFormatException) OrigErr() error {
 	return nil
 }
 
-func (s MarksNotSupportedForFormatException) Error() string {
+func (s *MarksNotSupportedForFormatException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MarksNotSupportedForFormatException) StatusCode() int {
+func (s *MarksNotSupportedForFormatException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MarksNotSupportedForFormatException) RequestID() string {
+func (s *MarksNotSupportedForFormatException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2313,12 +2313,12 @@ func newErrorMaxLexemeLengthExceededException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s MaxLexemeLengthExceededException) Code() string {
+func (s *MaxLexemeLengthExceededException) Code() string {
 	return "MaxLexemeLengthExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxLexemeLengthExceededException) Message() string {
+func (s *MaxLexemeLengthExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2326,21 +2326,21 @@ func (s MaxLexemeLengthExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxLexemeLengthExceededException) OrigErr() error {
+func (s *MaxLexemeLengthExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxLexemeLengthExceededException) Error() string {
+func (s *MaxLexemeLengthExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxLexemeLengthExceededException) StatusCode() int {
+func (s *MaxLexemeLengthExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxLexemeLengthExceededException) RequestID() string {
+func (s *MaxLexemeLengthExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2369,12 +2369,12 @@ func newErrorMaxLexiconsNumberExceededException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s MaxLexiconsNumberExceededException) Code() string {
+func (s *MaxLexiconsNumberExceededException) Code() string {
 	return "MaxLexiconsNumberExceededException"
 }
 
 // Message returns the exception's message.
-func (s MaxLexiconsNumberExceededException) Message() string {
+func (s *MaxLexiconsNumberExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2382,21 +2382,21 @@ func (s MaxLexiconsNumberExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxLexiconsNumberExceededException) OrigErr() error {
+func (s *MaxLexiconsNumberExceededException) OrigErr() error {
 	return nil
 }
 
-func (s MaxLexiconsNumberExceededException) Error() string {
+func (s *MaxLexiconsNumberExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxLexiconsNumberExceededException) StatusCode() int {
+func (s *MaxLexiconsNumberExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxLexiconsNumberExceededException) RequestID() string {
+func (s *MaxLexiconsNumberExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2496,12 +2496,12 @@ func newErrorServiceFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceFailureException) Code() string {
+func (s *ServiceFailureException) Code() string {
 	return "ServiceFailureException"
 }
 
 // Message returns the exception's message.
-func (s ServiceFailureException) Message() string {
+func (s *ServiceFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2509,21 +2509,21 @@ func (s ServiceFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceFailureException) OrigErr() error {
+func (s *ServiceFailureException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceFailureException) Error() string {
+func (s *ServiceFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceFailureException) StatusCode() int {
+func (s *ServiceFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceFailureException) RequestID() string {
+func (s *ServiceFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2552,12 +2552,12 @@ func newErrorSsmlMarksNotSupportedForTextTypeException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s SsmlMarksNotSupportedForTextTypeException) Code() string {
+func (s *SsmlMarksNotSupportedForTextTypeException) Code() string {
 	return "SsmlMarksNotSupportedForTextTypeException"
 }
 
 // Message returns the exception's message.
-func (s SsmlMarksNotSupportedForTextTypeException) Message() string {
+func (s *SsmlMarksNotSupportedForTextTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2565,21 +2565,21 @@ func (s SsmlMarksNotSupportedForTextTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SsmlMarksNotSupportedForTextTypeException) OrigErr() error {
+func (s *SsmlMarksNotSupportedForTextTypeException) OrigErr() error {
 	return nil
 }
 
-func (s SsmlMarksNotSupportedForTextTypeException) Error() string {
+func (s *SsmlMarksNotSupportedForTextTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SsmlMarksNotSupportedForTextTypeException) StatusCode() int {
+func (s *SsmlMarksNotSupportedForTextTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SsmlMarksNotSupportedForTextTypeException) RequestID() string {
+func (s *SsmlMarksNotSupportedForTextTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2978,12 +2978,12 @@ func newErrorSynthesisTaskNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SynthesisTaskNotFoundException) Code() string {
+func (s *SynthesisTaskNotFoundException) Code() string {
 	return "SynthesisTaskNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s SynthesisTaskNotFoundException) Message() string {
+func (s *SynthesisTaskNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2991,21 +2991,21 @@ func (s SynthesisTaskNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SynthesisTaskNotFoundException) OrigErr() error {
+func (s *SynthesisTaskNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s SynthesisTaskNotFoundException) Error() string {
+func (s *SynthesisTaskNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SynthesisTaskNotFoundException) StatusCode() int {
+func (s *SynthesisTaskNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SynthesisTaskNotFoundException) RequestID() string {
+func (s *SynthesisTaskNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3239,12 +3239,12 @@ func newErrorTextLengthExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TextLengthExceededException) Code() string {
+func (s *TextLengthExceededException) Code() string {
 	return "TextLengthExceededException"
 }
 
 // Message returns the exception's message.
-func (s TextLengthExceededException) Message() string {
+func (s *TextLengthExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3252,21 +3252,21 @@ func (s TextLengthExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TextLengthExceededException) OrigErr() error {
+func (s *TextLengthExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TextLengthExceededException) Error() string {
+func (s *TextLengthExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TextLengthExceededException) StatusCode() int {
+func (s *TextLengthExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TextLengthExceededException) RequestID() string {
+func (s *TextLengthExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3296,12 +3296,12 @@ func newErrorUnsupportedPlsAlphabetException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s UnsupportedPlsAlphabetException) Code() string {
+func (s *UnsupportedPlsAlphabetException) Code() string {
 	return "UnsupportedPlsAlphabetException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedPlsAlphabetException) Message() string {
+func (s *UnsupportedPlsAlphabetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3309,21 +3309,21 @@ func (s UnsupportedPlsAlphabetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedPlsAlphabetException) OrigErr() error {
+func (s *UnsupportedPlsAlphabetException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedPlsAlphabetException) Error() string {
+func (s *UnsupportedPlsAlphabetException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedPlsAlphabetException) StatusCode() int {
+func (s *UnsupportedPlsAlphabetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedPlsAlphabetException) RequestID() string {
+func (s *UnsupportedPlsAlphabetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3353,12 +3353,12 @@ func newErrorUnsupportedPlsLanguageException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s UnsupportedPlsLanguageException) Code() string {
+func (s *UnsupportedPlsLanguageException) Code() string {
 	return "UnsupportedPlsLanguageException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedPlsLanguageException) Message() string {
+func (s *UnsupportedPlsLanguageException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3366,21 +3366,21 @@ func (s UnsupportedPlsLanguageException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedPlsLanguageException) OrigErr() error {
+func (s *UnsupportedPlsLanguageException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedPlsLanguageException) Error() string {
+func (s *UnsupportedPlsLanguageException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedPlsLanguageException) StatusCode() int {
+func (s *UnsupportedPlsLanguageException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedPlsLanguageException) RequestID() string {
+func (s *UnsupportedPlsLanguageException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/pricing/api.go
+++ b/service/pricing/api.go
@@ -628,12 +628,12 @@ func newErrorExpiredNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExpiredNextTokenException) Code() string {
+func (s *ExpiredNextTokenException) Code() string {
 	return "ExpiredNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s ExpiredNextTokenException) Message() string {
+func (s *ExpiredNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -641,21 +641,21 @@ func (s ExpiredNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExpiredNextTokenException) OrigErr() error {
+func (s *ExpiredNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s ExpiredNextTokenException) Error() string {
+func (s *ExpiredNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExpiredNextTokenException) StatusCode() int {
+func (s *ExpiredNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExpiredNextTokenException) RequestID() string {
+func (s *ExpiredNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1004,12 +1004,12 @@ func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalErrorException) Code() string {
+func (s *InternalErrorException) Code() string {
 	return "InternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalErrorException) Message() string {
+func (s *InternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1017,21 +1017,21 @@ func (s InternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalErrorException) OrigErr() error {
+func (s *InternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalErrorException) Error() string {
+func (s *InternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalErrorException) StatusCode() int {
+func (s *InternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalErrorException) RequestID() string {
+func (s *InternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1060,12 +1060,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1073,21 +1073,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1116,12 +1116,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1129,21 +1129,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1172,12 +1172,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1185,21 +1185,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/qldb/api.go
+++ b/service/qldb/api.go
@@ -2374,12 +2374,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2387,21 +2387,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2593,12 +2593,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2606,21 +2606,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3008,12 +3008,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3021,21 +3021,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3070,12 +3070,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3083,21 +3083,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3132,12 +3132,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3145,21 +3145,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3194,12 +3194,12 @@ func newErrorResourcePreconditionNotMetException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s ResourcePreconditionNotMetException) Code() string {
+func (s *ResourcePreconditionNotMetException) Code() string {
 	return "ResourcePreconditionNotMetException"
 }
 
 // Message returns the exception's message.
-func (s ResourcePreconditionNotMetException) Message() string {
+func (s *ResourcePreconditionNotMetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3207,21 +3207,21 @@ func (s ResourcePreconditionNotMetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourcePreconditionNotMetException) OrigErr() error {
+func (s *ResourcePreconditionNotMetException) OrigErr() error {
 	return nil
 }
 
-func (s ResourcePreconditionNotMetException) Error() string {
+func (s *ResourcePreconditionNotMetException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourcePreconditionNotMetException) StatusCode() int {
+func (s *ResourcePreconditionNotMetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourcePreconditionNotMetException) RequestID() string {
+func (s *ResourcePreconditionNotMetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/qldbsession/api.go
+++ b/service/qldbsession/api.go
@@ -162,12 +162,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -175,21 +175,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -531,12 +531,12 @@ func newErrorInvalidSessionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSessionException) Code() string {
+func (s *InvalidSessionException) Code() string {
 	return "InvalidSessionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidSessionException) Message() string {
+func (s *InvalidSessionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -544,21 +544,21 @@ func (s InvalidSessionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSessionException) OrigErr() error {
+func (s *InvalidSessionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSessionException) Error() string {
+func (s *InvalidSessionException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSessionException) StatusCode() int {
+func (s *InvalidSessionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSessionException) RequestID() string {
+func (s *InvalidSessionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -587,12 +587,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -600,21 +600,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -644,12 +644,12 @@ func newErrorOccConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OccConflictException) Code() string {
+func (s *OccConflictException) Code() string {
 	return "OccConflictException"
 }
 
 // Message returns the exception's message.
-func (s OccConflictException) Message() string {
+func (s *OccConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -657,21 +657,21 @@ func (s OccConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OccConflictException) OrigErr() error {
+func (s *OccConflictException) OrigErr() error {
 	return nil
 }
 
-func (s OccConflictException) Error() string {
+func (s *OccConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OccConflictException) StatusCode() int {
+func (s *OccConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OccConflictException) RequestID() string {
+func (s *OccConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -733,12 +733,12 @@ func newErrorRateExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RateExceededException) Code() string {
+func (s *RateExceededException) Code() string {
 	return "RateExceededException"
 }
 
 // Message returns the exception's message.
-func (s RateExceededException) Message() string {
+func (s *RateExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -746,21 +746,21 @@ func (s RateExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RateExceededException) OrigErr() error {
+func (s *RateExceededException) OrigErr() error {
 	return nil
 }
 
-func (s RateExceededException) Error() string {
+func (s *RateExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RateExceededException) StatusCode() int {
+func (s *RateExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RateExceededException) RequestID() string {
+func (s *RateExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/quicksight/api.go
+++ b/service/quicksight/api.go
@@ -7194,12 +7194,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7207,21 +7207,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8018,12 +8018,12 @@ func newErrorConcurrentUpdatingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConcurrentUpdatingException) Code() string {
+func (s *ConcurrentUpdatingException) Code() string {
 	return "ConcurrentUpdatingException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentUpdatingException) Message() string {
+func (s *ConcurrentUpdatingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8031,21 +8031,21 @@ func (s ConcurrentUpdatingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentUpdatingException) OrigErr() error {
+func (s *ConcurrentUpdatingException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentUpdatingException) Error() string {
+func (s *ConcurrentUpdatingException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentUpdatingException) StatusCode() int {
+func (s *ConcurrentUpdatingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentUpdatingException) RequestID() string {
+func (s *ConcurrentUpdatingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8077,12 +8077,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8090,21 +8090,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14234,12 +14234,12 @@ func newErrorDomainNotWhitelistedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DomainNotWhitelistedException) Code() string {
+func (s *DomainNotWhitelistedException) Code() string {
 	return "DomainNotWhitelistedException"
 }
 
 // Message returns the exception's message.
-func (s DomainNotWhitelistedException) Message() string {
+func (s *DomainNotWhitelistedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14247,21 +14247,21 @@ func (s DomainNotWhitelistedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DomainNotWhitelistedException) OrigErr() error {
+func (s *DomainNotWhitelistedException) OrigErr() error {
 	return nil
 }
 
-func (s DomainNotWhitelistedException) Error() string {
+func (s *DomainNotWhitelistedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DomainNotWhitelistedException) StatusCode() int {
+func (s *DomainNotWhitelistedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DomainNotWhitelistedException) RequestID() string {
+func (s *DomainNotWhitelistedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14823,12 +14823,12 @@ func newErrorIdentityTypeNotSupportedException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s IdentityTypeNotSupportedException) Code() string {
+func (s *IdentityTypeNotSupportedException) Code() string {
 	return "IdentityTypeNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s IdentityTypeNotSupportedException) Message() string {
+func (s *IdentityTypeNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14836,21 +14836,21 @@ func (s IdentityTypeNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdentityTypeNotSupportedException) OrigErr() error {
+func (s *IdentityTypeNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s IdentityTypeNotSupportedException) Error() string {
+func (s *IdentityTypeNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdentityTypeNotSupportedException) StatusCode() int {
+func (s *IdentityTypeNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdentityTypeNotSupportedException) RequestID() string {
+func (s *IdentityTypeNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15111,12 +15111,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15124,21 +15124,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15170,12 +15170,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15183,21 +15183,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15229,12 +15229,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15242,21 +15242,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15423,12 +15423,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15436,21 +15436,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17999,12 +17999,12 @@ func newErrorPreconditionNotMetException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PreconditionNotMetException) Code() string {
+func (s *PreconditionNotMetException) Code() string {
 	return "PreconditionNotMetException"
 }
 
 // Message returns the exception's message.
-func (s PreconditionNotMetException) Message() string {
+func (s *PreconditionNotMetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18012,21 +18012,21 @@ func (s PreconditionNotMetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PreconditionNotMetException) OrigErr() error {
+func (s *PreconditionNotMetException) OrigErr() error {
 	return nil
 }
 
-func (s PreconditionNotMetException) Error() string {
+func (s *PreconditionNotMetException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PreconditionNotMetException) StatusCode() int {
+func (s *PreconditionNotMetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PreconditionNotMetException) RequestID() string {
+func (s *PreconditionNotMetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18713,12 +18713,12 @@ func newErrorResourceExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceExistsException) Code() string {
+func (s *ResourceExistsException) Code() string {
 	return "ResourceExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceExistsException) Message() string {
+func (s *ResourceExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18726,21 +18726,21 @@ func (s ResourceExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceExistsException) OrigErr() error {
+func (s *ResourceExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceExistsException) Error() string {
+func (s *ResourceExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceExistsException) StatusCode() int {
+func (s *ResourceExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceExistsException) RequestID() string {
+func (s *ResourceExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18775,12 +18775,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18788,21 +18788,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18899,12 +18899,12 @@ func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceUnavailableException) Code() string {
+func (s *ResourceUnavailableException) Code() string {
 	return "ResourceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ResourceUnavailableException) Message() string {
+func (s *ResourceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18912,21 +18912,21 @@ func (s ResourceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceUnavailableException) OrigErr() error {
+func (s *ResourceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceUnavailableException) Error() string {
+func (s *ResourceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceUnavailableException) StatusCode() int {
+func (s *ResourceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceUnavailableException) RequestID() string {
+func (s *ResourceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19352,12 +19352,12 @@ func newErrorSessionLifetimeInMinutesInvalidException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s SessionLifetimeInMinutesInvalidException) Code() string {
+func (s *SessionLifetimeInMinutesInvalidException) Code() string {
 	return "SessionLifetimeInMinutesInvalidException"
 }
 
 // Message returns the exception's message.
-func (s SessionLifetimeInMinutesInvalidException) Message() string {
+func (s *SessionLifetimeInMinutesInvalidException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19365,21 +19365,21 @@ func (s SessionLifetimeInMinutesInvalidException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SessionLifetimeInMinutesInvalidException) OrigErr() error {
+func (s *SessionLifetimeInMinutesInvalidException) OrigErr() error {
 	return nil
 }
 
-func (s SessionLifetimeInMinutesInvalidException) Error() string {
+func (s *SessionLifetimeInMinutesInvalidException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SessionLifetimeInMinutesInvalidException) StatusCode() int {
+func (s *SessionLifetimeInMinutesInvalidException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SessionLifetimeInMinutesInvalidException) RequestID() string {
+func (s *SessionLifetimeInMinutesInvalidException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20540,12 +20540,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20553,21 +20553,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -20773,12 +20773,12 @@ func newErrorUnsupportedUserEditionException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s UnsupportedUserEditionException) Code() string {
+func (s *UnsupportedUserEditionException) Code() string {
 	return "UnsupportedUserEditionException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedUserEditionException) Message() string {
+func (s *UnsupportedUserEditionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -20786,21 +20786,21 @@ func (s UnsupportedUserEditionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedUserEditionException) OrigErr() error {
+func (s *UnsupportedUserEditionException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedUserEditionException) Error() string {
+func (s *UnsupportedUserEditionException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedUserEditionException) StatusCode() int {
+func (s *UnsupportedUserEditionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedUserEditionException) RequestID() string {
+func (s *UnsupportedUserEditionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23293,12 +23293,12 @@ func newErrorUserNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UserNotFoundException) Code() string {
+func (s *UserNotFoundException) Code() string {
 	return "QuickSightUserNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s UserNotFoundException) Message() string {
+func (s *UserNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23306,21 +23306,21 @@ func (s UserNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UserNotFoundException) OrigErr() error {
+func (s *UserNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s UserNotFoundException) Error() string {
+func (s *UserNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UserNotFoundException) StatusCode() int {
+func (s *UserNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UserNotFoundException) RequestID() string {
+func (s *UserNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/ram/api.go
+++ b/service/ram/api.go
@@ -3994,12 +3994,12 @@ func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatchException) Code() string {
+func (s *IdempotentParameterMismatchException) Code() string {
 	return "IdempotentParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatchException) Message() string {
+func (s *IdempotentParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4007,21 +4007,21 @@ func (s IdempotentParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatchException) OrigErr() error {
+func (s *IdempotentParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatchException) Error() string {
+func (s *IdempotentParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatchException) StatusCode() int {
+func (s *IdempotentParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatchException) RequestID() string {
+func (s *IdempotentParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4050,12 +4050,12 @@ func newErrorInvalidClientTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidClientTokenException) Code() string {
+func (s *InvalidClientTokenException) Code() string {
 	return "InvalidClientTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidClientTokenException) Message() string {
+func (s *InvalidClientTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4063,21 +4063,21 @@ func (s InvalidClientTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidClientTokenException) OrigErr() error {
+func (s *InvalidClientTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidClientTokenException) Error() string {
+func (s *InvalidClientTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidClientTokenException) StatusCode() int {
+func (s *InvalidClientTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidClientTokenException) RequestID() string {
+func (s *InvalidClientTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4106,12 +4106,12 @@ func newErrorInvalidMaxResultsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidMaxResultsException) Code() string {
+func (s *InvalidMaxResultsException) Code() string {
 	return "InvalidMaxResultsException"
 }
 
 // Message returns the exception's message.
-func (s InvalidMaxResultsException) Message() string {
+func (s *InvalidMaxResultsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4119,21 +4119,21 @@ func (s InvalidMaxResultsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidMaxResultsException) OrigErr() error {
+func (s *InvalidMaxResultsException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidMaxResultsException) Error() string {
+func (s *InvalidMaxResultsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidMaxResultsException) StatusCode() int {
+func (s *InvalidMaxResultsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidMaxResultsException) RequestID() string {
+func (s *InvalidMaxResultsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4162,12 +4162,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4175,21 +4175,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4218,12 +4218,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4231,21 +4231,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4274,12 +4274,12 @@ func newErrorInvalidResourceTypeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceTypeException) Code() string {
+func (s *InvalidResourceTypeException) Code() string {
 	return "InvalidResourceTypeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceTypeException) Message() string {
+func (s *InvalidResourceTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4287,21 +4287,21 @@ func (s InvalidResourceTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceTypeException) OrigErr() error {
+func (s *InvalidResourceTypeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceTypeException) Error() string {
+func (s *InvalidResourceTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceTypeException) StatusCode() int {
+func (s *InvalidResourceTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceTypeException) RequestID() string {
+func (s *InvalidResourceTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4330,12 +4330,12 @@ func newErrorInvalidStateTransitionException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidStateTransitionException) Code() string {
+func (s *InvalidStateTransitionException) Code() string {
 	return "InvalidStateTransitionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateTransitionException) Message() string {
+func (s *InvalidStateTransitionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4343,21 +4343,21 @@ func (s InvalidStateTransitionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateTransitionException) OrigErr() error {
+func (s *InvalidStateTransitionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateTransitionException) Error() string {
+func (s *InvalidStateTransitionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateTransitionException) StatusCode() int {
+func (s *InvalidStateTransitionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateTransitionException) RequestID() string {
+func (s *InvalidStateTransitionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4927,12 +4927,12 @@ func newErrorMalformedArnException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MalformedArnException) Code() string {
+func (s *MalformedArnException) Code() string {
 	return "MalformedArnException"
 }
 
 // Message returns the exception's message.
-func (s MalformedArnException) Message() string {
+func (s *MalformedArnException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4940,21 +4940,21 @@ func (s MalformedArnException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MalformedArnException) OrigErr() error {
+func (s *MalformedArnException) OrigErr() error {
 	return nil
 }
 
-func (s MalformedArnException) Error() string {
+func (s *MalformedArnException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MalformedArnException) StatusCode() int {
+func (s *MalformedArnException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MalformedArnException) RequestID() string {
+func (s *MalformedArnException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4983,12 +4983,12 @@ func newErrorMissingRequiredParameterException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s MissingRequiredParameterException) Code() string {
+func (s *MissingRequiredParameterException) Code() string {
 	return "MissingRequiredParameterException"
 }
 
 // Message returns the exception's message.
-func (s MissingRequiredParameterException) Message() string {
+func (s *MissingRequiredParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4996,21 +4996,21 @@ func (s MissingRequiredParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MissingRequiredParameterException) OrigErr() error {
+func (s *MissingRequiredParameterException) OrigErr() error {
 	return nil
 }
 
-func (s MissingRequiredParameterException) Error() string {
+func (s *MissingRequiredParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MissingRequiredParameterException) StatusCode() int {
+func (s *MissingRequiredParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MissingRequiredParameterException) RequestID() string {
+func (s *MissingRequiredParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5039,12 +5039,12 @@ func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotPermittedException) Code() string {
+func (s *OperationNotPermittedException) Code() string {
 	return "OperationNotPermittedException"
 }
 
 // Message returns the exception's message.
-func (s OperationNotPermittedException) Message() string {
+func (s *OperationNotPermittedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5052,21 +5052,21 @@ func (s OperationNotPermittedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotPermittedException) OrigErr() error {
+func (s *OperationNotPermittedException) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotPermittedException) Error() string {
+func (s *OperationNotPermittedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotPermittedException) StatusCode() int {
+func (s *OperationNotPermittedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotPermittedException) RequestID() string {
+func (s *OperationNotPermittedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5386,12 +5386,12 @@ func newErrorResourceArnNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceArnNotFoundException) Code() string {
+func (s *ResourceArnNotFoundException) Code() string {
 	return "ResourceArnNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceArnNotFoundException) Message() string {
+func (s *ResourceArnNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5399,21 +5399,21 @@ func (s ResourceArnNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceArnNotFoundException) OrigErr() error {
+func (s *ResourceArnNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceArnNotFoundException) Error() string {
+func (s *ResourceArnNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceArnNotFoundException) StatusCode() int {
+func (s *ResourceArnNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceArnNotFoundException) RequestID() string {
+func (s *ResourceArnNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5749,12 +5749,12 @@ func newErrorResourceShareInvitationAlreadyAcceptedException(v protocol.Response
 }
 
 // Code returns the exception type name.
-func (s ResourceShareInvitationAlreadyAcceptedException) Code() string {
+func (s *ResourceShareInvitationAlreadyAcceptedException) Code() string {
 	return "ResourceShareInvitationAlreadyAcceptedException"
 }
 
 // Message returns the exception's message.
-func (s ResourceShareInvitationAlreadyAcceptedException) Message() string {
+func (s *ResourceShareInvitationAlreadyAcceptedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5762,21 +5762,21 @@ func (s ResourceShareInvitationAlreadyAcceptedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceShareInvitationAlreadyAcceptedException) OrigErr() error {
+func (s *ResourceShareInvitationAlreadyAcceptedException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceShareInvitationAlreadyAcceptedException) Error() string {
+func (s *ResourceShareInvitationAlreadyAcceptedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceShareInvitationAlreadyAcceptedException) StatusCode() int {
+func (s *ResourceShareInvitationAlreadyAcceptedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceShareInvitationAlreadyAcceptedException) RequestID() string {
+func (s *ResourceShareInvitationAlreadyAcceptedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5805,12 +5805,12 @@ func newErrorResourceShareInvitationAlreadyRejectedException(v protocol.Response
 }
 
 // Code returns the exception type name.
-func (s ResourceShareInvitationAlreadyRejectedException) Code() string {
+func (s *ResourceShareInvitationAlreadyRejectedException) Code() string {
 	return "ResourceShareInvitationAlreadyRejectedException"
 }
 
 // Message returns the exception's message.
-func (s ResourceShareInvitationAlreadyRejectedException) Message() string {
+func (s *ResourceShareInvitationAlreadyRejectedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5818,21 +5818,21 @@ func (s ResourceShareInvitationAlreadyRejectedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceShareInvitationAlreadyRejectedException) OrigErr() error {
+func (s *ResourceShareInvitationAlreadyRejectedException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceShareInvitationAlreadyRejectedException) Error() string {
+func (s *ResourceShareInvitationAlreadyRejectedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceShareInvitationAlreadyRejectedException) StatusCode() int {
+func (s *ResourceShareInvitationAlreadyRejectedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceShareInvitationAlreadyRejectedException) RequestID() string {
+func (s *ResourceShareInvitationAlreadyRejectedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5861,12 +5861,12 @@ func newErrorResourceShareInvitationArnNotFoundException(v protocol.ResponseMeta
 }
 
 // Code returns the exception type name.
-func (s ResourceShareInvitationArnNotFoundException) Code() string {
+func (s *ResourceShareInvitationArnNotFoundException) Code() string {
 	return "ResourceShareInvitationArnNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceShareInvitationArnNotFoundException) Message() string {
+func (s *ResourceShareInvitationArnNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5874,21 +5874,21 @@ func (s ResourceShareInvitationArnNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceShareInvitationArnNotFoundException) OrigErr() error {
+func (s *ResourceShareInvitationArnNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceShareInvitationArnNotFoundException) Error() string {
+func (s *ResourceShareInvitationArnNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceShareInvitationArnNotFoundException) StatusCode() int {
+func (s *ResourceShareInvitationArnNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceShareInvitationArnNotFoundException) RequestID() string {
+func (s *ResourceShareInvitationArnNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5917,12 +5917,12 @@ func newErrorResourceShareInvitationExpiredException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s ResourceShareInvitationExpiredException) Code() string {
+func (s *ResourceShareInvitationExpiredException) Code() string {
 	return "ResourceShareInvitationExpiredException"
 }
 
 // Message returns the exception's message.
-func (s ResourceShareInvitationExpiredException) Message() string {
+func (s *ResourceShareInvitationExpiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5930,21 +5930,21 @@ func (s ResourceShareInvitationExpiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceShareInvitationExpiredException) OrigErr() error {
+func (s *ResourceShareInvitationExpiredException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceShareInvitationExpiredException) Error() string {
+func (s *ResourceShareInvitationExpiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceShareInvitationExpiredException) StatusCode() int {
+func (s *ResourceShareInvitationExpiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceShareInvitationExpiredException) RequestID() string {
+func (s *ResourceShareInvitationExpiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5973,12 +5973,12 @@ func newErrorResourceShareLimitExceededException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s ResourceShareLimitExceededException) Code() string {
+func (s *ResourceShareLimitExceededException) Code() string {
 	return "ResourceShareLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceShareLimitExceededException) Message() string {
+func (s *ResourceShareLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5986,21 +5986,21 @@ func (s ResourceShareLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceShareLimitExceededException) OrigErr() error {
+func (s *ResourceShareLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceShareLimitExceededException) Error() string {
+func (s *ResourceShareLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceShareLimitExceededException) StatusCode() int {
+func (s *ResourceShareLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceShareLimitExceededException) RequestID() string {
+func (s *ResourceShareLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6207,12 +6207,12 @@ func newErrorServerInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServerInternalException) Code() string {
+func (s *ServerInternalException) Code() string {
 	return "ServerInternalException"
 }
 
 // Message returns the exception's message.
-func (s ServerInternalException) Message() string {
+func (s *ServerInternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6220,21 +6220,21 @@ func (s ServerInternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServerInternalException) OrigErr() error {
+func (s *ServerInternalException) OrigErr() error {
 	return nil
 }
 
-func (s ServerInternalException) Error() string {
+func (s *ServerInternalException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServerInternalException) StatusCode() int {
+func (s *ServerInternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServerInternalException) RequestID() string {
+func (s *ServerInternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6263,12 +6263,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6276,21 +6276,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6385,12 +6385,12 @@ func newErrorTagLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagLimitExceededException) Code() string {
+func (s *TagLimitExceededException) Code() string {
 	return "TagLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TagLimitExceededException) Message() string {
+func (s *TagLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6398,21 +6398,21 @@ func (s TagLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagLimitExceededException) OrigErr() error {
+func (s *TagLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TagLimitExceededException) Error() string {
+func (s *TagLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagLimitExceededException) StatusCode() int {
+func (s *TagLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagLimitExceededException) RequestID() string {
+func (s *TagLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6441,12 +6441,12 @@ func newErrorTagPolicyViolationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagPolicyViolationException) Code() string {
+func (s *TagPolicyViolationException) Code() string {
 	return "TagPolicyViolationException"
 }
 
 // Message returns the exception's message.
-func (s TagPolicyViolationException) Message() string {
+func (s *TagPolicyViolationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6454,21 +6454,21 @@ func (s TagPolicyViolationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagPolicyViolationException) OrigErr() error {
+func (s *TagPolicyViolationException) OrigErr() error {
 	return nil
 }
 
-func (s TagPolicyViolationException) Error() string {
+func (s *TagPolicyViolationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagPolicyViolationException) StatusCode() int {
+func (s *TagPolicyViolationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagPolicyViolationException) RequestID() string {
+func (s *TagPolicyViolationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6563,12 +6563,12 @@ func newErrorUnknownResourceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnknownResourceException) Code() string {
+func (s *UnknownResourceException) Code() string {
 	return "UnknownResourceException"
 }
 
 // Message returns the exception's message.
-func (s UnknownResourceException) Message() string {
+func (s *UnknownResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6576,21 +6576,21 @@ func (s UnknownResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnknownResourceException) OrigErr() error {
+func (s *UnknownResourceException) OrigErr() error {
 	return nil
 }
 
-func (s UnknownResourceException) Error() string {
+func (s *UnknownResourceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnknownResourceException) StatusCode() int {
+func (s *UnknownResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnknownResourceException) RequestID() string {
+func (s *UnknownResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/rdsdataservice/api.go
+++ b/service/rdsdataservice/api.go
@@ -681,12 +681,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -694,21 +694,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1635,12 +1635,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1648,21 +1648,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1691,12 +1691,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1704,21 +1704,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1748,12 +1748,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1761,21 +1761,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2024,12 +2024,12 @@ func newErrorServiceUnavailableError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableError) Code() string {
+func (s *ServiceUnavailableError) Code() string {
 	return "ServiceUnavailableError"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableError) Message() string {
+func (s *ServiceUnavailableError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2037,21 +2037,21 @@ func (s ServiceUnavailableError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableError) OrigErr() error {
+func (s *ServiceUnavailableError) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableError) Error() string {
+func (s *ServiceUnavailableError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableError) StatusCode() int {
+func (s *ServiceUnavailableError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableError) RequestID() string {
+func (s *ServiceUnavailableError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2175,12 +2175,12 @@ func newErrorStatementTimeoutException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StatementTimeoutException) Code() string {
+func (s *StatementTimeoutException) Code() string {
 	return "StatementTimeoutException"
 }
 
 // Message returns the exception's message.
-func (s StatementTimeoutException) Message() string {
+func (s *StatementTimeoutException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2188,21 +2188,21 @@ func (s StatementTimeoutException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StatementTimeoutException) OrigErr() error {
+func (s *StatementTimeoutException) OrigErr() error {
 	return nil
 }
 
-func (s StatementTimeoutException) Error() string {
+func (s *StatementTimeoutException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StatementTimeoutException) StatusCode() int {
+func (s *StatementTimeoutException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StatementTimeoutException) RequestID() string {
+func (s *StatementTimeoutException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/rekognition/api.go
+++ b/service/rekognition/api.go
@@ -5863,12 +5863,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5876,21 +5876,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10296,12 +10296,12 @@ func newErrorHumanLoopQuotaExceededException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s HumanLoopQuotaExceededException) Code() string {
+func (s *HumanLoopQuotaExceededException) Code() string {
 	return "HumanLoopQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s HumanLoopQuotaExceededException) Message() string {
+func (s *HumanLoopQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10309,21 +10309,21 @@ func (s HumanLoopQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s HumanLoopQuotaExceededException) OrigErr() error {
+func (s *HumanLoopQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s HumanLoopQuotaExceededException) Error() string {
+func (s *HumanLoopQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s HumanLoopQuotaExceededException) StatusCode() int {
+func (s *HumanLoopQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s HumanLoopQuotaExceededException) RequestID() string {
+func (s *HumanLoopQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10354,12 +10354,12 @@ func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatchException) Code() string {
+func (s *IdempotentParameterMismatchException) Code() string {
 	return "IdempotentParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatchException) Message() string {
+func (s *IdempotentParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10367,21 +10367,21 @@ func (s IdempotentParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatchException) OrigErr() error {
+func (s *IdempotentParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatchException) Error() string {
+func (s *IdempotentParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatchException) StatusCode() int {
+func (s *IdempotentParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatchException) RequestID() string {
+func (s *IdempotentParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10524,12 +10524,12 @@ func newErrorImageTooLargeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ImageTooLargeException) Code() string {
+func (s *ImageTooLargeException) Code() string {
 	return "ImageTooLargeException"
 }
 
 // Message returns the exception's message.
-func (s ImageTooLargeException) Message() string {
+func (s *ImageTooLargeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10537,21 +10537,21 @@ func (s ImageTooLargeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ImageTooLargeException) OrigErr() error {
+func (s *ImageTooLargeException) OrigErr() error {
 	return nil
 }
 
-func (s ImageTooLargeException) Error() string {
+func (s *ImageTooLargeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ImageTooLargeException) StatusCode() int {
+func (s *ImageTooLargeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ImageTooLargeException) RequestID() string {
+func (s *ImageTooLargeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10834,12 +10834,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10847,21 +10847,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10890,12 +10890,12 @@ func newErrorInvalidImageFormatException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidImageFormatException) Code() string {
+func (s *InvalidImageFormatException) Code() string {
 	return "InvalidImageFormatException"
 }
 
 // Message returns the exception's message.
-func (s InvalidImageFormatException) Message() string {
+func (s *InvalidImageFormatException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10903,21 +10903,21 @@ func (s InvalidImageFormatException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidImageFormatException) OrigErr() error {
+func (s *InvalidImageFormatException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidImageFormatException) Error() string {
+func (s *InvalidImageFormatException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidImageFormatException) StatusCode() int {
+func (s *InvalidImageFormatException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidImageFormatException) RequestID() string {
+func (s *InvalidImageFormatException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10946,12 +10946,12 @@ func newErrorInvalidPaginationTokenException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidPaginationTokenException) Code() string {
+func (s *InvalidPaginationTokenException) Code() string {
 	return "InvalidPaginationTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPaginationTokenException) Message() string {
+func (s *InvalidPaginationTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10959,21 +10959,21 @@ func (s InvalidPaginationTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPaginationTokenException) OrigErr() error {
+func (s *InvalidPaginationTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPaginationTokenException) Error() string {
+func (s *InvalidPaginationTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPaginationTokenException) StatusCode() int {
+func (s *InvalidPaginationTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPaginationTokenException) RequestID() string {
+func (s *InvalidPaginationTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11003,12 +11003,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11016,21 +11016,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11059,12 +11059,12 @@ func newErrorInvalidS3ObjectException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidS3ObjectException) Code() string {
+func (s *InvalidS3ObjectException) Code() string {
 	return "InvalidS3ObjectException"
 }
 
 // Message returns the exception's message.
-func (s InvalidS3ObjectException) Message() string {
+func (s *InvalidS3ObjectException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11072,21 +11072,21 @@ func (s InvalidS3ObjectException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidS3ObjectException) OrigErr() error {
+func (s *InvalidS3ObjectException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidS3ObjectException) Error() string {
+func (s *InvalidS3ObjectException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidS3ObjectException) StatusCode() int {
+func (s *InvalidS3ObjectException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidS3ObjectException) RequestID() string {
+func (s *InvalidS3ObjectException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11305,12 +11305,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11318,21 +11318,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12244,12 +12244,12 @@ func newErrorProvisionedThroughputExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s ProvisionedThroughputExceededException) Code() string {
+func (s *ProvisionedThroughputExceededException) Code() string {
 	return "ProvisionedThroughputExceededException"
 }
 
 // Message returns the exception's message.
-func (s ProvisionedThroughputExceededException) Message() string {
+func (s *ProvisionedThroughputExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12257,21 +12257,21 @@ func (s ProvisionedThroughputExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProvisionedThroughputExceededException) OrigErr() error {
+func (s *ProvisionedThroughputExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ProvisionedThroughputExceededException) Error() string {
+func (s *ProvisionedThroughputExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProvisionedThroughputExceededException) StatusCode() int {
+func (s *ProvisionedThroughputExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProvisionedThroughputExceededException) RequestID() string {
+func (s *ProvisionedThroughputExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12430,12 +12430,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12443,21 +12443,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12485,12 +12485,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12498,21 +12498,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12541,12 +12541,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12554,21 +12554,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12598,12 +12598,12 @@ func newErrorResourceNotReadyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotReadyException) Code() string {
+func (s *ResourceNotReadyException) Code() string {
 	return "ResourceNotReadyException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotReadyException) Message() string {
+func (s *ResourceNotReadyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12611,21 +12611,21 @@ func (s ResourceNotReadyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotReadyException) OrigErr() error {
+func (s *ResourceNotReadyException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotReadyException) Error() string {
+func (s *ResourceNotReadyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotReadyException) StatusCode() int {
+func (s *ResourceNotReadyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotReadyException) RequestID() string {
+func (s *ResourceNotReadyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14624,12 +14624,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14637,21 +14637,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14921,12 +14921,12 @@ func newErrorVideoTooLargeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s VideoTooLargeException) Code() string {
+func (s *VideoTooLargeException) Code() string {
 	return "VideoTooLargeException"
 }
 
 // Message returns the exception's message.
-func (s VideoTooLargeException) Message() string {
+func (s *VideoTooLargeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14934,21 +14934,21 @@ func (s VideoTooLargeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s VideoTooLargeException) OrigErr() error {
+func (s *VideoTooLargeException) OrigErr() error {
 	return nil
 }
 
-func (s VideoTooLargeException) Error() string {
+func (s *VideoTooLargeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s VideoTooLargeException) StatusCode() int {
+func (s *VideoTooLargeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s VideoTooLargeException) RequestID() string {
+func (s *VideoTooLargeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/resourcegroups/api.go
+++ b/service/resourcegroups/api.go
@@ -1357,12 +1357,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1370,21 +1370,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1605,12 +1605,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1618,21 +1618,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2040,12 +2040,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2053,21 +2053,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2347,12 +2347,12 @@ func newErrorMethodNotAllowedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MethodNotAllowedException) Code() string {
+func (s *MethodNotAllowedException) Code() string {
 	return "MethodNotAllowedException"
 }
 
 // Message returns the exception's message.
-func (s MethodNotAllowedException) Message() string {
+func (s *MethodNotAllowedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2360,21 +2360,21 @@ func (s MethodNotAllowedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MethodNotAllowedException) OrigErr() error {
+func (s *MethodNotAllowedException) OrigErr() error {
 	return nil
 }
 
-func (s MethodNotAllowedException) Error() string {
+func (s *MethodNotAllowedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MethodNotAllowedException) StatusCode() int {
+func (s *MethodNotAllowedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MethodNotAllowedException) RequestID() string {
+func (s *MethodNotAllowedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2403,12 +2403,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2416,21 +2416,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2882,12 +2882,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2895,21 +2895,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2939,12 +2939,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2952,21 +2952,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/resourcegroupstaggingapi/api.go
+++ b/service/resourcegroupstaggingapi/api.go
@@ -1235,12 +1235,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1248,21 +1248,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1305,12 +1305,12 @@ func newErrorConstraintViolationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConstraintViolationException) Code() string {
+func (s *ConstraintViolationException) Code() string {
 	return "ConstraintViolationException"
 }
 
 // Message returns the exception's message.
-func (s ConstraintViolationException) Message() string {
+func (s *ConstraintViolationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1318,21 +1318,21 @@ func (s ConstraintViolationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConstraintViolationException) OrigErr() error {
+func (s *ConstraintViolationException) OrigErr() error {
 	return nil
 }
 
-func (s ConstraintViolationException) Error() string {
+func (s *ConstraintViolationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConstraintViolationException) StatusCode() int {
+func (s *ConstraintViolationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConstraintViolationException) RequestID() string {
+func (s *ConstraintViolationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2008,12 +2008,12 @@ func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceException) Code() string {
+func (s *InternalServiceException) Code() string {
 	return "InternalServiceException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceException) Message() string {
+func (s *InternalServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2021,21 +2021,21 @@ func (s InternalServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceException) OrigErr() error {
+func (s *InternalServiceException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceException) Error() string {
+func (s *InternalServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceException) StatusCode() int {
+func (s *InternalServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceException) RequestID() string {
+func (s *InternalServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2077,12 +2077,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2090,21 +2090,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2134,12 +2134,12 @@ func newErrorPaginationTokenExpiredException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s PaginationTokenExpiredException) Code() string {
+func (s *PaginationTokenExpiredException) Code() string {
 	return "PaginationTokenExpiredException"
 }
 
 // Message returns the exception's message.
-func (s PaginationTokenExpiredException) Message() string {
+func (s *PaginationTokenExpiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2147,21 +2147,21 @@ func (s PaginationTokenExpiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PaginationTokenExpiredException) OrigErr() error {
+func (s *PaginationTokenExpiredException) OrigErr() error {
 	return nil
 }
 
-func (s PaginationTokenExpiredException) Error() string {
+func (s *PaginationTokenExpiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PaginationTokenExpiredException) StatusCode() int {
+func (s *PaginationTokenExpiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PaginationTokenExpiredException) RequestID() string {
+func (s *PaginationTokenExpiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2545,12 +2545,12 @@ func newErrorThrottledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottledException) Code() string {
+func (s *ThrottledException) Code() string {
 	return "ThrottledException"
 }
 
 // Message returns the exception's message.
-func (s ThrottledException) Message() string {
+func (s *ThrottledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2558,21 +2558,21 @@ func (s ThrottledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottledException) OrigErr() error {
+func (s *ThrottledException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottledException) Error() string {
+func (s *ThrottledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottledException) StatusCode() int {
+func (s *ThrottledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottledException) RequestID() string {
+func (s *ThrottledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/robomaker/api.go
+++ b/service/robomaker/api.go
@@ -4427,12 +4427,12 @@ func newErrorConcurrentDeploymentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConcurrentDeploymentException) Code() string {
+func (s *ConcurrentDeploymentException) Code() string {
 	return "ConcurrentDeploymentException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentDeploymentException) Message() string {
+func (s *ConcurrentDeploymentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4440,21 +4440,21 @@ func (s ConcurrentDeploymentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentDeploymentException) OrigErr() error {
+func (s *ConcurrentDeploymentException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentDeploymentException) Error() string {
+func (s *ConcurrentDeploymentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentDeploymentException) StatusCode() int {
+func (s *ConcurrentDeploymentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentDeploymentException) RequestID() string {
+func (s *ConcurrentDeploymentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8301,12 +8301,12 @@ func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatchException) Code() string {
+func (s *IdempotentParameterMismatchException) Code() string {
 	return "IdempotentParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatchException) Message() string {
+func (s *IdempotentParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8314,21 +8314,21 @@ func (s IdempotentParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatchException) OrigErr() error {
+func (s *IdempotentParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatchException) Error() string {
+func (s *IdempotentParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatchException) StatusCode() int {
+func (s *IdempotentParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatchException) RequestID() string {
+func (s *IdempotentParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8357,12 +8357,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8370,21 +8370,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8414,12 +8414,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8427,21 +8427,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8565,12 +8565,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8578,21 +8578,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9968,12 +9968,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9981,21 +9981,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10024,12 +10024,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10037,21 +10037,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10577,12 +10577,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10590,21 +10590,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12052,12 +12052,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12065,21 +12065,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -3027,12 +3027,12 @@ func newErrorDomainLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DomainLimitExceeded) Code() string {
+func (s *DomainLimitExceeded) Code() string {
 	return "DomainLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s DomainLimitExceeded) Message() string {
+func (s *DomainLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3040,21 +3040,21 @@ func (s DomainLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DomainLimitExceeded) OrigErr() error {
+func (s *DomainLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s DomainLimitExceeded) Error() string {
+func (s *DomainLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DomainLimitExceeded) StatusCode() int {
+func (s *DomainLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DomainLimitExceeded) RequestID() string {
+func (s *DomainLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3257,12 +3257,12 @@ func newErrorDuplicateRequest(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateRequest) Code() string {
+func (s *DuplicateRequest) Code() string {
 	return "DuplicateRequest"
 }
 
 // Message returns the exception's message.
-func (s DuplicateRequest) Message() string {
+func (s *DuplicateRequest) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3270,21 +3270,21 @@ func (s DuplicateRequest) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateRequest) OrigErr() error {
+func (s *DuplicateRequest) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateRequest) Error() string {
+func (s *DuplicateRequest) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateRequest) StatusCode() int {
+func (s *DuplicateRequest) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateRequest) RequestID() string {
+func (s *DuplicateRequest) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4080,12 +4080,12 @@ func newErrorInvalidInput(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInput) Code() string {
+func (s *InvalidInput) Code() string {
 	return "InvalidInput"
 }
 
 // Message returns the exception's message.
-func (s InvalidInput) Message() string {
+func (s *InvalidInput) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4093,21 +4093,21 @@ func (s InvalidInput) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInput) OrigErr() error {
+func (s *InvalidInput) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInput) Error() string {
+func (s *InvalidInput) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInput) StatusCode() int {
+func (s *InvalidInput) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInput) RequestID() string {
+func (s *InvalidInput) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4426,12 +4426,12 @@ func newErrorOperationLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationLimitExceeded) Code() string {
+func (s *OperationLimitExceeded) Code() string {
 	return "OperationLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s OperationLimitExceeded) Message() string {
+func (s *OperationLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4439,21 +4439,21 @@ func (s OperationLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationLimitExceeded) OrigErr() error {
+func (s *OperationLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s OperationLimitExceeded) Error() string {
+func (s *OperationLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationLimitExceeded) StatusCode() int {
+func (s *OperationLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationLimitExceeded) RequestID() string {
+func (s *OperationLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4991,12 +4991,12 @@ func newErrorTLDRulesViolation(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TLDRulesViolation) Code() string {
+func (s *TLDRulesViolation) Code() string {
 	return "TLDRulesViolation"
 }
 
 // Message returns the exception's message.
-func (s TLDRulesViolation) Message() string {
+func (s *TLDRulesViolation) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5004,21 +5004,21 @@ func (s TLDRulesViolation) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TLDRulesViolation) OrigErr() error {
+func (s *TLDRulesViolation) OrigErr() error {
 	return nil
 }
 
-func (s TLDRulesViolation) Error() string {
+func (s *TLDRulesViolation) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TLDRulesViolation) StatusCode() int {
+func (s *TLDRulesViolation) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TLDRulesViolation) RequestID() string {
+func (s *TLDRulesViolation) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5333,12 +5333,12 @@ func newErrorUnsupportedTLD(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedTLD) Code() string {
+func (s *UnsupportedTLD) Code() string {
 	return "UnsupportedTLD"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedTLD) Message() string {
+func (s *UnsupportedTLD) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5346,21 +5346,21 @@ func (s UnsupportedTLD) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedTLD) OrigErr() error {
+func (s *UnsupportedTLD) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedTLD) Error() string {
+func (s *UnsupportedTLD) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedTLD) StatusCode() int {
+func (s *UnsupportedTLD) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedTLD) RequestID() string {
+func (s *UnsupportedTLD) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/route53resolver/api.go
+++ b/service/route53resolver/api.go
@@ -3435,12 +3435,12 @@ func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceErrorException) Code() string {
+func (s *InternalServiceErrorException) Code() string {
 	return "InternalServiceErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceErrorException) Message() string {
+func (s *InternalServiceErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3448,21 +3448,21 @@ func (s InternalServiceErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceErrorException) OrigErr() error {
+func (s *InternalServiceErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceErrorException) Error() string {
+func (s *InternalServiceErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceErrorException) StatusCode() int {
+func (s *InternalServiceErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceErrorException) RequestID() string {
+func (s *InternalServiceErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3491,12 +3491,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3504,21 +3504,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3551,12 +3551,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3564,21 +3564,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3607,12 +3607,12 @@ func newErrorInvalidPolicyDocument(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPolicyDocument) Code() string {
+func (s *InvalidPolicyDocument) Code() string {
 	return "InvalidPolicyDocument"
 }
 
 // Message returns the exception's message.
-func (s InvalidPolicyDocument) Message() string {
+func (s *InvalidPolicyDocument) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3620,21 +3620,21 @@ func (s InvalidPolicyDocument) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPolicyDocument) OrigErr() error {
+func (s *InvalidPolicyDocument) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPolicyDocument) Error() string {
+func (s *InvalidPolicyDocument) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPolicyDocument) StatusCode() int {
+func (s *InvalidPolicyDocument) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPolicyDocument) RequestID() string {
+func (s *InvalidPolicyDocument) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3663,12 +3663,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3676,21 +3676,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3719,12 +3719,12 @@ func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTagException) Code() string {
+func (s *InvalidTagException) Code() string {
 	return "InvalidTagException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTagException) Message() string {
+func (s *InvalidTagException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3732,21 +3732,21 @@ func (s InvalidTagException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTagException) OrigErr() error {
+func (s *InvalidTagException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTagException) Error() string {
+func (s *InvalidTagException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTagException) StatusCode() int {
+func (s *InvalidTagException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTagException) RequestID() string {
+func (s *InvalidTagException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3979,12 +3979,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3992,21 +3992,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5115,12 +5115,12 @@ func newErrorResourceExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceExistsException) Code() string {
+func (s *ResourceExistsException) Code() string {
 	return "ResourceExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceExistsException) Message() string {
+func (s *ResourceExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5128,21 +5128,21 @@ func (s ResourceExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceExistsException) OrigErr() error {
+func (s *ResourceExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceExistsException) Error() string {
+func (s *ResourceExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceExistsException) StatusCode() int {
+func (s *ResourceExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceExistsException) RequestID() string {
+func (s *ResourceExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5175,12 +5175,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5188,21 +5188,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5235,12 +5235,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5248,21 +5248,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5295,12 +5295,12 @@ func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceUnavailableException) Code() string {
+func (s *ResourceUnavailableException) Code() string {
 	return "ResourceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ResourceUnavailableException) Message() string {
+func (s *ResourceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5308,21 +5308,21 @@ func (s ResourceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceUnavailableException) OrigErr() error {
+func (s *ResourceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceUnavailableException) Error() string {
+func (s *ResourceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceUnavailableException) StatusCode() int {
+func (s *ResourceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceUnavailableException) RequestID() string {
+func (s *ResourceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5523,12 +5523,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5536,21 +5536,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5579,12 +5579,12 @@ func newErrorUnknownResourceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnknownResourceException) Code() string {
+func (s *UnknownResourceException) Code() string {
 	return "UnknownResourceException"
 }
 
 // Message returns the exception's message.
-func (s UnknownResourceException) Message() string {
+func (s *UnknownResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5592,21 +5592,21 @@ func (s UnknownResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnknownResourceException) OrigErr() error {
+func (s *UnknownResourceException) OrigErr() error {
 	return nil
 }
 
-func (s UnknownResourceException) Error() string {
+func (s *UnknownResourceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnknownResourceException) StatusCode() int {
+func (s *UnknownResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnknownResourceException) RequestID() string {
+func (s *UnknownResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/sagemaker/api.go
+++ b/service/sagemaker/api.go
@@ -15335,12 +15335,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15348,21 +15348,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -39363,12 +39363,12 @@ func newErrorResourceInUse(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUse) Code() string {
+func (s *ResourceInUse) Code() string {
 	return "ResourceInUse"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUse) Message() string {
+func (s *ResourceInUse) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -39376,21 +39376,21 @@ func (s ResourceInUse) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUse) OrigErr() error {
+func (s *ResourceInUse) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUse) Error() string {
+func (s *ResourceInUse) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUse) StatusCode() int {
+func (s *ResourceInUse) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUse) RequestID() string {
+func (s *ResourceInUse) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -39420,12 +39420,12 @@ func newErrorResourceLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceeded) Code() string {
+func (s *ResourceLimitExceeded) Code() string {
 	return "ResourceLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceeded) Message() string {
+func (s *ResourceLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -39433,21 +39433,21 @@ func (s ResourceLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceeded) OrigErr() error {
+func (s *ResourceLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceeded) Error() string {
+func (s *ResourceLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceeded) StatusCode() int {
+func (s *ResourceLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceeded) RequestID() string {
+func (s *ResourceLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -39538,12 +39538,12 @@ func newErrorResourceNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFound) Code() string {
+func (s *ResourceNotFound) Code() string {
 	return "ResourceNotFound"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFound) Message() string {
+func (s *ResourceNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -39551,21 +39551,21 @@ func (s ResourceNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFound) OrigErr() error {
+func (s *ResourceNotFound) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFound) Error() string {
+func (s *ResourceNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFound) StatusCode() int {
+func (s *ResourceNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFound) RequestID() string {
+func (s *ResourceNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/sagemakerruntime/api.go
+++ b/service/sagemakerruntime/api.go
@@ -147,12 +147,12 @@ func newErrorInternalFailure(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailure) Code() string {
+func (s *InternalFailure) Code() string {
 	return "InternalFailure"
 }
 
 // Message returns the exception's message.
-func (s InternalFailure) Message() string {
+func (s *InternalFailure) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -160,21 +160,21 @@ func (s InternalFailure) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailure) OrigErr() error {
+func (s *InternalFailure) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailure) Error() string {
+func (s *InternalFailure) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailure) StatusCode() int {
+func (s *InternalFailure) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailure) RequestID() string {
+func (s *InternalFailure) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -389,12 +389,12 @@ func newErrorModelError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ModelError) Code() string {
+func (s *ModelError) Code() string {
 	return "ModelError"
 }
 
 // Message returns the exception's message.
-func (s ModelError) Message() string {
+func (s *ModelError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -402,21 +402,21 @@ func (s ModelError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ModelError) OrigErr() error {
+func (s *ModelError) OrigErr() error {
 	return nil
 }
 
-func (s ModelError) Error() string {
+func (s *ModelError) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ModelError) StatusCode() int {
+func (s *ModelError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ModelError) RequestID() string {
+func (s *ModelError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -445,12 +445,12 @@ func newErrorServiceUnavailable(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailable) Code() string {
+func (s *ServiceUnavailable) Code() string {
 	return "ServiceUnavailable"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailable) Message() string {
+func (s *ServiceUnavailable) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -458,21 +458,21 @@ func (s ServiceUnavailable) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailable) OrigErr() error {
+func (s *ServiceUnavailable) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailable) Error() string {
+func (s *ServiceUnavailable) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailable) StatusCode() int {
+func (s *ServiceUnavailable) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailable) RequestID() string {
+func (s *ServiceUnavailable) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -501,12 +501,12 @@ func newErrorValidationError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationError) Code() string {
+func (s *ValidationError) Code() string {
 	return "ValidationError"
 }
 
 // Message returns the exception's message.
-func (s ValidationError) Message() string {
+func (s *ValidationError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -514,20 +514,20 @@ func (s ValidationError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationError) OrigErr() error {
+func (s *ValidationError) OrigErr() error {
 	return nil
 }
 
-func (s ValidationError) Error() string {
+func (s *ValidationError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationError) StatusCode() int {
+func (s *ValidationError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationError) RequestID() string {
+func (s *ValidationError) RequestID() string {
 	return s.RespMetadata.RequestID
 }

--- a/service/savingsplans/api.go
+++ b/service/savingsplans/api.go
@@ -1348,12 +1348,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1361,21 +1361,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1534,12 +1534,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1547,21 +1547,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2286,12 +2286,12 @@ func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaExceededException) Code() string {
+func (s *ServiceQuotaExceededException) Code() string {
 	return "ServiceQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaExceededException) Message() string {
+func (s *ServiceQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2299,21 +2299,21 @@ func (s ServiceQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaExceededException) OrigErr() error {
+func (s *ServiceQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaExceededException) Error() string {
+func (s *ServiceQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaExceededException) StatusCode() int {
+func (s *ServiceQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaExceededException) RequestID() string {
+func (s *ServiceQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2475,12 +2475,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2488,21 +2488,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/schemas/api.go
+++ b/service/schemas/api.go
@@ -2854,12 +2854,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2867,21 +2867,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2911,12 +2911,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2924,21 +2924,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4142,12 +4142,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4155,21 +4155,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4371,12 +4371,12 @@ func newErrorGoneException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s GoneException) Code() string {
+func (s *GoneException) Code() string {
 	return "GoneException"
 }
 
 // Message returns the exception's message.
-func (s GoneException) Message() string {
+func (s *GoneException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4384,21 +4384,21 @@ func (s GoneException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s GoneException) OrigErr() error {
+func (s *GoneException) OrigErr() error {
 	return nil
 }
 
-func (s GoneException) Error() string {
+func (s *GoneException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s GoneException) StatusCode() int {
+func (s *GoneException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s GoneException) RequestID() string {
+func (s *GoneException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4428,12 +4428,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4441,21 +4441,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4986,12 +4986,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4999,21 +4999,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5486,12 +5486,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5499,21 +5499,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5748,12 +5748,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5761,21 +5761,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5805,12 +5805,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5818,21 +5818,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/secretsmanager/api.go
+++ b/service/secretsmanager/api.go
@@ -2897,12 +2897,12 @@ func newErrorDecryptionFailure(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DecryptionFailure) Code() string {
+func (s *DecryptionFailure) Code() string {
 	return "DecryptionFailure"
 }
 
 // Message returns the exception's message.
-func (s DecryptionFailure) Message() string {
+func (s *DecryptionFailure) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2910,21 +2910,21 @@ func (s DecryptionFailure) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DecryptionFailure) OrigErr() error {
+func (s *DecryptionFailure) OrigErr() error {
 	return nil
 }
 
-func (s DecryptionFailure) Error() string {
+func (s *DecryptionFailure) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DecryptionFailure) StatusCode() int {
+func (s *DecryptionFailure) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DecryptionFailure) RequestID() string {
+func (s *DecryptionFailure) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3394,12 +3394,12 @@ func newErrorEncryptionFailure(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EncryptionFailure) Code() string {
+func (s *EncryptionFailure) Code() string {
 	return "EncryptionFailure"
 }
 
 // Message returns the exception's message.
-func (s EncryptionFailure) Message() string {
+func (s *EncryptionFailure) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3407,21 +3407,21 @@ func (s EncryptionFailure) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EncryptionFailure) OrigErr() error {
+func (s *EncryptionFailure) OrigErr() error {
 	return nil
 }
 
-func (s EncryptionFailure) Error() string {
+func (s *EncryptionFailure) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EncryptionFailure) StatusCode() int {
+func (s *EncryptionFailure) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EncryptionFailure) RequestID() string {
+func (s *EncryptionFailure) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3888,12 +3888,12 @@ func newErrorInternalServiceError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceError) Code() string {
+func (s *InternalServiceError) Code() string {
 	return "InternalServiceError"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceError) Message() string {
+func (s *InternalServiceError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3901,21 +3901,21 @@ func (s InternalServiceError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceError) OrigErr() error {
+func (s *InternalServiceError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceError) Error() string {
+func (s *InternalServiceError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceError) StatusCode() int {
+func (s *InternalServiceError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceError) RequestID() string {
+func (s *InternalServiceError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3944,12 +3944,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3957,21 +3957,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4000,12 +4000,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4013,21 +4013,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4066,12 +4066,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4079,21 +4079,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4123,12 +4123,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4136,21 +4136,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4440,12 +4440,12 @@ func newErrorMalformedPolicyDocumentException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s MalformedPolicyDocumentException) Code() string {
+func (s *MalformedPolicyDocumentException) Code() string {
 	return "MalformedPolicyDocumentException"
 }
 
 // Message returns the exception's message.
-func (s MalformedPolicyDocumentException) Message() string {
+func (s *MalformedPolicyDocumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4453,21 +4453,21 @@ func (s MalformedPolicyDocumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MalformedPolicyDocumentException) OrigErr() error {
+func (s *MalformedPolicyDocumentException) OrigErr() error {
 	return nil
 }
 
-func (s MalformedPolicyDocumentException) Error() string {
+func (s *MalformedPolicyDocumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MalformedPolicyDocumentException) StatusCode() int {
+func (s *MalformedPolicyDocumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MalformedPolicyDocumentException) RequestID() string {
+func (s *MalformedPolicyDocumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4496,12 +4496,12 @@ func newErrorPreconditionNotMetException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PreconditionNotMetException) Code() string {
+func (s *PreconditionNotMetException) Code() string {
 	return "PreconditionNotMetException"
 }
 
 // Message returns the exception's message.
-func (s PreconditionNotMetException) Message() string {
+func (s *PreconditionNotMetException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4509,21 +4509,21 @@ func (s PreconditionNotMetException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PreconditionNotMetException) OrigErr() error {
+func (s *PreconditionNotMetException) OrigErr() error {
 	return nil
 }
 
-func (s PreconditionNotMetException) Error() string {
+func (s *PreconditionNotMetException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PreconditionNotMetException) StatusCode() int {
+func (s *PreconditionNotMetException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PreconditionNotMetException) RequestID() string {
+func (s *PreconditionNotMetException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4879,12 +4879,12 @@ func newErrorResourceExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceExistsException) Code() string {
+func (s *ResourceExistsException) Code() string {
 	return "ResourceExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceExistsException) Message() string {
+func (s *ResourceExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4892,21 +4892,21 @@ func (s ResourceExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceExistsException) OrigErr() error {
+func (s *ResourceExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceExistsException) Error() string {
+func (s *ResourceExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceExistsException) StatusCode() int {
+func (s *ResourceExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceExistsException) RequestID() string {
+func (s *ResourceExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4935,12 +4935,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4948,21 +4948,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/securityhub/api.go
+++ b/service/securityhub/api.go
@@ -4526,12 +4526,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4539,21 +4539,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11303,12 +11303,12 @@ func newErrorInternalException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalException) Code() string {
+func (s *InternalException) Code() string {
 	return "InternalException"
 }
 
 // Message returns the exception's message.
-func (s InternalException) Message() string {
+func (s *InternalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11316,21 +11316,21 @@ func (s InternalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalException) OrigErr() error {
+func (s *InternalException) OrigErr() error {
 	return nil
 }
 
-func (s InternalException) Error() string {
+func (s *InternalException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalException) StatusCode() int {
+func (s *InternalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalException) RequestID() string {
+func (s *InternalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11361,12 +11361,12 @@ func newErrorInvalidAccessException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAccessException) Code() string {
+func (s *InvalidAccessException) Code() string {
 	return "InvalidAccessException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAccessException) Message() string {
+func (s *InvalidAccessException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11374,21 +11374,21 @@ func (s InvalidAccessException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAccessException) OrigErr() error {
+func (s *InvalidAccessException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAccessException) Error() string {
+func (s *InvalidAccessException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAccessException) StatusCode() int {
+func (s *InvalidAccessException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAccessException) RequestID() string {
+func (s *InvalidAccessException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11420,12 +11420,12 @@ func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInputException) Code() string {
+func (s *InvalidInputException) Code() string {
 	return "InvalidInputException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputException) Message() string {
+func (s *InvalidInputException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11433,21 +11433,21 @@ func (s InvalidInputException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputException) OrigErr() error {
+func (s *InvalidInputException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputException) Error() string {
+func (s *InvalidInputException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputException) StatusCode() int {
+func (s *InvalidInputException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputException) RequestID() string {
+func (s *InvalidInputException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11627,12 +11627,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11640,21 +11640,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12894,12 +12894,12 @@ func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceConflictException) Code() string {
+func (s *ResourceConflictException) Code() string {
 	return "ResourceConflictException"
 }
 
 // Message returns the exception's message.
-func (s ResourceConflictException) Message() string {
+func (s *ResourceConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12907,21 +12907,21 @@ func (s ResourceConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceConflictException) OrigErr() error {
+func (s *ResourceConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceConflictException) Error() string {
+func (s *ResourceConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceConflictException) StatusCode() int {
+func (s *ResourceConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceConflictException) RequestID() string {
+func (s *ResourceConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13181,12 +13181,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13194,21 +13194,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/serverlessapplicationrepository/api.go
+++ b/service/serverlessapplicationrepository/api.go
@@ -1754,12 +1754,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1767,21 +1767,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1814,12 +1814,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1827,21 +1827,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2704,12 +2704,12 @@ func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ForbiddenException) Code() string {
+func (s *ForbiddenException) Code() string {
 	return "ForbiddenException"
 }
 
 // Message returns the exception's message.
-func (s ForbiddenException) Message() string {
+func (s *ForbiddenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2717,21 +2717,21 @@ func (s ForbiddenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ForbiddenException) OrigErr() error {
+func (s *ForbiddenException) OrigErr() error {
 	return nil
 }
 
-func (s ForbiddenException) Error() string {
+func (s *ForbiddenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ForbiddenException) StatusCode() int {
+func (s *ForbiddenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ForbiddenException) RequestID() string {
+func (s *ForbiddenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3117,12 +3117,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3130,21 +3130,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3436,12 +3436,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3449,21 +3449,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3994,12 +3994,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4007,21 +4007,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/servicecatalog/api.go
+++ b/service/servicecatalog/api.go
@@ -13087,12 +13087,12 @@ func newErrorDuplicateResourceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateResourceException) Code() string {
+func (s *DuplicateResourceException) Code() string {
 	return "DuplicateResourceException"
 }
 
 // Message returns the exception's message.
-func (s DuplicateResourceException) Message() string {
+func (s *DuplicateResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13100,21 +13100,21 @@ func (s DuplicateResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateResourceException) OrigErr() error {
+func (s *DuplicateResourceException) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateResourceException) Error() string {
+func (s *DuplicateResourceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateResourceException) StatusCode() int {
+func (s *DuplicateResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateResourceException) RequestID() string {
+func (s *DuplicateResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13530,12 +13530,12 @@ func newErrorInvalidParametersException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParametersException) Code() string {
+func (s *InvalidParametersException) Code() string {
 	return "InvalidParametersException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParametersException) Message() string {
+func (s *InvalidParametersException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13543,21 +13543,21 @@ func (s InvalidParametersException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParametersException) OrigErr() error {
+func (s *InvalidParametersException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParametersException) Error() string {
+func (s *InvalidParametersException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParametersException) StatusCode() int {
+func (s *InvalidParametersException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParametersException) RequestID() string {
+func (s *InvalidParametersException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13588,12 +13588,12 @@ func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidStateException) Code() string {
+func (s *InvalidStateException) Code() string {
 	return "InvalidStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidStateException) Message() string {
+func (s *InvalidStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13601,21 +13601,21 @@ func (s InvalidStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidStateException) OrigErr() error {
+func (s *InvalidStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidStateException) Error() string {
+func (s *InvalidStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidStateException) StatusCode() int {
+func (s *InvalidStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidStateException) RequestID() string {
+func (s *InvalidStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13697,12 +13697,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13710,21 +13710,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15751,12 +15751,12 @@ func newErrorOperationNotSupportedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotSupportedException) Code() string {
+func (s *OperationNotSupportedException) Code() string {
 	return "OperationNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s OperationNotSupportedException) Message() string {
+func (s *OperationNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15764,21 +15764,21 @@ func (s OperationNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotSupportedException) OrigErr() error {
+func (s *OperationNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotSupportedException) Error() string {
+func (s *OperationNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotSupportedException) StatusCode() int {
+func (s *OperationNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotSupportedException) RequestID() string {
+func (s *OperationNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18101,12 +18101,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18114,21 +18114,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18157,12 +18157,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18170,21 +18170,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19149,12 +19149,12 @@ func newErrorTagOptionNotMigratedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagOptionNotMigratedException) Code() string {
+func (s *TagOptionNotMigratedException) Code() string {
 	return "TagOptionNotMigratedException"
 }
 
 // Message returns the exception's message.
-func (s TagOptionNotMigratedException) Message() string {
+func (s *TagOptionNotMigratedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19162,21 +19162,21 @@ func (s TagOptionNotMigratedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagOptionNotMigratedException) OrigErr() error {
+func (s *TagOptionNotMigratedException) OrigErr() error {
 	return nil
 }
 
-func (s TagOptionNotMigratedException) Error() string {
+func (s *TagOptionNotMigratedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagOptionNotMigratedException) StatusCode() int {
+func (s *TagOptionNotMigratedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagOptionNotMigratedException) RequestID() string {
+func (s *TagOptionNotMigratedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/servicediscovery/api.go
+++ b/service/servicediscovery/api.go
@@ -2595,12 +2595,12 @@ func newErrorCustomHealthNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CustomHealthNotFound) Code() string {
+func (s *CustomHealthNotFound) Code() string {
 	return "CustomHealthNotFound"
 }
 
 // Message returns the exception's message.
-func (s CustomHealthNotFound) Message() string {
+func (s *CustomHealthNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2608,21 +2608,21 @@ func (s CustomHealthNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CustomHealthNotFound) OrigErr() error {
+func (s *CustomHealthNotFound) OrigErr() error {
 	return nil
 }
 
-func (s CustomHealthNotFound) Error() string {
+func (s *CustomHealthNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CustomHealthNotFound) StatusCode() int {
+func (s *CustomHealthNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CustomHealthNotFound) RequestID() string {
+func (s *CustomHealthNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3274,12 +3274,12 @@ func newErrorDuplicateRequest(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateRequest) Code() string {
+func (s *DuplicateRequest) Code() string {
 	return "DuplicateRequest"
 }
 
 // Message returns the exception's message.
-func (s DuplicateRequest) Message() string {
+func (s *DuplicateRequest) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3287,21 +3287,21 @@ func (s DuplicateRequest) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateRequest) OrigErr() error {
+func (s *DuplicateRequest) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateRequest) Error() string {
+func (s *DuplicateRequest) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateRequest) StatusCode() int {
+func (s *DuplicateRequest) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateRequest) RequestID() string {
+func (s *DuplicateRequest) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4174,12 +4174,12 @@ func newErrorInstanceNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InstanceNotFound) Code() string {
+func (s *InstanceNotFound) Code() string {
 	return "InstanceNotFound"
 }
 
 // Message returns the exception's message.
-func (s InstanceNotFound) Message() string {
+func (s *InstanceNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4187,21 +4187,21 @@ func (s InstanceNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InstanceNotFound) OrigErr() error {
+func (s *InstanceNotFound) OrigErr() error {
 	return nil
 }
 
-func (s InstanceNotFound) Error() string {
+func (s *InstanceNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InstanceNotFound) StatusCode() int {
+func (s *InstanceNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InstanceNotFound) RequestID() string {
+func (s *InstanceNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4289,12 +4289,12 @@ func newErrorInvalidInput(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInput) Code() string {
+func (s *InvalidInput) Code() string {
 	return "InvalidInput"
 }
 
 // Message returns the exception's message.
-func (s InvalidInput) Message() string {
+func (s *InvalidInput) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4302,21 +4302,21 @@ func (s InvalidInput) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInput) OrigErr() error {
+func (s *InvalidInput) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInput) Error() string {
+func (s *InvalidInput) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInput) StatusCode() int {
+func (s *InvalidInput) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInput) RequestID() string {
+func (s *InvalidInput) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4910,12 +4910,12 @@ func newErrorNamespaceAlreadyExists(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NamespaceAlreadyExists) Code() string {
+func (s *NamespaceAlreadyExists) Code() string {
 	return "NamespaceAlreadyExists"
 }
 
 // Message returns the exception's message.
-func (s NamespaceAlreadyExists) Message() string {
+func (s *NamespaceAlreadyExists) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4923,21 +4923,21 @@ func (s NamespaceAlreadyExists) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NamespaceAlreadyExists) OrigErr() error {
+func (s *NamespaceAlreadyExists) OrigErr() error {
 	return nil
 }
 
-func (s NamespaceAlreadyExists) Error() string {
+func (s *NamespaceAlreadyExists) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NamespaceAlreadyExists) StatusCode() int {
+func (s *NamespaceAlreadyExists) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NamespaceAlreadyExists) RequestID() string {
+func (s *NamespaceAlreadyExists) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5042,12 +5042,12 @@ func newErrorNamespaceNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NamespaceNotFound) Code() string {
+func (s *NamespaceNotFound) Code() string {
 	return "NamespaceNotFound"
 }
 
 // Message returns the exception's message.
-func (s NamespaceNotFound) Message() string {
+func (s *NamespaceNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5055,21 +5055,21 @@ func (s NamespaceNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NamespaceNotFound) OrigErr() error {
+func (s *NamespaceNotFound) OrigErr() error {
 	return nil
 }
 
-func (s NamespaceNotFound) Error() string {
+func (s *NamespaceNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NamespaceNotFound) StatusCode() int {
+func (s *NamespaceNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NamespaceNotFound) RequestID() string {
+func (s *NamespaceNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5446,12 +5446,12 @@ func newErrorOperationNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotFound) Code() string {
+func (s *OperationNotFound) Code() string {
 	return "OperationNotFound"
 }
 
 // Message returns the exception's message.
-func (s OperationNotFound) Message() string {
+func (s *OperationNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5459,21 +5459,21 @@ func (s OperationNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotFound) OrigErr() error {
+func (s *OperationNotFound) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotFound) Error() string {
+func (s *OperationNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotFound) StatusCode() int {
+func (s *OperationNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotFound) RequestID() string {
+func (s *OperationNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5748,12 +5748,12 @@ func newErrorResourceInUse(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUse) Code() string {
+func (s *ResourceInUse) Code() string {
 	return "ResourceInUse"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUse) Message() string {
+func (s *ResourceInUse) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5761,21 +5761,21 @@ func (s ResourceInUse) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUse) OrigErr() error {
+func (s *ResourceInUse) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUse) Error() string {
+func (s *ResourceInUse) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUse) StatusCode() int {
+func (s *ResourceInUse) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUse) RequestID() string {
+func (s *ResourceInUse) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5805,12 +5805,12 @@ func newErrorResourceLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceeded) Code() string {
+func (s *ResourceLimitExceeded) Code() string {
 	return "ResourceLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceeded) Message() string {
+func (s *ResourceLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5818,21 +5818,21 @@ func (s ResourceLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceeded) OrigErr() error {
+func (s *ResourceLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceeded) Error() string {
+func (s *ResourceLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceeded) StatusCode() int {
+func (s *ResourceLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceeded) RequestID() string {
+func (s *ResourceLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6000,12 +6000,12 @@ func newErrorServiceAlreadyExists(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceAlreadyExists) Code() string {
+func (s *ServiceAlreadyExists) Code() string {
 	return "ServiceAlreadyExists"
 }
 
 // Message returns the exception's message.
-func (s ServiceAlreadyExists) Message() string {
+func (s *ServiceAlreadyExists) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6013,21 +6013,21 @@ func (s ServiceAlreadyExists) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceAlreadyExists) OrigErr() error {
+func (s *ServiceAlreadyExists) OrigErr() error {
 	return nil
 }
 
-func (s ServiceAlreadyExists) Error() string {
+func (s *ServiceAlreadyExists) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceAlreadyExists) StatusCode() int {
+func (s *ServiceAlreadyExists) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceAlreadyExists) RequestID() string {
+func (s *ServiceAlreadyExists) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6254,12 +6254,12 @@ func newErrorServiceNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceNotFound) Code() string {
+func (s *ServiceNotFound) Code() string {
 	return "ServiceNotFound"
 }
 
 // Message returns the exception's message.
-func (s ServiceNotFound) Message() string {
+func (s *ServiceNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6267,21 +6267,21 @@ func (s ServiceNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceNotFound) OrigErr() error {
+func (s *ServiceNotFound) OrigErr() error {
 	return nil
 }
 
-func (s ServiceNotFound) Error() string {
+func (s *ServiceNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceNotFound) StatusCode() int {
+func (s *ServiceNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceNotFound) RequestID() string {
+func (s *ServiceNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/servicequotas/api.go
+++ b/service/servicequotas/api.go
@@ -2031,12 +2031,12 @@ func newErrorAWSServiceAccessNotEnabledException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s AWSServiceAccessNotEnabledException) Code() string {
+func (s *AWSServiceAccessNotEnabledException) Code() string {
 	return "AWSServiceAccessNotEnabledException"
 }
 
 // Message returns the exception's message.
-func (s AWSServiceAccessNotEnabledException) Message() string {
+func (s *AWSServiceAccessNotEnabledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2044,21 +2044,21 @@ func (s AWSServiceAccessNotEnabledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AWSServiceAccessNotEnabledException) OrigErr() error {
+func (s *AWSServiceAccessNotEnabledException) OrigErr() error {
 	return nil
 }
 
-func (s AWSServiceAccessNotEnabledException) Error() string {
+func (s *AWSServiceAccessNotEnabledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AWSServiceAccessNotEnabledException) StatusCode() int {
+func (s *AWSServiceAccessNotEnabledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AWSServiceAccessNotEnabledException) RequestID() string {
+func (s *AWSServiceAccessNotEnabledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2087,12 +2087,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2100,21 +2100,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2260,12 +2260,12 @@ func newErrorDependencyAccessDeniedException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s DependencyAccessDeniedException) Code() string {
+func (s *DependencyAccessDeniedException) Code() string {
 	return "DependencyAccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s DependencyAccessDeniedException) Message() string {
+func (s *DependencyAccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2273,21 +2273,21 @@ func (s DependencyAccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DependencyAccessDeniedException) OrigErr() error {
+func (s *DependencyAccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s DependencyAccessDeniedException) Error() string {
+func (s *DependencyAccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DependencyAccessDeniedException) StatusCode() int {
+func (s *DependencyAccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DependencyAccessDeniedException) RequestID() string {
+func (s *DependencyAccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2754,12 +2754,12 @@ func newErrorIllegalArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IllegalArgumentException) Code() string {
+func (s *IllegalArgumentException) Code() string {
 	return "IllegalArgumentException"
 }
 
 // Message returns the exception's message.
-func (s IllegalArgumentException) Message() string {
+func (s *IllegalArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2767,21 +2767,21 @@ func (s IllegalArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IllegalArgumentException) OrigErr() error {
+func (s *IllegalArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s IllegalArgumentException) Error() string {
+func (s *IllegalArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IllegalArgumentException) StatusCode() int {
+func (s *IllegalArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IllegalArgumentException) RequestID() string {
+func (s *IllegalArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2810,12 +2810,12 @@ func newErrorInvalidPaginationTokenException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidPaginationTokenException) Code() string {
+func (s *InvalidPaginationTokenException) Code() string {
 	return "InvalidPaginationTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPaginationTokenException) Message() string {
+func (s *InvalidPaginationTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2823,21 +2823,21 @@ func (s InvalidPaginationTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPaginationTokenException) OrigErr() error {
+func (s *InvalidPaginationTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPaginationTokenException) Error() string {
+func (s *InvalidPaginationTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPaginationTokenException) StatusCode() int {
+func (s *InvalidPaginationTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPaginationTokenException) RequestID() string {
+func (s *InvalidPaginationTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2866,12 +2866,12 @@ func newErrorInvalidResourceStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceStateException) Code() string {
+func (s *InvalidResourceStateException) Code() string {
 	return "InvalidResourceStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceStateException) Message() string {
+func (s *InvalidResourceStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2879,21 +2879,21 @@ func (s InvalidResourceStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceStateException) OrigErr() error {
+func (s *InvalidResourceStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceStateException) Error() string {
+func (s *InvalidResourceStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceStateException) StatusCode() int {
+func (s *InvalidResourceStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceStateException) RequestID() string {
+func (s *InvalidResourceStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3661,12 +3661,12 @@ func newErrorNoAvailableOrganizationException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s NoAvailableOrganizationException) Code() string {
+func (s *NoAvailableOrganizationException) Code() string {
 	return "NoAvailableOrganizationException"
 }
 
 // Message returns the exception's message.
-func (s NoAvailableOrganizationException) Message() string {
+func (s *NoAvailableOrganizationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3674,21 +3674,21 @@ func (s NoAvailableOrganizationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoAvailableOrganizationException) OrigErr() error {
+func (s *NoAvailableOrganizationException) OrigErr() error {
 	return nil
 }
 
-func (s NoAvailableOrganizationException) Error() string {
+func (s *NoAvailableOrganizationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoAvailableOrganizationException) StatusCode() int {
+func (s *NoAvailableOrganizationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoAvailableOrganizationException) RequestID() string {
+func (s *NoAvailableOrganizationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3717,12 +3717,12 @@ func newErrorNoSuchResourceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoSuchResourceException) Code() string {
+func (s *NoSuchResourceException) Code() string {
 	return "NoSuchResourceException"
 }
 
 // Message returns the exception's message.
-func (s NoSuchResourceException) Message() string {
+func (s *NoSuchResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3730,21 +3730,21 @@ func (s NoSuchResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoSuchResourceException) OrigErr() error {
+func (s *NoSuchResourceException) OrigErr() error {
 	return nil
 }
 
-func (s NoSuchResourceException) Error() string {
+func (s *NoSuchResourceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoSuchResourceException) StatusCode() int {
+func (s *NoSuchResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoSuchResourceException) RequestID() string {
+func (s *NoSuchResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3774,12 +3774,12 @@ func newErrorOrganizationNotInAllFeaturesModeException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s OrganizationNotInAllFeaturesModeException) Code() string {
+func (s *OrganizationNotInAllFeaturesModeException) Code() string {
 	return "OrganizationNotInAllFeaturesModeException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationNotInAllFeaturesModeException) Message() string {
+func (s *OrganizationNotInAllFeaturesModeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3787,21 +3787,21 @@ func (s OrganizationNotInAllFeaturesModeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationNotInAllFeaturesModeException) OrigErr() error {
+func (s *OrganizationNotInAllFeaturesModeException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationNotInAllFeaturesModeException) Error() string {
+func (s *OrganizationNotInAllFeaturesModeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationNotInAllFeaturesModeException) StatusCode() int {
+func (s *OrganizationNotInAllFeaturesModeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationNotInAllFeaturesModeException) RequestID() string {
+func (s *OrganizationNotInAllFeaturesModeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3944,12 +3944,12 @@ func newErrorQuotaExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s QuotaExceededException) Code() string {
+func (s *QuotaExceededException) Code() string {
 	return "QuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s QuotaExceededException) Message() string {
+func (s *QuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3957,21 +3957,21 @@ func (s QuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s QuotaExceededException) OrigErr() error {
+func (s *QuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s QuotaExceededException) Error() string {
+func (s *QuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s QuotaExceededException) StatusCode() int {
+func (s *QuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s QuotaExceededException) RequestID() string {
+func (s *QuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4271,12 +4271,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4284,21 +4284,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4327,12 +4327,12 @@ func newErrorServiceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceException) Code() string {
+func (s *ServiceException) Code() string {
 	return "ServiceException"
 }
 
 // Message returns the exception's message.
-func (s ServiceException) Message() string {
+func (s *ServiceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4340,21 +4340,21 @@ func (s ServiceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceException) OrigErr() error {
+func (s *ServiceException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceException) Error() string {
+func (s *ServiceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceException) StatusCode() int {
+func (s *ServiceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceException) RequestID() string {
+func (s *ServiceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4632,12 +4632,12 @@ func newErrorServiceQuotaTemplateNotInUseException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s ServiceQuotaTemplateNotInUseException) Code() string {
+func (s *ServiceQuotaTemplateNotInUseException) Code() string {
 	return "ServiceQuotaTemplateNotInUseException"
 }
 
 // Message returns the exception's message.
-func (s ServiceQuotaTemplateNotInUseException) Message() string {
+func (s *ServiceQuotaTemplateNotInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4645,21 +4645,21 @@ func (s ServiceQuotaTemplateNotInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceQuotaTemplateNotInUseException) OrigErr() error {
+func (s *ServiceQuotaTemplateNotInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceQuotaTemplateNotInUseException) Error() string {
+func (s *ServiceQuotaTemplateNotInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceQuotaTemplateNotInUseException) StatusCode() int {
+func (s *ServiceQuotaTemplateNotInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceQuotaTemplateNotInUseException) RequestID() string {
+func (s *ServiceQuotaTemplateNotInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4689,12 +4689,12 @@ func newErrorTemplatesNotAvailableInRegionException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s TemplatesNotAvailableInRegionException) Code() string {
+func (s *TemplatesNotAvailableInRegionException) Code() string {
 	return "TemplatesNotAvailableInRegionException"
 }
 
 // Message returns the exception's message.
-func (s TemplatesNotAvailableInRegionException) Message() string {
+func (s *TemplatesNotAvailableInRegionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4702,21 +4702,21 @@ func (s TemplatesNotAvailableInRegionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TemplatesNotAvailableInRegionException) OrigErr() error {
+func (s *TemplatesNotAvailableInRegionException) OrigErr() error {
 	return nil
 }
 
-func (s TemplatesNotAvailableInRegionException) Error() string {
+func (s *TemplatesNotAvailableInRegionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TemplatesNotAvailableInRegionException) StatusCode() int {
+func (s *TemplatesNotAvailableInRegionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TemplatesNotAvailableInRegionException) RequestID() string {
+func (s *TemplatesNotAvailableInRegionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4746,12 +4746,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4759,21 +4759,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/sesv2/api.go
+++ b/service/sesv2/api.go
@@ -4878,12 +4878,12 @@ func newErrorAccountSuspendedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccountSuspendedException) Code() string {
+func (s *AccountSuspendedException) Code() string {
 	return "AccountSuspendedException"
 }
 
 // Message returns the exception's message.
-func (s AccountSuspendedException) Message() string {
+func (s *AccountSuspendedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4891,21 +4891,21 @@ func (s AccountSuspendedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccountSuspendedException) OrigErr() error {
+func (s *AccountSuspendedException) OrigErr() error {
 	return nil
 }
 
-func (s AccountSuspendedException) Error() string {
+func (s *AccountSuspendedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccountSuspendedException) StatusCode() int {
+func (s *AccountSuspendedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccountSuspendedException) RequestID() string {
+func (s *AccountSuspendedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4934,12 +4934,12 @@ func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyExistsException) Code() string {
+func (s *AlreadyExistsException) Code() string {
 	return "AlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyExistsException) Message() string {
+func (s *AlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4947,21 +4947,21 @@ func (s AlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyExistsException) OrigErr() error {
+func (s *AlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyExistsException) Error() string {
+func (s *AlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyExistsException) StatusCode() int {
+func (s *AlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyExistsException) RequestID() string {
+func (s *AlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4990,12 +4990,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5003,21 +5003,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5284,12 +5284,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5297,21 +5297,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8479,12 +8479,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8492,21 +8492,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8626,12 +8626,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8639,21 +8639,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9364,12 +9364,12 @@ func newErrorMailFromDomainNotVerifiedException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s MailFromDomainNotVerifiedException) Code() string {
+func (s *MailFromDomainNotVerifiedException) Code() string {
 	return "MailFromDomainNotVerifiedException"
 }
 
 // Message returns the exception's message.
-func (s MailFromDomainNotVerifiedException) Message() string {
+func (s *MailFromDomainNotVerifiedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9377,21 +9377,21 @@ func (s MailFromDomainNotVerifiedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MailFromDomainNotVerifiedException) OrigErr() error {
+func (s *MailFromDomainNotVerifiedException) OrigErr() error {
 	return nil
 }
 
-func (s MailFromDomainNotVerifiedException) Error() string {
+func (s *MailFromDomainNotVerifiedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MailFromDomainNotVerifiedException) StatusCode() int {
+func (s *MailFromDomainNotVerifiedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MailFromDomainNotVerifiedException) RequestID() string {
+func (s *MailFromDomainNotVerifiedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9487,12 +9487,12 @@ func newErrorMessageRejected(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MessageRejected) Code() string {
+func (s *MessageRejected) Code() string {
 	return "MessageRejected"
 }
 
 // Message returns the exception's message.
-func (s MessageRejected) Message() string {
+func (s *MessageRejected) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9500,21 +9500,21 @@ func (s MessageRejected) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MessageRejected) OrigErr() error {
+func (s *MessageRejected) OrigErr() error {
 	return nil
 }
 
-func (s MessageRejected) Error() string {
+func (s *MessageRejected) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MessageRejected) StatusCode() int {
+func (s *MessageRejected) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MessageRejected) RequestID() string {
+func (s *MessageRejected) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9609,12 +9609,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9622,21 +9622,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11315,12 +11315,12 @@ func newErrorSendingPausedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SendingPausedException) Code() string {
+func (s *SendingPausedException) Code() string {
 	return "SendingPausedException"
 }
 
 // Message returns the exception's message.
-func (s SendingPausedException) Message() string {
+func (s *SendingPausedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11328,21 +11328,21 @@ func (s SendingPausedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SendingPausedException) OrigErr() error {
+func (s *SendingPausedException) OrigErr() error {
 	return nil
 }
 
-func (s SendingPausedException) Error() string {
+func (s *SendingPausedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SendingPausedException) StatusCode() int {
+func (s *SendingPausedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SendingPausedException) RequestID() string {
+func (s *SendingPausedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11830,12 +11830,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11843,21 +11843,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/sfn/api.go
+++ b/service/sfn/api.go
@@ -2300,12 +2300,12 @@ func newErrorActivityDoesNotExist(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ActivityDoesNotExist) Code() string {
+func (s *ActivityDoesNotExist) Code() string {
 	return "ActivityDoesNotExist"
 }
 
 // Message returns the exception's message.
-func (s ActivityDoesNotExist) Message() string {
+func (s *ActivityDoesNotExist) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2313,21 +2313,21 @@ func (s ActivityDoesNotExist) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ActivityDoesNotExist) OrigErr() error {
+func (s *ActivityDoesNotExist) OrigErr() error {
 	return nil
 }
 
-func (s ActivityDoesNotExist) Error() string {
+func (s *ActivityDoesNotExist) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ActivityDoesNotExist) StatusCode() int {
+func (s *ActivityDoesNotExist) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ActivityDoesNotExist) RequestID() string {
+func (s *ActivityDoesNotExist) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2390,12 +2390,12 @@ func newErrorActivityLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ActivityLimitExceeded) Code() string {
+func (s *ActivityLimitExceeded) Code() string {
 	return "ActivityLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ActivityLimitExceeded) Message() string {
+func (s *ActivityLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2403,21 +2403,21 @@ func (s ActivityLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ActivityLimitExceeded) OrigErr() error {
+func (s *ActivityLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ActivityLimitExceeded) Error() string {
+func (s *ActivityLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ActivityLimitExceeded) StatusCode() int {
+func (s *ActivityLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ActivityLimitExceeded) RequestID() string {
+func (s *ActivityLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2680,12 +2680,12 @@ func newErrorActivityWorkerLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ActivityWorkerLimitExceeded) Code() string {
+func (s *ActivityWorkerLimitExceeded) Code() string {
 	return "ActivityWorkerLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ActivityWorkerLimitExceeded) Message() string {
+func (s *ActivityWorkerLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2693,21 +2693,21 @@ func (s ActivityWorkerLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ActivityWorkerLimitExceeded) OrigErr() error {
+func (s *ActivityWorkerLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ActivityWorkerLimitExceeded) Error() string {
+func (s *ActivityWorkerLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ActivityWorkerLimitExceeded) StatusCode() int {
+func (s *ActivityWorkerLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ActivityWorkerLimitExceeded) RequestID() string {
+func (s *ActivityWorkerLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3761,12 +3761,12 @@ func newErrorExecutionAlreadyExists(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExecutionAlreadyExists) Code() string {
+func (s *ExecutionAlreadyExists) Code() string {
 	return "ExecutionAlreadyExists"
 }
 
 // Message returns the exception's message.
-func (s ExecutionAlreadyExists) Message() string {
+func (s *ExecutionAlreadyExists) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3774,21 +3774,21 @@ func (s ExecutionAlreadyExists) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExecutionAlreadyExists) OrigErr() error {
+func (s *ExecutionAlreadyExists) OrigErr() error {
 	return nil
 }
 
-func (s ExecutionAlreadyExists) Error() string {
+func (s *ExecutionAlreadyExists) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExecutionAlreadyExists) StatusCode() int {
+func (s *ExecutionAlreadyExists) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExecutionAlreadyExists) RequestID() string {
+func (s *ExecutionAlreadyExists) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3817,12 +3817,12 @@ func newErrorExecutionDoesNotExist(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExecutionDoesNotExist) Code() string {
+func (s *ExecutionDoesNotExist) Code() string {
 	return "ExecutionDoesNotExist"
 }
 
 // Message returns the exception's message.
-func (s ExecutionDoesNotExist) Message() string {
+func (s *ExecutionDoesNotExist) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3830,21 +3830,21 @@ func (s ExecutionDoesNotExist) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExecutionDoesNotExist) OrigErr() error {
+func (s *ExecutionDoesNotExist) OrigErr() error {
 	return nil
 }
 
-func (s ExecutionDoesNotExist) Error() string {
+func (s *ExecutionDoesNotExist) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExecutionDoesNotExist) StatusCode() int {
+func (s *ExecutionDoesNotExist) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExecutionDoesNotExist) RequestID() string {
+func (s *ExecutionDoesNotExist) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3907,12 +3907,12 @@ func newErrorExecutionLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExecutionLimitExceeded) Code() string {
+func (s *ExecutionLimitExceeded) Code() string {
 	return "ExecutionLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ExecutionLimitExceeded) Message() string {
+func (s *ExecutionLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3920,21 +3920,21 @@ func (s ExecutionLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExecutionLimitExceeded) OrigErr() error {
+func (s *ExecutionLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ExecutionLimitExceeded) Error() string {
+func (s *ExecutionLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExecutionLimitExceeded) StatusCode() int {
+func (s *ExecutionLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExecutionLimitExceeded) RequestID() string {
+func (s *ExecutionLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4705,12 +4705,12 @@ func newErrorInvalidArn(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArn) Code() string {
+func (s *InvalidArn) Code() string {
 	return "InvalidArn"
 }
 
 // Message returns the exception's message.
-func (s InvalidArn) Message() string {
+func (s *InvalidArn) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4718,21 +4718,21 @@ func (s InvalidArn) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArn) OrigErr() error {
+func (s *InvalidArn) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArn) Error() string {
+func (s *InvalidArn) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArn) StatusCode() int {
+func (s *InvalidArn) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArn) RequestID() string {
+func (s *InvalidArn) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4761,12 +4761,12 @@ func newErrorInvalidDefinition(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDefinition) Code() string {
+func (s *InvalidDefinition) Code() string {
 	return "InvalidDefinition"
 }
 
 // Message returns the exception's message.
-func (s InvalidDefinition) Message() string {
+func (s *InvalidDefinition) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4774,21 +4774,21 @@ func (s InvalidDefinition) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDefinition) OrigErr() error {
+func (s *InvalidDefinition) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDefinition) Error() string {
+func (s *InvalidDefinition) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDefinition) StatusCode() int {
+func (s *InvalidDefinition) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDefinition) RequestID() string {
+func (s *InvalidDefinition) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4817,12 +4817,12 @@ func newErrorInvalidExecutionInput(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidExecutionInput) Code() string {
+func (s *InvalidExecutionInput) Code() string {
 	return "InvalidExecutionInput"
 }
 
 // Message returns the exception's message.
-func (s InvalidExecutionInput) Message() string {
+func (s *InvalidExecutionInput) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4830,21 +4830,21 @@ func (s InvalidExecutionInput) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidExecutionInput) OrigErr() error {
+func (s *InvalidExecutionInput) OrigErr() error {
 	return nil
 }
 
-func (s InvalidExecutionInput) Error() string {
+func (s *InvalidExecutionInput) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidExecutionInput) StatusCode() int {
+func (s *InvalidExecutionInput) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidExecutionInput) RequestID() string {
+func (s *InvalidExecutionInput) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4872,12 +4872,12 @@ func newErrorInvalidLoggingConfiguration(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidLoggingConfiguration) Code() string {
+func (s *InvalidLoggingConfiguration) Code() string {
 	return "InvalidLoggingConfiguration"
 }
 
 // Message returns the exception's message.
-func (s InvalidLoggingConfiguration) Message() string {
+func (s *InvalidLoggingConfiguration) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4885,21 +4885,21 @@ func (s InvalidLoggingConfiguration) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidLoggingConfiguration) OrigErr() error {
+func (s *InvalidLoggingConfiguration) OrigErr() error {
 	return nil
 }
 
-func (s InvalidLoggingConfiguration) Error() string {
+func (s *InvalidLoggingConfiguration) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidLoggingConfiguration) StatusCode() int {
+func (s *InvalidLoggingConfiguration) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidLoggingConfiguration) RequestID() string {
+func (s *InvalidLoggingConfiguration) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4928,12 +4928,12 @@ func newErrorInvalidName(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidName) Code() string {
+func (s *InvalidName) Code() string {
 	return "InvalidName"
 }
 
 // Message returns the exception's message.
-func (s InvalidName) Message() string {
+func (s *InvalidName) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4941,21 +4941,21 @@ func (s InvalidName) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidName) OrigErr() error {
+func (s *InvalidName) OrigErr() error {
 	return nil
 }
 
-func (s InvalidName) Error() string {
+func (s *InvalidName) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidName) StatusCode() int {
+func (s *InvalidName) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidName) RequestID() string {
+func (s *InvalidName) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4984,12 +4984,12 @@ func newErrorInvalidOutput(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOutput) Code() string {
+func (s *InvalidOutput) Code() string {
 	return "InvalidOutput"
 }
 
 // Message returns the exception's message.
-func (s InvalidOutput) Message() string {
+func (s *InvalidOutput) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4997,21 +4997,21 @@ func (s InvalidOutput) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOutput) OrigErr() error {
+func (s *InvalidOutput) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOutput) Error() string {
+func (s *InvalidOutput) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOutput) StatusCode() int {
+func (s *InvalidOutput) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOutput) RequestID() string {
+func (s *InvalidOutput) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5040,12 +5040,12 @@ func newErrorInvalidToken(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidToken) Code() string {
+func (s *InvalidToken) Code() string {
 	return "InvalidToken"
 }
 
 // Message returns the exception's message.
-func (s InvalidToken) Message() string {
+func (s *InvalidToken) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5053,21 +5053,21 @@ func (s InvalidToken) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidToken) OrigErr() error {
+func (s *InvalidToken) OrigErr() error {
 	return nil
 }
 
-func (s InvalidToken) Error() string {
+func (s *InvalidToken) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidToken) StatusCode() int {
+func (s *InvalidToken) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidToken) RequestID() string {
+func (s *InvalidToken) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5826,12 +5826,12 @@ func newErrorMissingRequiredParameter(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MissingRequiredParameter) Code() string {
+func (s *MissingRequiredParameter) Code() string {
 	return "MissingRequiredParameter"
 }
 
 // Message returns the exception's message.
-func (s MissingRequiredParameter) Message() string {
+func (s *MissingRequiredParameter) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5839,21 +5839,21 @@ func (s MissingRequiredParameter) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MissingRequiredParameter) OrigErr() error {
+func (s *MissingRequiredParameter) OrigErr() error {
 	return nil
 }
 
-func (s MissingRequiredParameter) Error() string {
+func (s *MissingRequiredParameter) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MissingRequiredParameter) StatusCode() int {
+func (s *MissingRequiredParameter) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MissingRequiredParameter) RequestID() string {
+func (s *MissingRequiredParameter) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5885,12 +5885,12 @@ func newErrorResourceNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFound) Code() string {
+func (s *ResourceNotFound) Code() string {
 	return "ResourceNotFound"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFound) Message() string {
+func (s *ResourceNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5898,21 +5898,21 @@ func (s ResourceNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFound) OrigErr() error {
+func (s *ResourceNotFound) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFound) Error() string {
+func (s *ResourceNotFound) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFound) StatusCode() int {
+func (s *ResourceNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFound) RequestID() string {
+func (s *ResourceNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6351,12 +6351,12 @@ func newErrorStateMachineAlreadyExists(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StateMachineAlreadyExists) Code() string {
+func (s *StateMachineAlreadyExists) Code() string {
 	return "StateMachineAlreadyExists"
 }
 
 // Message returns the exception's message.
-func (s StateMachineAlreadyExists) Message() string {
+func (s *StateMachineAlreadyExists) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6364,21 +6364,21 @@ func (s StateMachineAlreadyExists) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StateMachineAlreadyExists) OrigErr() error {
+func (s *StateMachineAlreadyExists) OrigErr() error {
 	return nil
 }
 
-func (s StateMachineAlreadyExists) Error() string {
+func (s *StateMachineAlreadyExists) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StateMachineAlreadyExists) StatusCode() int {
+func (s *StateMachineAlreadyExists) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StateMachineAlreadyExists) RequestID() string {
+func (s *StateMachineAlreadyExists) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6407,12 +6407,12 @@ func newErrorStateMachineDeleting(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StateMachineDeleting) Code() string {
+func (s *StateMachineDeleting) Code() string {
 	return "StateMachineDeleting"
 }
 
 // Message returns the exception's message.
-func (s StateMachineDeleting) Message() string {
+func (s *StateMachineDeleting) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6420,21 +6420,21 @@ func (s StateMachineDeleting) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StateMachineDeleting) OrigErr() error {
+func (s *StateMachineDeleting) OrigErr() error {
 	return nil
 }
 
-func (s StateMachineDeleting) Error() string {
+func (s *StateMachineDeleting) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StateMachineDeleting) StatusCode() int {
+func (s *StateMachineDeleting) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StateMachineDeleting) RequestID() string {
+func (s *StateMachineDeleting) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6463,12 +6463,12 @@ func newErrorStateMachineDoesNotExist(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StateMachineDoesNotExist) Code() string {
+func (s *StateMachineDoesNotExist) Code() string {
 	return "StateMachineDoesNotExist"
 }
 
 // Message returns the exception's message.
-func (s StateMachineDoesNotExist) Message() string {
+func (s *StateMachineDoesNotExist) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6476,21 +6476,21 @@ func (s StateMachineDoesNotExist) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StateMachineDoesNotExist) OrigErr() error {
+func (s *StateMachineDoesNotExist) OrigErr() error {
 	return nil
 }
 
-func (s StateMachineDoesNotExist) Error() string {
+func (s *StateMachineDoesNotExist) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StateMachineDoesNotExist) StatusCode() int {
+func (s *StateMachineDoesNotExist) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StateMachineDoesNotExist) RequestID() string {
+func (s *StateMachineDoesNotExist) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6520,12 +6520,12 @@ func newErrorStateMachineLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StateMachineLimitExceeded) Code() string {
+func (s *StateMachineLimitExceeded) Code() string {
 	return "StateMachineLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s StateMachineLimitExceeded) Message() string {
+func (s *StateMachineLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6533,21 +6533,21 @@ func (s StateMachineLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StateMachineLimitExceeded) OrigErr() error {
+func (s *StateMachineLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s StateMachineLimitExceeded) Error() string {
+func (s *StateMachineLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StateMachineLimitExceeded) StatusCode() int {
+func (s *StateMachineLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StateMachineLimitExceeded) RequestID() string {
+func (s *StateMachineLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6647,12 +6647,12 @@ func newErrorStateMachineTypeNotSupported(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StateMachineTypeNotSupported) Code() string {
+func (s *StateMachineTypeNotSupported) Code() string {
 	return "StateMachineTypeNotSupported"
 }
 
 // Message returns the exception's message.
-func (s StateMachineTypeNotSupported) Message() string {
+func (s *StateMachineTypeNotSupported) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6660,21 +6660,21 @@ func (s StateMachineTypeNotSupported) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StateMachineTypeNotSupported) OrigErr() error {
+func (s *StateMachineTypeNotSupported) OrigErr() error {
 	return nil
 }
 
-func (s StateMachineTypeNotSupported) Error() string {
+func (s *StateMachineTypeNotSupported) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StateMachineTypeNotSupported) StatusCode() int {
+func (s *StateMachineTypeNotSupported) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StateMachineTypeNotSupported) RequestID() string {
+func (s *StateMachineTypeNotSupported) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6923,12 +6923,12 @@ func newErrorTaskDoesNotExist(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TaskDoesNotExist) Code() string {
+func (s *TaskDoesNotExist) Code() string {
 	return "TaskDoesNotExist"
 }
 
 // Message returns the exception's message.
-func (s TaskDoesNotExist) Message() string {
+func (s *TaskDoesNotExist) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6936,21 +6936,21 @@ func (s TaskDoesNotExist) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TaskDoesNotExist) OrigErr() error {
+func (s *TaskDoesNotExist) OrigErr() error {
 	return nil
 }
 
-func (s TaskDoesNotExist) Error() string {
+func (s *TaskDoesNotExist) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TaskDoesNotExist) StatusCode() int {
+func (s *TaskDoesNotExist) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TaskDoesNotExist) RequestID() string {
+func (s *TaskDoesNotExist) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7341,12 +7341,12 @@ func newErrorTaskTimedOut(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TaskTimedOut) Code() string {
+func (s *TaskTimedOut) Code() string {
 	return "TaskTimedOut"
 }
 
 // Message returns the exception's message.
-func (s TaskTimedOut) Message() string {
+func (s *TaskTimedOut) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7354,21 +7354,21 @@ func (s TaskTimedOut) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TaskTimedOut) OrigErr() error {
+func (s *TaskTimedOut) OrigErr() error {
 	return nil
 }
 
-func (s TaskTimedOut) Error() string {
+func (s *TaskTimedOut) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TaskTimedOut) StatusCode() int {
+func (s *TaskTimedOut) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TaskTimedOut) RequestID() string {
+func (s *TaskTimedOut) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7456,12 +7456,12 @@ func newErrorTooManyTags(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTags) Code() string {
+func (s *TooManyTags) Code() string {
 	return "TooManyTags"
 }
 
 // Message returns the exception's message.
-func (s TooManyTags) Message() string {
+func (s *TooManyTags) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7469,21 +7469,21 @@ func (s TooManyTags) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTags) OrigErr() error {
+func (s *TooManyTags) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTags) Error() string {
+func (s *TooManyTags) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTags) StatusCode() int {
+func (s *TooManyTags) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTags) RequestID() string {
+func (s *TooManyTags) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/shield/api.go
+++ b/service/shield/api.go
@@ -1963,12 +1963,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1976,21 +1976,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2022,12 +2022,12 @@ func newErrorAccessDeniedForDependencyException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedForDependencyException) Code() string {
+func (s *AccessDeniedForDependencyException) Code() string {
 	return "AccessDeniedForDependencyException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedForDependencyException) Message() string {
+func (s *AccessDeniedForDependencyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2035,21 +2035,21 @@ func (s AccessDeniedForDependencyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedForDependencyException) OrigErr() error {
+func (s *AccessDeniedForDependencyException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedForDependencyException) Error() string {
+func (s *AccessDeniedForDependencyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedForDependencyException) StatusCode() int {
+func (s *AccessDeniedForDependencyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedForDependencyException) RequestID() string {
+func (s *AccessDeniedForDependencyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3293,12 +3293,12 @@ func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalErrorException) Code() string {
+func (s *InternalErrorException) Code() string {
 	return "InternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalErrorException) Message() string {
+func (s *InternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3306,21 +3306,21 @@ func (s InternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalErrorException) OrigErr() error {
+func (s *InternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalErrorException) Error() string {
+func (s *InternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalErrorException) StatusCode() int {
+func (s *InternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalErrorException) RequestID() string {
+func (s *InternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3350,12 +3350,12 @@ func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOperationException) Code() string {
+func (s *InvalidOperationException) Code() string {
 	return "InvalidOperationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOperationException) Message() string {
+func (s *InvalidOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3363,21 +3363,21 @@ func (s InvalidOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOperationException) OrigErr() error {
+func (s *InvalidOperationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOperationException) Error() string {
+func (s *InvalidOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOperationException) StatusCode() int {
+func (s *InvalidOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOperationException) RequestID() string {
+func (s *InvalidOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3407,12 +3407,12 @@ func newErrorInvalidPaginationTokenException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidPaginationTokenException) Code() string {
+func (s *InvalidPaginationTokenException) Code() string {
 	return "InvalidPaginationTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPaginationTokenException) Message() string {
+func (s *InvalidPaginationTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3420,21 +3420,21 @@ func (s InvalidPaginationTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPaginationTokenException) OrigErr() error {
+func (s *InvalidPaginationTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPaginationTokenException) Error() string {
+func (s *InvalidPaginationTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPaginationTokenException) StatusCode() int {
+func (s *InvalidPaginationTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPaginationTokenException) RequestID() string {
+func (s *InvalidPaginationTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3463,12 +3463,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3476,21 +3476,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3520,12 +3520,12 @@ func newErrorInvalidResourceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceException) Code() string {
+func (s *InvalidResourceException) Code() string {
 	return "InvalidResourceException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceException) Message() string {
+func (s *InvalidResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3533,21 +3533,21 @@ func (s InvalidResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceException) OrigErr() error {
+func (s *InvalidResourceException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceException) Error() string {
+func (s *InvalidResourceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceException) StatusCode() int {
+func (s *InvalidResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceException) RequestID() string {
+func (s *InvalidResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3617,12 +3617,12 @@ func newErrorLimitsExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitsExceededException) Code() string {
+func (s *LimitsExceededException) Code() string {
 	return "LimitsExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitsExceededException) Message() string {
+func (s *LimitsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3630,21 +3630,21 @@ func (s LimitsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitsExceededException) OrigErr() error {
+func (s *LimitsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitsExceededException) Error() string {
+func (s *LimitsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitsExceededException) StatusCode() int {
+func (s *LimitsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitsExceededException) RequestID() string {
+func (s *LimitsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3895,12 +3895,12 @@ func newErrorLockedSubscriptionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LockedSubscriptionException) Code() string {
+func (s *LockedSubscriptionException) Code() string {
 	return "LockedSubscriptionException"
 }
 
 // Message returns the exception's message.
-func (s LockedSubscriptionException) Message() string {
+func (s *LockedSubscriptionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3908,21 +3908,21 @@ func (s LockedSubscriptionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LockedSubscriptionException) OrigErr() error {
+func (s *LockedSubscriptionException) OrigErr() error {
 	return nil
 }
 
-func (s LockedSubscriptionException) Error() string {
+func (s *LockedSubscriptionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LockedSubscriptionException) StatusCode() int {
+func (s *LockedSubscriptionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LockedSubscriptionException) RequestID() string {
+func (s *LockedSubscriptionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3975,12 +3975,12 @@ func newErrorNoAssociatedRoleException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoAssociatedRoleException) Code() string {
+func (s *NoAssociatedRoleException) Code() string {
 	return "NoAssociatedRoleException"
 }
 
 // Message returns the exception's message.
-func (s NoAssociatedRoleException) Message() string {
+func (s *NoAssociatedRoleException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3988,21 +3988,21 @@ func (s NoAssociatedRoleException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoAssociatedRoleException) OrigErr() error {
+func (s *NoAssociatedRoleException) OrigErr() error {
 	return nil
 }
 
-func (s NoAssociatedRoleException) Error() string {
+func (s *NoAssociatedRoleException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoAssociatedRoleException) StatusCode() int {
+func (s *NoAssociatedRoleException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoAssociatedRoleException) RequestID() string {
+func (s *NoAssociatedRoleException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4032,12 +4032,12 @@ func newErrorOptimisticLockException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OptimisticLockException) Code() string {
+func (s *OptimisticLockException) Code() string {
 	return "OptimisticLockException"
 }
 
 // Message returns the exception's message.
-func (s OptimisticLockException) Message() string {
+func (s *OptimisticLockException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4045,21 +4045,21 @@ func (s OptimisticLockException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OptimisticLockException) OrigErr() error {
+func (s *OptimisticLockException) OrigErr() error {
 	return nil
 }
 
-func (s OptimisticLockException) Error() string {
+func (s *OptimisticLockException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OptimisticLockException) StatusCode() int {
+func (s *OptimisticLockException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OptimisticLockException) RequestID() string {
+func (s *OptimisticLockException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4140,12 +4140,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4153,21 +4153,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4196,12 +4196,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4209,21 +4209,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/signer/api.go
+++ b/service/signer/api.go
@@ -1312,12 +1312,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1325,21 +1325,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1369,12 +1369,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1382,21 +1382,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2009,12 +2009,12 @@ func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceErrorException) Code() string {
+func (s *InternalServiceErrorException) Code() string {
 	return "InternalServiceErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceErrorException) Message() string {
+func (s *InternalServiceErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2022,21 +2022,21 @@ func (s InternalServiceErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceErrorException) OrigErr() error {
+func (s *InternalServiceErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceErrorException) Error() string {
+func (s *InternalServiceErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceErrorException) StatusCode() int {
+func (s *InternalServiceErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceErrorException) RequestID() string {
+func (s *InternalServiceErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2437,12 +2437,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2450,21 +2450,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2624,12 +2624,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2637,21 +2637,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3484,12 +3484,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3497,21 +3497,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3612,12 +3612,12 @@ func newErrorValidationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ValidationException) Code() string {
+func (s *ValidationException) Code() string {
 	return "ValidationException"
 }
 
 // Message returns the exception's message.
-func (s ValidationException) Message() string {
+func (s *ValidationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3625,21 +3625,21 @@ func (s ValidationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ValidationException) OrigErr() error {
+func (s *ValidationException) OrigErr() error {
 	return nil
 }
 
-func (s ValidationException) Error() string {
+func (s *ValidationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ValidationException) StatusCode() int {
+func (s *ValidationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ValidationException) RequestID() string {
+func (s *ValidationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/sms/api.go
+++ b/service/sms/api.go
@@ -4313,12 +4313,12 @@ func newErrorInternalError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalError) Code() string {
+func (s *InternalError) Code() string {
 	return "InternalError"
 }
 
 // Message returns the exception's message.
-func (s InternalError) Message() string {
+func (s *InternalError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4326,21 +4326,21 @@ func (s InternalError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalError) OrigErr() error {
+func (s *InternalError) OrigErr() error {
 	return nil
 }
 
-func (s InternalError) Error() string {
+func (s *InternalError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalError) StatusCode() int {
+func (s *InternalError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalError) RequestID() string {
+func (s *InternalError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4369,12 +4369,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4382,21 +4382,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4579,12 +4579,12 @@ func newErrorMissingRequiredParameterException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s MissingRequiredParameterException) Code() string {
+func (s *MissingRequiredParameterException) Code() string {
 	return "MissingRequiredParameterException"
 }
 
 // Message returns the exception's message.
-func (s MissingRequiredParameterException) Message() string {
+func (s *MissingRequiredParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4592,21 +4592,21 @@ func (s MissingRequiredParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MissingRequiredParameterException) OrigErr() error {
+func (s *MissingRequiredParameterException) OrigErr() error {
 	return nil
 }
 
-func (s MissingRequiredParameterException) Error() string {
+func (s *MissingRequiredParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MissingRequiredParameterException) StatusCode() int {
+func (s *MissingRequiredParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MissingRequiredParameterException) RequestID() string {
+func (s *MissingRequiredParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4635,12 +4635,12 @@ func newErrorNoConnectorsAvailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NoConnectorsAvailableException) Code() string {
+func (s *NoConnectorsAvailableException) Code() string {
 	return "NoConnectorsAvailableException"
 }
 
 // Message returns the exception's message.
-func (s NoConnectorsAvailableException) Message() string {
+func (s *NoConnectorsAvailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4648,21 +4648,21 @@ func (s NoConnectorsAvailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NoConnectorsAvailableException) OrigErr() error {
+func (s *NoConnectorsAvailableException) OrigErr() error {
 	return nil
 }
 
-func (s NoConnectorsAvailableException) Error() string {
+func (s *NoConnectorsAvailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NoConnectorsAvailableException) StatusCode() int {
+func (s *NoConnectorsAvailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NoConnectorsAvailableException) RequestID() string {
+func (s *NoConnectorsAvailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4691,12 +4691,12 @@ func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotPermittedException) Code() string {
+func (s *OperationNotPermittedException) Code() string {
 	return "OperationNotPermittedException"
 }
 
 // Message returns the exception's message.
-func (s OperationNotPermittedException) Message() string {
+func (s *OperationNotPermittedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4704,21 +4704,21 @@ func (s OperationNotPermittedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotPermittedException) OrigErr() error {
+func (s *OperationNotPermittedException) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotPermittedException) Error() string {
+func (s *OperationNotPermittedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotPermittedException) StatusCode() int {
+func (s *OperationNotPermittedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotPermittedException) RequestID() string {
+func (s *OperationNotPermittedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5040,12 +5040,12 @@ func newErrorReplicationJobAlreadyExistsException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s ReplicationJobAlreadyExistsException) Code() string {
+func (s *ReplicationJobAlreadyExistsException) Code() string {
 	return "ReplicationJobAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ReplicationJobAlreadyExistsException) Message() string {
+func (s *ReplicationJobAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5053,21 +5053,21 @@ func (s ReplicationJobAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReplicationJobAlreadyExistsException) OrigErr() error {
+func (s *ReplicationJobAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ReplicationJobAlreadyExistsException) Error() string {
+func (s *ReplicationJobAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReplicationJobAlreadyExistsException) StatusCode() int {
+func (s *ReplicationJobAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReplicationJobAlreadyExistsException) RequestID() string {
+func (s *ReplicationJobAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5096,12 +5096,12 @@ func newErrorReplicationJobNotFoundException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ReplicationJobNotFoundException) Code() string {
+func (s *ReplicationJobNotFoundException) Code() string {
 	return "ReplicationJobNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ReplicationJobNotFoundException) Message() string {
+func (s *ReplicationJobNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5109,21 +5109,21 @@ func (s ReplicationJobNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReplicationJobNotFoundException) OrigErr() error {
+func (s *ReplicationJobNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ReplicationJobNotFoundException) Error() string {
+func (s *ReplicationJobNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReplicationJobNotFoundException) StatusCode() int {
+func (s *ReplicationJobNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReplicationJobNotFoundException) RequestID() string {
+func (s *ReplicationJobNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5280,12 +5280,12 @@ func newErrorReplicationRunLimitExceededException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s ReplicationRunLimitExceededException) Code() string {
+func (s *ReplicationRunLimitExceededException) Code() string {
 	return "ReplicationRunLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ReplicationRunLimitExceededException) Message() string {
+func (s *ReplicationRunLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5293,21 +5293,21 @@ func (s ReplicationRunLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReplicationRunLimitExceededException) OrigErr() error {
+func (s *ReplicationRunLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ReplicationRunLimitExceededException) Error() string {
+func (s *ReplicationRunLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReplicationRunLimitExceededException) StatusCode() int {
+func (s *ReplicationRunLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReplicationRunLimitExceededException) RequestID() string {
+func (s *ReplicationRunLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5462,12 +5462,12 @@ func newErrorServerCannotBeReplicatedException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ServerCannotBeReplicatedException) Code() string {
+func (s *ServerCannotBeReplicatedException) Code() string {
 	return "ServerCannotBeReplicatedException"
 }
 
 // Message returns the exception's message.
-func (s ServerCannotBeReplicatedException) Message() string {
+func (s *ServerCannotBeReplicatedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5475,21 +5475,21 @@ func (s ServerCannotBeReplicatedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServerCannotBeReplicatedException) OrigErr() error {
+func (s *ServerCannotBeReplicatedException) OrigErr() error {
 	return nil
 }
 
-func (s ServerCannotBeReplicatedException) Error() string {
+func (s *ServerCannotBeReplicatedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServerCannotBeReplicatedException) StatusCode() int {
+func (s *ServerCannotBeReplicatedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServerCannotBeReplicatedException) RequestID() string {
+func (s *ServerCannotBeReplicatedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6032,12 +6032,12 @@ func newErrorTemporarilyUnavailableException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s TemporarilyUnavailableException) Code() string {
+func (s *TemporarilyUnavailableException) Code() string {
 	return "TemporarilyUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s TemporarilyUnavailableException) Message() string {
+func (s *TemporarilyUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6045,21 +6045,21 @@ func (s TemporarilyUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TemporarilyUnavailableException) OrigErr() error {
+func (s *TemporarilyUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s TemporarilyUnavailableException) Error() string {
+func (s *TemporarilyUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TemporarilyUnavailableException) StatusCode() int {
+func (s *TemporarilyUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TemporarilyUnavailableException) RequestID() string {
+func (s *TemporarilyUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6126,12 +6126,12 @@ func newErrorUnauthorizedOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedOperationException) Code() string {
+func (s *UnauthorizedOperationException) Code() string {
 	return "UnauthorizedOperationException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedOperationException) Message() string {
+func (s *UnauthorizedOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6139,21 +6139,21 @@ func (s UnauthorizedOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedOperationException) OrigErr() error {
+func (s *UnauthorizedOperationException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedOperationException) Error() string {
+func (s *UnauthorizedOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedOperationException) StatusCode() int {
+func (s *UnauthorizedOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedOperationException) RequestID() string {
+func (s *UnauthorizedOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/snowball/api.go
+++ b/service/snowball/api.go
@@ -2169,12 +2169,12 @@ func newErrorClusterLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ClusterLimitExceededException) Code() string {
+func (s *ClusterLimitExceededException) Code() string {
 	return "ClusterLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ClusterLimitExceededException) Message() string {
+func (s *ClusterLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2182,21 +2182,21 @@ func (s ClusterLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ClusterLimitExceededException) OrigErr() error {
+func (s *ClusterLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ClusterLimitExceededException) Error() string {
+func (s *ClusterLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ClusterLimitExceededException) StatusCode() int {
+func (s *ClusterLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ClusterLimitExceededException) RequestID() string {
+func (s *ClusterLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3383,12 +3383,12 @@ func newErrorEc2RequestFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s Ec2RequestFailedException) Code() string {
+func (s *Ec2RequestFailedException) Code() string {
 	return "Ec2RequestFailedException"
 }
 
 // Message returns the exception's message.
-func (s Ec2RequestFailedException) Message() string {
+func (s *Ec2RequestFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3396,21 +3396,21 @@ func (s Ec2RequestFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s Ec2RequestFailedException) OrigErr() error {
+func (s *Ec2RequestFailedException) OrigErr() error {
 	return nil
 }
 
-func (s Ec2RequestFailedException) Error() string {
+func (s *Ec2RequestFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s Ec2RequestFailedException) StatusCode() int {
+func (s *Ec2RequestFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s Ec2RequestFailedException) RequestID() string {
+func (s *Ec2RequestFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3736,12 +3736,12 @@ func newErrorInvalidAddressException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAddressException) Code() string {
+func (s *InvalidAddressException) Code() string {
 	return "InvalidAddressException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAddressException) Message() string {
+func (s *InvalidAddressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3749,21 +3749,21 @@ func (s InvalidAddressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAddressException) OrigErr() error {
+func (s *InvalidAddressException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAddressException) Error() string {
+func (s *InvalidAddressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAddressException) StatusCode() int {
+func (s *InvalidAddressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAddressException) RequestID() string {
+func (s *InvalidAddressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3794,12 +3794,12 @@ func newErrorInvalidInputCombinationException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidInputCombinationException) Code() string {
+func (s *InvalidInputCombinationException) Code() string {
 	return "InvalidInputCombinationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInputCombinationException) Message() string {
+func (s *InvalidInputCombinationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3807,21 +3807,21 @@ func (s InvalidInputCombinationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInputCombinationException) OrigErr() error {
+func (s *InvalidInputCombinationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInputCombinationException) Error() string {
+func (s *InvalidInputCombinationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInputCombinationException) StatusCode() int {
+func (s *InvalidInputCombinationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInputCombinationException) RequestID() string {
+func (s *InvalidInputCombinationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3851,12 +3851,12 @@ func newErrorInvalidJobStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidJobStateException) Code() string {
+func (s *InvalidJobStateException) Code() string {
 	return "InvalidJobStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidJobStateException) Message() string {
+func (s *InvalidJobStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3864,21 +3864,21 @@ func (s InvalidJobStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidJobStateException) OrigErr() error {
+func (s *InvalidJobStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidJobStateException) Error() string {
+func (s *InvalidJobStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidJobStateException) StatusCode() int {
+func (s *InvalidJobStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidJobStateException) RequestID() string {
+func (s *InvalidJobStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3908,12 +3908,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3921,21 +3921,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3968,12 +3968,12 @@ func newErrorInvalidResourceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceException) Code() string {
+func (s *InvalidResourceException) Code() string {
 	return "InvalidResourceException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceException) Message() string {
+func (s *InvalidResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3981,21 +3981,21 @@ func (s InvalidResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceException) OrigErr() error {
+func (s *InvalidResourceException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceException) Error() string {
+func (s *InvalidResourceException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceException) StatusCode() int {
+func (s *InvalidResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceException) RequestID() string {
+func (s *InvalidResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4441,12 +4441,12 @@ func newErrorKMSRequestFailedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s KMSRequestFailedException) Code() string {
+func (s *KMSRequestFailedException) Code() string {
 	return "KMSRequestFailedException"
 }
 
 // Message returns the exception's message.
-func (s KMSRequestFailedException) Message() string {
+func (s *KMSRequestFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4454,21 +4454,21 @@ func (s KMSRequestFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s KMSRequestFailedException) OrigErr() error {
+func (s *KMSRequestFailedException) OrigErr() error {
 	return nil
 }
 
-func (s KMSRequestFailedException) Error() string {
+func (s *KMSRequestFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s KMSRequestFailedException) StatusCode() int {
+func (s *KMSRequestFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s KMSRequestFailedException) RequestID() string {
+func (s *KMSRequestFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5166,12 +5166,12 @@ func newErrorUnsupportedAddressException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedAddressException) Code() string {
+func (s *UnsupportedAddressException) Code() string {
 	return "UnsupportedAddressException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedAddressException) Message() string {
+func (s *UnsupportedAddressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5179,21 +5179,21 @@ func (s UnsupportedAddressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedAddressException) OrigErr() error {
+func (s *UnsupportedAddressException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedAddressException) Error() string {
+func (s *UnsupportedAddressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedAddressException) StatusCode() int {
+func (s *UnsupportedAddressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedAddressException) RequestID() string {
+func (s *UnsupportedAddressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -12348,12 +12348,12 @@ func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AlreadyExistsException) Code() string {
+func (s *AlreadyExistsException) Code() string {
 	return "AlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s AlreadyExistsException) Message() string {
+func (s *AlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12361,21 +12361,21 @@ func (s AlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AlreadyExistsException) OrigErr() error {
+func (s *AlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s AlreadyExistsException) Error() string {
+func (s *AlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AlreadyExistsException) StatusCode() int {
+func (s *AlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AlreadyExistsException) RequestID() string {
+func (s *AlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12405,12 +12405,12 @@ func newErrorAssociatedInstances(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AssociatedInstances) Code() string {
+func (s *AssociatedInstances) Code() string {
 	return "AssociatedInstances"
 }
 
 // Message returns the exception's message.
-func (s AssociatedInstances) Message() string {
+func (s *AssociatedInstances) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12418,21 +12418,21 @@ func (s AssociatedInstances) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AssociatedInstances) OrigErr() error {
+func (s *AssociatedInstances) OrigErr() error {
 	return nil
 }
 
-func (s AssociatedInstances) Error() string {
+func (s *AssociatedInstances) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AssociatedInstances) StatusCode() int {
+func (s *AssociatedInstances) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AssociatedInstances) RequestID() string {
+func (s *AssociatedInstances) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12567,12 +12567,12 @@ func newErrorAssociationAlreadyExists(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AssociationAlreadyExists) Code() string {
+func (s *AssociationAlreadyExists) Code() string {
 	return "AssociationAlreadyExists"
 }
 
 // Message returns the exception's message.
-func (s AssociationAlreadyExists) Message() string {
+func (s *AssociationAlreadyExists) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12580,21 +12580,21 @@ func (s AssociationAlreadyExists) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AssociationAlreadyExists) OrigErr() error {
+func (s *AssociationAlreadyExists) OrigErr() error {
 	return nil
 }
 
-func (s AssociationAlreadyExists) Error() string {
+func (s *AssociationAlreadyExists) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AssociationAlreadyExists) StatusCode() int {
+func (s *AssociationAlreadyExists) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AssociationAlreadyExists) RequestID() string {
+func (s *AssociationAlreadyExists) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12839,12 +12839,12 @@ func newErrorAssociationDoesNotExist(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AssociationDoesNotExist) Code() string {
+func (s *AssociationDoesNotExist) Code() string {
 	return "AssociationDoesNotExist"
 }
 
 // Message returns the exception's message.
-func (s AssociationDoesNotExist) Message() string {
+func (s *AssociationDoesNotExist) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12852,21 +12852,21 @@ func (s AssociationDoesNotExist) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AssociationDoesNotExist) OrigErr() error {
+func (s *AssociationDoesNotExist) OrigErr() error {
 	return nil
 }
 
-func (s AssociationDoesNotExist) Error() string {
+func (s *AssociationDoesNotExist) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AssociationDoesNotExist) StatusCode() int {
+func (s *AssociationDoesNotExist) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AssociationDoesNotExist) RequestID() string {
+func (s *AssociationDoesNotExist) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12983,12 +12983,12 @@ func newErrorAssociationExecutionDoesNotExist(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s AssociationExecutionDoesNotExist) Code() string {
+func (s *AssociationExecutionDoesNotExist) Code() string {
 	return "AssociationExecutionDoesNotExist"
 }
 
 // Message returns the exception's message.
-func (s AssociationExecutionDoesNotExist) Message() string {
+func (s *AssociationExecutionDoesNotExist) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12996,21 +12996,21 @@ func (s AssociationExecutionDoesNotExist) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AssociationExecutionDoesNotExist) OrigErr() error {
+func (s *AssociationExecutionDoesNotExist) OrigErr() error {
 	return nil
 }
 
-func (s AssociationExecutionDoesNotExist) Error() string {
+func (s *AssociationExecutionDoesNotExist) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AssociationExecutionDoesNotExist) StatusCode() int {
+func (s *AssociationExecutionDoesNotExist) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AssociationExecutionDoesNotExist) RequestID() string {
+func (s *AssociationExecutionDoesNotExist) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13317,12 +13317,12 @@ func newErrorAssociationLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AssociationLimitExceeded) Code() string {
+func (s *AssociationLimitExceeded) Code() string {
 	return "AssociationLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s AssociationLimitExceeded) Message() string {
+func (s *AssociationLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13330,21 +13330,21 @@ func (s AssociationLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AssociationLimitExceeded) OrigErr() error {
+func (s *AssociationLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s AssociationLimitExceeded) Error() string {
+func (s *AssociationLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AssociationLimitExceeded) StatusCode() int {
+func (s *AssociationLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AssociationLimitExceeded) RequestID() string {
+func (s *AssociationLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13654,12 +13654,12 @@ func newErrorAssociationVersionLimitExceeded(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s AssociationVersionLimitExceeded) Code() string {
+func (s *AssociationVersionLimitExceeded) Code() string {
 	return "AssociationVersionLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s AssociationVersionLimitExceeded) Message() string {
+func (s *AssociationVersionLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13667,21 +13667,21 @@ func (s AssociationVersionLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AssociationVersionLimitExceeded) OrigErr() error {
+func (s *AssociationVersionLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s AssociationVersionLimitExceeded) Error() string {
+func (s *AssociationVersionLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AssociationVersionLimitExceeded) StatusCode() int {
+func (s *AssociationVersionLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AssociationVersionLimitExceeded) RequestID() string {
+func (s *AssociationVersionLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13867,12 +13867,12 @@ func newErrorAutomationDefinitionNotFoundException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s AutomationDefinitionNotFoundException) Code() string {
+func (s *AutomationDefinitionNotFoundException) Code() string {
 	return "AutomationDefinitionNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s AutomationDefinitionNotFoundException) Message() string {
+func (s *AutomationDefinitionNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13880,21 +13880,21 @@ func (s AutomationDefinitionNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AutomationDefinitionNotFoundException) OrigErr() error {
+func (s *AutomationDefinitionNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s AutomationDefinitionNotFoundException) Error() string {
+func (s *AutomationDefinitionNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AutomationDefinitionNotFoundException) StatusCode() int {
+func (s *AutomationDefinitionNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AutomationDefinitionNotFoundException) RequestID() string {
+func (s *AutomationDefinitionNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13923,12 +13923,12 @@ func newErrorAutomationDefinitionVersionNotFoundException(v protocol.ResponseMet
 }
 
 // Code returns the exception type name.
-func (s AutomationDefinitionVersionNotFoundException) Code() string {
+func (s *AutomationDefinitionVersionNotFoundException) Code() string {
 	return "AutomationDefinitionVersionNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s AutomationDefinitionVersionNotFoundException) Message() string {
+func (s *AutomationDefinitionVersionNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13936,21 +13936,21 @@ func (s AutomationDefinitionVersionNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AutomationDefinitionVersionNotFoundException) OrigErr() error {
+func (s *AutomationDefinitionVersionNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s AutomationDefinitionVersionNotFoundException) Error() string {
+func (s *AutomationDefinitionVersionNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AutomationDefinitionVersionNotFoundException) StatusCode() int {
+func (s *AutomationDefinitionVersionNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AutomationDefinitionVersionNotFoundException) RequestID() string {
+func (s *AutomationDefinitionVersionNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14288,12 +14288,12 @@ func newErrorAutomationExecutionLimitExceededException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s AutomationExecutionLimitExceededException) Code() string {
+func (s *AutomationExecutionLimitExceededException) Code() string {
 	return "AutomationExecutionLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s AutomationExecutionLimitExceededException) Message() string {
+func (s *AutomationExecutionLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14301,21 +14301,21 @@ func (s AutomationExecutionLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AutomationExecutionLimitExceededException) OrigErr() error {
+func (s *AutomationExecutionLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s AutomationExecutionLimitExceededException) Error() string {
+func (s *AutomationExecutionLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AutomationExecutionLimitExceededException) StatusCode() int {
+func (s *AutomationExecutionLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AutomationExecutionLimitExceededException) RequestID() string {
+func (s *AutomationExecutionLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14563,12 +14563,12 @@ func newErrorAutomationExecutionNotFoundException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s AutomationExecutionNotFoundException) Code() string {
+func (s *AutomationExecutionNotFoundException) Code() string {
 	return "AutomationExecutionNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s AutomationExecutionNotFoundException) Message() string {
+func (s *AutomationExecutionNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14576,21 +14576,21 @@ func (s AutomationExecutionNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AutomationExecutionNotFoundException) OrigErr() error {
+func (s *AutomationExecutionNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s AutomationExecutionNotFoundException) Error() string {
+func (s *AutomationExecutionNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AutomationExecutionNotFoundException) StatusCode() int {
+func (s *AutomationExecutionNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AutomationExecutionNotFoundException) RequestID() string {
+func (s *AutomationExecutionNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14620,12 +14620,12 @@ func newErrorAutomationStepNotFoundException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s AutomationStepNotFoundException) Code() string {
+func (s *AutomationStepNotFoundException) Code() string {
 	return "AutomationStepNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s AutomationStepNotFoundException) Message() string {
+func (s *AutomationStepNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14633,21 +14633,21 @@ func (s AutomationStepNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AutomationStepNotFoundException) OrigErr() error {
+func (s *AutomationStepNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s AutomationStepNotFoundException) Error() string {
+func (s *AutomationStepNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AutomationStepNotFoundException) StatusCode() int {
+func (s *AutomationStepNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AutomationStepNotFoundException) RequestID() string {
+func (s *AutomationStepNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15978,12 +15978,12 @@ func newErrorComplianceTypeCountLimitExceededException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s ComplianceTypeCountLimitExceededException) Code() string {
+func (s *ComplianceTypeCountLimitExceededException) Code() string {
 	return "ComplianceTypeCountLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ComplianceTypeCountLimitExceededException) Message() string {
+func (s *ComplianceTypeCountLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15991,21 +15991,21 @@ func (s ComplianceTypeCountLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ComplianceTypeCountLimitExceededException) OrigErr() error {
+func (s *ComplianceTypeCountLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ComplianceTypeCountLimitExceededException) Error() string {
+func (s *ComplianceTypeCountLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ComplianceTypeCountLimitExceededException) StatusCode() int {
+func (s *ComplianceTypeCountLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ComplianceTypeCountLimitExceededException) RequestID() string {
+func (s *ComplianceTypeCountLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17748,12 +17748,12 @@ func newErrorCustomSchemaCountLimitExceededException(v protocol.ResponseMetadata
 }
 
 // Code returns the exception type name.
-func (s CustomSchemaCountLimitExceededException) Code() string {
+func (s *CustomSchemaCountLimitExceededException) Code() string {
 	return "CustomSchemaCountLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s CustomSchemaCountLimitExceededException) Message() string {
+func (s *CustomSchemaCountLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17761,21 +17761,21 @@ func (s CustomSchemaCountLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CustomSchemaCountLimitExceededException) OrigErr() error {
+func (s *CustomSchemaCountLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s CustomSchemaCountLimitExceededException) Error() string {
+func (s *CustomSchemaCountLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CustomSchemaCountLimitExceededException) StatusCode() int {
+func (s *CustomSchemaCountLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CustomSchemaCountLimitExceededException) RequestID() string {
+func (s *CustomSchemaCountLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22405,12 +22405,12 @@ func newErrorDocumentAlreadyExists(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DocumentAlreadyExists) Code() string {
+func (s *DocumentAlreadyExists) Code() string {
 	return "DocumentAlreadyExists"
 }
 
 // Message returns the exception's message.
-func (s DocumentAlreadyExists) Message() string {
+func (s *DocumentAlreadyExists) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22418,21 +22418,21 @@ func (s DocumentAlreadyExists) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DocumentAlreadyExists) OrigErr() error {
+func (s *DocumentAlreadyExists) OrigErr() error {
 	return nil
 }
 
-func (s DocumentAlreadyExists) Error() string {
+func (s *DocumentAlreadyExists) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DocumentAlreadyExists) StatusCode() int {
+func (s *DocumentAlreadyExists) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DocumentAlreadyExists) RequestID() string {
+func (s *DocumentAlreadyExists) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -22974,12 +22974,12 @@ func newErrorDocumentLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DocumentLimitExceeded) Code() string {
+func (s *DocumentLimitExceeded) Code() string {
 	return "DocumentLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s DocumentLimitExceeded) Message() string {
+func (s *DocumentLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -22987,21 +22987,21 @@ func (s DocumentLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DocumentLimitExceeded) OrigErr() error {
+func (s *DocumentLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s DocumentLimitExceeded) Error() string {
+func (s *DocumentLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DocumentLimitExceeded) StatusCode() int {
+func (s *DocumentLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DocumentLimitExceeded) RequestID() string {
+func (s *DocumentLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23086,12 +23086,12 @@ func newErrorDocumentPermissionLimit(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DocumentPermissionLimit) Code() string {
+func (s *DocumentPermissionLimit) Code() string {
 	return "DocumentPermissionLimit"
 }
 
 // Message returns the exception's message.
-func (s DocumentPermissionLimit) Message() string {
+func (s *DocumentPermissionLimit) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23099,21 +23099,21 @@ func (s DocumentPermissionLimit) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DocumentPermissionLimit) OrigErr() error {
+func (s *DocumentPermissionLimit) OrigErr() error {
 	return nil
 }
 
-func (s DocumentPermissionLimit) Error() string {
+func (s *DocumentPermissionLimit) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DocumentPermissionLimit) StatusCode() int {
+func (s *DocumentPermissionLimit) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DocumentPermissionLimit) RequestID() string {
+func (s *DocumentPermissionLimit) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23285,12 +23285,12 @@ func newErrorDocumentVersionLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DocumentVersionLimitExceeded) Code() string {
+func (s *DocumentVersionLimitExceeded) Code() string {
 	return "DocumentVersionLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s DocumentVersionLimitExceeded) Message() string {
+func (s *DocumentVersionLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23298,21 +23298,21 @@ func (s DocumentVersionLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DocumentVersionLimitExceeded) OrigErr() error {
+func (s *DocumentVersionLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s DocumentVersionLimitExceeded) Error() string {
+func (s *DocumentVersionLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DocumentVersionLimitExceeded) StatusCode() int {
+func (s *DocumentVersionLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DocumentVersionLimitExceeded) RequestID() string {
+func (s *DocumentVersionLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23346,12 +23346,12 @@ func newErrorDoesNotExistException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DoesNotExistException) Code() string {
+func (s *DoesNotExistException) Code() string {
 	return "DoesNotExistException"
 }
 
 // Message returns the exception's message.
-func (s DoesNotExistException) Message() string {
+func (s *DoesNotExistException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23359,21 +23359,21 @@ func (s DoesNotExistException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DoesNotExistException) OrigErr() error {
+func (s *DoesNotExistException) OrigErr() error {
 	return nil
 }
 
-func (s DoesNotExistException) Error() string {
+func (s *DoesNotExistException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DoesNotExistException) StatusCode() int {
+func (s *DoesNotExistException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DoesNotExistException) RequestID() string {
+func (s *DoesNotExistException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23403,12 +23403,12 @@ func newErrorDuplicateDocumentContent(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateDocumentContent) Code() string {
+func (s *DuplicateDocumentContent) Code() string {
 	return "DuplicateDocumentContent"
 }
 
 // Message returns the exception's message.
-func (s DuplicateDocumentContent) Message() string {
+func (s *DuplicateDocumentContent) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23416,21 +23416,21 @@ func (s DuplicateDocumentContent) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateDocumentContent) OrigErr() error {
+func (s *DuplicateDocumentContent) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateDocumentContent) Error() string {
+func (s *DuplicateDocumentContent) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateDocumentContent) StatusCode() int {
+func (s *DuplicateDocumentContent) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateDocumentContent) RequestID() string {
+func (s *DuplicateDocumentContent) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23460,12 +23460,12 @@ func newErrorDuplicateDocumentVersionName(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateDocumentVersionName) Code() string {
+func (s *DuplicateDocumentVersionName) Code() string {
 	return "DuplicateDocumentVersionName"
 }
 
 // Message returns the exception's message.
-func (s DuplicateDocumentVersionName) Message() string {
+func (s *DuplicateDocumentVersionName) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23473,21 +23473,21 @@ func (s DuplicateDocumentVersionName) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateDocumentVersionName) OrigErr() error {
+func (s *DuplicateDocumentVersionName) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateDocumentVersionName) Error() string {
+func (s *DuplicateDocumentVersionName) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateDocumentVersionName) StatusCode() int {
+func (s *DuplicateDocumentVersionName) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateDocumentVersionName) RequestID() string {
+func (s *DuplicateDocumentVersionName) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23516,12 +23516,12 @@ func newErrorDuplicateInstanceId(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DuplicateInstanceId) Code() string {
+func (s *DuplicateInstanceId) Code() string {
 	return "DuplicateInstanceId"
 }
 
 // Message returns the exception's message.
-func (s DuplicateInstanceId) Message() string {
+func (s *DuplicateInstanceId) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23529,21 +23529,21 @@ func (s DuplicateInstanceId) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DuplicateInstanceId) OrigErr() error {
+func (s *DuplicateInstanceId) OrigErr() error {
 	return nil
 }
 
-func (s DuplicateInstanceId) Error() string {
+func (s *DuplicateInstanceId) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DuplicateInstanceId) StatusCode() int {
+func (s *DuplicateInstanceId) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DuplicateInstanceId) RequestID() string {
+func (s *DuplicateInstanceId) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -23700,12 +23700,12 @@ func newErrorFeatureNotAvailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FeatureNotAvailableException) Code() string {
+func (s *FeatureNotAvailableException) Code() string {
 	return "FeatureNotAvailableException"
 }
 
 // Message returns the exception's message.
-func (s FeatureNotAvailableException) Message() string {
+func (s *FeatureNotAvailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -23713,21 +23713,21 @@ func (s FeatureNotAvailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FeatureNotAvailableException) OrigErr() error {
+func (s *FeatureNotAvailableException) OrigErr() error {
 	return nil
 }
 
-func (s FeatureNotAvailableException) Error() string {
+func (s *FeatureNotAvailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FeatureNotAvailableException) StatusCode() int {
+func (s *FeatureNotAvailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FeatureNotAvailableException) RequestID() string {
+func (s *FeatureNotAvailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26808,12 +26808,12 @@ func newErrorHierarchyLevelLimitExceededException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s HierarchyLevelLimitExceededException) Code() string {
+func (s *HierarchyLevelLimitExceededException) Code() string {
 	return "HierarchyLevelLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s HierarchyLevelLimitExceededException) Message() string {
+func (s *HierarchyLevelLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26821,21 +26821,21 @@ func (s HierarchyLevelLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s HierarchyLevelLimitExceededException) OrigErr() error {
+func (s *HierarchyLevelLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s HierarchyLevelLimitExceededException) Error() string {
+func (s *HierarchyLevelLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s HierarchyLevelLimitExceededException) StatusCode() int {
+func (s *HierarchyLevelLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s HierarchyLevelLimitExceededException) RequestID() string {
+func (s *HierarchyLevelLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26869,12 +26869,12 @@ func newErrorHierarchyTypeMismatchException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s HierarchyTypeMismatchException) Code() string {
+func (s *HierarchyTypeMismatchException) Code() string {
 	return "HierarchyTypeMismatchException"
 }
 
 // Message returns the exception's message.
-func (s HierarchyTypeMismatchException) Message() string {
+func (s *HierarchyTypeMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26882,21 +26882,21 @@ func (s HierarchyTypeMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s HierarchyTypeMismatchException) OrigErr() error {
+func (s *HierarchyTypeMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s HierarchyTypeMismatchException) Error() string {
+func (s *HierarchyTypeMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s HierarchyTypeMismatchException) StatusCode() int {
+func (s *HierarchyTypeMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s HierarchyTypeMismatchException) RequestID() string {
+func (s *HierarchyTypeMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26926,12 +26926,12 @@ func newErrorIdempotentParameterMismatch(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatch) Code() string {
+func (s *IdempotentParameterMismatch) Code() string {
 	return "IdempotentParameterMismatch"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatch) Message() string {
+func (s *IdempotentParameterMismatch) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26939,21 +26939,21 @@ func (s IdempotentParameterMismatch) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatch) OrigErr() error {
+func (s *IdempotentParameterMismatch) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatch) Error() string {
+func (s *IdempotentParameterMismatch) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatch) StatusCode() int {
+func (s *IdempotentParameterMismatch) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatch) RequestID() string {
+func (s *IdempotentParameterMismatch) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -26984,12 +26984,12 @@ func newErrorIncompatiblePolicyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IncompatiblePolicyException) Code() string {
+func (s *IncompatiblePolicyException) Code() string {
 	return "IncompatiblePolicyException"
 }
 
 // Message returns the exception's message.
-func (s IncompatiblePolicyException) Message() string {
+func (s *IncompatiblePolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -26997,21 +26997,21 @@ func (s IncompatiblePolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IncompatiblePolicyException) OrigErr() error {
+func (s *IncompatiblePolicyException) OrigErr() error {
 	return nil
 }
 
-func (s IncompatiblePolicyException) Error() string {
+func (s *IncompatiblePolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IncompatiblePolicyException) StatusCode() int {
+func (s *IncompatiblePolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IncompatiblePolicyException) RequestID() string {
+func (s *IncompatiblePolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27938,12 +27938,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -27951,21 +27951,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -27995,12 +27995,12 @@ func newErrorInvalidActivation(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidActivation) Code() string {
+func (s *InvalidActivation) Code() string {
 	return "InvalidActivation"
 }
 
 // Message returns the exception's message.
-func (s InvalidActivation) Message() string {
+func (s *InvalidActivation) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28008,21 +28008,21 @@ func (s InvalidActivation) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidActivation) OrigErr() error {
+func (s *InvalidActivation) OrigErr() error {
 	return nil
 }
 
-func (s InvalidActivation) Error() string {
+func (s *InvalidActivation) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidActivation) StatusCode() int {
+func (s *InvalidActivation) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidActivation) RequestID() string {
+func (s *InvalidActivation) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28052,12 +28052,12 @@ func newErrorInvalidActivationId(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidActivationId) Code() string {
+func (s *InvalidActivationId) Code() string {
 	return "InvalidActivationId"
 }
 
 // Message returns the exception's message.
-func (s InvalidActivationId) Message() string {
+func (s *InvalidActivationId) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28065,21 +28065,21 @@ func (s InvalidActivationId) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidActivationId) OrigErr() error {
+func (s *InvalidActivationId) OrigErr() error {
 	return nil
 }
 
-func (s InvalidActivationId) Error() string {
+func (s *InvalidActivationId) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidActivationId) StatusCode() int {
+func (s *InvalidActivationId) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidActivationId) RequestID() string {
+func (s *InvalidActivationId) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28109,12 +28109,12 @@ func newErrorInvalidAggregatorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAggregatorException) Code() string {
+func (s *InvalidAggregatorException) Code() string {
 	return "InvalidAggregatorException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAggregatorException) Message() string {
+func (s *InvalidAggregatorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28122,21 +28122,21 @@ func (s InvalidAggregatorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAggregatorException) OrigErr() error {
+func (s *InvalidAggregatorException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAggregatorException) Error() string {
+func (s *InvalidAggregatorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAggregatorException) StatusCode() int {
+func (s *InvalidAggregatorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAggregatorException) RequestID() string {
+func (s *InvalidAggregatorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28166,12 +28166,12 @@ func newErrorInvalidAllowedPatternException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAllowedPatternException) Code() string {
+func (s *InvalidAllowedPatternException) Code() string {
 	return "InvalidAllowedPatternException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAllowedPatternException) Message() string {
+func (s *InvalidAllowedPatternException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28179,21 +28179,21 @@ func (s InvalidAllowedPatternException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAllowedPatternException) OrigErr() error {
+func (s *InvalidAllowedPatternException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAllowedPatternException) Error() string {
+func (s *InvalidAllowedPatternException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAllowedPatternException) StatusCode() int {
+func (s *InvalidAllowedPatternException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAllowedPatternException) RequestID() string {
+func (s *InvalidAllowedPatternException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28222,12 +28222,12 @@ func newErrorInvalidAssociation(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAssociation) Code() string {
+func (s *InvalidAssociation) Code() string {
 	return "InvalidAssociation"
 }
 
 // Message returns the exception's message.
-func (s InvalidAssociation) Message() string {
+func (s *InvalidAssociation) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28235,21 +28235,21 @@ func (s InvalidAssociation) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAssociation) OrigErr() error {
+func (s *InvalidAssociation) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAssociation) Error() string {
+func (s *InvalidAssociation) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAssociation) StatusCode() int {
+func (s *InvalidAssociation) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAssociation) RequestID() string {
+func (s *InvalidAssociation) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28280,12 +28280,12 @@ func newErrorInvalidAssociationVersion(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAssociationVersion) Code() string {
+func (s *InvalidAssociationVersion) Code() string {
 	return "InvalidAssociationVersion"
 }
 
 // Message returns the exception's message.
-func (s InvalidAssociationVersion) Message() string {
+func (s *InvalidAssociationVersion) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28293,21 +28293,21 @@ func (s InvalidAssociationVersion) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAssociationVersion) OrigErr() error {
+func (s *InvalidAssociationVersion) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAssociationVersion) Error() string {
+func (s *InvalidAssociationVersion) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAssociationVersion) StatusCode() int {
+func (s *InvalidAssociationVersion) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAssociationVersion) RequestID() string {
+func (s *InvalidAssociationVersion) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28338,12 +28338,12 @@ func newErrorInvalidAutomationExecutionParametersException(v protocol.ResponseMe
 }
 
 // Code returns the exception type name.
-func (s InvalidAutomationExecutionParametersException) Code() string {
+func (s *InvalidAutomationExecutionParametersException) Code() string {
 	return "InvalidAutomationExecutionParametersException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAutomationExecutionParametersException) Message() string {
+func (s *InvalidAutomationExecutionParametersException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28351,21 +28351,21 @@ func (s InvalidAutomationExecutionParametersException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAutomationExecutionParametersException) OrigErr() error {
+func (s *InvalidAutomationExecutionParametersException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAutomationExecutionParametersException) Error() string {
+func (s *InvalidAutomationExecutionParametersException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAutomationExecutionParametersException) StatusCode() int {
+func (s *InvalidAutomationExecutionParametersException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAutomationExecutionParametersException) RequestID() string {
+func (s *InvalidAutomationExecutionParametersException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28394,12 +28394,12 @@ func newErrorInvalidAutomationSignalException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidAutomationSignalException) Code() string {
+func (s *InvalidAutomationSignalException) Code() string {
 	return "InvalidAutomationSignalException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAutomationSignalException) Message() string {
+func (s *InvalidAutomationSignalException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28407,21 +28407,21 @@ func (s InvalidAutomationSignalException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAutomationSignalException) OrigErr() error {
+func (s *InvalidAutomationSignalException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAutomationSignalException) Error() string {
+func (s *InvalidAutomationSignalException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAutomationSignalException) StatusCode() int {
+func (s *InvalidAutomationSignalException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAutomationSignalException) RequestID() string {
+func (s *InvalidAutomationSignalException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28450,12 +28450,12 @@ func newErrorInvalidAutomationStatusUpdateException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s InvalidAutomationStatusUpdateException) Code() string {
+func (s *InvalidAutomationStatusUpdateException) Code() string {
 	return "InvalidAutomationStatusUpdateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAutomationStatusUpdateException) Message() string {
+func (s *InvalidAutomationStatusUpdateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28463,21 +28463,21 @@ func (s InvalidAutomationStatusUpdateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAutomationStatusUpdateException) OrigErr() error {
+func (s *InvalidAutomationStatusUpdateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAutomationStatusUpdateException) Error() string {
+func (s *InvalidAutomationStatusUpdateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAutomationStatusUpdateException) StatusCode() int {
+func (s *InvalidAutomationStatusUpdateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAutomationStatusUpdateException) RequestID() string {
+func (s *InvalidAutomationStatusUpdateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28505,12 +28505,12 @@ func newErrorInvalidCommandId(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidCommandId) Code() string {
+func (s *InvalidCommandId) Code() string {
 	return "InvalidCommandId"
 }
 
 // Message returns the exception's message.
-func (s InvalidCommandId) Message() string {
+func (s *InvalidCommandId) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28518,21 +28518,21 @@ func (s InvalidCommandId) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCommandId) OrigErr() error {
+func (s *InvalidCommandId) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCommandId) Error() string {
+func (s *InvalidCommandId) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCommandId) StatusCode() int {
+func (s *InvalidCommandId) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCommandId) RequestID() string {
+func (s *InvalidCommandId) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28562,12 +28562,12 @@ func newErrorInvalidDeleteInventoryParametersException(v protocol.ResponseMetada
 }
 
 // Code returns the exception type name.
-func (s InvalidDeleteInventoryParametersException) Code() string {
+func (s *InvalidDeleteInventoryParametersException) Code() string {
 	return "InvalidDeleteInventoryParametersException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeleteInventoryParametersException) Message() string {
+func (s *InvalidDeleteInventoryParametersException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28575,21 +28575,21 @@ func (s InvalidDeleteInventoryParametersException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeleteInventoryParametersException) OrigErr() error {
+func (s *InvalidDeleteInventoryParametersException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeleteInventoryParametersException) Error() string {
+func (s *InvalidDeleteInventoryParametersException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeleteInventoryParametersException) StatusCode() int {
+func (s *InvalidDeleteInventoryParametersException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeleteInventoryParametersException) RequestID() string {
+func (s *InvalidDeleteInventoryParametersException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28619,12 +28619,12 @@ func newErrorInvalidDeletionIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDeletionIdException) Code() string {
+func (s *InvalidDeletionIdException) Code() string {
 	return "InvalidDeletionIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidDeletionIdException) Message() string {
+func (s *InvalidDeletionIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28632,21 +28632,21 @@ func (s InvalidDeletionIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDeletionIdException) OrigErr() error {
+func (s *InvalidDeletionIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDeletionIdException) Error() string {
+func (s *InvalidDeletionIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDeletionIdException) StatusCode() int {
+func (s *InvalidDeletionIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDeletionIdException) RequestID() string {
+func (s *InvalidDeletionIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28679,12 +28679,12 @@ func newErrorInvalidDocument(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDocument) Code() string {
+func (s *InvalidDocument) Code() string {
 	return "InvalidDocument"
 }
 
 // Message returns the exception's message.
-func (s InvalidDocument) Message() string {
+func (s *InvalidDocument) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28692,21 +28692,21 @@ func (s InvalidDocument) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDocument) OrigErr() error {
+func (s *InvalidDocument) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDocument) Error() string {
+func (s *InvalidDocument) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDocument) StatusCode() int {
+func (s *InvalidDocument) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDocument) RequestID() string {
+func (s *InvalidDocument) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28736,12 +28736,12 @@ func newErrorInvalidDocumentContent(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDocumentContent) Code() string {
+func (s *InvalidDocumentContent) Code() string {
 	return "InvalidDocumentContent"
 }
 
 // Message returns the exception's message.
-func (s InvalidDocumentContent) Message() string {
+func (s *InvalidDocumentContent) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28749,21 +28749,21 @@ func (s InvalidDocumentContent) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDocumentContent) OrigErr() error {
+func (s *InvalidDocumentContent) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDocumentContent) Error() string {
+func (s *InvalidDocumentContent) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDocumentContent) StatusCode() int {
+func (s *InvalidDocumentContent) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDocumentContent) RequestID() string {
+func (s *InvalidDocumentContent) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28793,12 +28793,12 @@ func newErrorInvalidDocumentOperation(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDocumentOperation) Code() string {
+func (s *InvalidDocumentOperation) Code() string {
 	return "InvalidDocumentOperation"
 }
 
 // Message returns the exception's message.
-func (s InvalidDocumentOperation) Message() string {
+func (s *InvalidDocumentOperation) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28806,21 +28806,21 @@ func (s InvalidDocumentOperation) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDocumentOperation) OrigErr() error {
+func (s *InvalidDocumentOperation) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDocumentOperation) Error() string {
+func (s *InvalidDocumentOperation) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDocumentOperation) StatusCode() int {
+func (s *InvalidDocumentOperation) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDocumentOperation) RequestID() string {
+func (s *InvalidDocumentOperation) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28849,12 +28849,12 @@ func newErrorInvalidDocumentSchemaVersion(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDocumentSchemaVersion) Code() string {
+func (s *InvalidDocumentSchemaVersion) Code() string {
 	return "InvalidDocumentSchemaVersion"
 }
 
 // Message returns the exception's message.
-func (s InvalidDocumentSchemaVersion) Message() string {
+func (s *InvalidDocumentSchemaVersion) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28862,21 +28862,21 @@ func (s InvalidDocumentSchemaVersion) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDocumentSchemaVersion) OrigErr() error {
+func (s *InvalidDocumentSchemaVersion) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDocumentSchemaVersion) Error() string {
+func (s *InvalidDocumentSchemaVersion) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDocumentSchemaVersion) StatusCode() int {
+func (s *InvalidDocumentSchemaVersion) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDocumentSchemaVersion) RequestID() string {
+func (s *InvalidDocumentSchemaVersion) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28906,12 +28906,12 @@ func newErrorInvalidDocumentType(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDocumentType) Code() string {
+func (s *InvalidDocumentType) Code() string {
 	return "InvalidDocumentType"
 }
 
 // Message returns the exception's message.
-func (s InvalidDocumentType) Message() string {
+func (s *InvalidDocumentType) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28919,21 +28919,21 @@ func (s InvalidDocumentType) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDocumentType) OrigErr() error {
+func (s *InvalidDocumentType) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDocumentType) Error() string {
+func (s *InvalidDocumentType) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDocumentType) StatusCode() int {
+func (s *InvalidDocumentType) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDocumentType) RequestID() string {
+func (s *InvalidDocumentType) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -28962,12 +28962,12 @@ func newErrorInvalidDocumentVersion(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidDocumentVersion) Code() string {
+func (s *InvalidDocumentVersion) Code() string {
 	return "InvalidDocumentVersion"
 }
 
 // Message returns the exception's message.
-func (s InvalidDocumentVersion) Message() string {
+func (s *InvalidDocumentVersion) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -28975,21 +28975,21 @@ func (s InvalidDocumentVersion) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidDocumentVersion) OrigErr() error {
+func (s *InvalidDocumentVersion) OrigErr() error {
 	return nil
 }
 
-func (s InvalidDocumentVersion) Error() string {
+func (s *InvalidDocumentVersion) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidDocumentVersion) StatusCode() int {
+func (s *InvalidDocumentVersion) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidDocumentVersion) RequestID() string {
+func (s *InvalidDocumentVersion) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29019,12 +29019,12 @@ func newErrorInvalidFilter(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFilter) Code() string {
+func (s *InvalidFilter) Code() string {
 	return "InvalidFilter"
 }
 
 // Message returns the exception's message.
-func (s InvalidFilter) Message() string {
+func (s *InvalidFilter) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29032,21 +29032,21 @@ func (s InvalidFilter) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFilter) OrigErr() error {
+func (s *InvalidFilter) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFilter) Error() string {
+func (s *InvalidFilter) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFilter) StatusCode() int {
+func (s *InvalidFilter) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFilter) RequestID() string {
+func (s *InvalidFilter) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29075,12 +29075,12 @@ func newErrorInvalidFilterKey(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFilterKey) Code() string {
+func (s *InvalidFilterKey) Code() string {
 	return "InvalidFilterKey"
 }
 
 // Message returns the exception's message.
-func (s InvalidFilterKey) Message() string {
+func (s *InvalidFilterKey) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29088,21 +29088,21 @@ func (s InvalidFilterKey) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFilterKey) OrigErr() error {
+func (s *InvalidFilterKey) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFilterKey) Error() string {
+func (s *InvalidFilterKey) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFilterKey) StatusCode() int {
+func (s *InvalidFilterKey) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFilterKey) RequestID() string {
+func (s *InvalidFilterKey) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29134,12 +29134,12 @@ func newErrorInvalidFilterOption(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFilterOption) Code() string {
+func (s *InvalidFilterOption) Code() string {
 	return "InvalidFilterOption"
 }
 
 // Message returns the exception's message.
-func (s InvalidFilterOption) Message() string {
+func (s *InvalidFilterOption) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29147,21 +29147,21 @@ func (s InvalidFilterOption) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFilterOption) OrigErr() error {
+func (s *InvalidFilterOption) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFilterOption) Error() string {
+func (s *InvalidFilterOption) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFilterOption) StatusCode() int {
+func (s *InvalidFilterOption) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFilterOption) RequestID() string {
+func (s *InvalidFilterOption) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29190,12 +29190,12 @@ func newErrorInvalidFilterValue(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFilterValue) Code() string {
+func (s *InvalidFilterValue) Code() string {
 	return "InvalidFilterValue"
 }
 
 // Message returns the exception's message.
-func (s InvalidFilterValue) Message() string {
+func (s *InvalidFilterValue) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29203,21 +29203,21 @@ func (s InvalidFilterValue) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFilterValue) OrigErr() error {
+func (s *InvalidFilterValue) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFilterValue) Error() string {
+func (s *InvalidFilterValue) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFilterValue) StatusCode() int {
+func (s *InvalidFilterValue) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFilterValue) RequestID() string {
+func (s *InvalidFilterValue) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29255,12 +29255,12 @@ func newErrorInvalidInstanceId(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInstanceId) Code() string {
+func (s *InvalidInstanceId) Code() string {
 	return "InvalidInstanceId"
 }
 
 // Message returns the exception's message.
-func (s InvalidInstanceId) Message() string {
+func (s *InvalidInstanceId) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29268,21 +29268,21 @@ func (s InvalidInstanceId) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInstanceId) OrigErr() error {
+func (s *InvalidInstanceId) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInstanceId) Error() string {
+func (s *InvalidInstanceId) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInstanceId) StatusCode() int {
+func (s *InvalidInstanceId) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInstanceId) RequestID() string {
+func (s *InvalidInstanceId) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29311,12 +29311,12 @@ func newErrorInvalidInstanceInformationFilterValue(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s InvalidInstanceInformationFilterValue) Code() string {
+func (s *InvalidInstanceInformationFilterValue) Code() string {
 	return "InvalidInstanceInformationFilterValue"
 }
 
 // Message returns the exception's message.
-func (s InvalidInstanceInformationFilterValue) Message() string {
+func (s *InvalidInstanceInformationFilterValue) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29324,21 +29324,21 @@ func (s InvalidInstanceInformationFilterValue) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInstanceInformationFilterValue) OrigErr() error {
+func (s *InvalidInstanceInformationFilterValue) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInstanceInformationFilterValue) Error() string {
+func (s *InvalidInstanceInformationFilterValue) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInstanceInformationFilterValue) StatusCode() int {
+func (s *InvalidInstanceInformationFilterValue) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInstanceInformationFilterValue) RequestID() string {
+func (s *InvalidInstanceInformationFilterValue) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29367,12 +29367,12 @@ func newErrorInvalidInventoryGroupException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidInventoryGroupException) Code() string {
+func (s *InvalidInventoryGroupException) Code() string {
 	return "InvalidInventoryGroupException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInventoryGroupException) Message() string {
+func (s *InvalidInventoryGroupException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29380,21 +29380,21 @@ func (s InvalidInventoryGroupException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInventoryGroupException) OrigErr() error {
+func (s *InvalidInventoryGroupException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInventoryGroupException) Error() string {
+func (s *InvalidInventoryGroupException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInventoryGroupException) StatusCode() int {
+func (s *InvalidInventoryGroupException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInventoryGroupException) RequestID() string {
+func (s *InvalidInventoryGroupException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29424,12 +29424,12 @@ func newErrorInvalidInventoryItemContextException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s InvalidInventoryItemContextException) Code() string {
+func (s *InvalidInventoryItemContextException) Code() string {
 	return "InvalidInventoryItemContextException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInventoryItemContextException) Message() string {
+func (s *InvalidInventoryItemContextException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29437,21 +29437,21 @@ func (s InvalidInventoryItemContextException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInventoryItemContextException) OrigErr() error {
+func (s *InvalidInventoryItemContextException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInventoryItemContextException) Error() string {
+func (s *InvalidInventoryItemContextException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInventoryItemContextException) StatusCode() int {
+func (s *InvalidInventoryItemContextException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInventoryItemContextException) RequestID() string {
+func (s *InvalidInventoryItemContextException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29480,12 +29480,12 @@ func newErrorInvalidInventoryRequestException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidInventoryRequestException) Code() string {
+func (s *InvalidInventoryRequestException) Code() string {
 	return "InvalidInventoryRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidInventoryRequestException) Message() string {
+func (s *InvalidInventoryRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29493,21 +29493,21 @@ func (s InvalidInventoryRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidInventoryRequestException) OrigErr() error {
+func (s *InvalidInventoryRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidInventoryRequestException) Error() string {
+func (s *InvalidInventoryRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidInventoryRequestException) StatusCode() int {
+func (s *InvalidInventoryRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidInventoryRequestException) RequestID() string {
+func (s *InvalidInventoryRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29538,12 +29538,12 @@ func newErrorInvalidItemContentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidItemContentException) Code() string {
+func (s *InvalidItemContentException) Code() string {
 	return "InvalidItemContentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidItemContentException) Message() string {
+func (s *InvalidItemContentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29551,21 +29551,21 @@ func (s InvalidItemContentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidItemContentException) OrigErr() error {
+func (s *InvalidItemContentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidItemContentException) Error() string {
+func (s *InvalidItemContentException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidItemContentException) StatusCode() int {
+func (s *InvalidItemContentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidItemContentException) RequestID() string {
+func (s *InvalidItemContentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29594,12 +29594,12 @@ func newErrorInvalidKeyId(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidKeyId) Code() string {
+func (s *InvalidKeyId) Code() string {
 	return "InvalidKeyId"
 }
 
 // Message returns the exception's message.
-func (s InvalidKeyId) Message() string {
+func (s *InvalidKeyId) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29607,21 +29607,21 @@ func (s InvalidKeyId) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidKeyId) OrigErr() error {
+func (s *InvalidKeyId) OrigErr() error {
 	return nil
 }
 
-func (s InvalidKeyId) Error() string {
+func (s *InvalidKeyId) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidKeyId) StatusCode() int {
+func (s *InvalidKeyId) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidKeyId) RequestID() string {
+func (s *InvalidKeyId) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29650,12 +29650,12 @@ func newErrorInvalidNextToken(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextToken) Code() string {
+func (s *InvalidNextToken) Code() string {
 	return "InvalidNextToken"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextToken) Message() string {
+func (s *InvalidNextToken) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29663,21 +29663,21 @@ func (s InvalidNextToken) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextToken) OrigErr() error {
+func (s *InvalidNextToken) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextToken) Error() string {
+func (s *InvalidNextToken) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextToken) StatusCode() int {
+func (s *InvalidNextToken) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextToken) RequestID() string {
+func (s *InvalidNextToken) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29707,12 +29707,12 @@ func newErrorInvalidNotificationConfig(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNotificationConfig) Code() string {
+func (s *InvalidNotificationConfig) Code() string {
 	return "InvalidNotificationConfig"
 }
 
 // Message returns the exception's message.
-func (s InvalidNotificationConfig) Message() string {
+func (s *InvalidNotificationConfig) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29720,21 +29720,21 @@ func (s InvalidNotificationConfig) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNotificationConfig) OrigErr() error {
+func (s *InvalidNotificationConfig) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNotificationConfig) Error() string {
+func (s *InvalidNotificationConfig) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNotificationConfig) StatusCode() int {
+func (s *InvalidNotificationConfig) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNotificationConfig) RequestID() string {
+func (s *InvalidNotificationConfig) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29764,12 +29764,12 @@ func newErrorInvalidOptionException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOptionException) Code() string {
+func (s *InvalidOptionException) Code() string {
 	return "InvalidOptionException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOptionException) Message() string {
+func (s *InvalidOptionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29777,21 +29777,21 @@ func (s InvalidOptionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOptionException) OrigErr() error {
+func (s *InvalidOptionException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOptionException) Error() string {
+func (s *InvalidOptionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOptionException) StatusCode() int {
+func (s *InvalidOptionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOptionException) RequestID() string {
+func (s *InvalidOptionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29820,12 +29820,12 @@ func newErrorInvalidOutputFolder(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOutputFolder) Code() string {
+func (s *InvalidOutputFolder) Code() string {
 	return "InvalidOutputFolder"
 }
 
 // Message returns the exception's message.
-func (s InvalidOutputFolder) Message() string {
+func (s *InvalidOutputFolder) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29833,21 +29833,21 @@ func (s InvalidOutputFolder) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOutputFolder) OrigErr() error {
+func (s *InvalidOutputFolder) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOutputFolder) Error() string {
+func (s *InvalidOutputFolder) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOutputFolder) StatusCode() int {
+func (s *InvalidOutputFolder) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOutputFolder) RequestID() string {
+func (s *InvalidOutputFolder) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29876,12 +29876,12 @@ func newErrorInvalidOutputLocation(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOutputLocation) Code() string {
+func (s *InvalidOutputLocation) Code() string {
 	return "InvalidOutputLocation"
 }
 
 // Message returns the exception's message.
-func (s InvalidOutputLocation) Message() string {
+func (s *InvalidOutputLocation) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29889,21 +29889,21 @@ func (s InvalidOutputLocation) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOutputLocation) OrigErr() error {
+func (s *InvalidOutputLocation) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOutputLocation) Error() string {
+func (s *InvalidOutputLocation) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOutputLocation) StatusCode() int {
+func (s *InvalidOutputLocation) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOutputLocation) RequestID() string {
+func (s *InvalidOutputLocation) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29934,12 +29934,12 @@ func newErrorInvalidParameters(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameters) Code() string {
+func (s *InvalidParameters) Code() string {
 	return "InvalidParameters"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameters) Message() string {
+func (s *InvalidParameters) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -29947,21 +29947,21 @@ func (s InvalidParameters) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameters) OrigErr() error {
+func (s *InvalidParameters) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameters) Error() string {
+func (s *InvalidParameters) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameters) StatusCode() int {
+func (s *InvalidParameters) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameters) RequestID() string {
+func (s *InvalidParameters) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -29991,12 +29991,12 @@ func newErrorInvalidPermissionType(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPermissionType) Code() string {
+func (s *InvalidPermissionType) Code() string {
 	return "InvalidPermissionType"
 }
 
 // Message returns the exception's message.
-func (s InvalidPermissionType) Message() string {
+func (s *InvalidPermissionType) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30004,21 +30004,21 @@ func (s InvalidPermissionType) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPermissionType) OrigErr() error {
+func (s *InvalidPermissionType) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPermissionType) Error() string {
+func (s *InvalidPermissionType) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPermissionType) StatusCode() int {
+func (s *InvalidPermissionType) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPermissionType) RequestID() string {
+func (s *InvalidPermissionType) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30047,12 +30047,12 @@ func newErrorInvalidPluginName(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPluginName) Code() string {
+func (s *InvalidPluginName) Code() string {
 	return "InvalidPluginName"
 }
 
 // Message returns the exception's message.
-func (s InvalidPluginName) Message() string {
+func (s *InvalidPluginName) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30060,21 +30060,21 @@ func (s InvalidPluginName) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPluginName) OrigErr() error {
+func (s *InvalidPluginName) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPluginName) Error() string {
+func (s *InvalidPluginName) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPluginName) StatusCode() int {
+func (s *InvalidPluginName) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPluginName) RequestID() string {
+func (s *InvalidPluginName) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30103,12 +30103,12 @@ func newErrorInvalidPolicyAttributeException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidPolicyAttributeException) Code() string {
+func (s *InvalidPolicyAttributeException) Code() string {
 	return "InvalidPolicyAttributeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPolicyAttributeException) Message() string {
+func (s *InvalidPolicyAttributeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30116,21 +30116,21 @@ func (s InvalidPolicyAttributeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPolicyAttributeException) OrigErr() error {
+func (s *InvalidPolicyAttributeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPolicyAttributeException) Error() string {
+func (s *InvalidPolicyAttributeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPolicyAttributeException) StatusCode() int {
+func (s *InvalidPolicyAttributeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPolicyAttributeException) RequestID() string {
+func (s *InvalidPolicyAttributeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30160,12 +30160,12 @@ func newErrorInvalidPolicyTypeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPolicyTypeException) Code() string {
+func (s *InvalidPolicyTypeException) Code() string {
 	return "InvalidPolicyTypeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPolicyTypeException) Message() string {
+func (s *InvalidPolicyTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30173,21 +30173,21 @@ func (s InvalidPolicyTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPolicyTypeException) OrigErr() error {
+func (s *InvalidPolicyTypeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPolicyTypeException) Error() string {
+func (s *InvalidPolicyTypeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPolicyTypeException) StatusCode() int {
+func (s *InvalidPolicyTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPolicyTypeException) RequestID() string {
+func (s *InvalidPolicyTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30217,12 +30217,12 @@ func newErrorInvalidResourceId(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceId) Code() string {
+func (s *InvalidResourceId) Code() string {
 	return "InvalidResourceId"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceId) Message() string {
+func (s *InvalidResourceId) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30230,21 +30230,21 @@ func (s InvalidResourceId) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceId) OrigErr() error {
+func (s *InvalidResourceId) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceId) Error() string {
+func (s *InvalidResourceId) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceId) StatusCode() int {
+func (s *InvalidResourceId) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceId) RequestID() string {
+func (s *InvalidResourceId) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30274,12 +30274,12 @@ func newErrorInvalidResourceType(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceType) Code() string {
+func (s *InvalidResourceType) Code() string {
 	return "InvalidResourceType"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceType) Message() string {
+func (s *InvalidResourceType) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30287,21 +30287,21 @@ func (s InvalidResourceType) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceType) OrigErr() error {
+func (s *InvalidResourceType) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceType) Error() string {
+func (s *InvalidResourceType) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceType) StatusCode() int {
+func (s *InvalidResourceType) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceType) RequestID() string {
+func (s *InvalidResourceType) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30330,12 +30330,12 @@ func newErrorInvalidResultAttributeException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidResultAttributeException) Code() string {
+func (s *InvalidResultAttributeException) Code() string {
 	return "InvalidResultAttributeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResultAttributeException) Message() string {
+func (s *InvalidResultAttributeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30343,21 +30343,21 @@ func (s InvalidResultAttributeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResultAttributeException) OrigErr() error {
+func (s *InvalidResultAttributeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResultAttributeException) Error() string {
+func (s *InvalidResultAttributeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResultAttributeException) StatusCode() int {
+func (s *InvalidResultAttributeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResultAttributeException) RequestID() string {
+func (s *InvalidResultAttributeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30390,12 +30390,12 @@ func newErrorInvalidRole(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRole) Code() string {
+func (s *InvalidRole) Code() string {
 	return "InvalidRole"
 }
 
 // Message returns the exception's message.
-func (s InvalidRole) Message() string {
+func (s *InvalidRole) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30403,21 +30403,21 @@ func (s InvalidRole) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRole) OrigErr() error {
+func (s *InvalidRole) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRole) Error() string {
+func (s *InvalidRole) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRole) StatusCode() int {
+func (s *InvalidRole) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRole) RequestID() string {
+func (s *InvalidRole) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30446,12 +30446,12 @@ func newErrorInvalidSchedule(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidSchedule) Code() string {
+func (s *InvalidSchedule) Code() string {
 	return "InvalidSchedule"
 }
 
 // Message returns the exception's message.
-func (s InvalidSchedule) Message() string {
+func (s *InvalidSchedule) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30459,21 +30459,21 @@ func (s InvalidSchedule) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidSchedule) OrigErr() error {
+func (s *InvalidSchedule) OrigErr() error {
 	return nil
 }
 
-func (s InvalidSchedule) Error() string {
+func (s *InvalidSchedule) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidSchedule) StatusCode() int {
+func (s *InvalidSchedule) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidSchedule) RequestID() string {
+func (s *InvalidSchedule) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30503,12 +30503,12 @@ func newErrorInvalidTarget(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTarget) Code() string {
+func (s *InvalidTarget) Code() string {
 	return "InvalidTarget"
 }
 
 // Message returns the exception's message.
-func (s InvalidTarget) Message() string {
+func (s *InvalidTarget) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30516,21 +30516,21 @@ func (s InvalidTarget) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTarget) OrigErr() error {
+func (s *InvalidTarget) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTarget) Error() string {
+func (s *InvalidTarget) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTarget) StatusCode() int {
+func (s *InvalidTarget) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTarget) RequestID() string {
+func (s *InvalidTarget) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30559,12 +30559,12 @@ func newErrorInvalidTypeNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidTypeNameException) Code() string {
+func (s *InvalidTypeNameException) Code() string {
 	return "InvalidTypeNameException"
 }
 
 // Message returns the exception's message.
-func (s InvalidTypeNameException) Message() string {
+func (s *InvalidTypeNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30572,21 +30572,21 @@ func (s InvalidTypeNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidTypeNameException) OrigErr() error {
+func (s *InvalidTypeNameException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidTypeNameException) Error() string {
+func (s *InvalidTypeNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidTypeNameException) StatusCode() int {
+func (s *InvalidTypeNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidTypeNameException) RequestID() string {
+func (s *InvalidTypeNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -30615,12 +30615,12 @@ func newErrorInvalidUpdate(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidUpdate) Code() string {
+func (s *InvalidUpdate) Code() string {
 	return "InvalidUpdate"
 }
 
 // Message returns the exception's message.
-func (s InvalidUpdate) Message() string {
+func (s *InvalidUpdate) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -30628,21 +30628,21 @@ func (s InvalidUpdate) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidUpdate) OrigErr() error {
+func (s *InvalidUpdate) OrigErr() error {
 	return nil
 }
 
-func (s InvalidUpdate) Error() string {
+func (s *InvalidUpdate) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidUpdate) StatusCode() int {
+func (s *InvalidUpdate) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidUpdate) RequestID() string {
+func (s *InvalidUpdate) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -31374,12 +31374,12 @@ func newErrorInvocationDoesNotExist(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvocationDoesNotExist) Code() string {
+func (s *InvocationDoesNotExist) Code() string {
 	return "InvocationDoesNotExist"
 }
 
 // Message returns the exception's message.
-func (s InvocationDoesNotExist) Message() string {
+func (s *InvocationDoesNotExist) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -31387,21 +31387,21 @@ func (s InvocationDoesNotExist) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvocationDoesNotExist) OrigErr() error {
+func (s *InvocationDoesNotExist) OrigErr() error {
 	return nil
 }
 
-func (s InvocationDoesNotExist) Error() string {
+func (s *InvocationDoesNotExist) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvocationDoesNotExist) StatusCode() int {
+func (s *InvocationDoesNotExist) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvocationDoesNotExist) RequestID() string {
+func (s *InvocationDoesNotExist) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -31432,12 +31432,12 @@ func newErrorItemContentMismatchException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ItemContentMismatchException) Code() string {
+func (s *ItemContentMismatchException) Code() string {
 	return "ItemContentMismatchException"
 }
 
 // Message returns the exception's message.
-func (s ItemContentMismatchException) Message() string {
+func (s *ItemContentMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -31445,21 +31445,21 @@ func (s ItemContentMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ItemContentMismatchException) OrigErr() error {
+func (s *ItemContentMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s ItemContentMismatchException) Error() string {
+func (s *ItemContentMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ItemContentMismatchException) StatusCode() int {
+func (s *ItemContentMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ItemContentMismatchException) RequestID() string {
+func (s *ItemContentMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -31490,12 +31490,12 @@ func newErrorItemSizeLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ItemSizeLimitExceededException) Code() string {
+func (s *ItemSizeLimitExceededException) Code() string {
 	return "ItemSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ItemSizeLimitExceededException) Message() string {
+func (s *ItemSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -31503,21 +31503,21 @@ func (s ItemSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ItemSizeLimitExceededException) OrigErr() error {
+func (s *ItemSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ItemSizeLimitExceededException) Error() string {
+func (s *ItemSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ItemSizeLimitExceededException) StatusCode() int {
+func (s *ItemSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ItemSizeLimitExceededException) RequestID() string {
+func (s *ItemSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -34264,12 +34264,12 @@ func newErrorMaxDocumentSizeExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MaxDocumentSizeExceeded) Code() string {
+func (s *MaxDocumentSizeExceeded) Code() string {
 	return "MaxDocumentSizeExceeded"
 }
 
 // Message returns the exception's message.
-func (s MaxDocumentSizeExceeded) Message() string {
+func (s *MaxDocumentSizeExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -34277,21 +34277,21 @@ func (s MaxDocumentSizeExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MaxDocumentSizeExceeded) OrigErr() error {
+func (s *MaxDocumentSizeExceeded) OrigErr() error {
 	return nil
 }
 
-func (s MaxDocumentSizeExceeded) Error() string {
+func (s *MaxDocumentSizeExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MaxDocumentSizeExceeded) StatusCode() int {
+func (s *MaxDocumentSizeExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MaxDocumentSizeExceeded) RequestID() string {
+func (s *MaxDocumentSizeExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -34942,12 +34942,12 @@ func newErrorOpsItemAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OpsItemAlreadyExistsException) Code() string {
+func (s *OpsItemAlreadyExistsException) Code() string {
 	return "OpsItemAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s OpsItemAlreadyExistsException) Message() string {
+func (s *OpsItemAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -34955,21 +34955,21 @@ func (s OpsItemAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OpsItemAlreadyExistsException) OrigErr() error {
+func (s *OpsItemAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s OpsItemAlreadyExistsException) Error() string {
+func (s *OpsItemAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OpsItemAlreadyExistsException) StatusCode() int {
+func (s *OpsItemAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OpsItemAlreadyExistsException) RequestID() string {
+func (s *OpsItemAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -35102,12 +35102,12 @@ func newErrorOpsItemInvalidParameterException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s OpsItemInvalidParameterException) Code() string {
+func (s *OpsItemInvalidParameterException) Code() string {
 	return "OpsItemInvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s OpsItemInvalidParameterException) Message() string {
+func (s *OpsItemInvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -35115,21 +35115,21 @@ func (s OpsItemInvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OpsItemInvalidParameterException) OrigErr() error {
+func (s *OpsItemInvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s OpsItemInvalidParameterException) Error() string {
+func (s *OpsItemInvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OpsItemInvalidParameterException) StatusCode() int {
+func (s *OpsItemInvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OpsItemInvalidParameterException) RequestID() string {
+func (s *OpsItemInvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -35165,12 +35165,12 @@ func newErrorOpsItemLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OpsItemLimitExceededException) Code() string {
+func (s *OpsItemLimitExceededException) Code() string {
 	return "OpsItemLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s OpsItemLimitExceededException) Message() string {
+func (s *OpsItemLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -35178,21 +35178,21 @@ func (s OpsItemLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OpsItemLimitExceededException) OrigErr() error {
+func (s *OpsItemLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s OpsItemLimitExceededException) Error() string {
+func (s *OpsItemLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OpsItemLimitExceededException) StatusCode() int {
+func (s *OpsItemLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OpsItemLimitExceededException) RequestID() string {
+func (s *OpsItemLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -35221,12 +35221,12 @@ func newErrorOpsItemNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OpsItemNotFoundException) Code() string {
+func (s *OpsItemNotFoundException) Code() string {
 	return "OpsItemNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s OpsItemNotFoundException) Message() string {
+func (s *OpsItemNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -35234,21 +35234,21 @@ func (s OpsItemNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OpsItemNotFoundException) OrigErr() error {
+func (s *OpsItemNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s OpsItemNotFoundException) Error() string {
+func (s *OpsItemNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OpsItemNotFoundException) StatusCode() int {
+func (s *OpsItemNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OpsItemNotFoundException) RequestID() string {
+func (s *OpsItemNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -35600,12 +35600,12 @@ func newErrorParameterAlreadyExists(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ParameterAlreadyExists) Code() string {
+func (s *ParameterAlreadyExists) Code() string {
 	return "ParameterAlreadyExists"
 }
 
 // Message returns the exception's message.
-func (s ParameterAlreadyExists) Message() string {
+func (s *ParameterAlreadyExists) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -35613,21 +35613,21 @@ func (s ParameterAlreadyExists) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterAlreadyExists) OrigErr() error {
+func (s *ParameterAlreadyExists) OrigErr() error {
 	return nil
 }
 
-func (s ParameterAlreadyExists) Error() string {
+func (s *ParameterAlreadyExists) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterAlreadyExists) StatusCode() int {
+func (s *ParameterAlreadyExists) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterAlreadyExists) RequestID() string {
+func (s *ParameterAlreadyExists) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -35831,12 +35831,12 @@ func newErrorParameterLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ParameterLimitExceeded) Code() string {
+func (s *ParameterLimitExceeded) Code() string {
 	return "ParameterLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ParameterLimitExceeded) Message() string {
+func (s *ParameterLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -35844,21 +35844,21 @@ func (s ParameterLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterLimitExceeded) OrigErr() error {
+func (s *ParameterLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ParameterLimitExceeded) Error() string {
+func (s *ParameterLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterLimitExceeded) StatusCode() int {
+func (s *ParameterLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterLimitExceeded) RequestID() string {
+func (s *ParameterLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -35887,12 +35887,12 @@ func newErrorParameterMaxVersionLimitExceeded(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s ParameterMaxVersionLimitExceeded) Code() string {
+func (s *ParameterMaxVersionLimitExceeded) Code() string {
 	return "ParameterMaxVersionLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ParameterMaxVersionLimitExceeded) Message() string {
+func (s *ParameterMaxVersionLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -35900,21 +35900,21 @@ func (s ParameterMaxVersionLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterMaxVersionLimitExceeded) OrigErr() error {
+func (s *ParameterMaxVersionLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ParameterMaxVersionLimitExceeded) Error() string {
+func (s *ParameterMaxVersionLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterMaxVersionLimitExceeded) StatusCode() int {
+func (s *ParameterMaxVersionLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterMaxVersionLimitExceeded) RequestID() string {
+func (s *ParameterMaxVersionLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -36052,12 +36052,12 @@ func newErrorParameterNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ParameterNotFound) Code() string {
+func (s *ParameterNotFound) Code() string {
 	return "ParameterNotFound"
 }
 
 // Message returns the exception's message.
-func (s ParameterNotFound) Message() string {
+func (s *ParameterNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -36065,21 +36065,21 @@ func (s ParameterNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterNotFound) OrigErr() error {
+func (s *ParameterNotFound) OrigErr() error {
 	return nil
 }
 
-func (s ParameterNotFound) Error() string {
+func (s *ParameterNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterNotFound) StatusCode() int {
+func (s *ParameterNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterNotFound) RequestID() string {
+func (s *ParameterNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -36109,12 +36109,12 @@ func newErrorParameterPatternMismatchException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ParameterPatternMismatchException) Code() string {
+func (s *ParameterPatternMismatchException) Code() string {
 	return "ParameterPatternMismatchException"
 }
 
 // Message returns the exception's message.
-func (s ParameterPatternMismatchException) Message() string {
+func (s *ParameterPatternMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -36122,21 +36122,21 @@ func (s ParameterPatternMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterPatternMismatchException) OrigErr() error {
+func (s *ParameterPatternMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s ParameterPatternMismatchException) Error() string {
+func (s *ParameterPatternMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterPatternMismatchException) StatusCode() int {
+func (s *ParameterPatternMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterPatternMismatchException) RequestID() string {
+func (s *ParameterPatternMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -36252,12 +36252,12 @@ func newErrorParameterVersionLabelLimitExceeded(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s ParameterVersionLabelLimitExceeded) Code() string {
+func (s *ParameterVersionLabelLimitExceeded) Code() string {
 	return "ParameterVersionLabelLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s ParameterVersionLabelLimitExceeded) Message() string {
+func (s *ParameterVersionLabelLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -36265,21 +36265,21 @@ func (s ParameterVersionLabelLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterVersionLabelLimitExceeded) OrigErr() error {
+func (s *ParameterVersionLabelLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s ParameterVersionLabelLimitExceeded) Error() string {
+func (s *ParameterVersionLabelLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterVersionLabelLimitExceeded) StatusCode() int {
+func (s *ParameterVersionLabelLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterVersionLabelLimitExceeded) RequestID() string {
+func (s *ParameterVersionLabelLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -36309,12 +36309,12 @@ func newErrorParameterVersionNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ParameterVersionNotFound) Code() string {
+func (s *ParameterVersionNotFound) Code() string {
 	return "ParameterVersionNotFound"
 }
 
 // Message returns the exception's message.
-func (s ParameterVersionNotFound) Message() string {
+func (s *ParameterVersionNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -36322,21 +36322,21 @@ func (s ParameterVersionNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ParameterVersionNotFound) OrigErr() error {
+func (s *ParameterVersionNotFound) OrigErr() error {
 	return nil
 }
 
-func (s ParameterVersionNotFound) Error() string {
+func (s *ParameterVersionNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ParameterVersionNotFound) StatusCode() int {
+func (s *ParameterVersionNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ParameterVersionNotFound) RequestID() string {
+func (s *ParameterVersionNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -37174,12 +37174,12 @@ func newErrorPoliciesLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s PoliciesLimitExceededException) Code() string {
+func (s *PoliciesLimitExceededException) Code() string {
 	return "PoliciesLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s PoliciesLimitExceededException) Message() string {
+func (s *PoliciesLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -37187,21 +37187,21 @@ func (s PoliciesLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s PoliciesLimitExceededException) OrigErr() error {
+func (s *PoliciesLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s PoliciesLimitExceededException) Error() string {
+func (s *PoliciesLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s PoliciesLimitExceededException) StatusCode() int {
+func (s *PoliciesLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s PoliciesLimitExceededException) RequestID() string {
+func (s *PoliciesLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -38815,12 +38815,12 @@ func newErrorResourceDataSyncAlreadyExistsException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s ResourceDataSyncAlreadyExistsException) Code() string {
+func (s *ResourceDataSyncAlreadyExistsException) Code() string {
 	return "ResourceDataSyncAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceDataSyncAlreadyExistsException) Message() string {
+func (s *ResourceDataSyncAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -38828,21 +38828,21 @@ func (s ResourceDataSyncAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceDataSyncAlreadyExistsException) OrigErr() error {
+func (s *ResourceDataSyncAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceDataSyncAlreadyExistsException) Error() string {
+func (s *ResourceDataSyncAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceDataSyncAlreadyExistsException) StatusCode() int {
+func (s *ResourceDataSyncAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceDataSyncAlreadyExistsException) RequestID() string {
+func (s *ResourceDataSyncAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -38941,12 +38941,12 @@ func newErrorResourceDataSyncConflictException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ResourceDataSyncConflictException) Code() string {
+func (s *ResourceDataSyncConflictException) Code() string {
 	return "ResourceDataSyncConflictException"
 }
 
 // Message returns the exception's message.
-func (s ResourceDataSyncConflictException) Message() string {
+func (s *ResourceDataSyncConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -38954,21 +38954,21 @@ func (s ResourceDataSyncConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceDataSyncConflictException) OrigErr() error {
+func (s *ResourceDataSyncConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceDataSyncConflictException) Error() string {
+func (s *ResourceDataSyncConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceDataSyncConflictException) StatusCode() int {
+func (s *ResourceDataSyncConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceDataSyncConflictException) RequestID() string {
+func (s *ResourceDataSyncConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -38997,12 +38997,12 @@ func newErrorResourceDataSyncCountExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s ResourceDataSyncCountExceededException) Code() string {
+func (s *ResourceDataSyncCountExceededException) Code() string {
 	return "ResourceDataSyncCountExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceDataSyncCountExceededException) Message() string {
+func (s *ResourceDataSyncCountExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -39010,21 +39010,21 @@ func (s ResourceDataSyncCountExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceDataSyncCountExceededException) OrigErr() error {
+func (s *ResourceDataSyncCountExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceDataSyncCountExceededException) Error() string {
+func (s *ResourceDataSyncCountExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceDataSyncCountExceededException) StatusCode() int {
+func (s *ResourceDataSyncCountExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceDataSyncCountExceededException) RequestID() string {
+func (s *ResourceDataSyncCountExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -39093,12 +39093,12 @@ func newErrorResourceDataSyncInvalidConfigurationException(v protocol.ResponseMe
 }
 
 // Code returns the exception type name.
-func (s ResourceDataSyncInvalidConfigurationException) Code() string {
+func (s *ResourceDataSyncInvalidConfigurationException) Code() string {
 	return "ResourceDataSyncInvalidConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s ResourceDataSyncInvalidConfigurationException) Message() string {
+func (s *ResourceDataSyncInvalidConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -39106,21 +39106,21 @@ func (s ResourceDataSyncInvalidConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceDataSyncInvalidConfigurationException) OrigErr() error {
+func (s *ResourceDataSyncInvalidConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceDataSyncInvalidConfigurationException) Error() string {
+func (s *ResourceDataSyncInvalidConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceDataSyncInvalidConfigurationException) StatusCode() int {
+func (s *ResourceDataSyncInvalidConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceDataSyncInvalidConfigurationException) RequestID() string {
+func (s *ResourceDataSyncInvalidConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -39262,12 +39262,12 @@ func newErrorResourceDataSyncNotFoundException(v protocol.ResponseMetadata) erro
 }
 
 // Code returns the exception type name.
-func (s ResourceDataSyncNotFoundException) Code() string {
+func (s *ResourceDataSyncNotFoundException) Code() string {
 	return "ResourceDataSyncNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceDataSyncNotFoundException) Message() string {
+func (s *ResourceDataSyncNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -39275,21 +39275,21 @@ func (s ResourceDataSyncNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceDataSyncNotFoundException) OrigErr() error {
+func (s *ResourceDataSyncNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceDataSyncNotFoundException) Error() string {
+func (s *ResourceDataSyncNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceDataSyncNotFoundException) StatusCode() int {
+func (s *ResourceDataSyncNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceDataSyncNotFoundException) RequestID() string {
+func (s *ResourceDataSyncNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -39639,12 +39639,12 @@ func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceInUseException) Code() string {
+func (s *ResourceInUseException) Code() string {
 	return "ResourceInUseException"
 }
 
 // Message returns the exception's message.
-func (s ResourceInUseException) Message() string {
+func (s *ResourceInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -39652,21 +39652,21 @@ func (s ResourceInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceInUseException) OrigErr() error {
+func (s *ResourceInUseException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceInUseException) Error() string {
+func (s *ResourceInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceInUseException) StatusCode() int {
+func (s *ResourceInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceInUseException) RequestID() string {
+func (s *ResourceInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -39700,12 +39700,12 @@ func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceededException) Code() string {
+func (s *ResourceLimitExceededException) Code() string {
 	return "ResourceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceededException) Message() string {
+func (s *ResourceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -39713,21 +39713,21 @@ func (s ResourceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceededException) OrigErr() error {
+func (s *ResourceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceededException) Error() string {
+func (s *ResourceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceededException) StatusCode() int {
+func (s *ResourceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceededException) RequestID() string {
+func (s *ResourceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -40488,12 +40488,12 @@ func newErrorServiceSettingNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceSettingNotFound) Code() string {
+func (s *ServiceSettingNotFound) Code() string {
 	return "ServiceSettingNotFound"
 }
 
 // Message returns the exception's message.
-func (s ServiceSettingNotFound) Message() string {
+func (s *ServiceSettingNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -40501,21 +40501,21 @@ func (s ServiceSettingNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceSettingNotFound) OrigErr() error {
+func (s *ServiceSettingNotFound) OrigErr() error {
 	return nil
 }
 
-func (s ServiceSettingNotFound) Error() string {
+func (s *ServiceSettingNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceSettingNotFound) StatusCode() int {
+func (s *ServiceSettingNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceSettingNotFound) RequestID() string {
+func (s *ServiceSettingNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -41238,12 +41238,12 @@ func newErrorStatusUnchanged(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StatusUnchanged) Code() string {
+func (s *StatusUnchanged) Code() string {
 	return "StatusUnchanged"
 }
 
 // Message returns the exception's message.
-func (s StatusUnchanged) Message() string {
+func (s *StatusUnchanged) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -41251,21 +41251,21 @@ func (s StatusUnchanged) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StatusUnchanged) OrigErr() error {
+func (s *StatusUnchanged) OrigErr() error {
 	return nil
 }
 
-func (s StatusUnchanged) Error() string {
+func (s *StatusUnchanged) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StatusUnchanged) StatusCode() int {
+func (s *StatusUnchanged) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StatusUnchanged) RequestID() string {
+func (s *StatusUnchanged) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -41642,12 +41642,12 @@ func newErrorSubTypeCountLimitExceededException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s SubTypeCountLimitExceededException) Code() string {
+func (s *SubTypeCountLimitExceededException) Code() string {
 	return "SubTypeCountLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s SubTypeCountLimitExceededException) Message() string {
+func (s *SubTypeCountLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -41655,21 +41655,21 @@ func (s SubTypeCountLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubTypeCountLimitExceededException) OrigErr() error {
+func (s *SubTypeCountLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s SubTypeCountLimitExceededException) Error() string {
+func (s *SubTypeCountLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubTypeCountLimitExceededException) StatusCode() int {
+func (s *SubTypeCountLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubTypeCountLimitExceededException) RequestID() string {
+func (s *SubTypeCountLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -41848,12 +41848,12 @@ func newErrorTargetInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TargetInUseException) Code() string {
+func (s *TargetInUseException) Code() string {
 	return "TargetInUseException"
 }
 
 // Message returns the exception's message.
-func (s TargetInUseException) Message() string {
+func (s *TargetInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -41861,21 +41861,21 @@ func (s TargetInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TargetInUseException) OrigErr() error {
+func (s *TargetInUseException) OrigErr() error {
 	return nil
 }
 
-func (s TargetInUseException) Error() string {
+func (s *TargetInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TargetInUseException) StatusCode() int {
+func (s *TargetInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TargetInUseException) RequestID() string {
+func (s *TargetInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -41995,12 +41995,12 @@ func newErrorTargetNotConnected(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TargetNotConnected) Code() string {
+func (s *TargetNotConnected) Code() string {
 	return "TargetNotConnected"
 }
 
 // Message returns the exception's message.
-func (s TargetNotConnected) Message() string {
+func (s *TargetNotConnected) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42008,21 +42008,21 @@ func (s TargetNotConnected) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TargetNotConnected) OrigErr() error {
+func (s *TargetNotConnected) OrigErr() error {
 	return nil
 }
 
-func (s TargetNotConnected) Error() string {
+func (s *TargetNotConnected) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TargetNotConnected) StatusCode() int {
+func (s *TargetNotConnected) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TargetNotConnected) RequestID() string {
+func (s *TargetNotConnected) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42116,12 +42116,12 @@ func newErrorTooManyTagsError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsError) Code() string {
+func (s *TooManyTagsError) Code() string {
 	return "TooManyTagsError"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsError) Message() string {
+func (s *TooManyTagsError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42129,21 +42129,21 @@ func (s TooManyTagsError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsError) OrigErr() error {
+func (s *TooManyTagsError) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsError) Error() string {
+func (s *TooManyTagsError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsError) StatusCode() int {
+func (s *TooManyTagsError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsError) RequestID() string {
+func (s *TooManyTagsError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42173,12 +42173,12 @@ func newErrorTooManyUpdates(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyUpdates) Code() string {
+func (s *TooManyUpdates) Code() string {
 	return "TooManyUpdates"
 }
 
 // Message returns the exception's message.
-func (s TooManyUpdates) Message() string {
+func (s *TooManyUpdates) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42186,21 +42186,21 @@ func (s TooManyUpdates) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyUpdates) OrigErr() error {
+func (s *TooManyUpdates) OrigErr() error {
 	return nil
 }
 
-func (s TooManyUpdates) Error() string {
+func (s *TooManyUpdates) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyUpdates) StatusCode() int {
+func (s *TooManyUpdates) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyUpdates) RequestID() string {
+func (s *TooManyUpdates) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42229,12 +42229,12 @@ func newErrorTotalSizeLimitExceededException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s TotalSizeLimitExceededException) Code() string {
+func (s *TotalSizeLimitExceededException) Code() string {
 	return "TotalSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TotalSizeLimitExceededException) Message() string {
+func (s *TotalSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42242,21 +42242,21 @@ func (s TotalSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TotalSizeLimitExceededException) OrigErr() error {
+func (s *TotalSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TotalSizeLimitExceededException) Error() string {
+func (s *TotalSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TotalSizeLimitExceededException) StatusCode() int {
+func (s *TotalSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TotalSizeLimitExceededException) RequestID() string {
+func (s *TotalSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42286,12 +42286,12 @@ func newErrorUnsupportedCalendarException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedCalendarException) Code() string {
+func (s *UnsupportedCalendarException) Code() string {
 	return "UnsupportedCalendarException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedCalendarException) Message() string {
+func (s *UnsupportedCalendarException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42299,21 +42299,21 @@ func (s UnsupportedCalendarException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedCalendarException) OrigErr() error {
+func (s *UnsupportedCalendarException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedCalendarException) Error() string {
+func (s *UnsupportedCalendarException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedCalendarException) StatusCode() int {
+func (s *UnsupportedCalendarException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedCalendarException) RequestID() string {
+func (s *UnsupportedCalendarException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42346,12 +42346,12 @@ func newErrorUnsupportedFeatureRequiredException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s UnsupportedFeatureRequiredException) Code() string {
+func (s *UnsupportedFeatureRequiredException) Code() string {
 	return "UnsupportedFeatureRequiredException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedFeatureRequiredException) Message() string {
+func (s *UnsupportedFeatureRequiredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42359,21 +42359,21 @@ func (s UnsupportedFeatureRequiredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedFeatureRequiredException) OrigErr() error {
+func (s *UnsupportedFeatureRequiredException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedFeatureRequiredException) Error() string {
+func (s *UnsupportedFeatureRequiredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedFeatureRequiredException) StatusCode() int {
+func (s *UnsupportedFeatureRequiredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedFeatureRequiredException) RequestID() string {
+func (s *UnsupportedFeatureRequiredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42406,12 +42406,12 @@ func newErrorUnsupportedInventoryItemContextException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s UnsupportedInventoryItemContextException) Code() string {
+func (s *UnsupportedInventoryItemContextException) Code() string {
 	return "UnsupportedInventoryItemContextException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedInventoryItemContextException) Message() string {
+func (s *UnsupportedInventoryItemContextException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42419,21 +42419,21 @@ func (s UnsupportedInventoryItemContextException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedInventoryItemContextException) OrigErr() error {
+func (s *UnsupportedInventoryItemContextException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedInventoryItemContextException) Error() string {
+func (s *UnsupportedInventoryItemContextException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedInventoryItemContextException) StatusCode() int {
+func (s *UnsupportedInventoryItemContextException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedInventoryItemContextException) RequestID() string {
+func (s *UnsupportedInventoryItemContextException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42464,12 +42464,12 @@ func newErrorUnsupportedInventorySchemaVersionException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s UnsupportedInventorySchemaVersionException) Code() string {
+func (s *UnsupportedInventorySchemaVersionException) Code() string {
 	return "UnsupportedInventorySchemaVersionException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedInventorySchemaVersionException) Message() string {
+func (s *UnsupportedInventorySchemaVersionException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42477,21 +42477,21 @@ func (s UnsupportedInventorySchemaVersionException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedInventorySchemaVersionException) OrigErr() error {
+func (s *UnsupportedInventorySchemaVersionException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedInventorySchemaVersionException) Error() string {
+func (s *UnsupportedInventorySchemaVersionException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedInventorySchemaVersionException) StatusCode() int {
+func (s *UnsupportedInventorySchemaVersionException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedInventorySchemaVersionException) RequestID() string {
+func (s *UnsupportedInventorySchemaVersionException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42522,12 +42522,12 @@ func newErrorUnsupportedOperatingSystem(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedOperatingSystem) Code() string {
+func (s *UnsupportedOperatingSystem) Code() string {
 	return "UnsupportedOperatingSystem"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedOperatingSystem) Message() string {
+func (s *UnsupportedOperatingSystem) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42535,21 +42535,21 @@ func (s UnsupportedOperatingSystem) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedOperatingSystem) OrigErr() error {
+func (s *UnsupportedOperatingSystem) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedOperatingSystem) Error() string {
+func (s *UnsupportedOperatingSystem) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedOperatingSystem) StatusCode() int {
+func (s *UnsupportedOperatingSystem) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedOperatingSystem) RequestID() string {
+func (s *UnsupportedOperatingSystem) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42578,12 +42578,12 @@ func newErrorUnsupportedParameterType(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedParameterType) Code() string {
+func (s *UnsupportedParameterType) Code() string {
 	return "UnsupportedParameterType"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedParameterType) Message() string {
+func (s *UnsupportedParameterType) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42591,21 +42591,21 @@ func (s UnsupportedParameterType) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedParameterType) OrigErr() error {
+func (s *UnsupportedParameterType) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedParameterType) Error() string {
+func (s *UnsupportedParameterType) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedParameterType) StatusCode() int {
+func (s *UnsupportedParameterType) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedParameterType) RequestID() string {
+func (s *UnsupportedParameterType) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -42635,12 +42635,12 @@ func newErrorUnsupportedPlatformType(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedPlatformType) Code() string {
+func (s *UnsupportedPlatformType) Code() string {
 	return "UnsupportedPlatformType"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedPlatformType) Message() string {
+func (s *UnsupportedPlatformType) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -42648,21 +42648,21 @@ func (s UnsupportedPlatformType) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedPlatformType) OrigErr() error {
+func (s *UnsupportedPlatformType) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedPlatformType) Error() string {
+func (s *UnsupportedPlatformType) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedPlatformType) StatusCode() int {
+func (s *UnsupportedPlatformType) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedPlatformType) RequestID() string {
+func (s *UnsupportedPlatformType) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/sso/api.go
+++ b/service/sso/api.go
@@ -658,12 +658,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -671,21 +671,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -972,12 +972,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -985,21 +985,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1121,12 +1121,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1134,21 +1134,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1178,12 +1178,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1191,20 +1191,20 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }

--- a/service/ssooidc/api.go
+++ b/service/ssooidc/api.go
@@ -354,12 +354,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -367,21 +367,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -415,12 +415,12 @@ func newErrorAuthorizationPendingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AuthorizationPendingException) Code() string {
+func (s *AuthorizationPendingException) Code() string {
 	return "AuthorizationPendingException"
 }
 
 // Message returns the exception's message.
-func (s AuthorizationPendingException) Message() string {
+func (s *AuthorizationPendingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -428,21 +428,21 @@ func (s AuthorizationPendingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AuthorizationPendingException) OrigErr() error {
+func (s *AuthorizationPendingException) OrigErr() error {
 	return nil
 }
 
-func (s AuthorizationPendingException) Error() string {
+func (s *AuthorizationPendingException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AuthorizationPendingException) StatusCode() int {
+func (s *AuthorizationPendingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AuthorizationPendingException) RequestID() string {
+func (s *AuthorizationPendingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -663,12 +663,12 @@ func newErrorExpiredTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ExpiredTokenException) Code() string {
+func (s *ExpiredTokenException) Code() string {
 	return "ExpiredTokenException"
 }
 
 // Message returns the exception's message.
-func (s ExpiredTokenException) Message() string {
+func (s *ExpiredTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -676,21 +676,21 @@ func (s ExpiredTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ExpiredTokenException) OrigErr() error {
+func (s *ExpiredTokenException) OrigErr() error {
 	return nil
 }
 
-func (s ExpiredTokenException) Error() string {
+func (s *ExpiredTokenException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ExpiredTokenException) StatusCode() int {
+func (s *ExpiredTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ExpiredTokenException) RequestID() string {
+func (s *ExpiredTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -724,12 +724,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -737,21 +737,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -786,12 +786,12 @@ func newErrorInvalidClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidClientException) Code() string {
+func (s *InvalidClientException) Code() string {
 	return "InvalidClientException"
 }
 
 // Message returns the exception's message.
-func (s InvalidClientException) Message() string {
+func (s *InvalidClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -799,21 +799,21 @@ func (s InvalidClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidClientException) OrigErr() error {
+func (s *InvalidClientException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidClientException) Error() string {
+func (s *InvalidClientException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidClientException) StatusCode() int {
+func (s *InvalidClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidClientException) RequestID() string {
+func (s *InvalidClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -847,12 +847,12 @@ func newErrorInvalidClientMetadataException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidClientMetadataException) Code() string {
+func (s *InvalidClientMetadataException) Code() string {
 	return "InvalidClientMetadataException"
 }
 
 // Message returns the exception's message.
-func (s InvalidClientMetadataException) Message() string {
+func (s *InvalidClientMetadataException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -860,21 +860,21 @@ func (s InvalidClientMetadataException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidClientMetadataException) OrigErr() error {
+func (s *InvalidClientMetadataException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidClientMetadataException) Error() string {
+func (s *InvalidClientMetadataException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidClientMetadataException) StatusCode() int {
+func (s *InvalidClientMetadataException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidClientMetadataException) RequestID() string {
+func (s *InvalidClientMetadataException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -908,12 +908,12 @@ func newErrorInvalidGrantException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidGrantException) Code() string {
+func (s *InvalidGrantException) Code() string {
 	return "InvalidGrantException"
 }
 
 // Message returns the exception's message.
-func (s InvalidGrantException) Message() string {
+func (s *InvalidGrantException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -921,21 +921,21 @@ func (s InvalidGrantException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidGrantException) OrigErr() error {
+func (s *InvalidGrantException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidGrantException) Error() string {
+func (s *InvalidGrantException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidGrantException) StatusCode() int {
+func (s *InvalidGrantException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidGrantException) RequestID() string {
+func (s *InvalidGrantException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -969,12 +969,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -982,21 +982,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1029,12 +1029,12 @@ func newErrorInvalidScopeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidScopeException) Code() string {
+func (s *InvalidScopeException) Code() string {
 	return "InvalidScopeException"
 }
 
 // Message returns the exception's message.
-func (s InvalidScopeException) Message() string {
+func (s *InvalidScopeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1042,21 +1042,21 @@ func (s InvalidScopeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidScopeException) OrigErr() error {
+func (s *InvalidScopeException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidScopeException) Error() string {
+func (s *InvalidScopeException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidScopeException) StatusCode() int {
+func (s *InvalidScopeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidScopeException) RequestID() string {
+func (s *InvalidScopeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1223,12 +1223,12 @@ func newErrorSlowDownException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SlowDownException) Code() string {
+func (s *SlowDownException) Code() string {
 	return "SlowDownException"
 }
 
 // Message returns the exception's message.
-func (s SlowDownException) Message() string {
+func (s *SlowDownException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1236,21 +1236,21 @@ func (s SlowDownException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SlowDownException) OrigErr() error {
+func (s *SlowDownException) OrigErr() error {
 	return nil
 }
 
-func (s SlowDownException) Error() string {
+func (s *SlowDownException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SlowDownException) StatusCode() int {
+func (s *SlowDownException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SlowDownException) RequestID() string {
+func (s *SlowDownException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1430,12 +1430,12 @@ func newErrorUnauthorizedClientException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedClientException) Code() string {
+func (s *UnauthorizedClientException) Code() string {
 	return "UnauthorizedClientException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedClientException) Message() string {
+func (s *UnauthorizedClientException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1443,21 +1443,21 @@ func (s UnauthorizedClientException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedClientException) OrigErr() error {
+func (s *UnauthorizedClientException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedClientException) Error() string {
+func (s *UnauthorizedClientException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedClientException) StatusCode() int {
+func (s *UnauthorizedClientException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedClientException) RequestID() string {
+func (s *UnauthorizedClientException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1490,12 +1490,12 @@ func newErrorUnsupportedGrantTypeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedGrantTypeException) Code() string {
+func (s *UnsupportedGrantTypeException) Code() string {
 	return "UnsupportedGrantTypeException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedGrantTypeException) Message() string {
+func (s *UnsupportedGrantTypeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1503,20 +1503,20 @@ func (s UnsupportedGrantTypeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedGrantTypeException) OrigErr() error {
+func (s *UnsupportedGrantTypeException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedGrantTypeException) Error() string {
+func (s *UnsupportedGrantTypeException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedGrantTypeException) StatusCode() int {
+func (s *UnsupportedGrantTypeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedGrantTypeException) RequestID() string {
+func (s *UnsupportedGrantTypeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -13290,12 +13290,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13303,21 +13303,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -13351,12 +13351,12 @@ func newErrorInvalidGatewayRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidGatewayRequestException) Code() string {
+func (s *InvalidGatewayRequestException) Code() string {
 	return "InvalidGatewayRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidGatewayRequestException) Message() string {
+func (s *InvalidGatewayRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -13364,21 +13364,21 @@ func (s InvalidGatewayRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidGatewayRequestException) OrigErr() error {
+func (s *InvalidGatewayRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidGatewayRequestException) Error() string {
+func (s *InvalidGatewayRequestException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidGatewayRequestException) StatusCode() int {
+func (s *InvalidGatewayRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidGatewayRequestException) RequestID() string {
+func (s *InvalidGatewayRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15426,12 +15426,12 @@ func newErrorServiceUnavailableError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableError) Code() string {
+func (s *ServiceUnavailableError) Code() string {
 	return "ServiceUnavailableError"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableError) Message() string {
+func (s *ServiceUnavailableError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15439,21 +15439,21 @@ func (s ServiceUnavailableError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableError) OrigErr() error {
+func (s *ServiceUnavailableError) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableError) Error() string {
+func (s *ServiceUnavailableError) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableError) StatusCode() int {
+func (s *ServiceUnavailableError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableError) RequestID() string {
+func (s *ServiceUnavailableError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -1716,12 +1716,12 @@ func newErrorAttachmentIdNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AttachmentIdNotFound) Code() string {
+func (s *AttachmentIdNotFound) Code() string {
 	return "AttachmentIdNotFound"
 }
 
 // Message returns the exception's message.
-func (s AttachmentIdNotFound) Message() string {
+func (s *AttachmentIdNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1729,21 +1729,21 @@ func (s AttachmentIdNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AttachmentIdNotFound) OrigErr() error {
+func (s *AttachmentIdNotFound) OrigErr() error {
 	return nil
 }
 
-func (s AttachmentIdNotFound) Error() string {
+func (s *AttachmentIdNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AttachmentIdNotFound) StatusCode() int {
+func (s *AttachmentIdNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AttachmentIdNotFound) RequestID() string {
+func (s *AttachmentIdNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1775,12 +1775,12 @@ func newErrorAttachmentLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AttachmentLimitExceeded) Code() string {
+func (s *AttachmentLimitExceeded) Code() string {
 	return "AttachmentLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s AttachmentLimitExceeded) Message() string {
+func (s *AttachmentLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1788,21 +1788,21 @@ func (s AttachmentLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AttachmentLimitExceeded) OrigErr() error {
+func (s *AttachmentLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s AttachmentLimitExceeded) Error() string {
+func (s *AttachmentLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AttachmentLimitExceeded) StatusCode() int {
+func (s *AttachmentLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AttachmentLimitExceeded) RequestID() string {
+func (s *AttachmentLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1834,12 +1834,12 @@ func newErrorAttachmentSetExpired(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AttachmentSetExpired) Code() string {
+func (s *AttachmentSetExpired) Code() string {
 	return "AttachmentSetExpired"
 }
 
 // Message returns the exception's message.
-func (s AttachmentSetExpired) Message() string {
+func (s *AttachmentSetExpired) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1847,21 +1847,21 @@ func (s AttachmentSetExpired) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AttachmentSetExpired) OrigErr() error {
+func (s *AttachmentSetExpired) OrigErr() error {
 	return nil
 }
 
-func (s AttachmentSetExpired) Error() string {
+func (s *AttachmentSetExpired) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AttachmentSetExpired) StatusCode() int {
+func (s *AttachmentSetExpired) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AttachmentSetExpired) RequestID() string {
+func (s *AttachmentSetExpired) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1891,12 +1891,12 @@ func newErrorAttachmentSetIdNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AttachmentSetIdNotFound) Code() string {
+func (s *AttachmentSetIdNotFound) Code() string {
 	return "AttachmentSetIdNotFound"
 }
 
 // Message returns the exception's message.
-func (s AttachmentSetIdNotFound) Message() string {
+func (s *AttachmentSetIdNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1904,21 +1904,21 @@ func (s AttachmentSetIdNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AttachmentSetIdNotFound) OrigErr() error {
+func (s *AttachmentSetIdNotFound) OrigErr() error {
 	return nil
 }
 
-func (s AttachmentSetIdNotFound) Error() string {
+func (s *AttachmentSetIdNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AttachmentSetIdNotFound) StatusCode() int {
+func (s *AttachmentSetIdNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AttachmentSetIdNotFound) RequestID() string {
+func (s *AttachmentSetIdNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1950,12 +1950,12 @@ func newErrorAttachmentSetSizeLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AttachmentSetSizeLimitExceeded) Code() string {
+func (s *AttachmentSetSizeLimitExceeded) Code() string {
 	return "AttachmentSetSizeLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s AttachmentSetSizeLimitExceeded) Message() string {
+func (s *AttachmentSetSizeLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1963,21 +1963,21 @@ func (s AttachmentSetSizeLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AttachmentSetSizeLimitExceeded) OrigErr() error {
+func (s *AttachmentSetSizeLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s AttachmentSetSizeLimitExceeded) Error() string {
+func (s *AttachmentSetSizeLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AttachmentSetSizeLimitExceeded) StatusCode() int {
+func (s *AttachmentSetSizeLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AttachmentSetSizeLimitExceeded) RequestID() string {
+func (s *AttachmentSetSizeLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2008,12 +2008,12 @@ func newErrorCaseCreationLimitExceeded(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CaseCreationLimitExceeded) Code() string {
+func (s *CaseCreationLimitExceeded) Code() string {
 	return "CaseCreationLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s CaseCreationLimitExceeded) Message() string {
+func (s *CaseCreationLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2021,21 +2021,21 @@ func (s CaseCreationLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CaseCreationLimitExceeded) OrigErr() error {
+func (s *CaseCreationLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s CaseCreationLimitExceeded) Error() string {
+func (s *CaseCreationLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CaseCreationLimitExceeded) StatusCode() int {
+func (s *CaseCreationLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CaseCreationLimitExceeded) RequestID() string {
+func (s *CaseCreationLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2234,12 +2234,12 @@ func newErrorCaseIdNotFound(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s CaseIdNotFound) Code() string {
+func (s *CaseIdNotFound) Code() string {
 	return "CaseIdNotFound"
 }
 
 // Message returns the exception's message.
-func (s CaseIdNotFound) Message() string {
+func (s *CaseIdNotFound) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2247,21 +2247,21 @@ func (s CaseIdNotFound) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CaseIdNotFound) OrigErr() error {
+func (s *CaseIdNotFound) OrigErr() error {
 	return nil
 }
 
-func (s CaseIdNotFound) Error() string {
+func (s *CaseIdNotFound) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CaseIdNotFound) StatusCode() int {
+func (s *CaseIdNotFound) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CaseIdNotFound) RequestID() string {
+func (s *CaseIdNotFound) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2588,12 +2588,12 @@ func newErrorDescribeAttachmentLimitExceeded(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s DescribeAttachmentLimitExceeded) Code() string {
+func (s *DescribeAttachmentLimitExceeded) Code() string {
 	return "DescribeAttachmentLimitExceeded"
 }
 
 // Message returns the exception's message.
-func (s DescribeAttachmentLimitExceeded) Message() string {
+func (s *DescribeAttachmentLimitExceeded) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2601,21 +2601,21 @@ func (s DescribeAttachmentLimitExceeded) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DescribeAttachmentLimitExceeded) OrigErr() error {
+func (s *DescribeAttachmentLimitExceeded) OrigErr() error {
 	return nil
 }
 
-func (s DescribeAttachmentLimitExceeded) Error() string {
+func (s *DescribeAttachmentLimitExceeded) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DescribeAttachmentLimitExceeded) StatusCode() int {
+func (s *DescribeAttachmentLimitExceeded) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DescribeAttachmentLimitExceeded) RequestID() string {
+func (s *DescribeAttachmentLimitExceeded) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3313,12 +3313,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3326,21 +3326,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -7166,12 +7166,12 @@ func newErrorDefaultUndefinedFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DefaultUndefinedFault) Code() string {
+func (s *DefaultUndefinedFault) Code() string {
 	return "DefaultUndefinedFault"
 }
 
 // Message returns the exception's message.
-func (s DefaultUndefinedFault) Message() string {
+func (s *DefaultUndefinedFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7179,21 +7179,21 @@ func (s DefaultUndefinedFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DefaultUndefinedFault) OrigErr() error {
+func (s *DefaultUndefinedFault) OrigErr() error {
 	return nil
 }
 
-func (s DefaultUndefinedFault) Error() string {
+func (s *DefaultUndefinedFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DefaultUndefinedFault) StatusCode() int {
+func (s *DefaultUndefinedFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DefaultUndefinedFault) RequestID() string {
+func (s *DefaultUndefinedFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7854,12 +7854,12 @@ func newErrorDomainAlreadyExistsFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DomainAlreadyExistsFault) Code() string {
+func (s *DomainAlreadyExistsFault) Code() string {
 	return "DomainAlreadyExistsFault"
 }
 
 // Message returns the exception's message.
-func (s DomainAlreadyExistsFault) Message() string {
+func (s *DomainAlreadyExistsFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7867,21 +7867,21 @@ func (s DomainAlreadyExistsFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DomainAlreadyExistsFault) OrigErr() error {
+func (s *DomainAlreadyExistsFault) OrigErr() error {
 	return nil
 }
 
-func (s DomainAlreadyExistsFault) Error() string {
+func (s *DomainAlreadyExistsFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DomainAlreadyExistsFault) StatusCode() int {
+func (s *DomainAlreadyExistsFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DomainAlreadyExistsFault) RequestID() string {
+func (s *DomainAlreadyExistsFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7937,12 +7937,12 @@ func newErrorDomainDeprecatedFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DomainDeprecatedFault) Code() string {
+func (s *DomainDeprecatedFault) Code() string {
 	return "DomainDeprecatedFault"
 }
 
 // Message returns the exception's message.
-func (s DomainDeprecatedFault) Message() string {
+func (s *DomainDeprecatedFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7950,21 +7950,21 @@ func (s DomainDeprecatedFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DomainDeprecatedFault) OrigErr() error {
+func (s *DomainDeprecatedFault) OrigErr() error {
 	return nil
 }
 
-func (s DomainDeprecatedFault) Error() string {
+func (s *DomainDeprecatedFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DomainDeprecatedFault) StatusCode() int {
+func (s *DomainDeprecatedFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DomainDeprecatedFault) RequestID() string {
+func (s *DomainDeprecatedFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9462,12 +9462,12 @@ func newErrorLimitExceededFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededFault) Code() string {
+func (s *LimitExceededFault) Code() string {
 	return "LimitExceededFault"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededFault) Message() string {
+func (s *LimitExceededFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9475,21 +9475,21 @@ func (s LimitExceededFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededFault) OrigErr() error {
+func (s *LimitExceededFault) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededFault) Error() string {
+func (s *LimitExceededFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededFault) StatusCode() int {
+func (s *LimitExceededFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededFault) RequestID() string {
+func (s *LimitExceededFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10376,12 +10376,12 @@ func newErrorOperationNotPermittedFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotPermittedFault) Code() string {
+func (s *OperationNotPermittedFault) Code() string {
 	return "OperationNotPermittedFault"
 }
 
 // Message returns the exception's message.
-func (s OperationNotPermittedFault) Message() string {
+func (s *OperationNotPermittedFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10389,21 +10389,21 @@ func (s OperationNotPermittedFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotPermittedFault) OrigErr() error {
+func (s *OperationNotPermittedFault) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotPermittedFault) Error() string {
+func (s *OperationNotPermittedFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotPermittedFault) StatusCode() int {
+func (s *OperationNotPermittedFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotPermittedFault) RequestID() string {
+func (s *OperationNotPermittedFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14626,12 +14626,12 @@ func newErrorTooManyTagsFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsFault) Code() string {
+func (s *TooManyTagsFault) Code() string {
 	return "TooManyTagsFault"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsFault) Message() string {
+func (s *TooManyTagsFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14639,21 +14639,21 @@ func (s TooManyTagsFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsFault) OrigErr() error {
+func (s *TooManyTagsFault) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsFault) Error() string {
+func (s *TooManyTagsFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsFault) StatusCode() int {
+func (s *TooManyTagsFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsFault) RequestID() string {
+func (s *TooManyTagsFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14685,12 +14685,12 @@ func newErrorTypeAlreadyExistsFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TypeAlreadyExistsFault) Code() string {
+func (s *TypeAlreadyExistsFault) Code() string {
 	return "TypeAlreadyExistsFault"
 }
 
 // Message returns the exception's message.
-func (s TypeAlreadyExistsFault) Message() string {
+func (s *TypeAlreadyExistsFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14698,21 +14698,21 @@ func (s TypeAlreadyExistsFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TypeAlreadyExistsFault) OrigErr() error {
+func (s *TypeAlreadyExistsFault) OrigErr() error {
 	return nil
 }
 
-func (s TypeAlreadyExistsFault) Error() string {
+func (s *TypeAlreadyExistsFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TypeAlreadyExistsFault) StatusCode() int {
+func (s *TypeAlreadyExistsFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TypeAlreadyExistsFault) RequestID() string {
+func (s *TypeAlreadyExistsFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14742,12 +14742,12 @@ func newErrorTypeDeprecatedFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TypeDeprecatedFault) Code() string {
+func (s *TypeDeprecatedFault) Code() string {
 	return "TypeDeprecatedFault"
 }
 
 // Message returns the exception's message.
-func (s TypeDeprecatedFault) Message() string {
+func (s *TypeDeprecatedFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14755,21 +14755,21 @@ func (s TypeDeprecatedFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TypeDeprecatedFault) OrigErr() error {
+func (s *TypeDeprecatedFault) OrigErr() error {
 	return nil
 }
 
-func (s TypeDeprecatedFault) Error() string {
+func (s *TypeDeprecatedFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TypeDeprecatedFault) StatusCode() int {
+func (s *TypeDeprecatedFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TypeDeprecatedFault) RequestID() string {
+func (s *TypeDeprecatedFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15004,12 +15004,12 @@ func newErrorUnknownResourceFault(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnknownResourceFault) Code() string {
+func (s *UnknownResourceFault) Code() string {
 	return "UnknownResourceFault"
 }
 
 // Message returns the exception's message.
-func (s UnknownResourceFault) Message() string {
+func (s *UnknownResourceFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15017,21 +15017,21 @@ func (s UnknownResourceFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnknownResourceFault) OrigErr() error {
+func (s *UnknownResourceFault) OrigErr() error {
 	return nil
 }
 
-func (s UnknownResourceFault) Error() string {
+func (s *UnknownResourceFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnknownResourceFault) StatusCode() int {
+func (s *UnknownResourceFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnknownResourceFault) RequestID() string {
+func (s *UnknownResourceFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -15190,12 +15190,12 @@ func newErrorWorkflowExecutionAlreadyStartedFault(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s WorkflowExecutionAlreadyStartedFault) Code() string {
+func (s *WorkflowExecutionAlreadyStartedFault) Code() string {
 	return "WorkflowExecutionAlreadyStartedFault"
 }
 
 // Message returns the exception's message.
-func (s WorkflowExecutionAlreadyStartedFault) Message() string {
+func (s *WorkflowExecutionAlreadyStartedFault) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -15203,21 +15203,21 @@ func (s WorkflowExecutionAlreadyStartedFault) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WorkflowExecutionAlreadyStartedFault) OrigErr() error {
+func (s *WorkflowExecutionAlreadyStartedFault) OrigErr() error {
 	return nil
 }
 
-func (s WorkflowExecutionAlreadyStartedFault) Error() string {
+func (s *WorkflowExecutionAlreadyStartedFault) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WorkflowExecutionAlreadyStartedFault) StatusCode() int {
+func (s *WorkflowExecutionAlreadyStartedFault) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WorkflowExecutionAlreadyStartedFault) RequestID() string {
+func (s *WorkflowExecutionAlreadyStartedFault) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/textract/api.go
+++ b/service/textract/api.go
@@ -854,12 +854,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -867,21 +867,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1041,12 +1041,12 @@ func newErrorBadDocumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadDocumentException) Code() string {
+func (s *BadDocumentException) Code() string {
 	return "BadDocumentException"
 }
 
 // Message returns the exception's message.
-func (s BadDocumentException) Message() string {
+func (s *BadDocumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1054,21 +1054,21 @@ func (s BadDocumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadDocumentException) OrigErr() error {
+func (s *BadDocumentException) OrigErr() error {
 	return nil
 }
 
-func (s BadDocumentException) Error() string {
+func (s *BadDocumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadDocumentException) StatusCode() int {
+func (s *BadDocumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadDocumentException) RequestID() string {
+func (s *BadDocumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1612,12 +1612,12 @@ func newErrorDocumentTooLargeException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DocumentTooLargeException) Code() string {
+func (s *DocumentTooLargeException) Code() string {
 	return "DocumentTooLargeException"
 }
 
 // Message returns the exception's message.
-func (s DocumentTooLargeException) Message() string {
+func (s *DocumentTooLargeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1625,21 +1625,21 @@ func (s DocumentTooLargeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DocumentTooLargeException) OrigErr() error {
+func (s *DocumentTooLargeException) OrigErr() error {
 	return nil
 }
 
-func (s DocumentTooLargeException) Error() string {
+func (s *DocumentTooLargeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DocumentTooLargeException) StatusCode() int {
+func (s *DocumentTooLargeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DocumentTooLargeException) RequestID() string {
+func (s *DocumentTooLargeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2150,12 +2150,12 @@ func newErrorHumanLoopQuotaExceededException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s HumanLoopQuotaExceededException) Code() string {
+func (s *HumanLoopQuotaExceededException) Code() string {
 	return "HumanLoopQuotaExceededException"
 }
 
 // Message returns the exception's message.
-func (s HumanLoopQuotaExceededException) Message() string {
+func (s *HumanLoopQuotaExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2163,21 +2163,21 @@ func (s HumanLoopQuotaExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s HumanLoopQuotaExceededException) OrigErr() error {
+func (s *HumanLoopQuotaExceededException) OrigErr() error {
 	return nil
 }
 
-func (s HumanLoopQuotaExceededException) Error() string {
+func (s *HumanLoopQuotaExceededException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s HumanLoopQuotaExceededException) StatusCode() int {
+func (s *HumanLoopQuotaExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s HumanLoopQuotaExceededException) RequestID() string {
+func (s *HumanLoopQuotaExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2208,12 +2208,12 @@ func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s IdempotentParameterMismatchException) Code() string {
+func (s *IdempotentParameterMismatchException) Code() string {
 	return "IdempotentParameterMismatchException"
 }
 
 // Message returns the exception's message.
-func (s IdempotentParameterMismatchException) Message() string {
+func (s *IdempotentParameterMismatchException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2221,21 +2221,21 @@ func (s IdempotentParameterMismatchException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IdempotentParameterMismatchException) OrigErr() error {
+func (s *IdempotentParameterMismatchException) OrigErr() error {
 	return nil
 }
 
-func (s IdempotentParameterMismatchException) Error() string {
+func (s *IdempotentParameterMismatchException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IdempotentParameterMismatchException) StatusCode() int {
+func (s *IdempotentParameterMismatchException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IdempotentParameterMismatchException) RequestID() string {
+func (s *IdempotentParameterMismatchException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2264,12 +2264,12 @@ func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerError) Code() string {
+func (s *InternalServerError) Code() string {
 	return "InternalServerError"
 }
 
 // Message returns the exception's message.
-func (s InternalServerError) Message() string {
+func (s *InternalServerError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2277,21 +2277,21 @@ func (s InternalServerError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerError) OrigErr() error {
+func (s *InternalServerError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerError) Error() string {
+func (s *InternalServerError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerError) StatusCode() int {
+func (s *InternalServerError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerError) RequestID() string {
+func (s *InternalServerError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2320,12 +2320,12 @@ func newErrorInvalidJobIdException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidJobIdException) Code() string {
+func (s *InvalidJobIdException) Code() string {
 	return "InvalidJobIdException"
 }
 
 // Message returns the exception's message.
-func (s InvalidJobIdException) Message() string {
+func (s *InvalidJobIdException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2333,21 +2333,21 @@ func (s InvalidJobIdException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidJobIdException) OrigErr() error {
+func (s *InvalidJobIdException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidJobIdException) Error() string {
+func (s *InvalidJobIdException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidJobIdException) StatusCode() int {
+func (s *InvalidJobIdException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidJobIdException) RequestID() string {
+func (s *InvalidJobIdException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2379,12 +2379,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2392,21 +2392,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2436,12 +2436,12 @@ func newErrorInvalidS3ObjectException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidS3ObjectException) Code() string {
+func (s *InvalidS3ObjectException) Code() string {
 	return "InvalidS3ObjectException"
 }
 
 // Message returns the exception's message.
-func (s InvalidS3ObjectException) Message() string {
+func (s *InvalidS3ObjectException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2449,21 +2449,21 @@ func (s InvalidS3ObjectException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidS3ObjectException) OrigErr() error {
+func (s *InvalidS3ObjectException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidS3ObjectException) Error() string {
+func (s *InvalidS3ObjectException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidS3ObjectException) StatusCode() int {
+func (s *InvalidS3ObjectException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidS3ObjectException) RequestID() string {
+func (s *InvalidS3ObjectException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2496,12 +2496,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2509,21 +2509,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2655,12 +2655,12 @@ func newErrorProvisionedThroughputExceededException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s ProvisionedThroughputExceededException) Code() string {
+func (s *ProvisionedThroughputExceededException) Code() string {
 	return "ProvisionedThroughputExceededException"
 }
 
 // Message returns the exception's message.
-func (s ProvisionedThroughputExceededException) Message() string {
+func (s *ProvisionedThroughputExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2668,21 +2668,21 @@ func (s ProvisionedThroughputExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProvisionedThroughputExceededException) OrigErr() error {
+func (s *ProvisionedThroughputExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ProvisionedThroughputExceededException) Error() string {
+func (s *ProvisionedThroughputExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProvisionedThroughputExceededException) StatusCode() int {
+func (s *ProvisionedThroughputExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProvisionedThroughputExceededException) RequestID() string {
+func (s *ProvisionedThroughputExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3071,12 +3071,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3084,21 +3084,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3129,12 +3129,12 @@ func newErrorUnsupportedDocumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedDocumentException) Code() string {
+func (s *UnsupportedDocumentException) Code() string {
 	return "UnsupportedDocumentException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedDocumentException) Message() string {
+func (s *UnsupportedDocumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3142,21 +3142,21 @@ func (s UnsupportedDocumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedDocumentException) OrigErr() error {
+func (s *UnsupportedDocumentException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedDocumentException) Error() string {
+func (s *UnsupportedDocumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedDocumentException) StatusCode() int {
+func (s *UnsupportedDocumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedDocumentException) RequestID() string {
+func (s *UnsupportedDocumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/transcribeservice/api.go
+++ b/service/transcribeservice/api.go
@@ -1548,12 +1548,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1561,21 +1561,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1609,12 +1609,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1622,21 +1622,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2450,12 +2450,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2463,21 +2463,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2554,12 +2554,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2567,21 +2567,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2994,12 +2994,12 @@ func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NotFoundException) Code() string {
+func (s *NotFoundException) Code() string {
 	return "NotFoundException"
 }
 
 // Message returns the exception's message.
-func (s NotFoundException) Message() string {
+func (s *NotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3007,21 +3007,21 @@ func (s NotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NotFoundException) OrigErr() error {
+func (s *NotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s NotFoundException) Error() string {
+func (s *NotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NotFoundException) StatusCode() int {
+func (s *NotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NotFoundException) RequestID() string {
+func (s *NotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/transcribestreamingservice/api.go
+++ b/service/transcribestreamingservice/api.go
@@ -552,12 +552,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "BadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -565,21 +565,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -636,12 +636,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -649,21 +649,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -720,12 +720,12 @@ func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalFailureException) Code() string {
+func (s *InternalFailureException) Code() string {
 	return "InternalFailureException"
 }
 
 // Message returns the exception's message.
-func (s InternalFailureException) Message() string {
+func (s *InternalFailureException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -733,21 +733,21 @@ func (s InternalFailureException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalFailureException) OrigErr() error {
+func (s *InternalFailureException) OrigErr() error {
 	return nil
 }
 
-func (s InternalFailureException) Error() string {
+func (s *InternalFailureException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalFailureException) StatusCode() int {
+func (s *InternalFailureException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalFailureException) RequestID() string {
+func (s *InternalFailureException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -861,12 +861,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -874,21 +874,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/transfer/api.go
+++ b/service/transfer/api.go
@@ -1950,12 +1950,12 @@ func newErrorConflictException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictException) Code() string {
+func (s *ConflictException) Code() string {
 	return "ConflictException"
 }
 
 // Message returns the exception's message.
-func (s ConflictException) Message() string {
+func (s *ConflictException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1963,21 +1963,21 @@ func (s ConflictException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictException) OrigErr() error {
+func (s *ConflictException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictException) Error() string {
+func (s *ConflictException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictException) StatusCode() int {
+func (s *ConflictException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictException) RequestID() string {
+func (s *ConflictException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3360,12 +3360,12 @@ func newErrorInternalServiceError(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServiceError) Code() string {
+func (s *InternalServiceError) Code() string {
 	return "InternalServiceError"
 }
 
 // Message returns the exception's message.
-func (s InternalServiceError) Message() string {
+func (s *InternalServiceError) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3373,21 +3373,21 @@ func (s InternalServiceError) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServiceError) OrigErr() error {
+func (s *InternalServiceError) OrigErr() error {
 	return nil
 }
 
-func (s InternalServiceError) Error() string {
+func (s *InternalServiceError) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServiceError) StatusCode() int {
+func (s *InternalServiceError) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServiceError) RequestID() string {
+func (s *InternalServiceError) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3416,12 +3416,12 @@ func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidNextTokenException) Code() string {
+func (s *InvalidNextTokenException) Code() string {
 	return "InvalidNextTokenException"
 }
 
 // Message returns the exception's message.
-func (s InvalidNextTokenException) Message() string {
+func (s *InvalidNextTokenException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3429,21 +3429,21 @@ func (s InvalidNextTokenException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidNextTokenException) OrigErr() error {
+func (s *InvalidNextTokenException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidNextTokenException) Error() string {
+func (s *InvalidNextTokenException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidNextTokenException) StatusCode() int {
+func (s *InvalidNextTokenException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidNextTokenException) RequestID() string {
+func (s *InvalidNextTokenException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3472,12 +3472,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3485,21 +3485,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4028,12 +4028,12 @@ func newErrorResourceExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceExistsException) Code() string {
+func (s *ResourceExistsException) Code() string {
 	return "ResourceExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceExistsException) Message() string {
+func (s *ResourceExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4041,21 +4041,21 @@ func (s ResourceExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceExistsException) OrigErr() error {
+func (s *ResourceExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceExistsException) Error() string {
+func (s *ResourceExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceExistsException) StatusCode() int {
+func (s *ResourceExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceExistsException) RequestID() string {
+func (s *ResourceExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4091,12 +4091,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4104,21 +4104,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4147,12 +4147,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4160,21 +4160,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4635,12 +4635,12 @@ func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottlingException) Code() string {
+func (s *ThrottlingException) Code() string {
 	return "ThrottlingException"
 }
 
 // Message returns the exception's message.
-func (s ThrottlingException) Message() string {
+func (s *ThrottlingException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4648,21 +4648,21 @@ func (s ThrottlingException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottlingException) OrigErr() error {
+func (s *ThrottlingException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottlingException) Error() string {
+func (s *ThrottlingException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottlingException) StatusCode() int {
+func (s *ThrottlingException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottlingException) RequestID() string {
+func (s *ThrottlingException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/translate/api.go
+++ b/service/translate/api.go
@@ -1184,12 +1184,12 @@ func newErrorDetectedLanguageLowConfidenceException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s DetectedLanguageLowConfidenceException) Code() string {
+func (s *DetectedLanguageLowConfidenceException) Code() string {
 	return "DetectedLanguageLowConfidenceException"
 }
 
 // Message returns the exception's message.
-func (s DetectedLanguageLowConfidenceException) Message() string {
+func (s *DetectedLanguageLowConfidenceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1197,21 +1197,21 @@ func (s DetectedLanguageLowConfidenceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DetectedLanguageLowConfidenceException) OrigErr() error {
+func (s *DetectedLanguageLowConfidenceException) OrigErr() error {
 	return nil
 }
 
-func (s DetectedLanguageLowConfidenceException) Error() string {
+func (s *DetectedLanguageLowConfidenceException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DetectedLanguageLowConfidenceException) StatusCode() int {
+func (s *DetectedLanguageLowConfidenceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DetectedLanguageLowConfidenceException) RequestID() string {
+func (s *DetectedLanguageLowConfidenceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1564,12 +1564,12 @@ func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerException) Code() string {
+func (s *InternalServerException) Code() string {
 	return "InternalServerException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerException) Message() string {
+func (s *InternalServerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1577,21 +1577,21 @@ func (s InternalServerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerException) OrigErr() error {
+func (s *InternalServerException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerException) Error() string {
+func (s *InternalServerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerException) StatusCode() int {
+func (s *InternalServerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerException) RequestID() string {
+func (s *InternalServerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1620,12 +1620,12 @@ func newErrorInvalidFilterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidFilterException) Code() string {
+func (s *InvalidFilterException) Code() string {
 	return "InvalidFilterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidFilterException) Message() string {
+func (s *InvalidFilterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1633,21 +1633,21 @@ func (s InvalidFilterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidFilterException) OrigErr() error {
+func (s *InvalidFilterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidFilterException) Error() string {
+func (s *InvalidFilterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidFilterException) StatusCode() int {
+func (s *InvalidFilterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidFilterException) RequestID() string {
+func (s *InvalidFilterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1677,12 +1677,12 @@ func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValueException) Code() string {
+func (s *InvalidParameterValueException) Code() string {
 	return "InvalidParameterValueException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValueException) Message() string {
+func (s *InvalidParameterValueException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1690,21 +1690,21 @@ func (s InvalidParameterValueException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValueException) OrigErr() error {
+func (s *InvalidParameterValueException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValueException) Error() string {
+func (s *InvalidParameterValueException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValueException) StatusCode() int {
+func (s *InvalidParameterValueException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValueException) RequestID() string {
+func (s *InvalidParameterValueException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1734,12 +1734,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1747,21 +1747,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -1835,12 +1835,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -1848,21 +1848,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2107,12 +2107,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2120,21 +2120,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2164,12 +2164,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2177,21 +2177,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -2890,12 +2890,12 @@ func newErrorTextSizeLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TextSizeLimitExceededException) Code() string {
+func (s *TextSizeLimitExceededException) Code() string {
 	return "TextSizeLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s TextSizeLimitExceededException) Message() string {
+func (s *TextSizeLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -2903,21 +2903,21 @@ func (s TextSizeLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TextSizeLimitExceededException) OrigErr() error {
+func (s *TextSizeLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s TextSizeLimitExceededException) Error() string {
+func (s *TextSizeLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TextSizeLimitExceededException) StatusCode() int {
+func (s *TextSizeLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TextSizeLimitExceededException) RequestID() string {
+func (s *TextSizeLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3156,12 +3156,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3169,21 +3169,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -3219,12 +3219,12 @@ func newErrorUnsupportedLanguagePairException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s UnsupportedLanguagePairException) Code() string {
+func (s *UnsupportedLanguagePairException) Code() string {
 	return "UnsupportedLanguagePairException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedLanguagePairException) Message() string {
+func (s *UnsupportedLanguagePairException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3232,21 +3232,21 @@ func (s UnsupportedLanguagePairException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedLanguagePairException) OrigErr() error {
+func (s *UnsupportedLanguagePairException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedLanguagePairException) Error() string {
+func (s *UnsupportedLanguagePairException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedLanguagePairException) StatusCode() int {
+func (s *UnsupportedLanguagePairException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedLanguagePairException) RequestID() string {
+func (s *UnsupportedLanguagePairException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -9540,12 +9540,12 @@ func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s BadRequestException) Code() string {
+func (s *BadRequestException) Code() string {
 	return "WAFBadRequestException"
 }
 
 // Message returns the exception's message.
-func (s BadRequestException) Message() string {
+func (s *BadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9553,21 +9553,21 @@ func (s BadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s BadRequestException) OrigErr() error {
+func (s *BadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s BadRequestException) Error() string {
+func (s *BadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s BadRequestException) StatusCode() int {
+func (s *BadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s BadRequestException) RequestID() string {
+func (s *BadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12485,12 +12485,12 @@ func newErrorDisallowedNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DisallowedNameException) Code() string {
+func (s *DisallowedNameException) Code() string {
 	return "WAFDisallowedNameException"
 }
 
 // Message returns the exception's message.
-func (s DisallowedNameException) Message() string {
+func (s *DisallowedNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12498,21 +12498,21 @@ func (s DisallowedNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DisallowedNameException) OrigErr() error {
+func (s *DisallowedNameException) OrigErr() error {
 	return nil
 }
 
-func (s DisallowedNameException) Error() string {
+func (s *DisallowedNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DisallowedNameException) StatusCode() int {
+func (s *DisallowedNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DisallowedNameException) RequestID() string {
+func (s *DisallowedNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14555,12 +14555,12 @@ func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalErrorException) Code() string {
+func (s *InternalErrorException) Code() string {
 	return "WAFInternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalErrorException) Message() string {
+func (s *InternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14568,21 +14568,21 @@ func (s InternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalErrorException) OrigErr() error {
+func (s *InternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalErrorException) Error() string {
+func (s *InternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalErrorException) StatusCode() int {
+func (s *InternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalErrorException) RequestID() string {
+func (s *InternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14612,12 +14612,12 @@ func newErrorInvalidAccountException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidAccountException) Code() string {
+func (s *InvalidAccountException) Code() string {
 	return "WAFInvalidAccountException"
 }
 
 // Message returns the exception's message.
-func (s InvalidAccountException) Message() string {
+func (s *InvalidAccountException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14625,21 +14625,21 @@ func (s InvalidAccountException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidAccountException) OrigErr() error {
+func (s *InvalidAccountException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidAccountException) Error() string {
+func (s *InvalidAccountException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidAccountException) StatusCode() int {
+func (s *InvalidAccountException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidAccountException) RequestID() string {
+func (s *InvalidAccountException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14683,12 +14683,12 @@ func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOperationException) Code() string {
+func (s *InvalidOperationException) Code() string {
 	return "WAFInvalidOperationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOperationException) Message() string {
+func (s *InvalidOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14696,21 +14696,21 @@ func (s InvalidOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOperationException) OrigErr() error {
+func (s *InvalidOperationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOperationException) Error() string {
+func (s *InvalidOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOperationException) StatusCode() int {
+func (s *InvalidOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOperationException) RequestID() string {
+func (s *InvalidOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14771,12 +14771,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "WAFInvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14784,21 +14784,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14848,12 +14848,12 @@ func newErrorInvalidPermissionPolicyException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidPermissionPolicyException) Code() string {
+func (s *InvalidPermissionPolicyException) Code() string {
 	return "WAFInvalidPermissionPolicyException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPermissionPolicyException) Message() string {
+func (s *InvalidPermissionPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14861,21 +14861,21 @@ func (s InvalidPermissionPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPermissionPolicyException) OrigErr() error {
+func (s *InvalidPermissionPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPermissionPolicyException) Error() string {
+func (s *InvalidPermissionPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPermissionPolicyException) StatusCode() int {
+func (s *InvalidPermissionPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPermissionPolicyException) RequestID() string {
+func (s *InvalidPermissionPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14904,12 +14904,12 @@ func newErrorInvalidRegexPatternException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRegexPatternException) Code() string {
+func (s *InvalidRegexPatternException) Code() string {
 	return "WAFInvalidRegexPatternException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRegexPatternException) Message() string {
+func (s *InvalidRegexPatternException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14917,21 +14917,21 @@ func (s InvalidRegexPatternException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRegexPatternException) OrigErr() error {
+func (s *InvalidRegexPatternException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRegexPatternException) Error() string {
+func (s *InvalidRegexPatternException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRegexPatternException) StatusCode() int {
+func (s *InvalidRegexPatternException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRegexPatternException) RequestID() string {
+func (s *InvalidRegexPatternException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -14963,12 +14963,12 @@ func newErrorLimitsExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitsExceededException) Code() string {
+func (s *LimitsExceededException) Code() string {
 	return "WAFLimitsExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitsExceededException) Message() string {
+func (s *LimitsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -14976,21 +14976,21 @@ func (s LimitsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitsExceededException) OrigErr() error {
+func (s *LimitsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitsExceededException) Error() string {
+func (s *LimitsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitsExceededException) StatusCode() int {
+func (s *LimitsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitsExceededException) RequestID() string {
+func (s *LimitsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16530,12 +16530,12 @@ func newErrorNonEmptyEntityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NonEmptyEntityException) Code() string {
+func (s *NonEmptyEntityException) Code() string {
 	return "WAFNonEmptyEntityException"
 }
 
 // Message returns the exception's message.
-func (s NonEmptyEntityException) Message() string {
+func (s *NonEmptyEntityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16543,21 +16543,21 @@ func (s NonEmptyEntityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NonEmptyEntityException) OrigErr() error {
+func (s *NonEmptyEntityException) OrigErr() error {
 	return nil
 }
 
-func (s NonEmptyEntityException) Error() string {
+func (s *NonEmptyEntityException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NonEmptyEntityException) StatusCode() int {
+func (s *NonEmptyEntityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NonEmptyEntityException) RequestID() string {
+func (s *NonEmptyEntityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16599,12 +16599,12 @@ func newErrorNonexistentContainerException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NonexistentContainerException) Code() string {
+func (s *NonexistentContainerException) Code() string {
 	return "WAFNonexistentContainerException"
 }
 
 // Message returns the exception's message.
-func (s NonexistentContainerException) Message() string {
+func (s *NonexistentContainerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16612,21 +16612,21 @@ func (s NonexistentContainerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NonexistentContainerException) OrigErr() error {
+func (s *NonexistentContainerException) OrigErr() error {
 	return nil
 }
 
-func (s NonexistentContainerException) Error() string {
+func (s *NonexistentContainerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NonexistentContainerException) StatusCode() int {
+func (s *NonexistentContainerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NonexistentContainerException) RequestID() string {
+func (s *NonexistentContainerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -16655,12 +16655,12 @@ func newErrorNonexistentItemException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NonexistentItemException) Code() string {
+func (s *NonexistentItemException) Code() string {
 	return "WAFNonexistentItemException"
 }
 
 // Message returns the exception's message.
-func (s NonexistentItemException) Message() string {
+func (s *NonexistentItemException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -16668,21 +16668,21 @@ func (s NonexistentItemException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NonexistentItemException) OrigErr() error {
+func (s *NonexistentItemException) OrigErr() error {
 	return nil
 }
 
-func (s NonexistentItemException) Error() string {
+func (s *NonexistentItemException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NonexistentItemException) StatusCode() int {
+func (s *NonexistentItemException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NonexistentItemException) RequestID() string {
+func (s *NonexistentItemException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -17052,12 +17052,12 @@ func newErrorReferencedItemException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ReferencedItemException) Code() string {
+func (s *ReferencedItemException) Code() string {
 	return "WAFReferencedItemException"
 }
 
 // Message returns the exception's message.
-func (s ReferencedItemException) Message() string {
+func (s *ReferencedItemException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -17065,21 +17065,21 @@ func (s ReferencedItemException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReferencedItemException) OrigErr() error {
+func (s *ReferencedItemException) OrigErr() error {
 	return nil
 }
 
-func (s ReferencedItemException) Error() string {
+func (s *ReferencedItemException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReferencedItemException) StatusCode() int {
+func (s *ReferencedItemException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReferencedItemException) RequestID() string {
+func (s *ReferencedItemException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18029,12 +18029,12 @@ func newErrorServiceLinkedRoleErrorException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ServiceLinkedRoleErrorException) Code() string {
+func (s *ServiceLinkedRoleErrorException) Code() string {
 	return "WAFServiceLinkedRoleErrorException"
 }
 
 // Message returns the exception's message.
-func (s ServiceLinkedRoleErrorException) Message() string {
+func (s *ServiceLinkedRoleErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18042,21 +18042,21 @@ func (s ServiceLinkedRoleErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceLinkedRoleErrorException) OrigErr() error {
+func (s *ServiceLinkedRoleErrorException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceLinkedRoleErrorException) Error() string {
+func (s *ServiceLinkedRoleErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceLinkedRoleErrorException) StatusCode() int {
+func (s *ServiceLinkedRoleErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceLinkedRoleErrorException) RequestID() string {
+func (s *ServiceLinkedRoleErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18732,12 +18732,12 @@ func newErrorStaleDataException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StaleDataException) Code() string {
+func (s *StaleDataException) Code() string {
 	return "WAFStaleDataException"
 }
 
 // Message returns the exception's message.
-func (s StaleDataException) Message() string {
+func (s *StaleDataException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18745,21 +18745,21 @@ func (s StaleDataException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StaleDataException) OrigErr() error {
+func (s *StaleDataException) OrigErr() error {
 	return nil
 }
 
-func (s StaleDataException) Error() string {
+func (s *StaleDataException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StaleDataException) StatusCode() int {
+func (s *StaleDataException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StaleDataException) RequestID() string {
+func (s *StaleDataException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18841,12 +18841,12 @@ func newErrorSubscriptionNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s SubscriptionNotFoundException) Code() string {
+func (s *SubscriptionNotFoundException) Code() string {
 	return "WAFSubscriptionNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s SubscriptionNotFoundException) Message() string {
+func (s *SubscriptionNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18854,21 +18854,21 @@ func (s SubscriptionNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s SubscriptionNotFoundException) OrigErr() error {
+func (s *SubscriptionNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s SubscriptionNotFoundException) Error() string {
+func (s *SubscriptionNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s SubscriptionNotFoundException) StatusCode() int {
+func (s *SubscriptionNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s SubscriptionNotFoundException) RequestID() string {
+func (s *SubscriptionNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -18969,12 +18969,12 @@ func newErrorTagOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TagOperationException) Code() string {
+func (s *TagOperationException) Code() string {
 	return "WAFTagOperationException"
 }
 
 // Message returns the exception's message.
-func (s TagOperationException) Message() string {
+func (s *TagOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -18982,21 +18982,21 @@ func (s TagOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagOperationException) OrigErr() error {
+func (s *TagOperationException) OrigErr() error {
 	return nil
 }
 
-func (s TagOperationException) Error() string {
+func (s *TagOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagOperationException) StatusCode() int {
+func (s *TagOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagOperationException) RequestID() string {
+func (s *TagOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -19024,12 +19024,12 @@ func newErrorTagOperationInternalErrorException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s TagOperationInternalErrorException) Code() string {
+func (s *TagOperationInternalErrorException) Code() string {
 	return "WAFTagOperationInternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s TagOperationInternalErrorException) Message() string {
+func (s *TagOperationInternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -19037,21 +19037,21 @@ func (s TagOperationInternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TagOperationInternalErrorException) OrigErr() error {
+func (s *TagOperationInternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s TagOperationInternalErrorException) Error() string {
+func (s *TagOperationInternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TagOperationInternalErrorException) StatusCode() int {
+func (s *TagOperationInternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TagOperationInternalErrorException) RequestID() string {
+func (s *TagOperationInternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/wafregional/api.go
+++ b/service/wafregional/api.go
@@ -10119,12 +10119,12 @@ func newErrorWAFBadRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFBadRequestException) Code() string {
+func (s *WAFBadRequestException) Code() string {
 	return "WAFBadRequestException"
 }
 
 // Message returns the exception's message.
-func (s WAFBadRequestException) Message() string {
+func (s *WAFBadRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10132,21 +10132,21 @@ func (s WAFBadRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFBadRequestException) OrigErr() error {
+func (s *WAFBadRequestException) OrigErr() error {
 	return nil
 }
 
-func (s WAFBadRequestException) Error() string {
+func (s *WAFBadRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFBadRequestException) StatusCode() int {
+func (s *WAFBadRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFBadRequestException) RequestID() string {
+func (s *WAFBadRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10175,12 +10175,12 @@ func newErrorWAFDisallowedNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFDisallowedNameException) Code() string {
+func (s *WAFDisallowedNameException) Code() string {
 	return "WAFDisallowedNameException"
 }
 
 // Message returns the exception's message.
-func (s WAFDisallowedNameException) Message() string {
+func (s *WAFDisallowedNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10188,21 +10188,21 @@ func (s WAFDisallowedNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFDisallowedNameException) OrigErr() error {
+func (s *WAFDisallowedNameException) OrigErr() error {
 	return nil
 }
 
-func (s WAFDisallowedNameException) Error() string {
+func (s *WAFDisallowedNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFDisallowedNameException) StatusCode() int {
+func (s *WAFDisallowedNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFDisallowedNameException) RequestID() string {
+func (s *WAFDisallowedNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10232,12 +10232,12 @@ func newErrorWAFInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFInternalErrorException) Code() string {
+func (s *WAFInternalErrorException) Code() string {
 	return "WAFInternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s WAFInternalErrorException) Message() string {
+func (s *WAFInternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10245,21 +10245,21 @@ func (s WAFInternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFInternalErrorException) OrigErr() error {
+func (s *WAFInternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s WAFInternalErrorException) Error() string {
+func (s *WAFInternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFInternalErrorException) StatusCode() int {
+func (s *WAFInternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFInternalErrorException) RequestID() string {
+func (s *WAFInternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10289,12 +10289,12 @@ func newErrorWAFInvalidAccountException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFInvalidAccountException) Code() string {
+func (s *WAFInvalidAccountException) Code() string {
 	return "WAFInvalidAccountException"
 }
 
 // Message returns the exception's message.
-func (s WAFInvalidAccountException) Message() string {
+func (s *WAFInvalidAccountException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10302,21 +10302,21 @@ func (s WAFInvalidAccountException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFInvalidAccountException) OrigErr() error {
+func (s *WAFInvalidAccountException) OrigErr() error {
 	return nil
 }
 
-func (s WAFInvalidAccountException) Error() string {
+func (s *WAFInvalidAccountException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFInvalidAccountException) StatusCode() int {
+func (s *WAFInvalidAccountException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFInvalidAccountException) RequestID() string {
+func (s *WAFInvalidAccountException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10360,12 +10360,12 @@ func newErrorWAFInvalidOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFInvalidOperationException) Code() string {
+func (s *WAFInvalidOperationException) Code() string {
 	return "WAFInvalidOperationException"
 }
 
 // Message returns the exception's message.
-func (s WAFInvalidOperationException) Message() string {
+func (s *WAFInvalidOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10373,21 +10373,21 @@ func (s WAFInvalidOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFInvalidOperationException) OrigErr() error {
+func (s *WAFInvalidOperationException) OrigErr() error {
 	return nil
 }
 
-func (s WAFInvalidOperationException) Error() string {
+func (s *WAFInvalidOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFInvalidOperationException) StatusCode() int {
+func (s *WAFInvalidOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFInvalidOperationException) RequestID() string {
+func (s *WAFInvalidOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10448,12 +10448,12 @@ func newErrorWAFInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFInvalidParameterException) Code() string {
+func (s *WAFInvalidParameterException) Code() string {
 	return "WAFInvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s WAFInvalidParameterException) Message() string {
+func (s *WAFInvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10461,21 +10461,21 @@ func (s WAFInvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFInvalidParameterException) OrigErr() error {
+func (s *WAFInvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s WAFInvalidParameterException) Error() string {
+func (s *WAFInvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFInvalidParameterException) StatusCode() int {
+func (s *WAFInvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFInvalidParameterException) RequestID() string {
+func (s *WAFInvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10525,12 +10525,12 @@ func newErrorWAFInvalidPermissionPolicyException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s WAFInvalidPermissionPolicyException) Code() string {
+func (s *WAFInvalidPermissionPolicyException) Code() string {
 	return "WAFInvalidPermissionPolicyException"
 }
 
 // Message returns the exception's message.
-func (s WAFInvalidPermissionPolicyException) Message() string {
+func (s *WAFInvalidPermissionPolicyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10538,21 +10538,21 @@ func (s WAFInvalidPermissionPolicyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFInvalidPermissionPolicyException) OrigErr() error {
+func (s *WAFInvalidPermissionPolicyException) OrigErr() error {
 	return nil
 }
 
-func (s WAFInvalidPermissionPolicyException) Error() string {
+func (s *WAFInvalidPermissionPolicyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFInvalidPermissionPolicyException) StatusCode() int {
+func (s *WAFInvalidPermissionPolicyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFInvalidPermissionPolicyException) RequestID() string {
+func (s *WAFInvalidPermissionPolicyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10581,12 +10581,12 @@ func newErrorWAFInvalidRegexPatternException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s WAFInvalidRegexPatternException) Code() string {
+func (s *WAFInvalidRegexPatternException) Code() string {
 	return "WAFInvalidRegexPatternException"
 }
 
 // Message returns the exception's message.
-func (s WAFInvalidRegexPatternException) Message() string {
+func (s *WAFInvalidRegexPatternException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10594,21 +10594,21 @@ func (s WAFInvalidRegexPatternException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFInvalidRegexPatternException) OrigErr() error {
+func (s *WAFInvalidRegexPatternException) OrigErr() error {
 	return nil
 }
 
-func (s WAFInvalidRegexPatternException) Error() string {
+func (s *WAFInvalidRegexPatternException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFInvalidRegexPatternException) StatusCode() int {
+func (s *WAFInvalidRegexPatternException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFInvalidRegexPatternException) RequestID() string {
+func (s *WAFInvalidRegexPatternException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10640,12 +10640,12 @@ func newErrorWAFLimitsExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFLimitsExceededException) Code() string {
+func (s *WAFLimitsExceededException) Code() string {
 	return "WAFLimitsExceededException"
 }
 
 // Message returns the exception's message.
-func (s WAFLimitsExceededException) Message() string {
+func (s *WAFLimitsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10653,21 +10653,21 @@ func (s WAFLimitsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFLimitsExceededException) OrigErr() error {
+func (s *WAFLimitsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s WAFLimitsExceededException) Error() string {
+func (s *WAFLimitsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFLimitsExceededException) StatusCode() int {
+func (s *WAFLimitsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFLimitsExceededException) RequestID() string {
+func (s *WAFLimitsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10707,12 +10707,12 @@ func newErrorWAFNonEmptyEntityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFNonEmptyEntityException) Code() string {
+func (s *WAFNonEmptyEntityException) Code() string {
 	return "WAFNonEmptyEntityException"
 }
 
 // Message returns the exception's message.
-func (s WAFNonEmptyEntityException) Message() string {
+func (s *WAFNonEmptyEntityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10720,21 +10720,21 @@ func (s WAFNonEmptyEntityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFNonEmptyEntityException) OrigErr() error {
+func (s *WAFNonEmptyEntityException) OrigErr() error {
 	return nil
 }
 
-func (s WAFNonEmptyEntityException) Error() string {
+func (s *WAFNonEmptyEntityException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFNonEmptyEntityException) StatusCode() int {
+func (s *WAFNonEmptyEntityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFNonEmptyEntityException) RequestID() string {
+func (s *WAFNonEmptyEntityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10776,12 +10776,12 @@ func newErrorWAFNonexistentContainerException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s WAFNonexistentContainerException) Code() string {
+func (s *WAFNonexistentContainerException) Code() string {
 	return "WAFNonexistentContainerException"
 }
 
 // Message returns the exception's message.
-func (s WAFNonexistentContainerException) Message() string {
+func (s *WAFNonexistentContainerException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10789,21 +10789,21 @@ func (s WAFNonexistentContainerException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFNonexistentContainerException) OrigErr() error {
+func (s *WAFNonexistentContainerException) OrigErr() error {
 	return nil
 }
 
-func (s WAFNonexistentContainerException) Error() string {
+func (s *WAFNonexistentContainerException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFNonexistentContainerException) StatusCode() int {
+func (s *WAFNonexistentContainerException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFNonexistentContainerException) RequestID() string {
+func (s *WAFNonexistentContainerException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10832,12 +10832,12 @@ func newErrorWAFNonexistentItemException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFNonexistentItemException) Code() string {
+func (s *WAFNonexistentItemException) Code() string {
 	return "WAFNonexistentItemException"
 }
 
 // Message returns the exception's message.
-func (s WAFNonexistentItemException) Message() string {
+func (s *WAFNonexistentItemException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10845,21 +10845,21 @@ func (s WAFNonexistentItemException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFNonexistentItemException) OrigErr() error {
+func (s *WAFNonexistentItemException) OrigErr() error {
 	return nil
 }
 
-func (s WAFNonexistentItemException) Error() string {
+func (s *WAFNonexistentItemException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFNonexistentItemException) StatusCode() int {
+func (s *WAFNonexistentItemException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFNonexistentItemException) RequestID() string {
+func (s *WAFNonexistentItemException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10893,12 +10893,12 @@ func newErrorWAFReferencedItemException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFReferencedItemException) Code() string {
+func (s *WAFReferencedItemException) Code() string {
 	return "WAFReferencedItemException"
 }
 
 // Message returns the exception's message.
-func (s WAFReferencedItemException) Message() string {
+func (s *WAFReferencedItemException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10906,21 +10906,21 @@ func (s WAFReferencedItemException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFReferencedItemException) OrigErr() error {
+func (s *WAFReferencedItemException) OrigErr() error {
 	return nil
 }
 
-func (s WAFReferencedItemException) Error() string {
+func (s *WAFReferencedItemException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFReferencedItemException) StatusCode() int {
+func (s *WAFReferencedItemException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFReferencedItemException) RequestID() string {
+func (s *WAFReferencedItemException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10956,12 +10956,12 @@ func newErrorWAFServiceLinkedRoleErrorException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s WAFServiceLinkedRoleErrorException) Code() string {
+func (s *WAFServiceLinkedRoleErrorException) Code() string {
 	return "WAFServiceLinkedRoleErrorException"
 }
 
 // Message returns the exception's message.
-func (s WAFServiceLinkedRoleErrorException) Message() string {
+func (s *WAFServiceLinkedRoleErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10969,21 +10969,21 @@ func (s WAFServiceLinkedRoleErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFServiceLinkedRoleErrorException) OrigErr() error {
+func (s *WAFServiceLinkedRoleErrorException) OrigErr() error {
 	return nil
 }
 
-func (s WAFServiceLinkedRoleErrorException) Error() string {
+func (s *WAFServiceLinkedRoleErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFServiceLinkedRoleErrorException) StatusCode() int {
+func (s *WAFServiceLinkedRoleErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFServiceLinkedRoleErrorException) RequestID() string {
+func (s *WAFServiceLinkedRoleErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11013,12 +11013,12 @@ func newErrorWAFStaleDataException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFStaleDataException) Code() string {
+func (s *WAFStaleDataException) Code() string {
 	return "WAFStaleDataException"
 }
 
 // Message returns the exception's message.
-func (s WAFStaleDataException) Message() string {
+func (s *WAFStaleDataException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11026,21 +11026,21 @@ func (s WAFStaleDataException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFStaleDataException) OrigErr() error {
+func (s *WAFStaleDataException) OrigErr() error {
 	return nil
 }
 
-func (s WAFStaleDataException) Error() string {
+func (s *WAFStaleDataException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFStaleDataException) StatusCode() int {
+func (s *WAFStaleDataException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFStaleDataException) RequestID() string {
+func (s *WAFStaleDataException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11069,12 +11069,12 @@ func newErrorWAFSubscriptionNotFoundException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s WAFSubscriptionNotFoundException) Code() string {
+func (s *WAFSubscriptionNotFoundException) Code() string {
 	return "WAFSubscriptionNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s WAFSubscriptionNotFoundException) Message() string {
+func (s *WAFSubscriptionNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11082,21 +11082,21 @@ func (s WAFSubscriptionNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFSubscriptionNotFoundException) OrigErr() error {
+func (s *WAFSubscriptionNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s WAFSubscriptionNotFoundException) Error() string {
+func (s *WAFSubscriptionNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFSubscriptionNotFoundException) StatusCode() int {
+func (s *WAFSubscriptionNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFSubscriptionNotFoundException) RequestID() string {
+func (s *WAFSubscriptionNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11124,12 +11124,12 @@ func newErrorWAFTagOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFTagOperationException) Code() string {
+func (s *WAFTagOperationException) Code() string {
 	return "WAFTagOperationException"
 }
 
 // Message returns the exception's message.
-func (s WAFTagOperationException) Message() string {
+func (s *WAFTagOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11137,21 +11137,21 @@ func (s WAFTagOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFTagOperationException) OrigErr() error {
+func (s *WAFTagOperationException) OrigErr() error {
 	return nil
 }
 
-func (s WAFTagOperationException) Error() string {
+func (s *WAFTagOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFTagOperationException) StatusCode() int {
+func (s *WAFTagOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFTagOperationException) RequestID() string {
+func (s *WAFTagOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11179,12 +11179,12 @@ func newErrorWAFTagOperationInternalErrorException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s WAFTagOperationInternalErrorException) Code() string {
+func (s *WAFTagOperationInternalErrorException) Code() string {
 	return "WAFTagOperationInternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s WAFTagOperationInternalErrorException) Message() string {
+func (s *WAFTagOperationInternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11192,21 +11192,21 @@ func (s WAFTagOperationInternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFTagOperationInternalErrorException) OrigErr() error {
+func (s *WAFTagOperationInternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s WAFTagOperationInternalErrorException) Error() string {
+func (s *WAFTagOperationInternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFTagOperationInternalErrorException) StatusCode() int {
+func (s *WAFTagOperationInternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFTagOperationInternalErrorException) RequestID() string {
+func (s *WAFTagOperationInternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -11236,12 +11236,12 @@ func newErrorWAFUnavailableEntityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFUnavailableEntityException) Code() string {
+func (s *WAFUnavailableEntityException) Code() string {
 	return "WAFUnavailableEntityException"
 }
 
 // Message returns the exception's message.
-func (s WAFUnavailableEntityException) Message() string {
+func (s *WAFUnavailableEntityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -11249,21 +11249,21 @@ func (s WAFUnavailableEntityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFUnavailableEntityException) OrigErr() error {
+func (s *WAFUnavailableEntityException) OrigErr() error {
 	return nil
 }
 
-func (s WAFUnavailableEntityException) Error() string {
+func (s *WAFUnavailableEntityException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFUnavailableEntityException) StatusCode() int {
+func (s *WAFUnavailableEntityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFUnavailableEntityException) RequestID() string {
+func (s *WAFUnavailableEntityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/wafv2/api.go
+++ b/service/wafv2/api.go
@@ -12006,12 +12006,12 @@ func newErrorWAFAssociatedItemException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFAssociatedItemException) Code() string {
+func (s *WAFAssociatedItemException) Code() string {
 	return "WAFAssociatedItemException"
 }
 
 // Message returns the exception's message.
-func (s WAFAssociatedItemException) Message() string {
+func (s *WAFAssociatedItemException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12019,21 +12019,21 @@ func (s WAFAssociatedItemException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFAssociatedItemException) OrigErr() error {
+func (s *WAFAssociatedItemException) OrigErr() error {
 	return nil
 }
 
-func (s WAFAssociatedItemException) Error() string {
+func (s *WAFAssociatedItemException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFAssociatedItemException) StatusCode() int {
+func (s *WAFAssociatedItemException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFAssociatedItemException) RequestID() string {
+func (s *WAFAssociatedItemException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12063,12 +12063,12 @@ func newErrorWAFDuplicateItemException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFDuplicateItemException) Code() string {
+func (s *WAFDuplicateItemException) Code() string {
 	return "WAFDuplicateItemException"
 }
 
 // Message returns the exception's message.
-func (s WAFDuplicateItemException) Message() string {
+func (s *WAFDuplicateItemException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12076,21 +12076,21 @@ func (s WAFDuplicateItemException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFDuplicateItemException) OrigErr() error {
+func (s *WAFDuplicateItemException) OrigErr() error {
 	return nil
 }
 
-func (s WAFDuplicateItemException) Error() string {
+func (s *WAFDuplicateItemException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFDuplicateItemException) StatusCode() int {
+func (s *WAFDuplicateItemException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFDuplicateItemException) RequestID() string {
+func (s *WAFDuplicateItemException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12120,12 +12120,12 @@ func newErrorWAFInternalErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFInternalErrorException) Code() string {
+func (s *WAFInternalErrorException) Code() string {
 	return "WAFInternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s WAFInternalErrorException) Message() string {
+func (s *WAFInternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12133,21 +12133,21 @@ func (s WAFInternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFInternalErrorException) OrigErr() error {
+func (s *WAFInternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s WAFInternalErrorException) Error() string {
+func (s *WAFInternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFInternalErrorException) StatusCode() int {
+func (s *WAFInternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFInternalErrorException) RequestID() string {
+func (s *WAFInternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12194,12 +12194,12 @@ func newErrorWAFInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFInvalidParameterException) Code() string {
+func (s *WAFInvalidParameterException) Code() string {
 	return "WAFInvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s WAFInvalidParameterException) Message() string {
+func (s *WAFInvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12207,21 +12207,21 @@ func (s WAFInvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFInvalidParameterException) OrigErr() error {
+func (s *WAFInvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s WAFInvalidParameterException) Error() string {
+func (s *WAFInvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFInvalidParameterException) StatusCode() int {
+func (s *WAFInvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFInvalidParameterException) RequestID() string {
+func (s *WAFInvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12251,12 +12251,12 @@ func newErrorWAFInvalidResourceException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFInvalidResourceException) Code() string {
+func (s *WAFInvalidResourceException) Code() string {
 	return "WAFInvalidResourceException"
 }
 
 // Message returns the exception's message.
-func (s WAFInvalidResourceException) Message() string {
+func (s *WAFInvalidResourceException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12264,21 +12264,21 @@ func (s WAFInvalidResourceException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFInvalidResourceException) OrigErr() error {
+func (s *WAFInvalidResourceException) OrigErr() error {
 	return nil
 }
 
-func (s WAFInvalidResourceException) Error() string {
+func (s *WAFInvalidResourceException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFInvalidResourceException) StatusCode() int {
+func (s *WAFInvalidResourceException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFInvalidResourceException) RequestID() string {
+func (s *WAFInvalidResourceException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12310,12 +12310,12 @@ func newErrorWAFLimitsExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFLimitsExceededException) Code() string {
+func (s *WAFLimitsExceededException) Code() string {
 	return "WAFLimitsExceededException"
 }
 
 // Message returns the exception's message.
-func (s WAFLimitsExceededException) Message() string {
+func (s *WAFLimitsExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12323,21 +12323,21 @@ func (s WAFLimitsExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFLimitsExceededException) OrigErr() error {
+func (s *WAFLimitsExceededException) OrigErr() error {
 	return nil
 }
 
-func (s WAFLimitsExceededException) Error() string {
+func (s *WAFLimitsExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFLimitsExceededException) StatusCode() int {
+func (s *WAFLimitsExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFLimitsExceededException) RequestID() string {
+func (s *WAFLimitsExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12367,12 +12367,12 @@ func newErrorWAFNonexistentItemException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFNonexistentItemException) Code() string {
+func (s *WAFNonexistentItemException) Code() string {
 	return "WAFNonexistentItemException"
 }
 
 // Message returns the exception's message.
-func (s WAFNonexistentItemException) Message() string {
+func (s *WAFNonexistentItemException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12380,21 +12380,21 @@ func (s WAFNonexistentItemException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFNonexistentItemException) OrigErr() error {
+func (s *WAFNonexistentItemException) OrigErr() error {
 	return nil
 }
 
-func (s WAFNonexistentItemException) Error() string {
+func (s *WAFNonexistentItemException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFNonexistentItemException) StatusCode() int {
+func (s *WAFNonexistentItemException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFNonexistentItemException) RequestID() string {
+func (s *WAFNonexistentItemException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12426,12 +12426,12 @@ func newErrorWAFOptimisticLockException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFOptimisticLockException) Code() string {
+func (s *WAFOptimisticLockException) Code() string {
 	return "WAFOptimisticLockException"
 }
 
 // Message returns the exception's message.
-func (s WAFOptimisticLockException) Message() string {
+func (s *WAFOptimisticLockException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12439,21 +12439,21 @@ func (s WAFOptimisticLockException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFOptimisticLockException) OrigErr() error {
+func (s *WAFOptimisticLockException) OrigErr() error {
 	return nil
 }
 
-func (s WAFOptimisticLockException) Error() string {
+func (s *WAFOptimisticLockException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFOptimisticLockException) StatusCode() int {
+func (s *WAFOptimisticLockException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFOptimisticLockException) RequestID() string {
+func (s *WAFOptimisticLockException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12489,12 +12489,12 @@ func newErrorWAFServiceLinkedRoleErrorException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s WAFServiceLinkedRoleErrorException) Code() string {
+func (s *WAFServiceLinkedRoleErrorException) Code() string {
 	return "WAFServiceLinkedRoleErrorException"
 }
 
 // Message returns the exception's message.
-func (s WAFServiceLinkedRoleErrorException) Message() string {
+func (s *WAFServiceLinkedRoleErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12502,21 +12502,21 @@ func (s WAFServiceLinkedRoleErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFServiceLinkedRoleErrorException) OrigErr() error {
+func (s *WAFServiceLinkedRoleErrorException) OrigErr() error {
 	return nil
 }
 
-func (s WAFServiceLinkedRoleErrorException) Error() string {
+func (s *WAFServiceLinkedRoleErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFServiceLinkedRoleErrorException) StatusCode() int {
+func (s *WAFServiceLinkedRoleErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFServiceLinkedRoleErrorException) RequestID() string {
+func (s *WAFServiceLinkedRoleErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12544,12 +12544,12 @@ func newErrorWAFSubscriptionNotFoundException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s WAFSubscriptionNotFoundException) Code() string {
+func (s *WAFSubscriptionNotFoundException) Code() string {
 	return "WAFSubscriptionNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s WAFSubscriptionNotFoundException) Message() string {
+func (s *WAFSubscriptionNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12557,21 +12557,21 @@ func (s WAFSubscriptionNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFSubscriptionNotFoundException) OrigErr() error {
+func (s *WAFSubscriptionNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s WAFSubscriptionNotFoundException) Error() string {
+func (s *WAFSubscriptionNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFSubscriptionNotFoundException) StatusCode() int {
+func (s *WAFSubscriptionNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFSubscriptionNotFoundException) RequestID() string {
+func (s *WAFSubscriptionNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12600,12 +12600,12 @@ func newErrorWAFTagOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFTagOperationException) Code() string {
+func (s *WAFTagOperationException) Code() string {
 	return "WAFTagOperationException"
 }
 
 // Message returns the exception's message.
-func (s WAFTagOperationException) Message() string {
+func (s *WAFTagOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12613,21 +12613,21 @@ func (s WAFTagOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFTagOperationException) OrigErr() error {
+func (s *WAFTagOperationException) OrigErr() error {
 	return nil
 }
 
-func (s WAFTagOperationException) Error() string {
+func (s *WAFTagOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFTagOperationException) StatusCode() int {
+func (s *WAFTagOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFTagOperationException) RequestID() string {
+func (s *WAFTagOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12657,12 +12657,12 @@ func newErrorWAFTagOperationInternalErrorException(v protocol.ResponseMetadata) 
 }
 
 // Code returns the exception type name.
-func (s WAFTagOperationInternalErrorException) Code() string {
+func (s *WAFTagOperationInternalErrorException) Code() string {
 	return "WAFTagOperationInternalErrorException"
 }
 
 // Message returns the exception's message.
-func (s WAFTagOperationInternalErrorException) Message() string {
+func (s *WAFTagOperationInternalErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12670,21 +12670,21 @@ func (s WAFTagOperationInternalErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFTagOperationInternalErrorException) OrigErr() error {
+func (s *WAFTagOperationInternalErrorException) OrigErr() error {
 	return nil
 }
 
-func (s WAFTagOperationInternalErrorException) Error() string {
+func (s *WAFTagOperationInternalErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFTagOperationInternalErrorException) StatusCode() int {
+func (s *WAFTagOperationInternalErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFTagOperationInternalErrorException) RequestID() string {
+func (s *WAFTagOperationInternalErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -12713,12 +12713,12 @@ func newErrorWAFUnavailableEntityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s WAFUnavailableEntityException) Code() string {
+func (s *WAFUnavailableEntityException) Code() string {
 	return "WAFUnavailableEntityException"
 }
 
 // Message returns the exception's message.
-func (s WAFUnavailableEntityException) Message() string {
+func (s *WAFUnavailableEntityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -12726,21 +12726,21 @@ func (s WAFUnavailableEntityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WAFUnavailableEntityException) OrigErr() error {
+func (s *WAFUnavailableEntityException) OrigErr() error {
 	return nil
 }
 
-func (s WAFUnavailableEntityException) Error() string {
+func (s *WAFUnavailableEntityException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WAFUnavailableEntityException) StatusCode() int {
+func (s *WAFUnavailableEntityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WAFUnavailableEntityException) RequestID() string {
+func (s *WAFUnavailableEntityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -4787,12 +4787,12 @@ func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ConcurrentModificationException) Code() string {
+func (s *ConcurrentModificationException) Code() string {
 	return "ConcurrentModificationException"
 }
 
 // Message returns the exception's message.
-func (s ConcurrentModificationException) Message() string {
+func (s *ConcurrentModificationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4800,21 +4800,21 @@ func (s ConcurrentModificationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConcurrentModificationException) OrigErr() error {
+func (s *ConcurrentModificationException) OrigErr() error {
 	return nil
 }
 
-func (s ConcurrentModificationException) Error() string {
+func (s *ConcurrentModificationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConcurrentModificationException) StatusCode() int {
+func (s *ConcurrentModificationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConcurrentModificationException) RequestID() string {
+func (s *ConcurrentModificationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4844,12 +4844,12 @@ func newErrorConflictingOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ConflictingOperationException) Code() string {
+func (s *ConflictingOperationException) Code() string {
 	return "ConflictingOperationException"
 }
 
 // Message returns the exception's message.
-func (s ConflictingOperationException) Message() string {
+func (s *ConflictingOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4857,21 +4857,21 @@ func (s ConflictingOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ConflictingOperationException) OrigErr() error {
+func (s *ConflictingOperationException) OrigErr() error {
 	return nil
 }
 
-func (s ConflictingOperationException) Error() string {
+func (s *ConflictingOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ConflictingOperationException) StatusCode() int {
+func (s *ConflictingOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ConflictingOperationException) RequestID() string {
+func (s *ConflictingOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5610,12 +5610,12 @@ func newErrorCustomMetadataLimitExceededException(v protocol.ResponseMetadata) e
 }
 
 // Code returns the exception type name.
-func (s CustomMetadataLimitExceededException) Code() string {
+func (s *CustomMetadataLimitExceededException) Code() string {
 	return "CustomMetadataLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s CustomMetadataLimitExceededException) Message() string {
+func (s *CustomMetadataLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5623,21 +5623,21 @@ func (s CustomMetadataLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s CustomMetadataLimitExceededException) OrigErr() error {
+func (s *CustomMetadataLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s CustomMetadataLimitExceededException) Error() string {
+func (s *CustomMetadataLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s CustomMetadataLimitExceededException) StatusCode() int {
+func (s *CustomMetadataLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s CustomMetadataLimitExceededException) RequestID() string {
+func (s *CustomMetadataLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5734,12 +5734,12 @@ func newErrorDeactivatingLastSystemUserException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s DeactivatingLastSystemUserException) Code() string {
+func (s *DeactivatingLastSystemUserException) Code() string {
 	return "DeactivatingLastSystemUserException"
 }
 
 // Message returns the exception's message.
-func (s DeactivatingLastSystemUserException) Message() string {
+func (s *DeactivatingLastSystemUserException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5747,21 +5747,21 @@ func (s DeactivatingLastSystemUserException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DeactivatingLastSystemUserException) OrigErr() error {
+func (s *DeactivatingLastSystemUserException) OrigErr() error {
 	return nil
 }
 
-func (s DeactivatingLastSystemUserException) Error() string {
+func (s *DeactivatingLastSystemUserException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DeactivatingLastSystemUserException) StatusCode() int {
+func (s *DeactivatingLastSystemUserException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DeactivatingLastSystemUserException) RequestID() string {
+func (s *DeactivatingLastSystemUserException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7654,12 +7654,12 @@ func newErrorDocumentLockedForCommentsException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s DocumentLockedForCommentsException) Code() string {
+func (s *DocumentLockedForCommentsException) Code() string {
 	return "DocumentLockedForCommentsException"
 }
 
 // Message returns the exception's message.
-func (s DocumentLockedForCommentsException) Message() string {
+func (s *DocumentLockedForCommentsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7667,21 +7667,21 @@ func (s DocumentLockedForCommentsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DocumentLockedForCommentsException) OrigErr() error {
+func (s *DocumentLockedForCommentsException) OrigErr() error {
 	return nil
 }
 
-func (s DocumentLockedForCommentsException) Error() string {
+func (s *DocumentLockedForCommentsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DocumentLockedForCommentsException) StatusCode() int {
+func (s *DocumentLockedForCommentsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DocumentLockedForCommentsException) RequestID() string {
+func (s *DocumentLockedForCommentsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7930,12 +7930,12 @@ func newErrorDraftUploadOutOfSyncException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DraftUploadOutOfSyncException) Code() string {
+func (s *DraftUploadOutOfSyncException) Code() string {
 	return "DraftUploadOutOfSyncException"
 }
 
 // Message returns the exception's message.
-func (s DraftUploadOutOfSyncException) Message() string {
+func (s *DraftUploadOutOfSyncException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7943,21 +7943,21 @@ func (s DraftUploadOutOfSyncException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DraftUploadOutOfSyncException) OrigErr() error {
+func (s *DraftUploadOutOfSyncException) OrigErr() error {
 	return nil
 }
 
-func (s DraftUploadOutOfSyncException) Error() string {
+func (s *DraftUploadOutOfSyncException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DraftUploadOutOfSyncException) StatusCode() int {
+func (s *DraftUploadOutOfSyncException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DraftUploadOutOfSyncException) RequestID() string {
+func (s *DraftUploadOutOfSyncException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7986,12 +7986,12 @@ func newErrorEntityAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EntityAlreadyExistsException) Code() string {
+func (s *EntityAlreadyExistsException) Code() string {
 	return "EntityAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s EntityAlreadyExistsException) Message() string {
+func (s *EntityAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7999,21 +7999,21 @@ func (s EntityAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EntityAlreadyExistsException) OrigErr() error {
+func (s *EntityAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s EntityAlreadyExistsException) Error() string {
+func (s *EntityAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EntityAlreadyExistsException) StatusCode() int {
+func (s *EntityAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EntityAlreadyExistsException) RequestID() string {
+func (s *EntityAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8044,12 +8044,12 @@ func newErrorEntityNotExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EntityNotExistsException) Code() string {
+func (s *EntityNotExistsException) Code() string {
 	return "EntityNotExistsException"
 }
 
 // Message returns the exception's message.
-func (s EntityNotExistsException) Message() string {
+func (s *EntityNotExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8057,21 +8057,21 @@ func (s EntityNotExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EntityNotExistsException) OrigErr() error {
+func (s *EntityNotExistsException) OrigErr() error {
 	return nil
 }
 
-func (s EntityNotExistsException) Error() string {
+func (s *EntityNotExistsException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EntityNotExistsException) StatusCode() int {
+func (s *EntityNotExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EntityNotExistsException) RequestID() string {
+func (s *EntityNotExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8102,12 +8102,12 @@ func newErrorFailedDependencyException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s FailedDependencyException) Code() string {
+func (s *FailedDependencyException) Code() string {
 	return "FailedDependencyException"
 }
 
 // Message returns the exception's message.
-func (s FailedDependencyException) Message() string {
+func (s *FailedDependencyException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8115,21 +8115,21 @@ func (s FailedDependencyException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s FailedDependencyException) OrigErr() error {
+func (s *FailedDependencyException) OrigErr() error {
 	return nil
 }
 
-func (s FailedDependencyException) Error() string {
+func (s *FailedDependencyException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s FailedDependencyException) StatusCode() int {
+func (s *FailedDependencyException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s FailedDependencyException) RequestID() string {
+func (s *FailedDependencyException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9038,12 +9038,12 @@ func newErrorIllegalUserStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s IllegalUserStateException) Code() string {
+func (s *IllegalUserStateException) Code() string {
 	return "IllegalUserStateException"
 }
 
 // Message returns the exception's message.
-func (s IllegalUserStateException) Message() string {
+func (s *IllegalUserStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9051,21 +9051,21 @@ func (s IllegalUserStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s IllegalUserStateException) OrigErr() error {
+func (s *IllegalUserStateException) OrigErr() error {
 	return nil
 }
 
-func (s IllegalUserStateException) Error() string {
+func (s *IllegalUserStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s IllegalUserStateException) StatusCode() int {
+func (s *IllegalUserStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s IllegalUserStateException) RequestID() string {
+func (s *IllegalUserStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9243,12 +9243,12 @@ func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidArgumentException) Code() string {
+func (s *InvalidArgumentException) Code() string {
 	return "InvalidArgumentException"
 }
 
 // Message returns the exception's message.
-func (s InvalidArgumentException) Message() string {
+func (s *InvalidArgumentException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9256,21 +9256,21 @@ func (s InvalidArgumentException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidArgumentException) OrigErr() error {
+func (s *InvalidArgumentException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidArgumentException) Error() string {
+func (s *InvalidArgumentException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidArgumentException) StatusCode() int {
+func (s *InvalidArgumentException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidArgumentException) RequestID() string {
+func (s *InvalidArgumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9299,12 +9299,12 @@ func newErrorInvalidCommentOperationException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s InvalidCommentOperationException) Code() string {
+func (s *InvalidCommentOperationException) Code() string {
 	return "InvalidCommentOperationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidCommentOperationException) Message() string {
+func (s *InvalidCommentOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9312,21 +9312,21 @@ func (s InvalidCommentOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidCommentOperationException) OrigErr() error {
+func (s *InvalidCommentOperationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidCommentOperationException) Error() string {
+func (s *InvalidCommentOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidCommentOperationException) StatusCode() int {
+func (s *InvalidCommentOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidCommentOperationException) RequestID() string {
+func (s *InvalidCommentOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9355,12 +9355,12 @@ func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidOperationException) Code() string {
+func (s *InvalidOperationException) Code() string {
 	return "InvalidOperationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidOperationException) Message() string {
+func (s *InvalidOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9368,21 +9368,21 @@ func (s InvalidOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidOperationException) OrigErr() error {
+func (s *InvalidOperationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidOperationException) Error() string {
+func (s *InvalidOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidOperationException) StatusCode() int {
+func (s *InvalidOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidOperationException) RequestID() string {
+func (s *InvalidOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9411,12 +9411,12 @@ func newErrorInvalidPasswordException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPasswordException) Code() string {
+func (s *InvalidPasswordException) Code() string {
 	return "InvalidPasswordException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPasswordException) Message() string {
+func (s *InvalidPasswordException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9424,21 +9424,21 @@ func (s InvalidPasswordException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPasswordException) OrigErr() error {
+func (s *InvalidPasswordException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPasswordException) Error() string {
+func (s *InvalidPasswordException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPasswordException) StatusCode() int {
+func (s *InvalidPasswordException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPasswordException) RequestID() string {
+func (s *InvalidPasswordException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9467,12 +9467,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9480,21 +9480,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9664,12 +9664,12 @@ func newErrorProhibitedStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ProhibitedStateException) Code() string {
+func (s *ProhibitedStateException) Code() string {
 	return "ProhibitedStateException"
 }
 
 // Message returns the exception's message.
-func (s ProhibitedStateException) Message() string {
+func (s *ProhibitedStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9677,21 +9677,21 @@ func (s ProhibitedStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ProhibitedStateException) OrigErr() error {
+func (s *ProhibitedStateException) OrigErr() error {
 	return nil
 }
 
-func (s ProhibitedStateException) Error() string {
+func (s *ProhibitedStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ProhibitedStateException) StatusCode() int {
+func (s *ProhibitedStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ProhibitedStateException) RequestID() string {
+func (s *ProhibitedStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9883,12 +9883,12 @@ func newErrorRequestedEntityTooLargeException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s RequestedEntityTooLargeException) Code() string {
+func (s *RequestedEntityTooLargeException) Code() string {
 	return "RequestedEntityTooLargeException"
 }
 
 // Message returns the exception's message.
-func (s RequestedEntityTooLargeException) Message() string {
+func (s *RequestedEntityTooLargeException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9896,21 +9896,21 @@ func (s RequestedEntityTooLargeException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RequestedEntityTooLargeException) OrigErr() error {
+func (s *RequestedEntityTooLargeException) OrigErr() error {
 	return nil
 }
 
-func (s RequestedEntityTooLargeException) Error() string {
+func (s *RequestedEntityTooLargeException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RequestedEntityTooLargeException) StatusCode() int {
+func (s *RequestedEntityTooLargeException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RequestedEntityTooLargeException) RequestID() string {
+func (s *RequestedEntityTooLargeException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9939,12 +9939,12 @@ func newErrorResourceAlreadyCheckedOutException(v protocol.ResponseMetadata) err
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyCheckedOutException) Code() string {
+func (s *ResourceAlreadyCheckedOutException) Code() string {
 	return "ResourceAlreadyCheckedOutException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyCheckedOutException) Message() string {
+func (s *ResourceAlreadyCheckedOutException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9952,21 +9952,21 @@ func (s ResourceAlreadyCheckedOutException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyCheckedOutException) OrigErr() error {
+func (s *ResourceAlreadyCheckedOutException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyCheckedOutException) Error() string {
+func (s *ResourceAlreadyCheckedOutException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyCheckedOutException) StatusCode() int {
+func (s *ResourceAlreadyCheckedOutException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyCheckedOutException) RequestID() string {
+func (s *ResourceAlreadyCheckedOutException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10131,12 +10131,12 @@ func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ServiceUnavailableException) Code() string {
+func (s *ServiceUnavailableException) Code() string {
 	return "ServiceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ServiceUnavailableException) Message() string {
+func (s *ServiceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10144,21 +10144,21 @@ func (s ServiceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ServiceUnavailableException) OrigErr() error {
+func (s *ServiceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ServiceUnavailableException) Error() string {
+func (s *ServiceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ServiceUnavailableException) StatusCode() int {
+func (s *ServiceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ServiceUnavailableException) RequestID() string {
+func (s *ServiceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10326,12 +10326,12 @@ func newErrorStorageLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s StorageLimitExceededException) Code() string {
+func (s *StorageLimitExceededException) Code() string {
 	return "StorageLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s StorageLimitExceededException) Message() string {
+func (s *StorageLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10339,21 +10339,21 @@ func (s StorageLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StorageLimitExceededException) OrigErr() error {
+func (s *StorageLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s StorageLimitExceededException) Error() string {
+func (s *StorageLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StorageLimitExceededException) StatusCode() int {
+func (s *StorageLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StorageLimitExceededException) RequestID() string {
+func (s *StorageLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10382,12 +10382,12 @@ func newErrorStorageLimitWillExceedException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s StorageLimitWillExceedException) Code() string {
+func (s *StorageLimitWillExceedException) Code() string {
 	return "StorageLimitWillExceedException"
 }
 
 // Message returns the exception's message.
-func (s StorageLimitWillExceedException) Message() string {
+func (s *StorageLimitWillExceedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10395,21 +10395,21 @@ func (s StorageLimitWillExceedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s StorageLimitWillExceedException) OrigErr() error {
+func (s *StorageLimitWillExceedException) OrigErr() error {
 	return nil
 }
 
-func (s StorageLimitWillExceedException) Error() string {
+func (s *StorageLimitWillExceedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s StorageLimitWillExceedException) StatusCode() int {
+func (s *StorageLimitWillExceedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s StorageLimitWillExceedException) RequestID() string {
+func (s *StorageLimitWillExceedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10513,12 +10513,12 @@ func newErrorTooManyLabelsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyLabelsException) Code() string {
+func (s *TooManyLabelsException) Code() string {
 	return "TooManyLabelsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyLabelsException) Message() string {
+func (s *TooManyLabelsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10526,21 +10526,21 @@ func (s TooManyLabelsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyLabelsException) OrigErr() error {
+func (s *TooManyLabelsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyLabelsException) Error() string {
+func (s *TooManyLabelsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyLabelsException) StatusCode() int {
+func (s *TooManyLabelsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyLabelsException) RequestID() string {
+func (s *TooManyLabelsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10570,12 +10570,12 @@ func newErrorTooManySubscriptionsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManySubscriptionsException) Code() string {
+func (s *TooManySubscriptionsException) Code() string {
 	return "TooManySubscriptionsException"
 }
 
 // Message returns the exception's message.
-func (s TooManySubscriptionsException) Message() string {
+func (s *TooManySubscriptionsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10583,21 +10583,21 @@ func (s TooManySubscriptionsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManySubscriptionsException) OrigErr() error {
+func (s *TooManySubscriptionsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManySubscriptionsException) Error() string {
+func (s *TooManySubscriptionsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManySubscriptionsException) StatusCode() int {
+func (s *TooManySubscriptionsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManySubscriptionsException) RequestID() string {
+func (s *TooManySubscriptionsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10626,12 +10626,12 @@ func newErrorUnauthorizedOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedOperationException) Code() string {
+func (s *UnauthorizedOperationException) Code() string {
 	return "UnauthorizedOperationException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedOperationException) Message() string {
+func (s *UnauthorizedOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10639,21 +10639,21 @@ func (s UnauthorizedOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedOperationException) OrigErr() error {
+func (s *UnauthorizedOperationException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedOperationException) Error() string {
+func (s *UnauthorizedOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedOperationException) StatusCode() int {
+func (s *UnauthorizedOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedOperationException) RequestID() string {
+func (s *UnauthorizedOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -10682,12 +10682,12 @@ func newErrorUnauthorizedResourceAccessException(v protocol.ResponseMetadata) er
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedResourceAccessException) Code() string {
+func (s *UnauthorizedResourceAccessException) Code() string {
 	return "UnauthorizedResourceAccessException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedResourceAccessException) Message() string {
+func (s *UnauthorizedResourceAccessException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -10695,21 +10695,21 @@ func (s UnauthorizedResourceAccessException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedResourceAccessException) OrigErr() error {
+func (s *UnauthorizedResourceAccessException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedResourceAccessException) Error() string {
+func (s *UnauthorizedResourceAccessException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedResourceAccessException) StatusCode() int {
+func (s *UnauthorizedResourceAccessException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedResourceAccessException) RequestID() string {
+func (s *UnauthorizedResourceAccessException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/worklink/api.go
+++ b/service/worklink/api.go
@@ -4670,12 +4670,12 @@ func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InternalServerErrorException) Code() string {
+func (s *InternalServerErrorException) Code() string {
 	return "InternalServerErrorException"
 }
 
 // Message returns the exception's message.
-func (s InternalServerErrorException) Message() string {
+func (s *InternalServerErrorException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4683,21 +4683,21 @@ func (s InternalServerErrorException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InternalServerErrorException) OrigErr() error {
+func (s *InternalServerErrorException) OrigErr() error {
 	return nil
 }
 
-func (s InternalServerErrorException) Error() string {
+func (s *InternalServerErrorException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InternalServerErrorException) StatusCode() int {
+func (s *InternalServerErrorException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InternalServerErrorException) RequestID() string {
+func (s *InternalServerErrorException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4726,12 +4726,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4739,21 +4739,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5260,12 +5260,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5273,21 +5273,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5316,12 +5316,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5329,21 +5329,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5588,12 +5588,12 @@ func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyRequestsException) Code() string {
+func (s *TooManyRequestsException) Code() string {
 	return "TooManyRequestsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyRequestsException) Message() string {
+func (s *TooManyRequestsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5601,21 +5601,21 @@ func (s TooManyRequestsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyRequestsException) OrigErr() error {
+func (s *TooManyRequestsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyRequestsException) Error() string {
+func (s *TooManyRequestsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyRequestsException) StatusCode() int {
+func (s *TooManyRequestsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyRequestsException) RequestID() string {
+func (s *TooManyRequestsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5644,12 +5644,12 @@ func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnauthorizedException) Code() string {
+func (s *UnauthorizedException) Code() string {
 	return "UnauthorizedException"
 }
 
 // Message returns the exception's message.
-func (s UnauthorizedException) Message() string {
+func (s *UnauthorizedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5657,21 +5657,21 @@ func (s UnauthorizedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnauthorizedException) OrigErr() error {
+func (s *UnauthorizedException) OrigErr() error {
 	return nil
 }
 
-func (s UnauthorizedException) Error() string {
+func (s *UnauthorizedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnauthorizedException) StatusCode() int {
+func (s *UnauthorizedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnauthorizedException) RequestID() string {
+func (s *UnauthorizedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/workmail/api.go
+++ b/service/workmail/api.go
@@ -6155,12 +6155,12 @@ func newErrorDirectoryServiceAuthenticationFailedException(v protocol.ResponseMe
 }
 
 // Code returns the exception type name.
-func (s DirectoryServiceAuthenticationFailedException) Code() string {
+func (s *DirectoryServiceAuthenticationFailedException) Code() string {
 	return "DirectoryServiceAuthenticationFailedException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryServiceAuthenticationFailedException) Message() string {
+func (s *DirectoryServiceAuthenticationFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6168,21 +6168,21 @@ func (s DirectoryServiceAuthenticationFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryServiceAuthenticationFailedException) OrigErr() error {
+func (s *DirectoryServiceAuthenticationFailedException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryServiceAuthenticationFailedException) Error() string {
+func (s *DirectoryServiceAuthenticationFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryServiceAuthenticationFailedException) StatusCode() int {
+func (s *DirectoryServiceAuthenticationFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryServiceAuthenticationFailedException) RequestID() string {
+func (s *DirectoryServiceAuthenticationFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6211,12 +6211,12 @@ func newErrorDirectoryUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s DirectoryUnavailableException) Code() string {
+func (s *DirectoryUnavailableException) Code() string {
 	return "DirectoryUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s DirectoryUnavailableException) Message() string {
+func (s *DirectoryUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6224,21 +6224,21 @@ func (s DirectoryUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s DirectoryUnavailableException) OrigErr() error {
+func (s *DirectoryUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s DirectoryUnavailableException) Error() string {
+func (s *DirectoryUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s DirectoryUnavailableException) StatusCode() int {
+func (s *DirectoryUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s DirectoryUnavailableException) RequestID() string {
+func (s *DirectoryUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6438,12 +6438,12 @@ func newErrorEmailAddressInUseException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EmailAddressInUseException) Code() string {
+func (s *EmailAddressInUseException) Code() string {
 	return "EmailAddressInUseException"
 }
 
 // Message returns the exception's message.
-func (s EmailAddressInUseException) Message() string {
+func (s *EmailAddressInUseException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6451,21 +6451,21 @@ func (s EmailAddressInUseException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EmailAddressInUseException) OrigErr() error {
+func (s *EmailAddressInUseException) OrigErr() error {
 	return nil
 }
 
-func (s EmailAddressInUseException) Error() string {
+func (s *EmailAddressInUseException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EmailAddressInUseException) StatusCode() int {
+func (s *EmailAddressInUseException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EmailAddressInUseException) RequestID() string {
+func (s *EmailAddressInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6494,12 +6494,12 @@ func newErrorEntityAlreadyRegisteredException(v protocol.ResponseMetadata) error
 }
 
 // Code returns the exception type name.
-func (s EntityAlreadyRegisteredException) Code() string {
+func (s *EntityAlreadyRegisteredException) Code() string {
 	return "EntityAlreadyRegisteredException"
 }
 
 // Message returns the exception's message.
-func (s EntityAlreadyRegisteredException) Message() string {
+func (s *EntityAlreadyRegisteredException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6507,21 +6507,21 @@ func (s EntityAlreadyRegisteredException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EntityAlreadyRegisteredException) OrigErr() error {
+func (s *EntityAlreadyRegisteredException) OrigErr() error {
 	return nil
 }
 
-func (s EntityAlreadyRegisteredException) Error() string {
+func (s *EntityAlreadyRegisteredException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EntityAlreadyRegisteredException) StatusCode() int {
+func (s *EntityAlreadyRegisteredException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EntityAlreadyRegisteredException) RequestID() string {
+func (s *EntityAlreadyRegisteredException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6551,12 +6551,12 @@ func newErrorEntityNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EntityNotFoundException) Code() string {
+func (s *EntityNotFoundException) Code() string {
 	return "EntityNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s EntityNotFoundException) Message() string {
+func (s *EntityNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6564,21 +6564,21 @@ func (s EntityNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EntityNotFoundException) OrigErr() error {
+func (s *EntityNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s EntityNotFoundException) Error() string {
+func (s *EntityNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EntityNotFoundException) StatusCode() int {
+func (s *EntityNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EntityNotFoundException) RequestID() string {
+func (s *EntityNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6608,12 +6608,12 @@ func newErrorEntityStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s EntityStateException) Code() string {
+func (s *EntityStateException) Code() string {
 	return "EntityStateException"
 }
 
 // Message returns the exception's message.
-func (s EntityStateException) Message() string {
+func (s *EntityStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6621,21 +6621,21 @@ func (s EntityStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s EntityStateException) OrigErr() error {
+func (s *EntityStateException) OrigErr() error {
 	return nil
 }
 
-func (s EntityStateException) Error() string {
+func (s *EntityStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s EntityStateException) StatusCode() int {
+func (s *EntityStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s EntityStateException) RequestID() string {
+func (s *EntityStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6945,12 +6945,12 @@ func newErrorInvalidConfigurationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidConfigurationException) Code() string {
+func (s *InvalidConfigurationException) Code() string {
 	return "InvalidConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s InvalidConfigurationException) Message() string {
+func (s *InvalidConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6958,21 +6958,21 @@ func (s InvalidConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidConfigurationException) OrigErr() error {
+func (s *InvalidConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidConfigurationException) Error() string {
+func (s *InvalidConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidConfigurationException) StatusCode() int {
+func (s *InvalidConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidConfigurationException) RequestID() string {
+func (s *InvalidConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7001,12 +7001,12 @@ func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterException) Code() string {
+func (s *InvalidParameterException) Code() string {
 	return "InvalidParameterException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterException) Message() string {
+func (s *InvalidParameterException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7014,21 +7014,21 @@ func (s InvalidParameterException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterException) OrigErr() error {
+func (s *InvalidParameterException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterException) Error() string {
+func (s *InvalidParameterException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterException) StatusCode() int {
+func (s *InvalidParameterException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterException) RequestID() string {
+func (s *InvalidParameterException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7058,12 +7058,12 @@ func newErrorInvalidPasswordException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidPasswordException) Code() string {
+func (s *InvalidPasswordException) Code() string {
 	return "InvalidPasswordException"
 }
 
 // Message returns the exception's message.
-func (s InvalidPasswordException) Message() string {
+func (s *InvalidPasswordException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7071,21 +7071,21 @@ func (s InvalidPasswordException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidPasswordException) OrigErr() error {
+func (s *InvalidPasswordException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidPasswordException) Error() string {
+func (s *InvalidPasswordException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidPasswordException) StatusCode() int {
+func (s *InvalidPasswordException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidPasswordException) RequestID() string {
+func (s *InvalidPasswordException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7114,12 +7114,12 @@ func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s LimitExceededException) Code() string {
+func (s *LimitExceededException) Code() string {
 	return "LimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s LimitExceededException) Message() string {
+func (s *LimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7127,21 +7127,21 @@ func (s LimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s LimitExceededException) OrigErr() error {
+func (s *LimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s LimitExceededException) Error() string {
+func (s *LimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s LimitExceededException) StatusCode() int {
+func (s *LimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s LimitExceededException) RequestID() string {
+func (s *LimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8122,12 +8122,12 @@ func newErrorMailDomainNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MailDomainNotFoundException) Code() string {
+func (s *MailDomainNotFoundException) Code() string {
 	return "MailDomainNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s MailDomainNotFoundException) Message() string {
+func (s *MailDomainNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8135,21 +8135,21 @@ func (s MailDomainNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MailDomainNotFoundException) OrigErr() error {
+func (s *MailDomainNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s MailDomainNotFoundException) Error() string {
+func (s *MailDomainNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MailDomainNotFoundException) StatusCode() int {
+func (s *MailDomainNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MailDomainNotFoundException) RequestID() string {
+func (s *MailDomainNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8179,12 +8179,12 @@ func newErrorMailDomainStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s MailDomainStateException) Code() string {
+func (s *MailDomainStateException) Code() string {
 	return "MailDomainStateException"
 }
 
 // Message returns the exception's message.
-func (s MailDomainStateException) Message() string {
+func (s *MailDomainStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8192,21 +8192,21 @@ func (s MailDomainStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s MailDomainStateException) OrigErr() error {
+func (s *MailDomainStateException) OrigErr() error {
 	return nil
 }
 
-func (s MailDomainStateException) Error() string {
+func (s *MailDomainStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s MailDomainStateException) StatusCode() int {
+func (s *MailDomainStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s MailDomainStateException) RequestID() string {
+func (s *MailDomainStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8304,12 +8304,12 @@ func newErrorNameAvailabilityException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s NameAvailabilityException) Code() string {
+func (s *NameAvailabilityException) Code() string {
 	return "NameAvailabilityException"
 }
 
 // Message returns the exception's message.
-func (s NameAvailabilityException) Message() string {
+func (s *NameAvailabilityException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8317,21 +8317,21 @@ func (s NameAvailabilityException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s NameAvailabilityException) OrigErr() error {
+func (s *NameAvailabilityException) OrigErr() error {
 	return nil
 }
 
-func (s NameAvailabilityException) Error() string {
+func (s *NameAvailabilityException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s NameAvailabilityException) StatusCode() int {
+func (s *NameAvailabilityException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s NameAvailabilityException) RequestID() string {
+func (s *NameAvailabilityException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8361,12 +8361,12 @@ func newErrorOrganizationNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OrganizationNotFoundException) Code() string {
+func (s *OrganizationNotFoundException) Code() string {
 	return "OrganizationNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationNotFoundException) Message() string {
+func (s *OrganizationNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8374,21 +8374,21 @@ func (s OrganizationNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationNotFoundException) OrigErr() error {
+func (s *OrganizationNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationNotFoundException) Error() string {
+func (s *OrganizationNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationNotFoundException) StatusCode() int {
+func (s *OrganizationNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationNotFoundException) RequestID() string {
+func (s *OrganizationNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8418,12 +8418,12 @@ func newErrorOrganizationStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OrganizationStateException) Code() string {
+func (s *OrganizationStateException) Code() string {
 	return "OrganizationStateException"
 }
 
 // Message returns the exception's message.
-func (s OrganizationStateException) Message() string {
+func (s *OrganizationStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8431,21 +8431,21 @@ func (s OrganizationStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OrganizationStateException) OrigErr() error {
+func (s *OrganizationStateException) OrigErr() error {
 	return nil
 }
 
-func (s OrganizationStateException) Error() string {
+func (s *OrganizationStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OrganizationStateException) StatusCode() int {
+func (s *OrganizationStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OrganizationStateException) RequestID() string {
+func (s *OrganizationStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8929,12 +8929,12 @@ func newErrorReservedNameException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ReservedNameException) Code() string {
+func (s *ReservedNameException) Code() string {
 	return "ReservedNameException"
 }
 
 // Message returns the exception's message.
-func (s ReservedNameException) Message() string {
+func (s *ReservedNameException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8942,21 +8942,21 @@ func (s ReservedNameException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ReservedNameException) OrigErr() error {
+func (s *ReservedNameException) OrigErr() error {
 	return nil
 }
 
-func (s ReservedNameException) Error() string {
+func (s *ReservedNameException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ReservedNameException) StatusCode() int {
+func (s *ReservedNameException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ReservedNameException) RequestID() string {
+func (s *ReservedNameException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9147,12 +9147,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9160,21 +9160,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9338,12 +9338,12 @@ func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s TooManyTagsException) Code() string {
+func (s *TooManyTagsException) Code() string {
 	return "TooManyTagsException"
 }
 
 // Message returns the exception's message.
-func (s TooManyTagsException) Message() string {
+func (s *TooManyTagsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9351,21 +9351,21 @@ func (s TooManyTagsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s TooManyTagsException) OrigErr() error {
+func (s *TooManyTagsException) OrigErr() error {
 	return nil
 }
 
-func (s TooManyTagsException) Error() string {
+func (s *TooManyTagsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s TooManyTagsException) StatusCode() int {
+func (s *TooManyTagsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s TooManyTagsException) RequestID() string {
+func (s *TooManyTagsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9394,12 +9394,12 @@ func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s UnsupportedOperationException) Code() string {
+func (s *UnsupportedOperationException) Code() string {
 	return "UnsupportedOperationException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedOperationException) Message() string {
+func (s *UnsupportedOperationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9407,21 +9407,21 @@ func (s UnsupportedOperationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedOperationException) OrigErr() error {
+func (s *UnsupportedOperationException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedOperationException) Error() string {
+func (s *UnsupportedOperationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedOperationException) StatusCode() int {
+func (s *UnsupportedOperationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedOperationException) RequestID() string {
+func (s *UnsupportedOperationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/workmailmessageflow/api.go
+++ b/service/workmailmessageflow/api.go
@@ -182,12 +182,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -195,20 +195,20 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -3819,12 +3819,12 @@ func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s AccessDeniedException) Code() string {
+func (s *AccessDeniedException) Code() string {
 	return "AccessDeniedException"
 }
 
 // Message returns the exception's message.
-func (s AccessDeniedException) Message() string {
+func (s *AccessDeniedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -3832,21 +3832,21 @@ func (s AccessDeniedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s AccessDeniedException) OrigErr() error {
+func (s *AccessDeniedException) OrigErr() error {
 	return nil
 }
 
-func (s AccessDeniedException) Error() string {
+func (s *AccessDeniedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s AccessDeniedException) StatusCode() int {
+func (s *AccessDeniedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s AccessDeniedException) RequestID() string {
+func (s *AccessDeniedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6079,12 +6079,12 @@ func newErrorInvalidParameterValuesException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s InvalidParameterValuesException) Code() string {
+func (s *InvalidParameterValuesException) Code() string {
 	return "InvalidParameterValuesException"
 }
 
 // Message returns the exception's message.
-func (s InvalidParameterValuesException) Message() string {
+func (s *InvalidParameterValuesException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6092,21 +6092,21 @@ func (s InvalidParameterValuesException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidParameterValuesException) OrigErr() error {
+func (s *InvalidParameterValuesException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidParameterValuesException) Error() string {
+func (s *InvalidParameterValuesException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidParameterValuesException) StatusCode() int {
+func (s *InvalidParameterValuesException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidParameterValuesException) RequestID() string {
+func (s *InvalidParameterValuesException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6135,12 +6135,12 @@ func newErrorInvalidResourceStateException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidResourceStateException) Code() string {
+func (s *InvalidResourceStateException) Code() string {
 	return "InvalidResourceStateException"
 }
 
 // Message returns the exception's message.
-func (s InvalidResourceStateException) Message() string {
+func (s *InvalidResourceStateException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6148,21 +6148,21 @@ func (s InvalidResourceStateException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidResourceStateException) OrigErr() error {
+func (s *InvalidResourceStateException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidResourceStateException) Error() string {
+func (s *InvalidResourceStateException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidResourceStateException) StatusCode() int {
+func (s *InvalidResourceStateException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidResourceStateException) RequestID() string {
+func (s *InvalidResourceStateException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -6981,12 +6981,12 @@ func newErrorOperationInProgressException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationInProgressException) Code() string {
+func (s *OperationInProgressException) Code() string {
 	return "OperationInProgressException"
 }
 
 // Message returns the exception's message.
-func (s OperationInProgressException) Message() string {
+func (s *OperationInProgressException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -6994,21 +6994,21 @@ func (s OperationInProgressException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationInProgressException) OrigErr() error {
+func (s *OperationInProgressException) OrigErr() error {
 	return nil
 }
 
-func (s OperationInProgressException) Error() string {
+func (s *OperationInProgressException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationInProgressException) StatusCode() int {
+func (s *OperationInProgressException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationInProgressException) RequestID() string {
+func (s *OperationInProgressException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7037,12 +7037,12 @@ func newErrorOperationNotSupportedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s OperationNotSupportedException) Code() string {
+func (s *OperationNotSupportedException) Code() string {
 	return "OperationNotSupportedException"
 }
 
 // Message returns the exception's message.
-func (s OperationNotSupportedException) Message() string {
+func (s *OperationNotSupportedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7050,21 +7050,21 @@ func (s OperationNotSupportedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s OperationNotSupportedException) OrigErr() error {
+func (s *OperationNotSupportedException) OrigErr() error {
 	return nil
 }
 
-func (s OperationNotSupportedException) Error() string {
+func (s *OperationNotSupportedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s OperationNotSupportedException) StatusCode() int {
+func (s *OperationNotSupportedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s OperationNotSupportedException) RequestID() string {
+func (s *OperationNotSupportedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7450,12 +7450,12 @@ func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAlreadyExistsException) Code() string {
+func (s *ResourceAlreadyExistsException) Code() string {
 	return "ResourceAlreadyExistsException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAlreadyExistsException) Message() string {
+func (s *ResourceAlreadyExistsException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7463,21 +7463,21 @@ func (s ResourceAlreadyExistsException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAlreadyExistsException) OrigErr() error {
+func (s *ResourceAlreadyExistsException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAlreadyExistsException) Error() string {
+func (s *ResourceAlreadyExistsException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAlreadyExistsException) StatusCode() int {
+func (s *ResourceAlreadyExistsException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAlreadyExistsException) RequestID() string {
+func (s *ResourceAlreadyExistsException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7506,12 +7506,12 @@ func newErrorResourceAssociatedException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceAssociatedException) Code() string {
+func (s *ResourceAssociatedException) Code() string {
 	return "ResourceAssociatedException"
 }
 
 // Message returns the exception's message.
-func (s ResourceAssociatedException) Message() string {
+func (s *ResourceAssociatedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7519,21 +7519,21 @@ func (s ResourceAssociatedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceAssociatedException) OrigErr() error {
+func (s *ResourceAssociatedException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceAssociatedException) Error() string {
+func (s *ResourceAssociatedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceAssociatedException) StatusCode() int {
+func (s *ResourceAssociatedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceAssociatedException) RequestID() string {
+func (s *ResourceAssociatedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7562,12 +7562,12 @@ func newErrorResourceCreationFailedException(v protocol.ResponseMetadata) error 
 }
 
 // Code returns the exception type name.
-func (s ResourceCreationFailedException) Code() string {
+func (s *ResourceCreationFailedException) Code() string {
 	return "ResourceCreationFailedException"
 }
 
 // Message returns the exception's message.
-func (s ResourceCreationFailedException) Message() string {
+func (s *ResourceCreationFailedException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7575,21 +7575,21 @@ func (s ResourceCreationFailedException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceCreationFailedException) OrigErr() error {
+func (s *ResourceCreationFailedException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceCreationFailedException) Error() string {
+func (s *ResourceCreationFailedException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceCreationFailedException) StatusCode() int {
+func (s *ResourceCreationFailedException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceCreationFailedException) RequestID() string {
+func (s *ResourceCreationFailedException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7619,12 +7619,12 @@ func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceLimitExceededException) Code() string {
+func (s *ResourceLimitExceededException) Code() string {
 	return "ResourceLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s ResourceLimitExceededException) Message() string {
+func (s *ResourceLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7632,21 +7632,21 @@ func (s ResourceLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceLimitExceededException) OrigErr() error {
+func (s *ResourceLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceLimitExceededException) Error() string {
+func (s *ResourceLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceLimitExceededException) StatusCode() int {
+func (s *ResourceLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceLimitExceededException) RequestID() string {
+func (s *ResourceLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7679,12 +7679,12 @@ func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceNotFoundException) Code() string {
+func (s *ResourceNotFoundException) Code() string {
 	return "ResourceNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s ResourceNotFoundException) Message() string {
+func (s *ResourceNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7692,21 +7692,21 @@ func (s ResourceNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceNotFoundException) OrigErr() error {
+func (s *ResourceNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceNotFoundException) Error() string {
+func (s *ResourceNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceNotFoundException) StatusCode() int {
+func (s *ResourceNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceNotFoundException) RequestID() string {
+func (s *ResourceNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -7739,12 +7739,12 @@ func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ResourceUnavailableException) Code() string {
+func (s *ResourceUnavailableException) Code() string {
 	return "ResourceUnavailableException"
 }
 
 // Message returns the exception's message.
-func (s ResourceUnavailableException) Message() string {
+func (s *ResourceUnavailableException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -7752,21 +7752,21 @@ func (s ResourceUnavailableException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ResourceUnavailableException) OrigErr() error {
+func (s *ResourceUnavailableException) OrigErr() error {
 	return nil
 }
 
-func (s ResourceUnavailableException) Error() string {
+func (s *ResourceUnavailableException) Error() string {
 	return fmt.Sprintf("%s: %s\n%s", s.Code(), s.Message(), s.String())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ResourceUnavailableException) StatusCode() int {
+func (s *ResourceUnavailableException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ResourceUnavailableException) RequestID() string {
+func (s *ResourceUnavailableException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8368,12 +8368,12 @@ func newErrorUnsupportedNetworkConfigurationException(v protocol.ResponseMetadat
 }
 
 // Code returns the exception type name.
-func (s UnsupportedNetworkConfigurationException) Code() string {
+func (s *UnsupportedNetworkConfigurationException) Code() string {
 	return "UnsupportedNetworkConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedNetworkConfigurationException) Message() string {
+func (s *UnsupportedNetworkConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8381,21 +8381,21 @@ func (s UnsupportedNetworkConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedNetworkConfigurationException) OrigErr() error {
+func (s *UnsupportedNetworkConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedNetworkConfigurationException) Error() string {
+func (s *UnsupportedNetworkConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedNetworkConfigurationException) StatusCode() int {
+func (s *UnsupportedNetworkConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedNetworkConfigurationException) RequestID() string {
+func (s *UnsupportedNetworkConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -8426,12 +8426,12 @@ func newErrorUnsupportedWorkspaceConfigurationException(v protocol.ResponseMetad
 }
 
 // Code returns the exception type name.
-func (s UnsupportedWorkspaceConfigurationException) Code() string {
+func (s *UnsupportedWorkspaceConfigurationException) Code() string {
 	return "UnsupportedWorkspaceConfigurationException"
 }
 
 // Message returns the exception's message.
-func (s UnsupportedWorkspaceConfigurationException) Message() string {
+func (s *UnsupportedWorkspaceConfigurationException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -8439,21 +8439,21 @@ func (s UnsupportedWorkspaceConfigurationException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s UnsupportedWorkspaceConfigurationException) OrigErr() error {
+func (s *UnsupportedWorkspaceConfigurationException) OrigErr() error {
 	return nil
 }
 
-func (s UnsupportedWorkspaceConfigurationException) Error() string {
+func (s *UnsupportedWorkspaceConfigurationException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s UnsupportedWorkspaceConfigurationException) StatusCode() int {
+func (s *UnsupportedWorkspaceConfigurationException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s UnsupportedWorkspaceConfigurationException) RequestID() string {
+func (s *UnsupportedWorkspaceConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -9482,12 +9482,12 @@ func newErrorWorkspacesDefaultRoleNotFoundException(v protocol.ResponseMetadata)
 }
 
 // Code returns the exception type name.
-func (s WorkspacesDefaultRoleNotFoundException) Code() string {
+func (s *WorkspacesDefaultRoleNotFoundException) Code() string {
 	return "WorkspacesDefaultRoleNotFoundException"
 }
 
 // Message returns the exception's message.
-func (s WorkspacesDefaultRoleNotFoundException) Message() string {
+func (s *WorkspacesDefaultRoleNotFoundException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -9495,21 +9495,21 @@ func (s WorkspacesDefaultRoleNotFoundException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s WorkspacesDefaultRoleNotFoundException) OrigErr() error {
+func (s *WorkspacesDefaultRoleNotFoundException) OrigErr() error {
 	return nil
 }
 
-func (s WorkspacesDefaultRoleNotFoundException) Error() string {
+func (s *WorkspacesDefaultRoleNotFoundException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s WorkspacesDefaultRoleNotFoundException) StatusCode() int {
+func (s *WorkspacesDefaultRoleNotFoundException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s WorkspacesDefaultRoleNotFoundException) RequestID() string {
+func (s *WorkspacesDefaultRoleNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 

--- a/service/xray/api.go
+++ b/service/xray/api.go
@@ -4395,12 +4395,12 @@ func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s InvalidRequestException) Code() string {
+func (s *InvalidRequestException) Code() string {
 	return "InvalidRequestException"
 }
 
 // Message returns the exception's message.
-func (s InvalidRequestException) Message() string {
+func (s *InvalidRequestException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4408,21 +4408,21 @@ func (s InvalidRequestException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s InvalidRequestException) OrigErr() error {
+func (s *InvalidRequestException) OrigErr() error {
 	return nil
 }
 
-func (s InvalidRequestException) Error() string {
+func (s *InvalidRequestException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s InvalidRequestException) StatusCode() int {
+func (s *InvalidRequestException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s InvalidRequestException) RequestID() string {
+func (s *InvalidRequestException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -4884,12 +4884,12 @@ func newErrorRuleLimitExceededException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s RuleLimitExceededException) Code() string {
+func (s *RuleLimitExceededException) Code() string {
 	return "RuleLimitExceededException"
 }
 
 // Message returns the exception's message.
-func (s RuleLimitExceededException) Message() string {
+func (s *RuleLimitExceededException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -4897,21 +4897,21 @@ func (s RuleLimitExceededException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s RuleLimitExceededException) OrigErr() error {
+func (s *RuleLimitExceededException) OrigErr() error {
 	return nil
 }
 
-func (s RuleLimitExceededException) Error() string {
+func (s *RuleLimitExceededException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s RuleLimitExceededException) StatusCode() int {
+func (s *RuleLimitExceededException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s RuleLimitExceededException) RequestID() string {
+func (s *RuleLimitExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
@@ -5968,12 +5968,12 @@ func newErrorThrottledException(v protocol.ResponseMetadata) error {
 }
 
 // Code returns the exception type name.
-func (s ThrottledException) Code() string {
+func (s *ThrottledException) Code() string {
 	return "ThrottledException"
 }
 
 // Message returns the exception's message.
-func (s ThrottledException) Message() string {
+func (s *ThrottledException) Message() string {
 	if s.Message_ != nil {
 		return *s.Message_
 	}
@@ -5981,21 +5981,21 @@ func (s ThrottledException) Message() string {
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.
-func (s ThrottledException) OrigErr() error {
+func (s *ThrottledException) OrigErr() error {
 	return nil
 }
 
-func (s ThrottledException) Error() string {
+func (s *ThrottledException) Error() string {
 	return fmt.Sprintf("%s: %s", s.Code(), s.Message())
 }
 
 // Status code returns the HTTP status code for the request's response error.
-func (s ThrottledException) StatusCode() int {
+func (s *ThrottledException) StatusCode() int {
 	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
-func (s ThrottledException) RequestID() string {
+func (s *ThrottledException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 


### PR DESCRIPTION
Fixes the generated SDK API errors to use pointer function receivers instead of value. This fixes potential confusion writing code and not casting to the correct type. The SDK will always return the API error as a pointer, not value.

Code that did type assertions from the operation's returned error to the value type would never be satisfied. Leading to errors being missed. Changing the function receiver to a pointer prevents this error. Highlighting it in code bases.

For example the following type assertion handling a service response would never work because the `cloudwatchlogs.DataAlreadyAcceptedException` error is returned as a pointer, not value.

```go
resp, err := client.SomeOperationCall(params)
if err != nil {
     switch tv := err.(type)  {
     case cloudwatchlogs.DataAlreadyAcceptedException:
          log.Printf("got DataAlreadyAcceptedException error, %s", tv.String()
     default:
          log.Printf("unknown error %T, %v", err, err)
     }
}
```

The code would need to be written with the type assertion on the pointer value, which is what the SDK will return.

```go
resp, err := client.SomeOperationCall(params)
if err != nil {
     switch tv := err.(type)  {
     case *cloudwatchlogs.DataAlreadyAcceptedException:
          log.Printf("got DataAlreadyAcceptedException error, %s", tv.String()
     default:
          log.Printf("unknown error %T, %v", err, err)
     }
}
```