### PR TITLE
private/model/api: Expose RespMetadata member on errors

### DIFF
--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -852,8 +852,8 @@ func (u unmarshalerForEventStreamEvent) UnmarshalerForEventName(eventType string
 }
 
 type ExceptionEvent struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	IntVal *int64 `type:"integer"`
 
@@ -936,8 +936,8 @@ func (s ExceptionEvent) RequestID() string {
 }
 
 type ExceptionEvent2 struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -853,7 +853,7 @@ func (u unmarshalerForEventStreamEvent) UnmarshalerForEventName(eventType string
 
 type ExceptionEvent struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	IntVal *int64 `type:"integer"`
 
@@ -899,7 +899,7 @@ func (s *ExceptionEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventst
 
 func newErrorExceptionEvent(v protocol.ResponseMetadata) error {
 	return &ExceptionEvent{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -927,17 +927,17 @@ func (s ExceptionEvent) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExceptionEvent) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExceptionEvent) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ExceptionEvent2 struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -981,7 +981,7 @@ func (s *ExceptionEvent2) MarshalEvent(pm protocol.PayloadMarshaler) (msg events
 
 func newErrorExceptionEvent2(v protocol.ResponseMetadata) error {
 	return &ExceptionEvent2{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1009,12 +1009,12 @@ func (s ExceptionEvent2) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExceptionEvent2) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExceptionEvent2) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ExplicitPayloadEvent struct {

--- a/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
@@ -455,7 +455,7 @@ func mockGetEventStreamReadEvents() (
 func TestGetEventStream_ReadException(t *testing.T) {
 	expectEvents := []EventStreamEvent{
 		&ExceptionEvent{
-			respMetadata: protocol.ResponseMetadata{
+			RespMetadata: protocol.ResponseMetadata{
 				StatusCode: 200,
 			},
 			IntVal:   aws.Int64(123),
@@ -510,7 +510,7 @@ func TestGetEventStream_ReadException(t *testing.T) {
 	}
 
 	expectErr := &ExceptionEvent{
-		respMetadata: protocol.ResponseMetadata{
+		RespMetadata: protocol.ResponseMetadata{
 			StatusCode: 200,
 		},
 		IntVal:   aws.Int64(123),

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -853,7 +853,7 @@ func (u unmarshalerForEventStreamEvent) UnmarshalerForEventName(eventType string
 
 type ExceptionEvent struct {
 	_            struct{} `locationName:"ExceptionEvent" type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	IntVal *int64 `type:"integer"`
 
@@ -899,7 +899,7 @@ func (s *ExceptionEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventst
 
 func newErrorExceptionEvent(v protocol.ResponseMetadata) error {
 	return &ExceptionEvent{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -927,17 +927,17 @@ func (s ExceptionEvent) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExceptionEvent) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExceptionEvent) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ExceptionEvent2 struct {
 	_            struct{} `locationName:"ExceptionEvent2" type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -981,7 +981,7 @@ func (s *ExceptionEvent2) MarshalEvent(pm protocol.PayloadMarshaler) (msg events
 
 func newErrorExceptionEvent2(v protocol.ResponseMetadata) error {
 	return &ExceptionEvent2{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1009,12 +1009,12 @@ func (s ExceptionEvent2) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExceptionEvent2) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExceptionEvent2) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ExplicitPayloadEvent struct {

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -852,8 +852,8 @@ func (u unmarshalerForEventStreamEvent) UnmarshalerForEventName(eventType string
 }
 
 type ExceptionEvent struct {
-	_            struct{} `locationName:"ExceptionEvent" type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `locationName:"ExceptionEvent" type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	IntVal *int64 `type:"integer"`
 
@@ -936,8 +936,8 @@ func (s ExceptionEvent) RequestID() string {
 }
 
 type ExceptionEvent2 struct {
-	_            struct{} `locationName:"ExceptionEvent2" type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `locationName:"ExceptionEvent2" type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
@@ -455,7 +455,7 @@ func mockGetEventStreamReadEvents() (
 func TestGetEventStream_ReadException(t *testing.T) {
 	expectEvents := []EventStreamEvent{
 		&ExceptionEvent{
-			respMetadata: protocol.ResponseMetadata{
+			RespMetadata: protocol.ResponseMetadata{
 				StatusCode: 200,
 			},
 			IntVal:   aws.Int64(123),
@@ -510,7 +510,7 @@ func TestGetEventStream_ReadException(t *testing.T) {
 	}
 
 	expectErr := &ExceptionEvent{
-		respMetadata: protocol.ResponseMetadata{
+		RespMetadata: protocol.ResponseMetadata{
 			StatusCode: 200,
 		},
 		IntVal:   aws.Int64(123),

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -966,7 +966,7 @@ func (u unmarshalerForEventStreamEvent) UnmarshalerForEventName(eventType string
 
 type ExceptionEvent struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	IntVal *int64 `type:"integer"`
 
@@ -1012,7 +1012,7 @@ func (s *ExceptionEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventst
 
 func newErrorExceptionEvent(v protocol.ResponseMetadata) error {
 	return &ExceptionEvent{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1040,17 +1040,17 @@ func (s ExceptionEvent) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExceptionEvent) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExceptionEvent) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ExceptionEvent2 struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1094,7 +1094,7 @@ func (s *ExceptionEvent2) MarshalEvent(pm protocol.PayloadMarshaler) (msg events
 
 func newErrorExceptionEvent2(v protocol.ResponseMetadata) error {
 	return &ExceptionEvent2{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1122,12 +1122,12 @@ func (s ExceptionEvent2) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExceptionEvent2) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExceptionEvent2) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ExplicitPayloadEvent struct {

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -965,8 +965,8 @@ func (u unmarshalerForEventStreamEvent) UnmarshalerForEventName(eventType string
 }
 
 type ExceptionEvent struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	IntVal *int64 `type:"integer"`
 
@@ -1049,8 +1049,8 @@ func (s ExceptionEvent) RequestID() string {
 }
 
 type ExceptionEvent2 struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/private/model/api/codegentest/service/rpcservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/rpcservice/eventstream_test.go
@@ -497,7 +497,7 @@ func TestGetEventStream_ReadException(t *testing.T) {
 			StrVal: aws.String("string value goes here"),
 		},
 		&ExceptionEvent{
-			respMetadata: protocol.ResponseMetadata{
+			RespMetadata: protocol.ResponseMetadata{
 				StatusCode: 200,
 			},
 			IntVal:   aws.Int64(123),
@@ -562,7 +562,7 @@ func TestGetEventStream_ReadException(t *testing.T) {
 	}
 
 	expectErr := &ExceptionEvent{
-		respMetadata: protocol.ResponseMetadata{
+		RespMetadata: protocol.ResponseMetadata{
 			StatusCode: 200,
 		},
 		IntVal:   aws.Int64(123),

--- a/private/model/api/eventstream_tmpl_readertests.go
+++ b/private/model/api/eventstream_tmpl_readertests.go
@@ -302,7 +302,7 @@ func (c *loopReader) Read(p []byte) (int, error) {
 {{ define "set event type" }}
 	&{{ $.ShapeName }}{
 		{{- if $.Exception }}
-			respMetadata: protocol.ResponseMetadata{
+			RespMetadata: protocol.ResponseMetadata{
 				StatusCode: 200,
 			},
 		{{- end }}

--- a/private/model/api/eventstream_tmpl_tests.go
+++ b/private/model/api/eventstream_tmpl_tests.go
@@ -103,7 +103,7 @@ func valueForType(s *Shape, visited []string) string {
 		w := bytes.NewBuffer(nil)
 		fmt.Fprintf(w, "&%s{\n", s.ShapeName)
 		if s.Exception {
-			fmt.Fprintf(w, `respMetadata: protocol.ResponseMetadata{
+			fmt.Fprintf(w, `RespMetadata: protocol.ResponseMetadata{
 	StatusCode: 200,
 },
 `)

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -414,7 +414,8 @@ func exceptionCollides(name string) bool {
 		"String",
 		"GoString",
 		"RequestID",
-		"StatusCode":
+		"StatusCode",
+		"RespMetadata":
 		return true
 	}
 	return false

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -691,7 +691,7 @@ type {{ $.ShapeName }} struct {
 
 	{{- if $.Exception }}
 		{{- $_ := $.API.AddSDKImport "private/protocol" }}
-		respMetadata protocol.ResponseMetadata
+		RespMetadata protocol.ResponseMetadata
 	{{- end }}
 
 	{{- if $.OutputEventStreamAPI }}
@@ -809,7 +809,7 @@ var exceptionShapeMethodTmpl = template.Must(
 {{/* TODO allow service custom input to be used */}}
 func newError{{ $.ShapeName }}(v protocol.ResponseMetadata) error {
 	return &{{ $.ShapeName }}{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -843,12 +843,12 @@ func (s {{ $.ShapeName }}) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s {{ $.ShapeName }}) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s {{ $.ShapeName }}) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 `))
 

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -691,7 +691,7 @@ type {{ $.ShapeName }} struct {
 
 	{{- if $.Exception }}
 		{{- $_ := $.API.AddSDKImport "private/protocol" }}
-		RespMetadata protocol.ResponseMetadata
+		RespMetadata protocol.ResponseMetadata` + "`json:\"-\" xml:\"-\"`" + `
 	{{- end }}
 
 	{{- if $.OutputEventStreamAPI }}

--- a/private/protocol/xml/xmlutil/build.go
+++ b/private/protocol/xml/xmlutil/build.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/private/protocol"
@@ -58,6 +59,14 @@ func (b *xmlBuilder) buildValue(value reflect.Value, current *XMLNode, tag refle
 		return nil
 	} else if tag.Get("location") != "" { // don't handle non-body location values
 		return nil
+	}
+
+	xml := tag.Get("xml")
+	if len(xml) != 0 {
+		name := strings.SplitAfterN(xml, ",", 2)[0]
+		if name == "-" {
+			return nil
+		}
 	}
 
 	t := tag.Get("type")

--- a/private/protocol/xml/xmlutil/unmarshal.go
+++ b/private/protocol/xml/xmlutil/unmarshal.go
@@ -64,6 +64,14 @@ func UnmarshalXML(v interface{}, d *xml.Decoder, wrapper string) error {
 // parse deserializes any value from the XMLNode. The type tag is used to infer the type, or reflect
 // will be used to determine the type from r.
 func parse(r reflect.Value, node *XMLNode, tag reflect.StructTag) error {
+	xml := tag.Get("xml")
+	if len(xml) != 0 {
+		name := strings.SplitAfterN(xml, ",", 2)[0]
+		if name == "-" {
+			return nil
+		}
+	}
+
 	rtype := r.Type()
 	if rtype.Kind() == reflect.Ptr {
 		rtype = rtype.Elem() // check kind of actual element type

--- a/service/accessanalyzer/api.go
+++ b/service/accessanalyzer/api.go
@@ -1901,7 +1901,7 @@ func (c *AccessAnalyzer) UpdateFindingsWithContext(ctx aws.Context, input *Updat
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1918,7 +1918,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1946,12 +1946,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about the analyzed resource.
@@ -2259,7 +2259,7 @@ func (s *ArchiveRuleSummary) SetUpdatedAt(v time.Time) *ArchiveRuleSummary {
 // A conflict exception error.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -2286,7 +2286,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2314,12 +2314,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Creates an analyzer.
@@ -3424,7 +3424,7 @@ func (s *InlineArchiveRule) SetRuleName(v string) *InlineArchiveRule {
 // Internal server error.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -3444,7 +3444,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3472,12 +3472,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Retrieves a list of resources that have been analyzed.
@@ -3943,7 +3943,7 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -3970,7 +3970,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3998,18 +3998,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Service quote met error.
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -4036,7 +4036,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4064,12 +4064,12 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The criteria used to sort.
@@ -4247,7 +4247,7 @@ func (s TagResourceOutput) GoString() string {
 // Throttling limit exceeded error.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -4267,7 +4267,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4295,12 +4295,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Removes a tag from the specified resource.
@@ -4580,7 +4580,7 @@ func (s UpdateFindingsOutput) GoString() string {
 // Validation exception error.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A list of fields that didn't validate.
 	FieldList []*ValidationExceptionField `locationName:"fieldList" type:"list"`
@@ -4605,7 +4605,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4633,12 +4633,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a validation exception.

--- a/service/accessanalyzer/api.go
+++ b/service/accessanalyzer/api.go
@@ -1900,8 +1900,8 @@ func (c *AccessAnalyzer) UpdateFindingsWithContext(ctx aws.Context, input *Updat
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2258,8 +2258,8 @@ func (s *ArchiveRuleSummary) SetUpdatedAt(v time.Time) *ArchiveRuleSummary {
 
 // A conflict exception error.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -3423,8 +3423,8 @@ func (s *InlineArchiveRule) SetRuleName(v string) *InlineArchiveRule {
 
 // Internal server error.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -3942,8 +3942,8 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -4008,8 +4008,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // Service quote met error.
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -4246,8 +4246,8 @@ func (s TagResourceOutput) GoString() string {
 
 // Throttling limit exceeded error.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -4579,8 +4579,8 @@ func (s UpdateFindingsOutput) GoString() string {
 
 // Validation exception error.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A list of fields that didn't validate.
 	FieldList []*ValidationExceptionField `locationName:"fieldList" type:"list"`

--- a/service/acm/api.go
+++ b/service/acm/api.go
@@ -2527,8 +2527,8 @@ func (s *ImportCertificateOutput) SetCertificateArn(v string) *ImportCertificate
 
 // One or more of of request parameters specified is not valid.
 type InvalidArgsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2583,8 +2583,8 @@ func (s InvalidArgsException) RequestID() string {
 
 // The requested Amazon Resource Name (ARN) does not refer to an existing resource.
 type InvalidArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2639,8 +2639,8 @@ func (s InvalidArnException) RequestID() string {
 
 // One or more values in the DomainValidationOption structure is incorrect.
 type InvalidDomainValidationOptionsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2695,8 +2695,8 @@ func (s InvalidDomainValidationOptionsException) RequestID() string {
 
 // An input parameter was invalid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2751,8 +2751,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // Processing has reached an invalid state.
 type InvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2808,8 +2808,8 @@ func (s InvalidStateException) RequestID() string {
 // One or both of the values that make up the key-value pair is not valid. For
 // example, you cannot specify a tag value that begins with aws:.
 type InvalidTagException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2889,8 +2889,8 @@ func (s *KeyUsage) SetName(v string) *KeyUsage {
 
 // An ACM limit has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3547,8 +3547,8 @@ func (s *RequestCertificateOutput) SetCertificateArn(v string) *RequestCertifica
 // The certificate request is in process and the certificate in your account
 // has not yet been issued.
 type RequestInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3715,8 +3715,8 @@ func (s ResendValidationEmailOutput) GoString() string {
 // The certificate is in use by another AWS service in the caller's account.
 // Remove the association and try again.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3772,8 +3772,8 @@ func (s ResourceInUseException) RequestID() string {
 // The specified certificate cannot be found in the caller's account or the
 // caller's account cannot be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3930,8 +3930,8 @@ func (s *Tag) SetValue(v string) *Tag {
 
 // A specified tag did not comply with an existing tag policy and was rejected.
 type TagPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3986,8 +3986,8 @@ func (s TagPolicyException) RequestID() string {
 
 // The request contains too many tags. Try the request again with fewer tags.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/acm/api.go
+++ b/service/acm/api.go
@@ -2528,7 +2528,7 @@ func (s *ImportCertificateOutput) SetCertificateArn(v string) *ImportCertificate
 // One or more of of request parameters specified is not valid.
 type InvalidArgsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2545,7 +2545,7 @@ func (s InvalidArgsException) GoString() string {
 
 func newErrorInvalidArgsException(v protocol.ResponseMetadata) error {
 	return &InvalidArgsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2573,18 +2573,18 @@ func (s InvalidArgsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested Amazon Resource Name (ARN) does not refer to an existing resource.
 type InvalidArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2601,7 +2601,7 @@ func (s InvalidArnException) GoString() string {
 
 func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 	return &InvalidArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2629,18 +2629,18 @@ func (s InvalidArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more values in the DomainValidationOption structure is incorrect.
 type InvalidDomainValidationOptionsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2657,7 +2657,7 @@ func (s InvalidDomainValidationOptionsException) GoString() string {
 
 func newErrorInvalidDomainValidationOptionsException(v protocol.ResponseMetadata) error {
 	return &InvalidDomainValidationOptionsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2685,18 +2685,18 @@ func (s InvalidDomainValidationOptionsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDomainValidationOptionsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDomainValidationOptionsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An input parameter was invalid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2713,7 +2713,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2741,18 +2741,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Processing has reached an invalid state.
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2769,7 +2769,7 @@ func (s InvalidStateException) GoString() string {
 
 func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 	return &InvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2797,19 +2797,19 @@ func (s InvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or both of the values that make up the key-value pair is not valid. For
 // example, you cannot specify a tag value that begins with aws:.
 type InvalidTagException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2826,7 +2826,7 @@ func (s InvalidTagException) GoString() string {
 
 func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 	return &InvalidTagException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2854,12 +2854,12 @@ func (s InvalidTagException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Key Usage X.509 v3 extension defines the purpose of the public key contained
@@ -2890,7 +2890,7 @@ func (s *KeyUsage) SetName(v string) *KeyUsage {
 // An ACM limit has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2907,7 +2907,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2935,12 +2935,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListCertificatesInput struct {
@@ -3548,7 +3548,7 @@ func (s *RequestCertificateOutput) SetCertificateArn(v string) *RequestCertifica
 // has not yet been issued.
 type RequestInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3565,7 +3565,7 @@ func (s RequestInProgressException) GoString() string {
 
 func newErrorRequestInProgressException(v protocol.ResponseMetadata) error {
 	return &RequestInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3593,12 +3593,12 @@ func (s RequestInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResendValidationEmailInput struct {
@@ -3716,7 +3716,7 @@ func (s ResendValidationEmailOutput) GoString() string {
 // Remove the association and try again.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3733,7 +3733,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3761,19 +3761,19 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified certificate cannot be found in the caller's account or the
 // caller's account cannot be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3790,7 +3790,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3818,12 +3818,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains a DNS record value that you can use to can use to validate ownership
@@ -3931,7 +3931,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // A specified tag did not comply with an existing tag policy and was rejected.
 type TagPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3948,7 +3948,7 @@ func (s TagPolicyException) GoString() string {
 
 func newErrorTagPolicyException(v protocol.ResponseMetadata) error {
 	return &TagPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3976,18 +3976,18 @@ func (s TagPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request contains too many tags. Try the request again with fewer tags.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4004,7 +4004,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4032,12 +4032,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateCertificateOptionsInput struct {

--- a/service/acmpca/api.go
+++ b/service/acmpca/api.go
@@ -2579,8 +2579,8 @@ func (s *CertificateAuthorityConfiguration) SetSubject(v *ASN1Subject) *Certific
 // The certificate authority certificate you are importing does not comply with
 // conditions specified in the certificate that signed it.
 type CertificateMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2635,8 +2635,8 @@ func (s CertificateMismatchException) RequestID() string {
 
 // A previous update to your private CA is still ongoing.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3848,8 +3848,8 @@ func (s ImportCertificateAuthorityCertificateOutput) GoString() string {
 
 // One or more of the specified arguments was not valid.
 type InvalidArgsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3904,8 +3904,8 @@ func (s InvalidArgsException) RequestID() string {
 
 // The requested Amazon Resource Name (ARN) does not refer to an existing resource.
 type InvalidArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3961,8 +3961,8 @@ func (s InvalidArnException) RequestID() string {
 // The token specified in the NextToken argument is not valid. Use the token
 // returned from your previous call to ListCertificateAuthorities.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4018,8 +4018,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // The S3 bucket policy is not valid. The policy must give ACM Private CA rights
 // to read from and write to the bucket and find the bucket location.
 type InvalidPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4074,8 +4074,8 @@ func (s InvalidPolicyException) RequestID() string {
 
 // The request action cannot be performed or is prohibited.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4131,8 +4131,8 @@ func (s InvalidRequestException) RequestID() string {
 // The private CA is in a state during which a report or certificate cannot
 // be generated.
 type InvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4188,8 +4188,8 @@ func (s InvalidStateException) RequestID() string {
 // The tag associated with the CA is not valid. The invalid argument is contained
 // in the message field.
 type InvalidTagException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4428,8 +4428,8 @@ func (s *IssueCertificateOutput) SetCertificateArn(v string) *IssueCertificateOu
 // An ACM Private CA limit has been exceeded. See the exception message returned
 // to determine the limit that was exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4784,8 +4784,8 @@ func (s *ListTagsOutput) SetTags(v []*Tag) *ListTagsOutput {
 
 // The certificate signing request is invalid.
 type MalformedCSRException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4840,8 +4840,8 @@ func (s MalformedCSRException) RequestID() string {
 
 // One or more fields in the certificate are invalid.
 type MalformedCertificateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4972,8 +4972,8 @@ func (s *Permission) SetSourceAccount(v string) *Permission {
 
 // The designated permission has already been given to the user.
 type PermissionAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5028,8 +5028,8 @@ func (s PermissionAlreadyExistsException) RequestID() string {
 
 // Your request has already been completed.
 type RequestAlreadyProcessedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5084,8 +5084,8 @@ func (s RequestAlreadyProcessedException) RequestID() string {
 
 // The request has failed for an unspecified reason.
 type RequestFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5140,8 +5140,8 @@ func (s RequestFailedException) RequestID() string {
 
 // Your request is already in progress.
 type RequestInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5197,8 +5197,8 @@ func (s RequestInProgressException) RequestID() string {
 // A resource such as a private CA, S3 bucket, certificate, or audit report
 // cannot be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5593,8 +5593,8 @@ func (s TagCertificateAuthorityOutput) GoString() string {
 // You can associate up to 50 tags with a private CA. Exception information
 // is contained in the exception message field.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/acmpca/api.go
+++ b/service/acmpca/api.go
@@ -2580,7 +2580,7 @@ func (s *CertificateAuthorityConfiguration) SetSubject(v *ASN1Subject) *Certific
 // conditions specified in the certificate that signed it.
 type CertificateMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2597,7 +2597,7 @@ func (s CertificateMismatchException) GoString() string {
 
 func newErrorCertificateMismatchException(v protocol.ResponseMetadata) error {
 	return &CertificateMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2625,18 +2625,18 @@ func (s CertificateMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CertificateMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CertificateMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A previous update to your private CA is still ongoing.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2653,7 +2653,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2681,12 +2681,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateCertificateAuthorityAuditReportInput struct {
@@ -3849,7 +3849,7 @@ func (s ImportCertificateAuthorityCertificateOutput) GoString() string {
 // One or more of the specified arguments was not valid.
 type InvalidArgsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3866,7 +3866,7 @@ func (s InvalidArgsException) GoString() string {
 
 func newErrorInvalidArgsException(v protocol.ResponseMetadata) error {
 	return &InvalidArgsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3894,18 +3894,18 @@ func (s InvalidArgsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested Amazon Resource Name (ARN) does not refer to an existing resource.
 type InvalidArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3922,7 +3922,7 @@ func (s InvalidArnException) GoString() string {
 
 func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 	return &InvalidArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3950,19 +3950,19 @@ func (s InvalidArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The token specified in the NextToken argument is not valid. Use the token
 // returned from your previous call to ListCertificateAuthorities.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3979,7 +3979,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4007,19 +4007,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The S3 bucket policy is not valid. The policy must give ACM Private CA rights
 // to read from and write to the bucket and find the bucket location.
 type InvalidPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4036,7 +4036,7 @@ func (s InvalidPolicyException) GoString() string {
 
 func newErrorInvalidPolicyException(v protocol.ResponseMetadata) error {
 	return &InvalidPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4064,18 +4064,18 @@ func (s InvalidPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request action cannot be performed or is prohibited.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4092,7 +4092,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4120,19 +4120,19 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The private CA is in a state during which a report or certificate cannot
 // be generated.
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4149,7 +4149,7 @@ func (s InvalidStateException) GoString() string {
 
 func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 	return &InvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4177,19 +4177,19 @@ func (s InvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The tag associated with the CA is not valid. The invalid argument is contained
 // in the message field.
 type InvalidTagException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4206,7 +4206,7 @@ func (s InvalidTagException) GoString() string {
 
 func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 	return &InvalidTagException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4234,12 +4234,12 @@ func (s InvalidTagException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type IssueCertificateInput struct {
@@ -4429,7 +4429,7 @@ func (s *IssueCertificateOutput) SetCertificateArn(v string) *IssueCertificateOu
 // to determine the limit that was exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4446,7 +4446,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4474,12 +4474,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListCertificateAuthoritiesInput struct {
@@ -4785,7 +4785,7 @@ func (s *ListTagsOutput) SetTags(v []*Tag) *ListTagsOutput {
 // The certificate signing request is invalid.
 type MalformedCSRException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4802,7 +4802,7 @@ func (s MalformedCSRException) GoString() string {
 
 func newErrorMalformedCSRException(v protocol.ResponseMetadata) error {
 	return &MalformedCSRException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4830,18 +4830,18 @@ func (s MalformedCSRException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MalformedCSRException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MalformedCSRException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more fields in the certificate are invalid.
 type MalformedCertificateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4858,7 +4858,7 @@ func (s MalformedCertificateException) GoString() string {
 
 func newErrorMalformedCertificateException(v protocol.ResponseMetadata) error {
 	return &MalformedCertificateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4886,12 +4886,12 @@ func (s MalformedCertificateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MalformedCertificateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MalformedCertificateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Permissions designate which private CA actions can be performed by an AWS
@@ -4973,7 +4973,7 @@ func (s *Permission) SetSourceAccount(v string) *Permission {
 // The designated permission has already been given to the user.
 type PermissionAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4990,7 +4990,7 @@ func (s PermissionAlreadyExistsException) GoString() string {
 
 func newErrorPermissionAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &PermissionAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5018,18 +5018,18 @@ func (s PermissionAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PermissionAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PermissionAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Your request has already been completed.
 type RequestAlreadyProcessedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5046,7 +5046,7 @@ func (s RequestAlreadyProcessedException) GoString() string {
 
 func newErrorRequestAlreadyProcessedException(v protocol.ResponseMetadata) error {
 	return &RequestAlreadyProcessedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5074,18 +5074,18 @@ func (s RequestAlreadyProcessedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestAlreadyProcessedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestAlreadyProcessedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request has failed for an unspecified reason.
 type RequestFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5102,7 +5102,7 @@ func (s RequestFailedException) GoString() string {
 
 func newErrorRequestFailedException(v protocol.ResponseMetadata) error {
 	return &RequestFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5130,18 +5130,18 @@ func (s RequestFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Your request is already in progress.
 type RequestInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5158,7 +5158,7 @@ func (s RequestInProgressException) GoString() string {
 
 func newErrorRequestInProgressException(v protocol.ResponseMetadata) error {
 	return &RequestInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5186,19 +5186,19 @@ func (s RequestInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A resource such as a private CA, S3 bucket, certificate, or audit report
 // cannot be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5215,7 +5215,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5243,12 +5243,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RestoreCertificateAuthorityInput struct {
@@ -5594,7 +5594,7 @@ func (s TagCertificateAuthorityOutput) GoString() string {
 // is contained in the exception message field.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5611,7 +5611,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5639,12 +5639,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagCertificateAuthorityInput struct {

--- a/service/alexaforbusiness/api.go
+++ b/service/alexaforbusiness/api.go
@@ -8725,8 +8725,8 @@ func (s *AddressBookData) SetName(v string) *AddressBookData {
 
 // The resource being created already exists.
 type AlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9497,8 +9497,8 @@ func (s *Category) SetCategoryName(v string) *Category {
 
 // There is a concurrent modification of resources.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12578,8 +12578,8 @@ func (s *DeviceNetworkProfileInfo) SetNetworkProfileArn(v string) *DeviceNetwork
 // The request failed because this device is no longer registered and therefore
 // no longer managed by this account.
 type DeviceNotRegisteredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14154,8 +14154,8 @@ func (s *InstantBooking) SetEnabled(v bool) *InstantBooking {
 
 // The Certificate Authority can't issue or revoke a certificate.
 type InvalidCertificateAuthorityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14210,8 +14210,8 @@ func (s InvalidCertificateAuthorityException) RequestID() string {
 
 // The device is in an invalid state.
 type InvalidDeviceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14266,8 +14266,8 @@ func (s InvalidDeviceException) RequestID() string {
 
 // A password in SecretsManager is in an invalid state.
 type InvalidSecretsManagerResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14322,8 +14322,8 @@ func (s InvalidSecretsManagerResourceException) RequestID() string {
 
 // The service linked role is locked for deletion.
 type InvalidServiceLinkedRoleStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14378,8 +14378,8 @@ func (s InvalidServiceLinkedRoleStateException) RequestID() string {
 
 // The attempt to update a user is invalid due to the user's current status.
 type InvalidUserStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14434,8 +14434,8 @@ func (s InvalidUserStatusException) RequestID() string {
 
 // You are performing an action that would put you beyond your account's limits.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15515,8 +15515,8 @@ func (s *MeetingSetting) SetRequirePin(v string) *MeetingSetting {
 
 // The name sent in the request is already in use.
 type NameInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15763,8 +15763,8 @@ func (s *NetworkProfileData) SetSsid(v string) *NetworkProfileData {
 
 // The resource is not found.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16795,8 +16795,8 @@ func (s *ResolveRoomOutput) SetRoomSkillParameters(v []*RoomSkillParameter) *Res
 
 // Another resource is associated with the resource in the request.
 type ResourceAssociatedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16851,8 +16851,8 @@ func (s ResourceAssociatedException) RequestID() string {
 
 // The resource in the request is already in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A unique, user-specified identifier for the request that ensures idempotency.
 	ClientRequestToken *string `min:"10" type:"string"`
@@ -18619,8 +18619,8 @@ func (s *SkillGroupData) SetSkillGroupName(v string) *SkillGroupData {
 
 // The skill must be linked to a third-party account.
 type SkillNotLinkedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19276,8 +19276,8 @@ func (s *Text) SetValue(v string) *Text {
 // The caller has no permissions to operate on the resource involved in the
 // API call.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/alexaforbusiness/api.go
+++ b/service/alexaforbusiness/api.go
@@ -8726,7 +8726,7 @@ func (s *AddressBookData) SetName(v string) *AddressBookData {
 // The resource being created already exists.
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8743,7 +8743,7 @@ func (s AlreadyExistsException) GoString() string {
 
 func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &AlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8771,12 +8771,12 @@ func (s AlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ApproveSkillInput struct {
@@ -9498,7 +9498,7 @@ func (s *Category) SetCategoryName(v string) *Category {
 // There is a concurrent modification of resources.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9515,7 +9515,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9543,12 +9543,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The default conference provider that is used if no other scheduled meetings
@@ -12579,7 +12579,7 @@ func (s *DeviceNetworkProfileInfo) SetNetworkProfileArn(v string) *DeviceNetwork
 // no longer managed by this account.
 type DeviceNotRegisteredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12596,7 +12596,7 @@ func (s DeviceNotRegisteredException) GoString() string {
 
 func newErrorDeviceNotRegisteredException(v protocol.ResponseMetadata) error {
 	return &DeviceNotRegisteredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12624,12 +12624,12 @@ func (s DeviceNotRegisteredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeviceNotRegisteredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeviceNotRegisteredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details of a device’s status.
@@ -14155,7 +14155,7 @@ func (s *InstantBooking) SetEnabled(v bool) *InstantBooking {
 // The Certificate Authority can't issue or revoke a certificate.
 type InvalidCertificateAuthorityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14172,7 +14172,7 @@ func (s InvalidCertificateAuthorityException) GoString() string {
 
 func newErrorInvalidCertificateAuthorityException(v protocol.ResponseMetadata) error {
 	return &InvalidCertificateAuthorityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14200,18 +14200,18 @@ func (s InvalidCertificateAuthorityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCertificateAuthorityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCertificateAuthorityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The device is in an invalid state.
 type InvalidDeviceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14228,7 +14228,7 @@ func (s InvalidDeviceException) GoString() string {
 
 func newErrorInvalidDeviceException(v protocol.ResponseMetadata) error {
 	return &InvalidDeviceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14256,18 +14256,18 @@ func (s InvalidDeviceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeviceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeviceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A password in SecretsManager is in an invalid state.
 type InvalidSecretsManagerResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14284,7 +14284,7 @@ func (s InvalidSecretsManagerResourceException) GoString() string {
 
 func newErrorInvalidSecretsManagerResourceException(v protocol.ResponseMetadata) error {
 	return &InvalidSecretsManagerResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14312,18 +14312,18 @@ func (s InvalidSecretsManagerResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSecretsManagerResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSecretsManagerResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service linked role is locked for deletion.
 type InvalidServiceLinkedRoleStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14340,7 +14340,7 @@ func (s InvalidServiceLinkedRoleStateException) GoString() string {
 
 func newErrorInvalidServiceLinkedRoleStateException(v protocol.ResponseMetadata) error {
 	return &InvalidServiceLinkedRoleStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14368,18 +14368,18 @@ func (s InvalidServiceLinkedRoleStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidServiceLinkedRoleStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidServiceLinkedRoleStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The attempt to update a user is invalid due to the user's current status.
 type InvalidUserStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14396,7 +14396,7 @@ func (s InvalidUserStatusException) GoString() string {
 
 func newErrorInvalidUserStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidUserStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14424,18 +14424,18 @@ func (s InvalidUserStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidUserStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidUserStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You are performing an action that would put you beyond your account's limits.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14452,7 +14452,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14480,12 +14480,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListBusinessReportSchedulesInput struct {
@@ -15516,7 +15516,7 @@ func (s *MeetingSetting) SetRequirePin(v string) *MeetingSetting {
 // The name sent in the request is already in use.
 type NameInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15533,7 +15533,7 @@ func (s NameInUseException) GoString() string {
 
 func newErrorNameInUseException(v protocol.ResponseMetadata) error {
 	return &NameInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15561,12 +15561,12 @@ func (s NameInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NameInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NameInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The network profile associated with a device.
@@ -15764,7 +15764,7 @@ func (s *NetworkProfileData) SetSsid(v string) *NetworkProfileData {
 // The resource is not found.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15781,7 +15781,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15809,12 +15809,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The information for public switched telephone network (PSTN) conferencing.
@@ -16796,7 +16796,7 @@ func (s *ResolveRoomOutput) SetRoomSkillParameters(v []*RoomSkillParameter) *Res
 // Another resource is associated with the resource in the request.
 type ResourceAssociatedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16813,7 +16813,7 @@ func (s ResourceAssociatedException) GoString() string {
 
 func newErrorResourceAssociatedException(v protocol.ResponseMetadata) error {
 	return &ResourceAssociatedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16841,18 +16841,18 @@ func (s ResourceAssociatedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAssociatedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAssociatedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource in the request is already in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A unique, user-specified identifier for the request that ensures idempotency.
 	ClientRequestToken *string `min:"10" type:"string"`
@@ -16872,7 +16872,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16900,12 +16900,12 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RevokeInvitationInput struct {
@@ -18620,7 +18620,7 @@ func (s *SkillGroupData) SetSkillGroupName(v string) *SkillGroupData {
 // The skill must be linked to a third-party account.
 type SkillNotLinkedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18637,7 +18637,7 @@ func (s SkillNotLinkedException) GoString() string {
 
 func newErrorSkillNotLinkedException(v protocol.ResponseMetadata) error {
 	return &SkillNotLinkedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18665,12 +18665,12 @@ func (s SkillNotLinkedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SkillNotLinkedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SkillNotLinkedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The summary of skills.
@@ -19277,7 +19277,7 @@ func (s *Text) SetValue(v string) *Text {
 // API call.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19294,7 +19294,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19322,12 +19322,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/amplify/api.go
+++ b/service/amplify/api.go
@@ -3840,7 +3840,7 @@ func (s *BackendEnvironment) SetUpdateTime(v time.Time) *BackendEnvironment {
 // Exception thrown when a request contains unexpected data.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3857,7 +3857,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3885,12 +3885,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Branch for an Amplify App, which maps to a 3rd party repository branch.
@@ -5664,7 +5664,7 @@ func (s *DeleteWebhookOutput) SetWebhook(v *Webhook) *DeleteWebhookOutput {
 // an exception.
 type DependentServiceFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5681,7 +5681,7 @@ func (s DependentServiceFailureException) GoString() string {
 
 func newErrorDependentServiceFailureException(v protocol.ResponseMetadata) error {
 	return &DependentServiceFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5709,12 +5709,12 @@ func (s DependentServiceFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DependentServiceFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DependentServiceFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Structure for Domain Association, which associates a custom domain with an
@@ -6480,7 +6480,7 @@ func (s *GetWebhookOutput) SetWebhook(v *Webhook) *GetWebhookOutput {
 // internal issue.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6497,7 +6497,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6525,12 +6525,12 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Structure for an execution job for an Amplify App.
@@ -6688,7 +6688,7 @@ func (s *JobSummary) SetStatus(v string) *JobSummary {
 // limits.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6705,7 +6705,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6733,12 +6733,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Request structure for an Amplify App list request.
@@ -7563,7 +7563,7 @@ func (s *ListWebhooksOutput) SetWebhooks(v []*Webhook) *ListWebhooksOutput {
 // Exception thrown when an entity has not been found during an operation.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7580,7 +7580,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7608,12 +7608,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Structure with Production Branch information.
@@ -7670,7 +7670,7 @@ func (s *ProductionBranch) SetThumbnailUrl(v string) *ProductionBranch {
 // Exception thrown when an operation fails due to non-existent resource.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -7689,7 +7689,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7717,12 +7717,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Request structure for start a deployment.
@@ -8382,7 +8382,7 @@ func (s TagResourceOutput) GoString() string {
 // Exception thrown when an operation fails due to a lack of access.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8399,7 +8399,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8427,12 +8427,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Request structure used to untag resource.

--- a/service/amplify/api.go
+++ b/service/amplify/api.go
@@ -3839,8 +3839,8 @@ func (s *BackendEnvironment) SetUpdateTime(v time.Time) *BackendEnvironment {
 
 // Exception thrown when a request contains unexpected data.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5663,8 +5663,8 @@ func (s *DeleteWebhookOutput) SetWebhook(v *Webhook) *DeleteWebhookOutput {
 // Exception thrown when an operation fails due to a dependent service throwing
 // an exception.
 type DependentServiceFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6479,8 +6479,8 @@ func (s *GetWebhookOutput) SetWebhook(v *Webhook) *GetWebhookOutput {
 // Exception thrown when the service fails to perform an operation due to an
 // internal issue.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6687,8 +6687,8 @@ func (s *JobSummary) SetStatus(v string) *JobSummary {
 // Exception thrown when a resource could not be created because of service
 // limits.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7562,8 +7562,8 @@ func (s *ListWebhooksOutput) SetWebhooks(v []*Webhook) *ListWebhooksOutput {
 
 // Exception thrown when an entity has not been found during an operation.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7669,8 +7669,8 @@ func (s *ProductionBranch) SetThumbnailUrl(v string) *ProductionBranch {
 
 // Exception thrown when an operation fails due to non-existent resource.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -8381,8 +8381,8 @@ func (s TagResourceOutput) GoString() string {
 
 // Exception thrown when an operation fails due to a lack of access.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -11767,8 +11767,8 @@ func (s *Authorizer) SetType(v string) *Authorizer {
 // The submitted request is not valid, for example, the input is incomplete
 // or incorrect. See the accompanying error message for details.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12004,8 +12004,8 @@ func (s *ClientCertificate) SetTags(v map[string]*string) *ClientCertificate {
 // The request configuration has conflicts. For details, see the accompanying
 // error message.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20283,8 +20283,8 @@ func (s *IntegrationResponse) SetStatusCode(v string) *IntegrationResponse {
 
 // The request exceeded the rate limit. Retry after the specified time period.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -20930,8 +20930,8 @@ func (s *Model) SetSchema(v string) *Model {
 
 // The requested resource is not found. Make sure that the request URI is correct.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22395,8 +22395,8 @@ func (s *SdkType) SetId(v string) *SdkType {
 // The requested service is not available. For details see the accompanying
 // error message. Retry after the specified time period.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -23178,8 +23178,8 @@ func (s *ThrottleSettings) SetRateLimit(v float64) *ThrottleSettings {
 // The request has reached its throttling limit. Retry after the specified time
 // period.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -23236,8 +23236,8 @@ func (s TooManyRequestsException) RequestID() string {
 
 // The request is denied because the caller has insufficient permissions.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -11768,7 +11768,7 @@ func (s *Authorizer) SetType(v string) *Authorizer {
 // or incorrect. See the accompanying error message for details.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11785,7 +11785,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11813,12 +11813,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the base path that callers of the API must provide as part of
@@ -12005,7 +12005,7 @@ func (s *ClientCertificate) SetTags(v map[string]*string) *ClientCertificate {
 // error message.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12022,7 +12022,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12050,12 +12050,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Request to create an ApiKey resource.
@@ -20284,7 +20284,7 @@ func (s *IntegrationResponse) SetStatusCode(v string) *IntegrationResponse {
 // The request exceeded the rate limit. Retry after the specified time period.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -20303,7 +20303,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20331,12 +20331,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a client-facing interface by which the client calls the API to
@@ -20931,7 +20931,7 @@ func (s *Model) SetSchema(v string) *Model {
 // The requested resource is not found. Make sure that the request URI is correct.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20948,7 +20948,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20976,12 +20976,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A single patch operation to apply to the specified resource. Please refer
@@ -22396,7 +22396,7 @@ func (s *SdkType) SetId(v string) *SdkType {
 // error message. Retry after the specified time period.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -22415,7 +22415,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22443,12 +22443,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a unique identifier for a version of a deployed RestApi that is
@@ -23179,7 +23179,7 @@ func (s *ThrottleSettings) SetRateLimit(v float64) *ThrottleSettings {
 // period.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -23198,7 +23198,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23226,18 +23226,18 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request is denied because the caller has insufficient permissions.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23254,7 +23254,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23282,12 +23282,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Removes a tag from a given resource.

--- a/service/apigatewaymanagementapi/api.go
+++ b/service/apigatewaymanagementapi/api.go
@@ -331,8 +331,8 @@ func (s DeleteConnectionOutput) GoString() string {
 
 // The caller is not authorized to invoke this operation.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -464,8 +464,8 @@ func (s *GetConnectionOutput) SetLastActiveAt(v time.Time) *GetConnectionOutput 
 
 // The connection with the provided id no longer exists.
 type GoneException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -557,8 +557,8 @@ func (s *Identity) SetUserAgent(v string) *Identity {
 // The client is sending more than the allowed number of requests per unit of
 // time or the WebSocket client side buffer is full.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -613,8 +613,8 @@ func (s LimitExceededException) RequestID() string {
 
 // The data has exceeded the maximum size allowed.
 type PayloadTooLargeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/apigatewaymanagementapi/api.go
+++ b/service/apigatewaymanagementapi/api.go
@@ -332,7 +332,7 @@ func (s DeleteConnectionOutput) GoString() string {
 // The caller is not authorized to invoke this operation.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -349,7 +349,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -377,12 +377,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetConnectionInput struct {
@@ -465,7 +465,7 @@ func (s *GetConnectionOutput) SetLastActiveAt(v time.Time) *GetConnectionOutput 
 // The connection with the provided id no longer exists.
 type GoneException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -482,7 +482,7 @@ func (s GoneException) GoString() string {
 
 func newErrorGoneException(v protocol.ResponseMetadata) error {
 	return &GoneException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -510,12 +510,12 @@ func (s GoneException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GoneException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GoneException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type Identity struct {
@@ -558,7 +558,7 @@ func (s *Identity) SetUserAgent(v string) *Identity {
 // time or the WebSocket client side buffer is full.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -575,7 +575,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -603,18 +603,18 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The data has exceeded the maximum size allowed.
 type PayloadTooLargeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -631,7 +631,7 @@ func (s PayloadTooLargeException) GoString() string {
 
 func newErrorPayloadTooLargeException(v protocol.ResponseMetadata) error {
 	return &PayloadTooLargeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -659,12 +659,12 @@ func (s PayloadTooLargeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PayloadTooLargeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PayloadTooLargeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PostToConnectionInput struct {

--- a/service/apigatewayv2/api.go
+++ b/service/apigatewayv2/api.go
@@ -6145,7 +6145,7 @@ func (c *ApiGatewayV2) UpdateVpcLinkWithContext(ctx aws.Context, input *UpdateVp
 
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6162,7 +6162,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6190,12 +6190,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Settings for logging access in a stage.
@@ -6575,7 +6575,7 @@ func (s *Authorizer) SetName(v string) *Authorizer {
 // See the accompanying error message for details.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Describes the error encountered.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6593,7 +6593,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6621,12 +6621,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested operation would cause a conflict with the current state of
@@ -6634,7 +6634,7 @@ func (s BadRequestException) RequestID() string {
 // retrying this request. See the accompanying error message for details.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Describes the error encountered.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6652,7 +6652,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6680,12 +6680,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a CORS configuration. Supported only for HTTP APIs. See Configuring
@@ -14275,7 +14275,7 @@ func (s *Model) SetSchema(v string) *Model {
 // for more information.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Describes the error encountered.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14296,7 +14296,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14324,12 +14324,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Validation constraints imposed on parameters of a request (path, query string,
@@ -15114,7 +15114,7 @@ func (s *TlsConfigInput) SetServerNameToVerify(v string) *TlsConfigInput {
 // A limit has been exceeded. See the accompanying error message for details.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	LimitType *string `locationName:"limitType" type:"string"`
 
@@ -15133,7 +15133,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15161,12 +15161,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/apigatewayv2/api.go
+++ b/service/apigatewayv2/api.go
@@ -6144,8 +6144,8 @@ func (c *ApiGatewayV2) UpdateVpcLinkWithContext(ctx aws.Context, input *UpdateVp
 }
 
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6574,8 +6574,8 @@ func (s *Authorizer) SetName(v string) *Authorizer {
 // The request is not valid, for example, the input is incomplete or incorrect.
 // See the accompanying error message for details.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Describes the error encountered.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6633,8 +6633,8 @@ func (s BadRequestException) RequestID() string {
 // a service resource associated with the request. Resolve the conflict before
 // retrying this request. See the accompanying error message for details.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Describes the error encountered.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14274,8 +14274,8 @@ func (s *Model) SetSchema(v string) *Model {
 // The resource specified in the request was not found. See the message field
 // for more information.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Describes the error encountered.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15113,8 +15113,8 @@ func (s *TlsConfigInput) SetServerNameToVerify(v string) *TlsConfigInput {
 
 // A limit has been exceeded. See the accompanying error message for details.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	LimitType *string `locationName:"limitType" type:"string"`
 

--- a/service/appconfig/api.go
+++ b/service/appconfig/api.go
@@ -2864,8 +2864,8 @@ func (s *Application) SetName(v string) *Application {
 
 // The input fails to satisfy the constraints specified by an AWS service.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2981,8 +2981,8 @@ func (s *ConfigurationProfileSummary) SetValidatorTypes(v []*string) *Configurat
 // The request could not be processed because of conflict in the current state
 // of the resource.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5153,8 +5153,8 @@ func (s *GetEnvironmentOutput) SetState(v string) *GetEnvironmentOutput {
 
 // There was an internal failure in the AppConfig service.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5807,8 +5807,8 @@ func (s *Monitor) SetAlarmRoleArn(v string) *Monitor {
 
 // The requested resource could not be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 

--- a/service/appconfig/api.go
+++ b/service/appconfig/api.go
@@ -2865,7 +2865,7 @@ func (s *Application) SetName(v string) *Application {
 // The input fails to satisfy the constraints specified by an AWS service.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2882,7 +2882,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2910,12 +2910,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A summary of a configuration profile.
@@ -2982,7 +2982,7 @@ func (s *ConfigurationProfileSummary) SetValidatorTypes(v []*string) *Configurat
 // of the resource.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2999,7 +2999,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3027,12 +3027,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateApplicationInput struct {
@@ -5154,7 +5154,7 @@ func (s *GetEnvironmentOutput) SetState(v string) *GetEnvironmentOutput {
 // There was an internal failure in the AppConfig service.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5171,7 +5171,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5199,12 +5199,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListApplicationsInput struct {
@@ -5808,7 +5808,7 @@ func (s *Monitor) SetAlarmRoleArn(v string) *Monitor {
 // The requested resource could not be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5827,7 +5827,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5855,12 +5855,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartDeploymentInput struct {

--- a/service/applicationautoscaling/api.go
+++ b/service/applicationautoscaling/api.go
@@ -1344,8 +1344,8 @@ func (s *Alarm) SetAlarmName(v string) *Alarm {
 // Concurrent updates caused an exception, for example, if you request an update
 // to an Application Auto Scaling resource that already has a pending update.
 type ConcurrentUpdateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2863,8 +2863,8 @@ func (s *DescribeScheduledActionsOutput) SetScheduledActions(v []*ScheduledActio
 // DescribeAlarms (https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarms.html)
 // on your behalf.
 type FailedResourceAccessException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2919,8 +2919,8 @@ func (s FailedResourceAccessException) RequestID() string {
 
 // The service encountered an internal error.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2975,8 +2975,8 @@ func (s InternalServiceException) RequestID() string {
 
 // The next token supplied was invalid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3032,8 +3032,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // A per-account resource limit is exceeded. For more information, see Application
 // Auto Scaling Limits (https://docs.aws.amazon.com/ApplicationAutoScaling/latest/userguide/application-auto-scaling-limits.html).
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3145,8 +3145,8 @@ func (s *MetricDimension) SetValue(v string) *MetricDimension {
 // does not exist. For any operation that deletes or deregisters a resource,
 // this exception is thrown if the resource cannot be found.
 type ObjectNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5213,8 +5213,8 @@ func (s *TargetTrackingScalingPolicyConfiguration) SetTargetValue(v float64) *Ta
 // An exception was thrown for a validation issue. Review the available parameters
 // for the API request.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/applicationautoscaling/api.go
+++ b/service/applicationautoscaling/api.go
@@ -1345,7 +1345,7 @@ func (s *Alarm) SetAlarmName(v string) *Alarm {
 // to an Application Auto Scaling resource that already has a pending update.
 type ConcurrentUpdateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1362,7 +1362,7 @@ func (s ConcurrentUpdateException) GoString() string {
 
 func newErrorConcurrentUpdateException(v protocol.ResponseMetadata) error {
 	return &ConcurrentUpdateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1390,12 +1390,12 @@ func (s ConcurrentUpdateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentUpdateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentUpdateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a CloudWatch metric of your choosing for a target tracking scaling
@@ -2864,7 +2864,7 @@ func (s *DescribeScheduledActionsOutput) SetScheduledActions(v []*ScheduledActio
 // on your behalf.
 type FailedResourceAccessException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2881,7 +2881,7 @@ func (s FailedResourceAccessException) GoString() string {
 
 func newErrorFailedResourceAccessException(v protocol.ResponseMetadata) error {
 	return &FailedResourceAccessException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2909,18 +2909,18 @@ func (s FailedResourceAccessException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FailedResourceAccessException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FailedResourceAccessException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service encountered an internal error.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2937,7 +2937,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2965,18 +2965,18 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The next token supplied was invalid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2993,7 +2993,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3021,19 +3021,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A per-account resource limit is exceeded. For more information, see Application
 // Auto Scaling Limits (https://docs.aws.amazon.com/ApplicationAutoScaling/latest/userguide/application-auto-scaling-limits.html).
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3050,7 +3050,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3078,12 +3078,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the dimension names and values associated with a metric.
@@ -3146,7 +3146,7 @@ func (s *MetricDimension) SetValue(v string) *MetricDimension {
 // this exception is thrown if the resource cannot be found.
 type ObjectNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3163,7 +3163,7 @@ func (s ObjectNotFoundException) GoString() string {
 
 func newErrorObjectNotFoundException(v protocol.ResponseMetadata) error {
 	return &ObjectNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3191,12 +3191,12 @@ func (s ObjectNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ObjectNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ObjectNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a predefined metric for a target tracking scaling policy to use
@@ -5214,7 +5214,7 @@ func (s *TargetTrackingScalingPolicyConfiguration) SetTargetValue(v float64) *Ta
 // for the API request.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5231,7 +5231,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5259,12 +5259,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/applicationdiscoveryservice/api.go
+++ b/service/applicationdiscoveryservice/api.go
@@ -2901,8 +2901,8 @@ func (s AssociateConfigurationItemsToApplicationOutput) GoString() string {
 // The AWS user account does not have permission to perform the action. Check
 // the IAM policy associated with this account.
 type AuthorizationErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3128,8 +3128,8 @@ func (s *ConfigurationTag) SetValue(v string) *ConfigurationTag {
 }
 
 type ConflictErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4874,8 +4874,8 @@ func (s *GetDiscoverySummaryOutput) SetServersMappedtoTags(v int64) *GetDiscover
 
 // The home region is not set. Set the home region to continue.
 type HomeRegionNotSetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5141,8 +5141,8 @@ func (s *ImportTaskFilter) SetValues(v []*string) *ImportTaskFilter {
 
 // One or more parameters are not valid. Verify the parameters and try again.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5198,8 +5198,8 @@ func (s InvalidParameterException) RequestID() string {
 // The value of one or more parameters are either invalid or out of range. Verify
 // the parameter values and try again.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5588,8 +5588,8 @@ func (s *NeighborConnectionDetail) SetTransportProtocol(v string) *NeighborConne
 
 // This operation is not permitted.
 type OperationNotPermittedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5696,8 +5696,8 @@ func (s *OrderByElement) SetSortOrder(v string) *OrderByElement {
 // the import tasks are meant to be different, use a different clientRequestToken,
 // and try again.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5753,8 +5753,8 @@ func (s ResourceInUseException) RequestID() string {
 // The specified configuration ID was not located. Verify the configuration
 // ID and try again.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5809,8 +5809,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The server experienced an internal error. Try again.
 type ServerInternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/applicationdiscoveryservice/api.go
+++ b/service/applicationdiscoveryservice/api.go
@@ -2902,7 +2902,7 @@ func (s AssociateConfigurationItemsToApplicationOutput) GoString() string {
 // the IAM policy associated with this account.
 type AuthorizationErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2919,7 +2919,7 @@ func (s AuthorizationErrorException) GoString() string {
 
 func newErrorAuthorizationErrorException(v protocol.ResponseMetadata) error {
 	return &AuthorizationErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2947,12 +2947,12 @@ func (s AuthorizationErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AuthorizationErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AuthorizationErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Error messages returned for each import task that you deleted as a response
@@ -3129,7 +3129,7 @@ func (s *ConfigurationTag) SetValue(v string) *ConfigurationTag {
 
 type ConflictErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3146,7 +3146,7 @@ func (s ConflictErrorException) GoString() string {
 
 func newErrorConflictErrorException(v protocol.ResponseMetadata) error {
 	return &ConflictErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3174,12 +3174,12 @@ func (s ConflictErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A list of continuous export descriptions.
@@ -4875,7 +4875,7 @@ func (s *GetDiscoverySummaryOutput) SetServersMappedtoTags(v int64) *GetDiscover
 // The home region is not set. Set the home region to continue.
 type HomeRegionNotSetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4892,7 +4892,7 @@ func (s HomeRegionNotSetException) GoString() string {
 
 func newErrorHomeRegionNotSetException(v protocol.ResponseMetadata) error {
 	return &HomeRegionNotSetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4920,12 +4920,12 @@ func (s HomeRegionNotSetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s HomeRegionNotSetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s HomeRegionNotSetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An array of information related to the import task request that includes
@@ -5142,7 +5142,7 @@ func (s *ImportTaskFilter) SetValues(v []*string) *ImportTaskFilter {
 // One or more parameters are not valid. Verify the parameters and try again.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5159,7 +5159,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5187,19 +5187,19 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The value of one or more parameters are either invalid or out of range. Verify
 // the parameter values and try again.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5216,7 +5216,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5244,12 +5244,12 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListConfigurationsInput struct {
@@ -5589,7 +5589,7 @@ func (s *NeighborConnectionDetail) SetTransportProtocol(v string) *NeighborConne
 // This operation is not permitted.
 type OperationNotPermittedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5606,7 +5606,7 @@ func (s OperationNotPermittedException) GoString() string {
 
 func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 	return &OperationNotPermittedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5634,12 +5634,12 @@ func (s OperationNotPermittedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotPermittedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotPermittedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A field and direction for ordered output.
@@ -5697,7 +5697,7 @@ func (s *OrderByElement) SetSortOrder(v string) *OrderByElement {
 // and try again.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5714,7 +5714,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5742,19 +5742,19 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified configuration ID was not located. Verify the configuration
 // ID and try again.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5771,7 +5771,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5799,18 +5799,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The server experienced an internal error. Try again.
 type ServerInternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5827,7 +5827,7 @@ func (s ServerInternalErrorException) GoString() string {
 
 func newErrorServerInternalErrorException(v protocol.ResponseMetadata) error {
 	return &ServerInternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5855,12 +5855,12 @@ func (s ServerInternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServerInternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServerInternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartContinuousExportInput struct {

--- a/service/applicationinsights/api.go
+++ b/service/applicationinsights/api.go
@@ -2829,8 +2829,8 @@ func (s *ApplicationInfo) SetResourceGroupName(v string) *ApplicationInfo {
 
 // The request is not understood by the server.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4143,8 +4143,8 @@ func (s *DescribeProblemOutput) SetProblem(v *Problem) *DescribeProblemOutput {
 
 // The server encountered an internal error and is unable to complete the request.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5220,8 +5220,8 @@ func (s *RelatedObservations) SetObservationList(v []*Observation) *RelatedObser
 
 // The resource is already created or in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5276,8 +5276,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The resource does not exist in the customer account.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5494,8 +5494,8 @@ func (s TagResourceOutput) GoString() string {
 
 // Tags are already registered for the specified application ARN.
 type TagsAlreadyExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5551,8 +5551,8 @@ func (s TagsAlreadyExistException) RequestID() string {
 // The number of the provided tags is beyond the limit, or the number of total
 // tags you are trying to attach to the specified resource exceeds the limit.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -6102,8 +6102,8 @@ func (s *UpdateLogPatternOutput) SetResourceGroupName(v string) *UpdateLogPatter
 
 // The parameter is not valid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/applicationinsights/api.go
+++ b/service/applicationinsights/api.go
@@ -2830,7 +2830,7 @@ func (s *ApplicationInfo) SetResourceGroupName(v string) *ApplicationInfo {
 // The request is not understood by the server.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2847,7 +2847,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2875,12 +2875,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The event information.
@@ -4144,7 +4144,7 @@ func (s *DescribeProblemOutput) SetProblem(v *Problem) *DescribeProblemOutput {
 // The server encountered an internal error and is unable to complete the request.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4161,7 +4161,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4189,12 +4189,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListApplicationsInput struct {
@@ -5221,7 +5221,7 @@ func (s *RelatedObservations) SetObservationList(v []*Observation) *RelatedObser
 // The resource is already created or in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5238,7 +5238,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5266,18 +5266,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource does not exist in the customer account.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5294,7 +5294,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5322,12 +5322,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that defines the tags associated with an application. A tag is
@@ -5495,7 +5495,7 @@ func (s TagResourceOutput) GoString() string {
 // Tags are already registered for the specified application ARN.
 type TagsAlreadyExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5512,7 +5512,7 @@ func (s TagsAlreadyExistException) GoString() string {
 
 func newErrorTagsAlreadyExistException(v protocol.ResponseMetadata) error {
 	return &TagsAlreadyExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5540,19 +5540,19 @@ func (s TagsAlreadyExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagsAlreadyExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagsAlreadyExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of the provided tags is beyond the limit, or the number of total
 // tags you are trying to attach to the specified resource exceeds the limit.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5572,7 +5572,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5600,12 +5600,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -6103,7 +6103,7 @@ func (s *UpdateLogPatternOutput) SetResourceGroupName(v string) *UpdateLogPatter
 // The parameter is not valid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6120,7 +6120,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6148,12 +6148,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/appmesh/api.go
+++ b/service/appmesh/api.go
@@ -3510,8 +3510,8 @@ func (s *BackendDefaults) SetClientPolicy(v *ClientPolicy) *BackendDefaults {
 
 // The request syntax was malformed. Check your request syntax and try again.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3667,8 +3667,8 @@ func (s *ClientPolicyTls) SetValidation(v *TlsValidationContext) *ClientPolicyTl
 // call with different specifications. Try the request again with a new client
 // token.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5414,8 +5414,8 @@ func (s *FileAccessLog) SetPath(v string) *FileAccessLog {
 
 // You don't have permissions to perform this action.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6445,8 +6445,8 @@ func (s *HttpRouteMatch) SetScheme(v string) *HttpRouteMatch {
 // The request processing has failed because of an unknown error, exception,
 // or failure.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6503,8 +6503,8 @@ func (s InternalServerErrorException) RequestID() string {
 // see Service Limits (https://docs.aws.amazon.com/app-mesh/latest/userguide/service_limits.html)
 // in the AWS App Mesh User Guide.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7674,8 +7674,8 @@ func (s *MeshStatus) SetStatus(v string) *MeshStatus {
 
 // The specified resource doesn't exist. Check your request syntax and try again.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7783,8 +7783,8 @@ func (s *PortMapping) SetProtocol(v string) *PortMapping {
 // You can't delete the specified resource because it's in use or required by
 // another resource.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8230,8 +8230,8 @@ func (s *ServiceDiscovery) SetDns(v *DnsServiceDiscovery) *ServiceDiscovery {
 
 // The request has failed due to a temporary failure of the service.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8688,8 +8688,8 @@ func (s *TlsValidationContextTrust) SetFile(v *TlsValidationContextFileTrust) *T
 // for your account. For best results, use an increasing or variable sleep interval
 // between requests.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8746,8 +8746,8 @@ func (s TooManyRequestsException) RequestID() string {
 // The current limit is 50 user tags per resource. You must reduce the number
 // of tags in the request. None of the tags in this request were applied.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/appmesh/api.go
+++ b/service/appmesh/api.go
@@ -3511,7 +3511,7 @@ func (s *BackendDefaults) SetClientPolicy(v *ClientPolicy) *BackendDefaults {
 // The request syntax was malformed. Check your request syntax and try again.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3528,7 +3528,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3556,12 +3556,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that represents a client policy.
@@ -3668,7 +3668,7 @@ func (s *ClientPolicyTls) SetValidation(v *TlsValidationContext) *ClientPolicyTl
 // token.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3685,7 +3685,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3713,12 +3713,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateMeshInput struct {
@@ -5415,7 +5415,7 @@ func (s *FileAccessLog) SetPath(v string) *FileAccessLog {
 // You don't have permissions to perform this action.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5432,7 +5432,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5460,12 +5460,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that represents a retry policy. Specify at least one value for
@@ -6446,7 +6446,7 @@ func (s *HttpRouteMatch) SetScheme(v string) *HttpRouteMatch {
 // or failure.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6463,7 +6463,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6491,12 +6491,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have exceeded a service limit for your account. For more information,
@@ -6504,7 +6504,7 @@ func (s InternalServerErrorException) RequestID() string {
 // in the AWS App Mesh User Guide.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6521,7 +6521,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6549,12 +6549,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListMeshesInput struct {
@@ -7675,7 +7675,7 @@ func (s *MeshStatus) SetStatus(v string) *MeshStatus {
 // The specified resource doesn't exist. Check your request syntax and try again.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7692,7 +7692,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7720,12 +7720,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that represents a port mapping.
@@ -7784,7 +7784,7 @@ func (s *PortMapping) SetProtocol(v string) *PortMapping {
 // another resource.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7801,7 +7801,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7829,12 +7829,12 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that represents metadata for a resource.
@@ -8231,7 +8231,7 @@ func (s *ServiceDiscovery) SetDns(v *DnsServiceDiscovery) *ServiceDiscovery {
 // The request has failed due to a temporary failure of the service.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8248,7 +8248,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8276,12 +8276,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Optional metadata that you apply to a resource to assist with categorization
@@ -8689,7 +8689,7 @@ func (s *TlsValidationContextTrust) SetFile(v *TlsValidationContextFileTrust) *T
 // between requests.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8706,7 +8706,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8734,12 +8734,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request exceeds the maximum allowed number of tags allowed per resource.
@@ -8747,7 +8747,7 @@ func (s TooManyRequestsException) RequestID() string {
 // of tags in the request. None of the tags in this request were applied.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8764,7 +8764,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8792,12 +8792,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/appstream/api.go
+++ b/service/appstream/api.go
@@ -4777,7 +4777,7 @@ func (s *ComputeCapacityStatus) SetRunning(v int64) *ComputeCapacityStatus {
 // An API error occurred. Wait a few minutes and try again.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -4795,7 +4795,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4823,12 +4823,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CopyImageInput struct {
@@ -8840,7 +8840,7 @@ func (s *ImageStateChangeReason) SetMessage(v string) *ImageStateChangeReason {
 // The image does not support storage connectors.
 type IncompatibleImageException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -8858,7 +8858,7 @@ func (s IncompatibleImageException) GoString() string {
 
 func newErrorIncompatibleImageException(v protocol.ResponseMetadata) error {
 	return &IncompatibleImageException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8886,19 +8886,19 @@ func (s IncompatibleImageException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncompatibleImageException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncompatibleImageException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource cannot be created because your AWS account is suspended. For
 // assistance, contact AWS Support.
 type InvalidAccountStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -8916,7 +8916,7 @@ func (s InvalidAccountStatusException) GoString() string {
 
 func newErrorInvalidAccountStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidAccountStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8944,18 +8944,18 @@ func (s InvalidAccountStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAccountStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAccountStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates an incorrect combination of parameters, or a missing parameter.
 type InvalidParameterCombinationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -8973,7 +8973,7 @@ func (s InvalidParameterCombinationException) GoString() string {
 
 func newErrorInvalidParameterCombinationException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterCombinationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9001,18 +9001,18 @@ func (s InvalidParameterCombinationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterCombinationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterCombinationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified role is invalid.
 type InvalidRoleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9030,7 +9030,7 @@ func (s InvalidRoleException) GoString() string {
 
 func newErrorInvalidRoleException(v protocol.ResponseMetadata) error {
 	return &InvalidRoleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9058,12 +9058,12 @@ func (s InvalidRoleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRoleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRoleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the error that is returned when a usage report can't be generated.
@@ -9104,7 +9104,7 @@ func (s *LastReportGenerationExecutionError) SetErrorMessage(v string) *LastRepo
 // The requested limit exceeds the permitted limit for an account.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9122,7 +9122,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9150,12 +9150,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAssociatedFleetsInput struct {
@@ -9432,7 +9432,7 @@ func (s *NetworkAccessConfiguration) SetEniPrivateIpAddress(v string) *NetworkAc
 // The attempted operation is not permitted.
 type OperationNotPermittedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9450,7 +9450,7 @@ func (s OperationNotPermittedException) GoString() string {
 
 func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 	return &OperationNotPermittedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9478,18 +9478,18 @@ func (s OperationNotPermittedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotPermittedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotPermittedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9507,7 +9507,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9535,12 +9535,12 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a resource error.
@@ -9588,7 +9588,7 @@ func (s *ResourceError) SetErrorTimestamp(v time.Time) *ResourceError {
 // The specified resource is in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9606,7 +9606,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9634,18 +9634,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource exists and is not in use, but isn't available.
 type ResourceNotAvailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9663,7 +9663,7 @@ func (s ResourceNotAvailableException) GoString() string {
 
 func newErrorResourceNotAvailableException(v protocol.ResponseMetadata) error {
 	return &ResourceNotAvailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9691,18 +9691,18 @@ func (s ResourceNotAvailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotAvailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotAvailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9720,7 +9720,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9748,12 +9748,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the credentials for the service account used by the fleet or image

--- a/service/appstream/api.go
+++ b/service/appstream/api.go
@@ -4776,8 +4776,8 @@ func (s *ComputeCapacityStatus) SetRunning(v int64) *ComputeCapacityStatus {
 
 // An API error occurred. Wait a few minutes and try again.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -8839,8 +8839,8 @@ func (s *ImageStateChangeReason) SetMessage(v string) *ImageStateChangeReason {
 
 // The image does not support storage connectors.
 type IncompatibleImageException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -8897,8 +8897,8 @@ func (s IncompatibleImageException) RequestID() string {
 // The resource cannot be created because your AWS account is suspended. For
 // assistance, contact AWS Support.
 type InvalidAccountStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -8954,8 +8954,8 @@ func (s InvalidAccountStatusException) RequestID() string {
 
 // Indicates an incorrect combination of parameters, or a missing parameter.
 type InvalidParameterCombinationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9011,8 +9011,8 @@ func (s InvalidParameterCombinationException) RequestID() string {
 
 // The specified role is invalid.
 type InvalidRoleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9103,8 +9103,8 @@ func (s *LastReportGenerationExecutionError) SetErrorMessage(v string) *LastRepo
 
 // The requested limit exceeds the permitted limit for an account.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9431,8 +9431,8 @@ func (s *NetworkAccessConfiguration) SetEniPrivateIpAddress(v string) *NetworkAc
 
 // The attempted operation is not permitted.
 type OperationNotPermittedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9488,8 +9488,8 @@ func (s OperationNotPermittedException) RequestID() string {
 
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9587,8 +9587,8 @@ func (s *ResourceError) SetErrorTimestamp(v time.Time) *ResourceError {
 
 // The specified resource is in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9644,8 +9644,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The specified resource exists and is not in use, but isn't available.
 type ResourceNotAvailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9701,8 +9701,8 @@ func (s ResourceNotAvailableException) RequestID() string {
 
 // The specified resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message in the exception.
 	Message_ *string `locationName:"Message" type:"string"`

--- a/service/appsync/api.go
+++ b/service/appsync/api.go
@@ -3838,8 +3838,8 @@ func (c *AppSync) UpdateTypeWithContext(ctx aws.Context, input *UpdateTypeInput,
 
 // You do not have access to perform this operation on this resource.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4136,8 +4136,8 @@ func (s *ApiKey) SetId(v string) *ApiKey {
 
 // The API key exceeded a limit. Try your request again.
 type ApiKeyLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4193,8 +4193,8 @@ func (s ApiKeyLimitExceededException) RequestID() string {
 // The API key expiration must be set to a value between 1 and 365 days from
 // creation (for CreateApiKey) or from update (for UpdateApiKey).
 type ApiKeyValidityOutOfBoundsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4249,8 +4249,8 @@ func (s ApiKeyValidityOutOfBoundsException) RequestID() string {
 
 // The GraphQL API exceeded a limit. Try your request again.
 type ApiLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4389,8 +4389,8 @@ func (s *AwsIamConfig) SetSigningServiceName(v string) *AwsIamConfig {
 // The request is not well formed. For example, a value is invalid or a required
 // field is missing. Check the field values, and then try again.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4547,8 +4547,8 @@ func (s *CognitoUserPoolConfig) SetUserPoolId(v string) *CognitoUserPoolConfig {
 // Another modification is in progress at this time and it must complete before
 // you can make your change.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7186,8 +7186,8 @@ func (s *GetTypeOutput) SetType(v *Type) *GetTypeOutput {
 
 // The GraphQL schema is not valid.
 type GraphQLSchemaException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7407,8 +7407,8 @@ func (s *HttpDataSourceConfig) SetEndpoint(v string) *HttpDataSourceConfig {
 
 // An internal AWS AppSync error occurred. Try your request again.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7527,8 +7527,8 @@ func (s *LambdaDataSourceConfig) SetLambdaFunctionArn(v string) *LambdaDataSourc
 
 // The request exceeded a limit. Try your request again.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8424,8 +8424,8 @@ func (s *LogConfig) SetFieldLogLevel(v string) *LogConfig {
 // The resource specified in the request was not found. Check the resource,
 // and then try again.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9053,8 +9053,8 @@ func (s *Type) SetName(v string) *Type {
 
 // You are not authorized to perform this operation.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/appsync/api.go
+++ b/service/appsync/api.go
@@ -3839,7 +3839,7 @@ func (c *AppSync) UpdateTypeWithContext(ctx aws.Context, input *UpdateTypeInput,
 // You do not have access to perform this operation on this resource.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3856,7 +3856,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3884,12 +3884,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes an additional authentication provider.
@@ -4137,7 +4137,7 @@ func (s *ApiKey) SetId(v string) *ApiKey {
 // The API key exceeded a limit. Try your request again.
 type ApiKeyLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4154,7 +4154,7 @@ func (s ApiKeyLimitExceededException) GoString() string {
 
 func newErrorApiKeyLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ApiKeyLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4182,19 +4182,19 @@ func (s ApiKeyLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApiKeyLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApiKeyLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The API key expiration must be set to a value between 1 and 365 days from
 // creation (for CreateApiKey) or from update (for UpdateApiKey).
 type ApiKeyValidityOutOfBoundsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4211,7 +4211,7 @@ func (s ApiKeyValidityOutOfBoundsException) GoString() string {
 
 func newErrorApiKeyValidityOutOfBoundsException(v protocol.ResponseMetadata) error {
 	return &ApiKeyValidityOutOfBoundsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4239,18 +4239,18 @@ func (s ApiKeyValidityOutOfBoundsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApiKeyValidityOutOfBoundsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApiKeyValidityOutOfBoundsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The GraphQL API exceeded a limit. Try your request again.
 type ApiLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4267,7 +4267,7 @@ func (s ApiLimitExceededException) GoString() string {
 
 func newErrorApiLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ApiLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4295,12 +4295,12 @@ func (s ApiLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApiLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApiLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The authorization config in case the HTTP endpoint requires authorization.
@@ -4390,7 +4390,7 @@ func (s *AwsIamConfig) SetSigningServiceName(v string) *AwsIamConfig {
 // field is missing. Check the field values, and then try again.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4407,7 +4407,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4435,12 +4435,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The caching configuration for a resolver that has caching enabled.
@@ -4548,7 +4548,7 @@ func (s *CognitoUserPoolConfig) SetUserPoolId(v string) *CognitoUserPoolConfig {
 // you can make your change.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4565,7 +4565,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4593,12 +4593,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of a CreateApiCache operation.
@@ -7187,7 +7187,7 @@ func (s *GetTypeOutput) SetType(v *Type) *GetTypeOutput {
 // The GraphQL schema is not valid.
 type GraphQLSchemaException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7204,7 +7204,7 @@ func (s GraphQLSchemaException) GoString() string {
 
 func newErrorGraphQLSchemaException(v protocol.ResponseMetadata) error {
 	return &GraphQLSchemaException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7232,12 +7232,12 @@ func (s GraphQLSchemaException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GraphQLSchemaException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GraphQLSchemaException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a GraphQL API.
@@ -7408,7 +7408,7 @@ func (s *HttpDataSourceConfig) SetEndpoint(v string) *HttpDataSourceConfig {
 // An internal AWS AppSync error occurred. Try your request again.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7425,7 +7425,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7453,12 +7453,12 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The LambdaConflictHandlerConfig object when configuring LAMBDA as the Conflict
@@ -7528,7 +7528,7 @@ func (s *LambdaDataSourceConfig) SetLambdaFunctionArn(v string) *LambdaDataSourc
 // The request exceeded a limit. Try your request again.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7545,7 +7545,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7573,12 +7573,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListApiKeysInput struct {
@@ -8425,7 +8425,7 @@ func (s *LogConfig) SetFieldLogLevel(v string) *LogConfig {
 // and then try again.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8442,7 +8442,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8470,12 +8470,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes an OpenID Connect configuration.
@@ -9054,7 +9054,7 @@ func (s *Type) SetName(v string) *Type {
 // You are not authorized to perform this operation.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9071,7 +9071,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9099,12 +9099,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/athena/api.go
+++ b/service/athena/api.go
@@ -2902,7 +2902,7 @@ func (s *GetWorkGroupOutput) SetWorkGroup(v *WorkGroup) *GetWorkGroupOutput {
 // outage.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2919,7 +2919,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2947,19 +2947,19 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that something is wrong with the input to the request. For example,
 // a required parameter may be missing or out of range.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error code returned when the query execution failed to process, or when
 	// the processing request for the named query failed.
@@ -2980,7 +2980,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3008,12 +3008,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListNamedQueriesInput struct {
@@ -3732,7 +3732,7 @@ func (s *QueryExecutionStatus) SetSubmissionDateTime(v time.Time) *QueryExecutio
 // A resource, such as a workgroup, was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3751,7 +3751,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3779,12 +3779,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The location in Amazon S3 where query results are stored and the encryption
@@ -4325,7 +4325,7 @@ func (s TagResourceOutput) GoString() string {
 // Indicates that the request was throttled.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -4346,7 +4346,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4374,12 +4374,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a named query ID that could not be processed.

--- a/service/athena/api.go
+++ b/service/athena/api.go
@@ -2901,8 +2901,8 @@ func (s *GetWorkGroupOutput) SetWorkGroup(v *WorkGroup) *GetWorkGroupOutput {
 // Indicates a platform issue, which may be due to a transient condition or
 // outage.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2958,8 +2958,8 @@ func (s InternalServerException) RequestID() string {
 // Indicates that something is wrong with the input to the request. For example,
 // a required parameter may be missing or out of range.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error code returned when the query execution failed to process, or when
 	// the processing request for the named query failed.
@@ -3731,8 +3731,8 @@ func (s *QueryExecutionStatus) SetSubmissionDateTime(v time.Time) *QueryExecutio
 
 // A resource, such as a workgroup, was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -4324,8 +4324,8 @@ func (s TagResourceOutput) GoString() string {
 
 // Indicates that the request was throttled.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 

--- a/service/augmentedairuntime/api.go
+++ b/service/augmentedairuntime/api.go
@@ -521,8 +521,8 @@ func (c *AugmentedAIRuntime) StopHumanLoopWithContext(ctx aws.Context, input *St
 // input data. You cannot start two human loops with the same name and different
 // input data.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -942,8 +942,8 @@ func (s *HumanLoopSummary) SetHumanLoopStatus(v string) *HumanLoopSummary {
 
 // Your request could not be processed.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1123,8 +1123,8 @@ func (s *ListHumanLoopsOutput) SetNextToken(v string) *ListHumanLoopsOutput {
 
 // We were unable to find the requested resource.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1180,8 +1180,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // You have exceeded your service quota. To perform the requested action, remove
 // some of the relevant resources, or request a service quota increase.
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1402,8 +1402,8 @@ func (s StopHumanLoopOutput) GoString() string {
 
 // Your request has exceeded the allowed amount of requests.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1458,8 +1458,8 @@ func (s ThrottlingException) RequestID() string {
 
 // Your request was not valid. Check the syntax and try again.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/augmentedairuntime/api.go
+++ b/service/augmentedairuntime/api.go
@@ -522,7 +522,7 @@ func (c *AugmentedAIRuntime) StopHumanLoopWithContext(ctx aws.Context, input *St
 // input data.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -539,7 +539,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -567,12 +567,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteHumanLoopInput struct {
@@ -943,7 +943,7 @@ func (s *HumanLoopSummary) SetHumanLoopStatus(v string) *HumanLoopSummary {
 // Your request could not be processed.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -960,7 +960,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -988,12 +988,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListHumanLoopsInput struct {
@@ -1124,7 +1124,7 @@ func (s *ListHumanLoopsOutput) SetNextToken(v string) *ListHumanLoopsOutput {
 // We were unable to find the requested resource.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1141,7 +1141,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1169,19 +1169,19 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have exceeded your service quota. To perform the requested action, remove
 // some of the relevant resources, or request a service quota increase.
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1198,7 +1198,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1226,12 +1226,12 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartHumanLoopInput struct {
@@ -1403,7 +1403,7 @@ func (s StopHumanLoopOutput) GoString() string {
 // Your request has exceeded the allowed amount of requests.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1420,7 +1420,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1448,18 +1448,18 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Your request was not valid. Check the syntax and try again.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1476,7 +1476,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1504,12 +1504,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/autoscalingplans/api.go
+++ b/service/autoscalingplans/api.go
@@ -613,7 +613,7 @@ func (s *ApplicationSource) SetTagFilters(v []*TagFilter) *ApplicationSource {
 // to a scaling plan that already has a pending update.
 type ConcurrentUpdateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -630,7 +630,7 @@ func (s ConcurrentUpdateException) GoString() string {
 
 func newErrorConcurrentUpdateException(v protocol.ResponseMetadata) error {
 	return &ConcurrentUpdateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -658,12 +658,12 @@ func (s ConcurrentUpdateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentUpdateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentUpdateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateScalingPlanInput struct {
@@ -1540,7 +1540,7 @@ func (s *GetScalingPlanResourceForecastDataOutput) SetDatapoints(v []*Datapoint)
 // The service encountered an internal error.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1557,7 +1557,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1585,18 +1585,18 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The token provided is not valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1613,7 +1613,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1641,19 +1641,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Your account exceeded a limit. This exception is thrown when a per-account
 // resource limit is exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1670,7 +1670,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1698,12 +1698,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a dimension for a customized metric.
@@ -1762,7 +1762,7 @@ func (s *MetricDimension) SetValue(v string) *MetricDimension {
 // The specified object could not be found.
 type ObjectNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1779,7 +1779,7 @@ func (s ObjectNotFoundException) GoString() string {
 
 func newErrorObjectNotFoundException(v protocol.ResponseMetadata) error {
 	return &ObjectNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1807,12 +1807,12 @@ func (s ObjectNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ObjectNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ObjectNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a predefined metric that can be used for predictive scaling.
@@ -2879,7 +2879,7 @@ func (s UpdateScalingPlanOutput) GoString() string {
 // An exception was thrown for a validation issue. Review the parameters provided.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2896,7 +2896,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2924,12 +2924,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/autoscalingplans/api.go
+++ b/service/autoscalingplans/api.go
@@ -612,8 +612,8 @@ func (s *ApplicationSource) SetTagFilters(v []*TagFilter) *ApplicationSource {
 // Concurrent updates caused an exception, for example, if you request an update
 // to a scaling plan that already has a pending update.
 type ConcurrentUpdateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1539,8 +1539,8 @@ func (s *GetScalingPlanResourceForecastDataOutput) SetDatapoints(v []*Datapoint)
 
 // The service encountered an internal error.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1595,8 +1595,8 @@ func (s InternalServiceException) RequestID() string {
 
 // The token provided is not valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1652,8 +1652,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // Your account exceeded a limit. This exception is thrown when a per-account
 // resource limit is exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1761,8 +1761,8 @@ func (s *MetricDimension) SetValue(v string) *MetricDimension {
 
 // The specified object could not be found.
 type ObjectNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2878,8 +2878,8 @@ func (s UpdateScalingPlanOutput) GoString() string {
 
 // An exception was thrown for a validation issue. Review the parameters provided.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/backup/api.go
+++ b/service/backup/api.go
@@ -4918,7 +4918,7 @@ func (c *Backup) UpdateRecoveryPointLifecycleWithContext(ctx aws.Context, input 
 // The required resource already exists.
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Arn *string `type:"string"`
 
@@ -4945,7 +4945,7 @@ func (s AlreadyExistsException) GoString() string {
 
 func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &AlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4973,12 +4973,12 @@ func (s AlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains DeleteAt and MoveToColdStorageAt timestamps, which are used to specify
@@ -6093,7 +6093,7 @@ func (s DeleteRecoveryPointOutput) GoString() string {
 // and the action cannot be completed.
 type DependencyFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -6116,7 +6116,7 @@ func (s DependencyFailureException) GoString() string {
 
 func newErrorDependencyFailureException(v protocol.ResponseMetadata) error {
 	return &DependencyFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6144,12 +6144,12 @@ func (s DependencyFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DependencyFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DependencyFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DescribeBackupJobInput struct {
@@ -7901,7 +7901,7 @@ func (s *GetSupportedResourceTypesOutput) SetResourceTypes(v []*string) *GetSupp
 // the value is out of range.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -7924,7 +7924,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7952,19 +7952,19 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that something is wrong with the input to the request. For example,
 // a parameter is of the wrong type.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -7987,7 +7987,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8015,12 +8015,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains detailed information about a backup job.
@@ -8264,7 +8264,7 @@ func (s *Lifecycle) SetMoveToColdStorageAfterDays(v int64) *Lifecycle {
 // items allowed in a request.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -8287,7 +8287,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8315,12 +8315,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListBackupJobsInput struct {
@@ -9616,7 +9616,7 @@ func (s *ListTagsOutput) SetTags(v map[string]*string) *ListTagsOutput {
 // Indicates that a required parameter is missing.
 type MissingParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -9639,7 +9639,7 @@ func (s MissingParameterValueException) GoString() string {
 
 func newErrorMissingParameterValueException(v protocol.ResponseMetadata) error {
 	return &MissingParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9667,12 +9667,12 @@ func (s MissingParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MissingParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MissingParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains an optional backup plan display name and an array of BackupRule
@@ -10442,7 +10442,7 @@ func (s *RecoveryPointCreator) SetBackupRuleId(v string) *RecoveryPointCreator {
 // A resource that is required for the action doesn't exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -10465,7 +10465,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10493,12 +10493,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains metadata about a restore job.
@@ -11034,7 +11034,7 @@ func (s *SelectionsListMember) SetSelectionName(v string) *SelectionsListMember 
 // The request failed due to a temporary failure of the server.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11057,7 +11057,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11085,12 +11085,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartBackupJobInput struct {

--- a/service/backup/api.go
+++ b/service/backup/api.go
@@ -4917,8 +4917,8 @@ func (c *Backup) UpdateRecoveryPointLifecycleWithContext(ctx aws.Context, input 
 
 // The required resource already exists.
 type AlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Arn *string `type:"string"`
 
@@ -6092,8 +6092,8 @@ func (s DeleteRecoveryPointOutput) GoString() string {
 // A dependent AWS service or resource returned an error to the AWS Backup service,
 // and the action cannot be completed.
 type DependencyFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -7900,8 +7900,8 @@ func (s *GetSupportedResourceTypesOutput) SetResourceTypes(v []*string) *GetSupp
 // Indicates that something is wrong with a parameter's value. For example,
 // the value is out of range.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -7963,8 +7963,8 @@ func (s InvalidParameterValueException) RequestID() string {
 // Indicates that something is wrong with the input to the request. For example,
 // a parameter is of the wrong type.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -8263,8 +8263,8 @@ func (s *Lifecycle) SetMoveToColdStorageAfterDays(v int64) *Lifecycle {
 // A limit in the request has been exceeded; for example, a maximum number of
 // items allowed in a request.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -9615,8 +9615,8 @@ func (s *ListTagsOutput) SetTags(v map[string]*string) *ListTagsOutput {
 
 // Indicates that a required parameter is missing.
 type MissingParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -10441,8 +10441,8 @@ func (s *RecoveryPointCreator) SetBackupRuleId(v string) *RecoveryPointCreator {
 
 // A resource that is required for the action doesn't exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11033,8 +11033,8 @@ func (s *SelectionsListMember) SetSelectionName(v string) *SelectionsListMember 
 
 // The request failed due to a temporary failure of the server.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 

--- a/service/batch/api.go
+++ b/service/batch/api.go
@@ -1979,7 +1979,7 @@ func (s CancelJobOutput) GoString() string {
 // action or resource, or specifying an identifier that is not valid.
 type ClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1996,7 +1996,7 @@ func (s ClientException) GoString() string {
 
 func newErrorClientException(v protocol.ResponseMetadata) error {
 	return &ClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2024,12 +2024,12 @@ func (s ClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing an AWS Batch compute environment.
@@ -5511,7 +5511,7 @@ func (s *RetryStrategy) SetAttempts(v int64) *RetryStrategy {
 // These errors are usually caused by a server issue.
 type ServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5528,7 +5528,7 @@ func (s ServerException) GoString() string {
 
 func newErrorServerException(v protocol.ResponseMetadata) error {
 	return &ServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5556,12 +5556,12 @@ func (s ServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SubmitJobInput struct {

--- a/service/batch/api.go
+++ b/service/batch/api.go
@@ -1978,8 +1978,8 @@ func (s CancelJobOutput) GoString() string {
 // or resource on behalf of a user that doesn't have permissions to use the
 // action or resource, or specifying an identifier that is not valid.
 type ClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5510,8 +5510,8 @@ func (s *RetryStrategy) SetAttempts(v int64) *RetryStrategy {
 
 // These errors are usually caused by a server issue.
 type ServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/budgets/api.go
+++ b/service/budgets/api.go
@@ -1318,8 +1318,8 @@ func (c *Budgets) UpdateSubscriberWithContext(ctx aws.Context, input *UpdateSubs
 
 // You are not authorized to use this operation with the given parameters.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2260,8 +2260,8 @@ func (s CreateSubscriberOutput) GoString() string {
 
 // You've exceeded the notification or subscriber limit.
 type CreationLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3163,8 +3163,8 @@ func (s *DescribeSubscribersForNotificationOutput) SetSubscribers(v []*Subscribe
 
 // The budget name already exists. Budget names must be unique within an account.
 type DuplicateRecordException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3220,8 +3220,8 @@ func (s DuplicateRecordException) RequestID() string {
 
 // The pagination token expired.
 type ExpiredNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3278,8 +3278,8 @@ func (s ExpiredNextTokenException) RequestID() string {
 // An error on the server occurred during the processing of your request. Try
 // again later.
 type InternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3335,8 +3335,8 @@ func (s InternalErrorException) RequestID() string {
 
 // The pagination token is invalid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3393,8 +3393,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // An error on the client occurred. Typically, the cause is an invalid input
 // value.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3450,8 +3450,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // We can’t locate the resource that you specified.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`

--- a/service/budgets/api.go
+++ b/service/budgets/api.go
@@ -1319,7 +1319,7 @@ func (c *Budgets) UpdateSubscriberWithContext(ctx aws.Context, input *UpdateSubs
 // You are not authorized to use this operation with the given parameters.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -1337,7 +1337,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1365,12 +1365,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the output of the CreateBudget operation. The content consists
@@ -2261,7 +2261,7 @@ func (s CreateSubscriberOutput) GoString() string {
 // You've exceeded the notification or subscriber limit.
 type CreationLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2279,7 +2279,7 @@ func (s CreationLimitExceededException) GoString() string {
 
 func newErrorCreationLimitExceededException(v protocol.ResponseMetadata) error {
 	return &CreationLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2307,12 +2307,12 @@ func (s CreationLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CreationLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CreationLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Request of DeleteBudget
@@ -3164,7 +3164,7 @@ func (s *DescribeSubscribersForNotificationOutput) SetSubscribers(v []*Subscribe
 // The budget name already exists. Budget names must be unique within an account.
 type DuplicateRecordException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3182,7 +3182,7 @@ func (s DuplicateRecordException) GoString() string {
 
 func newErrorDuplicateRecordException(v protocol.ResponseMetadata) error {
 	return &DuplicateRecordException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3210,18 +3210,18 @@ func (s DuplicateRecordException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateRecordException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateRecordException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pagination token expired.
 type ExpiredNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3239,7 +3239,7 @@ func (s ExpiredNextTokenException) GoString() string {
 
 func newErrorExpiredNextTokenException(v protocol.ResponseMetadata) error {
 	return &ExpiredNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3267,19 +3267,19 @@ func (s ExpiredNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExpiredNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExpiredNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An error on the server occurred during the processing of your request. Try
 // again later.
 type InternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3297,7 +3297,7 @@ func (s InternalErrorException) GoString() string {
 
 func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 	return &InternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3325,18 +3325,18 @@ func (s InternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pagination token is invalid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3354,7 +3354,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3382,19 +3382,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An error on the client occurred. Typically, the cause is an invalid input
 // value.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3412,7 +3412,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3440,18 +3440,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // We can’t locate the resource that you specified.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message the exception carries.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3469,7 +3469,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3497,12 +3497,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A notification that is associated with a budget. A budget can have up to

--- a/service/chime/api.go
+++ b/service/chime/api.go
@@ -10113,7 +10113,7 @@ func (c *Chime) UpdateVoiceConnectorGroupWithContext(ctx aws.Context, input *Upd
 // You don't have permissions to perform the requested operation.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -10132,7 +10132,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10160,12 +10160,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon Chime account details. An AWS account can have multiple Amazon
@@ -10718,7 +10718,7 @@ func (s *Attendee) SetJoinToken(v string) *Attendee {
 // The input parameters don't match the service's restrictions.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -10737,7 +10737,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10765,12 +10765,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type BatchCreateAttendeeInput struct {
@@ -11484,7 +11484,7 @@ func (s *BusinessCallingSettings) SetCdrBucket(v string) *BusinessCallingSetting
 // of the resource.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -11503,7 +11503,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11531,12 +11531,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateAccountInput struct {
@@ -13677,7 +13677,7 @@ func (s *EventsConfiguration) SetOutboundEventsHTTPSEndpoint(v string) *EventsCo
 // when a user tries to create an account from an unsupported Region.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -13696,7 +13696,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13724,12 +13724,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetAccountInput struct {
@@ -16724,7 +16724,7 @@ func (s *MembershipItem) SetRole(v string) *MembershipItem {
 // One or more of the resources in the request does not exist in the system.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -16743,7 +16743,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16771,12 +16771,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A phone number for which an order has been placed.
@@ -17959,7 +17959,7 @@ func (s *ResetPersonalPINOutput) SetUser(v *User) *ResetPersonalPINOutput {
 // The request exceeds the resource limit.
 type ResourceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -17978,7 +17978,7 @@ func (s ResourceLimitExceededException) GoString() string {
 
 func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18006,12 +18006,12 @@ func (s ResourceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RestorePhoneNumberInput struct {
@@ -18326,7 +18326,7 @@ func (s *SearchAvailablePhoneNumbersOutput) SetE164PhoneNumbers(v []*string) *Se
 // The service encountered an unexpected error.
 type ServiceFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18345,7 +18345,7 @@ func (s ServiceFailureException) GoString() string {
 
 func newErrorServiceFailureException(v protocol.ResponseMetadata) error {
 	return &ServiceFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18373,18 +18373,18 @@ func (s ServiceFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service is currently unavailable.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18403,7 +18403,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18431,12 +18431,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An Active Directory (AD) group whose members are granted permission to act
@@ -18694,7 +18694,7 @@ func (s *TerminationHealth) SetTimestamp(v time.Time) *TerminationHealth {
 // The client exceeded its request rate limit.
 type ThrottledClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18713,7 +18713,7 @@ func (s ThrottledClientException) GoString() string {
 
 func newErrorThrottledClientException(v protocol.ResponseMetadata) error {
 	return &ThrottledClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18741,18 +18741,18 @@ func (s ThrottledClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottledClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottledClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The client is not currently authorized to make the request.
 type UnauthorizedClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18771,7 +18771,7 @@ func (s UnauthorizedClientException) GoString() string {
 
 func newErrorUnauthorizedClientException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18799,19 +18799,19 @@ func (s UnauthorizedClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was well-formed but was unable to be followed due to semantic
 // errors.
 type UnprocessableEntityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18830,7 +18830,7 @@ func (s UnprocessableEntityException) GoString() string {
 
 func newErrorUnprocessableEntityException(v protocol.ResponseMetadata) error {
 	return &UnprocessableEntityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18858,12 +18858,12 @@ func (s UnprocessableEntityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnprocessableEntityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnprocessableEntityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateAccountInput struct {

--- a/service/chime/api.go
+++ b/service/chime/api.go
@@ -10112,8 +10112,8 @@ func (c *Chime) UpdateVoiceConnectorGroupWithContext(ctx aws.Context, input *Upd
 
 // You don't have permissions to perform the requested operation.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -10717,8 +10717,8 @@ func (s *Attendee) SetJoinToken(v string) *Attendee {
 
 // The input parameters don't match the service's restrictions.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -11483,8 +11483,8 @@ func (s *BusinessCallingSettings) SetCdrBucket(v string) *BusinessCallingSetting
 // The request could not be processed because of conflict in the current state
 // of the resource.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -13676,8 +13676,8 @@ func (s *EventsConfiguration) SetOutboundEventsHTTPSEndpoint(v string) *EventsCo
 // The client is permanently forbidden from making the request. For example,
 // when a user tries to create an account from an unsupported Region.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -16723,8 +16723,8 @@ func (s *MembershipItem) SetRole(v string) *MembershipItem {
 
 // One or more of the resources in the request does not exist in the system.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -17958,8 +17958,8 @@ func (s *ResetPersonalPINOutput) SetUser(v *User) *ResetPersonalPINOutput {
 
 // The request exceeds the resource limit.
 type ResourceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18325,8 +18325,8 @@ func (s *SearchAvailablePhoneNumbersOutput) SetE164PhoneNumbers(v []*string) *Se
 
 // The service encountered an unexpected error.
 type ServiceFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18383,8 +18383,8 @@ func (s ServiceFailureException) RequestID() string {
 
 // The service is currently unavailable.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18693,8 +18693,8 @@ func (s *TerminationHealth) SetTimestamp(v time.Time) *TerminationHealth {
 
 // The client exceeded its request rate limit.
 type ThrottledClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18751,8 +18751,8 @@ func (s ThrottledClientException) RequestID() string {
 
 // The client is not currently authorized to make the request.
 type UnauthorizedClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 
@@ -18810,8 +18810,8 @@ func (s UnauthorizedClientException) RequestID() string {
 // The request was well-formed but was unable to be followed due to semantic
 // errors.
 type UnprocessableEntityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string" enum:"ErrorCode"`
 

--- a/service/cloud9/api.go
+++ b/service/cloud9/api.go
@@ -1370,7 +1370,7 @@ func (c *Cloud9) UpdateEnvironmentMembershipWithContext(ctx aws.Context, input *
 // The target request is invalid.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1387,7 +1387,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1415,18 +1415,18 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A conflict occurred.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1443,7 +1443,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1471,12 +1471,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateEnvironmentEC2Input struct {
@@ -2319,7 +2319,7 @@ func (s *EnvironmentMember) SetUserId(v string) *EnvironmentMember {
 // An access permissions issue occurred.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2336,7 +2336,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2364,18 +2364,18 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An internal server error occurred.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2392,7 +2392,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2420,18 +2420,18 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A service limit was exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2448,7 +2448,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2476,12 +2476,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListEnvironmentsInput struct {
@@ -2621,7 +2621,7 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 // The target resource cannot be found.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2638,7 +2638,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2666,12 +2666,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Metadata that is associated with AWS resources. In particular, a name-value
@@ -2814,7 +2814,7 @@ func (s TagResourceOutput) GoString() string {
 // Too many service requests were made over the given time period.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2831,7 +2831,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2859,12 +2859,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/cloud9/api.go
+++ b/service/cloud9/api.go
@@ -1369,8 +1369,8 @@ func (c *Cloud9) UpdateEnvironmentMembershipWithContext(ctx aws.Context, input *
 
 // The target request is invalid.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1425,8 +1425,8 @@ func (s BadRequestException) RequestID() string {
 
 // A conflict occurred.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2318,8 +2318,8 @@ func (s *EnvironmentMember) SetUserId(v string) *EnvironmentMember {
 
 // An access permissions issue occurred.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2374,8 +2374,8 @@ func (s ForbiddenException) RequestID() string {
 
 // An internal server error occurred.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2430,8 +2430,8 @@ func (s InternalServerErrorException) RequestID() string {
 
 // A service limit was exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2620,8 +2620,8 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 
 // The target resource cannot be found.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2813,8 +2813,8 @@ func (s TagResourceOutput) GoString() string {
 
 // Too many service requests were made over the given time period.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/clouddirectory/api.go
+++ b/service/clouddirectory/api.go
@@ -8721,7 +8721,7 @@ func (c *CloudDirectory) UpgradePublishedSchemaWithContext(ctx aws.Context, inpu
 // Access denied. Check your permissions.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8738,7 +8738,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8766,12 +8766,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AddFacetToObjectInput struct {
@@ -12825,7 +12825,7 @@ func (s *BatchUpdateObjectAttributesResponse) SetObjectIdentifier(v string) *Bat
 // A BatchWrite exception has occurred.
 type BatchWriteException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Index *int64 `type:"integer"`
 
@@ -12846,7 +12846,7 @@ func (s BatchWriteException) GoString() string {
 
 func newErrorBatchWriteException(v protocol.ResponseMetadata) error {
 	return &BatchWriteException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12874,12 +12874,12 @@ func (s BatchWriteException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BatchWriteException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BatchWriteException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type BatchWriteInput struct {
@@ -13364,7 +13364,7 @@ func (s *BatchWriteOutput) SetResponses(v []*BatchWriteOperationResponse) *Batch
 // Cannot list the parents of a Directory root.
 type CannotListParentOfRootException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -13381,7 +13381,7 @@ func (s CannotListParentOfRootException) GoString() string {
 
 func newErrorCannotListParentOfRootException(v protocol.ResponseMetadata) error {
 	return &CannotListParentOfRootException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13409,12 +13409,12 @@ func (s CannotListParentOfRootException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CannotListParentOfRootException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CannotListParentOfRootException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateDirectoryInput struct {
@@ -14764,7 +14764,7 @@ func (s *Directory) SetState(v string) *Directory {
 // Choose a different name and try again.
 type DirectoryAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14781,7 +14781,7 @@ func (s DirectoryAlreadyExistsException) GoString() string {
 
 func newErrorDirectoryAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &DirectoryAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14809,19 +14809,19 @@ func (s DirectoryAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A directory that has been deleted and to which access has been attempted.
 // Note: The requested resource will eventually cease to exist.
 type DirectoryDeletedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14838,7 +14838,7 @@ func (s DirectoryDeletedException) GoString() string {
 
 func newErrorDirectoryDeletedException(v protocol.ResponseMetadata) error {
 	return &DirectoryDeletedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14866,18 +14866,18 @@ func (s DirectoryDeletedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryDeletedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryDeletedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An operation can only operate on a disabled directory.
 type DirectoryNotDisabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14894,7 +14894,7 @@ func (s DirectoryNotDisabledException) GoString() string {
 
 func newErrorDirectoryNotDisabledException(v protocol.ResponseMetadata) error {
 	return &DirectoryNotDisabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14922,18 +14922,18 @@ func (s DirectoryNotDisabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryNotDisabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryNotDisabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Operations are only permitted on enabled directories.
 type DirectoryNotEnabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14950,7 +14950,7 @@ func (s DirectoryNotEnabledException) GoString() string {
 
 func newErrorDirectoryNotEnabledException(v protocol.ResponseMetadata) error {
 	return &DirectoryNotEnabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14978,12 +14978,12 @@ func (s DirectoryNotEnabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryNotEnabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryNotEnabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DisableDirectoryInput struct {
@@ -15162,7 +15162,7 @@ func (s *Facet) SetObjectType(v string) *Facet {
 // A facet with the same name already exists.
 type FacetAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15179,7 +15179,7 @@ func (s FacetAlreadyExistsException) GoString() string {
 
 func newErrorFacetAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &FacetAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15207,12 +15207,12 @@ func (s FacetAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FacetAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FacetAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An attribute that is associated with the Facet.
@@ -15481,7 +15481,7 @@ func (s *FacetAttributeUpdate) SetAttribute(v *FacetAttribute) *FacetAttributeUp
 // to an attribute reference in a different facet.
 type FacetInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15498,7 +15498,7 @@ func (s FacetInUseException) GoString() string {
 
 func newErrorFacetInUseException(v protocol.ResponseMetadata) error {
 	return &FacetInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15526,18 +15526,18 @@ func (s FacetInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FacetInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FacetInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified Facet could not be found.
 type FacetNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15554,7 +15554,7 @@ func (s FacetNotFoundException) GoString() string {
 
 func newErrorFacetNotFoundException(v protocol.ResponseMetadata) error {
 	return &FacetNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15582,19 +15582,19 @@ func (s FacetNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FacetNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FacetNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Facet that you provided was not well formed or could not be validated
 // with the schema.
 type FacetValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15611,7 +15611,7 @@ func (s FacetValidationException) GoString() string {
 
 func newErrorFacetValidationException(v protocol.ResponseMetadata) error {
 	return &FacetValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15639,12 +15639,12 @@ func (s FacetValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FacetValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FacetValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetAppliedSchemaVersionInput struct {
@@ -16327,7 +16327,7 @@ func (s *GetTypedLinkFacetInformationOutput) SetIdentityAttributeOrder(v []*stri
 // the directory.
 type IncompatibleSchemaException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16344,7 +16344,7 @@ func (s IncompatibleSchemaException) GoString() string {
 
 func newErrorIncompatibleSchemaException(v protocol.ResponseMetadata) error {
 	return &IncompatibleSchemaException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16372,12 +16372,12 @@ func (s IncompatibleSchemaException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncompatibleSchemaException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncompatibleSchemaException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents an index and an attached object.
@@ -16420,7 +16420,7 @@ func (s *IndexAttachment) SetObjectIdentifier(v string) *IndexAttachment {
 // the appropriate attribute value.
 type IndexedAttributeMissingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16437,7 +16437,7 @@ func (s IndexedAttributeMissingException) GoString() string {
 
 func newErrorIndexedAttributeMissingException(v protocol.ResponseMetadata) error {
 	return &IndexedAttributeMissingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16465,12 +16465,12 @@ func (s IndexedAttributeMissingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IndexedAttributeMissingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IndexedAttributeMissingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates a problem that must be resolved by Amazon Web Services. This might
@@ -16479,7 +16479,7 @@ func (s IndexedAttributeMissingException) RequestID() string {
 // site to see if there are any operational issues with the service.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16496,7 +16496,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16524,18 +16524,18 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the provided ARN value is not valid.
 type InvalidArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16552,7 +16552,7 @@ func (s InvalidArnException) GoString() string {
 
 func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 	return &InvalidArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16580,12 +16580,12 @@ func (s InvalidArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that an attempt to make an attachment was invalid. For example,
@@ -16593,7 +16593,7 @@ func (s InvalidArnException) RequestID() string {
 // or attempting to apply a schema to a directory a second time.
 type InvalidAttachmentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16610,7 +16610,7 @@ func (s InvalidAttachmentException) GoString() string {
 
 func newErrorInvalidAttachmentException(v protocol.ResponseMetadata) error {
 	return &InvalidAttachmentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16638,18 +16638,18 @@ func (s InvalidAttachmentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAttachmentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAttachmentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An attempt to modify a Facet resulted in an invalid schema exception.
 type InvalidFacetUpdateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16666,7 +16666,7 @@ func (s InvalidFacetUpdateException) GoString() string {
 
 func newErrorInvalidFacetUpdateException(v protocol.ResponseMetadata) error {
 	return &InvalidFacetUpdateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16694,18 +16694,18 @@ func (s InvalidFacetUpdateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFacetUpdateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFacetUpdateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the NextToken value is not valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16722,7 +16722,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16750,18 +16750,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Occurs when any of the rule parameter keys or values are invalid.
 type InvalidRuleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16778,7 +16778,7 @@ func (s InvalidRuleException) GoString() string {
 
 func newErrorInvalidRuleException(v protocol.ResponseMetadata) error {
 	return &InvalidRuleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16806,18 +16806,18 @@ func (s InvalidRuleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRuleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRuleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the provided SchemaDoc value is not valid.
 type InvalidSchemaDocException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16834,7 +16834,7 @@ func (s InvalidSchemaDocException) GoString() string {
 
 func newErrorInvalidSchemaDocException(v protocol.ResponseMetadata) error {
 	return &InvalidSchemaDocException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16862,12 +16862,12 @@ func (s InvalidSchemaDocException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSchemaDocException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSchemaDocException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Can occur for multiple reasons such as when you tag a resource that doesn’t
@@ -16875,7 +16875,7 @@ func (s InvalidSchemaDocException) RequestID() string {
 // limit. Allowed limit is 50 tags per resource.
 type InvalidTaggingRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16892,7 +16892,7 @@ func (s InvalidTaggingRequestException) GoString() string {
 
 func newErrorInvalidTaggingRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidTaggingRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16920,19 +16920,19 @@ func (s InvalidTaggingRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTaggingRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTaggingRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that limits are exceeded. See Limits (https://docs.aws.amazon.com/clouddirectory/latest/developerguide/limits.html)
 // for more information.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16949,7 +16949,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16977,12 +16977,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The action to take on a typed link attribute value. Updates are only supported
@@ -17071,7 +17071,7 @@ func (s *LinkAttributeUpdate) SetAttributeKey(v *AttributeKey) *LinkAttributeUpd
 // a different name and then try again.
 type LinkNameAlreadyInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17088,7 +17088,7 @@ func (s LinkNameAlreadyInUseException) GoString() string {
 
 func newErrorLinkNameAlreadyInUseException(v protocol.ResponseMetadata) error {
 	return &LinkNameAlreadyInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17116,12 +17116,12 @@ func (s LinkNameAlreadyInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LinkNameAlreadyInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LinkNameAlreadyInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAppliedSchemaArnsInput struct {
@@ -19452,7 +19452,7 @@ func (s *LookupPolicyOutput) SetPolicyToPathList(v []*PolicyToPath) *LookupPolic
 // Indicates that the requested operation can only operate on index objects.
 type NotIndexException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19469,7 +19469,7 @@ func (s NotIndexException) GoString() string {
 
 func newErrorNotIndexException(v protocol.ResponseMetadata) error {
 	return &NotIndexException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19497,19 +19497,19 @@ func (s NotIndexException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotIndexException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotIndexException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Occurs when any invalid operations are performed on an object that is not
 // a node, such as calling ListObjectChildren for a leaf node object.
 type NotNodeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19526,7 +19526,7 @@ func (s NotNodeException) GoString() string {
 
 func newErrorNotNodeException(v protocol.ResponseMetadata) error {
 	return &NotNodeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19554,18 +19554,18 @@ func (s NotNodeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotNodeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotNodeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the requested operation can only operate on policy objects.
 type NotPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19582,7 +19582,7 @@ func (s NotPolicyException) GoString() string {
 
 func newErrorNotPolicyException(v protocol.ResponseMetadata) error {
 	return &NotPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19610,18 +19610,18 @@ func (s NotPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the object is not attached to the index.
 type ObjectAlreadyDetachedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19638,7 +19638,7 @@ func (s ObjectAlreadyDetachedException) GoString() string {
 
 func newErrorObjectAlreadyDetachedException(v protocol.ResponseMetadata) error {
 	return &ObjectAlreadyDetachedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19666,12 +19666,12 @@ func (s ObjectAlreadyDetachedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ObjectAlreadyDetachedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ObjectAlreadyDetachedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The action to take on the object attribute.
@@ -19845,7 +19845,7 @@ func (s *ObjectIdentifierAndLinkNameTuple) SetObjectIdentifier(v string) *Object
 // has not been detached from the tree.
 type ObjectNotDetachedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19862,7 +19862,7 @@ func (s ObjectNotDetachedException) GoString() string {
 
 func newErrorObjectNotDetachedException(v protocol.ResponseMetadata) error {
 	return &ObjectNotDetachedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19890,12 +19890,12 @@ func (s ObjectNotDetachedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ObjectNotDetachedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ObjectNotDetachedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The reference that identifies an object.
@@ -20319,7 +20319,7 @@ func (s RemoveFacetFromObjectOutput) GoString() string {
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20336,7 +20336,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20364,12 +20364,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Occurs when a conflict with a previous successful write is detected. For
@@ -20380,7 +20380,7 @@ func (s ResourceNotFoundException) RequestID() string {
 // backoff logic) is the recommended response to this exception.
 type RetryableConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20397,7 +20397,7 @@ func (s RetryableConflictException) GoString() string {
 
 func newErrorRetryableConflictException(v protocol.ResponseMetadata) error {
 	return &RetryableConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20425,12 +20425,12 @@ func (s RetryableConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RetryableConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RetryableConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains an Amazon Resource Name (ARN) and parameters that are associated
@@ -20471,7 +20471,7 @@ func (s *Rule) SetType(v string) *Rule {
 // select a different name and then try again.
 type SchemaAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20488,7 +20488,7 @@ func (s SchemaAlreadyExistsException) GoString() string {
 
 func newErrorSchemaAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &SchemaAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20516,18 +20516,18 @@ func (s SchemaAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SchemaAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SchemaAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that a schema is already published.
 type SchemaAlreadyPublishedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20544,7 +20544,7 @@ func (s SchemaAlreadyPublishedException) GoString() string {
 
 func newErrorSchemaAlreadyPublishedException(v protocol.ResponseMetadata) error {
 	return &SchemaAlreadyPublishedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20572,12 +20572,12 @@ func (s SchemaAlreadyPublishedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SchemaAlreadyPublishedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SchemaAlreadyPublishedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A facet.
@@ -20632,7 +20632,7 @@ func (s *SchemaFacet) SetSchemaArn(v string) *SchemaFacet {
 // and then try the operation again.
 type StillContainsLinksException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20649,7 +20649,7 @@ func (s StillContainsLinksException) GoString() string {
 
 func newErrorStillContainsLinksException(v protocol.ResponseMetadata) error {
 	return &StillContainsLinksException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20677,12 +20677,12 @@ func (s StillContainsLinksException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StillContainsLinksException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StillContainsLinksException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The tag structure that contains a tag key and value.
@@ -21374,7 +21374,7 @@ func (s *TypedLinkSpecifier) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName) *
 // Indicates that the requested index type is not supported.
 type UnsupportedIndexTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -21391,7 +21391,7 @@ func (s UnsupportedIndexTypeException) GoString() string {
 
 func newErrorUnsupportedIndexTypeException(v protocol.ResponseMetadata) error {
 	return &UnsupportedIndexTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21419,12 +21419,12 @@ func (s UnsupportedIndexTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedIndexTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedIndexTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -22188,7 +22188,7 @@ func (s *UpgradePublishedSchemaOutput) SetUpgradedSchemaArn(v string) *UpgradePu
 // message.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -22205,7 +22205,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22233,12 +22233,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/clouddirectory/api.go
+++ b/service/clouddirectory/api.go
@@ -8720,8 +8720,8 @@ func (c *CloudDirectory) UpgradePublishedSchemaWithContext(ctx aws.Context, inpu
 
 // Access denied. Check your permissions.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12824,8 +12824,8 @@ func (s *BatchUpdateObjectAttributesResponse) SetObjectIdentifier(v string) *Bat
 
 // A BatchWrite exception has occurred.
 type BatchWriteException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Index *int64 `type:"integer"`
 
@@ -13363,8 +13363,8 @@ func (s *BatchWriteOutput) SetResponses(v []*BatchWriteOperationResponse) *Batch
 
 // Cannot list the parents of a Directory root.
 type CannotListParentOfRootException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14763,8 +14763,8 @@ func (s *Directory) SetState(v string) *Directory {
 // Indicates that a Directory could not be created due to a naming conflict.
 // Choose a different name and try again.
 type DirectoryAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14820,8 +14820,8 @@ func (s DirectoryAlreadyExistsException) RequestID() string {
 // A directory that has been deleted and to which access has been attempted.
 // Note: The requested resource will eventually cease to exist.
 type DirectoryDeletedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14876,8 +14876,8 @@ func (s DirectoryDeletedException) RequestID() string {
 
 // An operation can only operate on a disabled directory.
 type DirectoryNotDisabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14932,8 +14932,8 @@ func (s DirectoryNotDisabledException) RequestID() string {
 
 // Operations are only permitted on enabled directories.
 type DirectoryNotEnabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15161,8 +15161,8 @@ func (s *Facet) SetObjectType(v string) *Facet {
 
 // A facet with the same name already exists.
 type FacetAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15480,8 +15480,8 @@ func (s *FacetAttributeUpdate) SetAttribute(v *FacetAttribute) *FacetAttributeUp
 // Occurs when deleting a facet that contains an attribute that is a target
 // to an attribute reference in a different facet.
 type FacetInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15536,8 +15536,8 @@ func (s FacetInUseException) RequestID() string {
 
 // The specified Facet could not be found.
 type FacetNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15593,8 +15593,8 @@ func (s FacetNotFoundException) RequestID() string {
 // The Facet that you provided was not well formed or could not be validated
 // with the schema.
 type FacetValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16326,8 +16326,8 @@ func (s *GetTypedLinkFacetInformationOutput) SetIdentityAttributeOrder(v []*stri
 // between the specified schema and the schema that is currently applied to
 // the directory.
 type IncompatibleSchemaException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16419,8 +16419,8 @@ func (s *IndexAttachment) SetObjectIdentifier(v string) *IndexAttachment {
 // An object has been attempted to be attached to an object that does not have
 // the appropriate attribute value.
 type IndexedAttributeMissingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16478,8 +16478,8 @@ func (s IndexedAttributeMissingException) RequestID() string {
 // Otherwise, go to the AWS Service Health Dashboard (http://status.aws.amazon.com/)
 // site to see if there are any operational issues with the service.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16534,8 +16534,8 @@ func (s InternalServiceException) RequestID() string {
 
 // Indicates that the provided ARN value is not valid.
 type InvalidArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16592,8 +16592,8 @@ func (s InvalidArnException) RequestID() string {
 // attaching two nodes with a link type that is not applicable to the nodes
 // or attempting to apply a schema to a directory a second time.
 type InvalidAttachmentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16648,8 +16648,8 @@ func (s InvalidAttachmentException) RequestID() string {
 
 // An attempt to modify a Facet resulted in an invalid schema exception.
 type InvalidFacetUpdateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16704,8 +16704,8 @@ func (s InvalidFacetUpdateException) RequestID() string {
 
 // Indicates that the NextToken value is not valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16760,8 +16760,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // Occurs when any of the rule parameter keys or values are invalid.
 type InvalidRuleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16816,8 +16816,8 @@ func (s InvalidRuleException) RequestID() string {
 
 // Indicates that the provided SchemaDoc value is not valid.
 type InvalidSchemaDocException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16874,8 +16874,8 @@ func (s InvalidSchemaDocException) RequestID() string {
 // exist or if you specify a higher number of tags for a resource than the allowed
 // limit. Allowed limit is 50 tags per resource.
 type InvalidTaggingRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -16931,8 +16931,8 @@ func (s InvalidTaggingRequestException) RequestID() string {
 // Indicates that limits are exceeded. See Limits (https://docs.aws.amazon.com/clouddirectory/latest/developerguide/limits.html)
 // for more information.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17070,8 +17070,8 @@ func (s *LinkAttributeUpdate) SetAttributeKey(v *AttributeKey) *LinkAttributeUpd
 // Indicates that a link could not be created due to a naming conflict. Choose
 // a different name and then try again.
 type LinkNameAlreadyInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19451,8 +19451,8 @@ func (s *LookupPolicyOutput) SetPolicyToPathList(v []*PolicyToPath) *LookupPolic
 
 // Indicates that the requested operation can only operate on index objects.
 type NotIndexException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19508,8 +19508,8 @@ func (s NotIndexException) RequestID() string {
 // Occurs when any invalid operations are performed on an object that is not
 // a node, such as calling ListObjectChildren for a leaf node object.
 type NotNodeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19564,8 +19564,8 @@ func (s NotNodeException) RequestID() string {
 
 // Indicates that the requested operation can only operate on policy objects.
 type NotPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19620,8 +19620,8 @@ func (s NotPolicyException) RequestID() string {
 
 // Indicates that the object is not attached to the index.
 type ObjectAlreadyDetachedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19844,8 +19844,8 @@ func (s *ObjectIdentifierAndLinkNameTuple) SetObjectIdentifier(v string) *Object
 // Indicates that the requested operation cannot be completed because the object
 // has not been detached from the tree.
 type ObjectNotDetachedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20318,8 +20318,8 @@ func (s RemoveFacetFromObjectOutput) GoString() string {
 
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20379,8 +20379,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // to propagate to the host serving the current request. A retry (with appropriate
 // backoff logic) is the recommended response to this exception.
 type RetryableConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20470,8 +20470,8 @@ func (s *Rule) SetType(v string) *Rule {
 // Indicates that a schema could not be created due to a naming conflict. Please
 // select a different name and then try again.
 type SchemaAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20526,8 +20526,8 @@ func (s SchemaAlreadyExistsException) RequestID() string {
 
 // Indicates that a schema is already published.
 type SchemaAlreadyPublishedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -20631,8 +20631,8 @@ func (s *SchemaFacet) SetSchemaArn(v string) *SchemaFacet {
 // The object could not be deleted because links still exist. Remove the links
 // and then try the operation again.
 type StillContainsLinksException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -21373,8 +21373,8 @@ func (s *TypedLinkSpecifier) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName) *
 
 // Indicates that the requested index type is not supported.
 type UnsupportedIndexTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -22187,8 +22187,8 @@ func (s *UpgradePublishedSchemaOutput) SetUpgradedSchemaArn(v string) *UpgradePu
 // Indicates that your request is malformed in some manner. See the exception
 // message.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -2019,7 +2019,7 @@ func (s *AddTagsToResourceOutput) SetStatus(v string) *AddTagsToResourceOutput {
 // Indicates that an internal error occurred.
 type CloudHsmInternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2036,7 +2036,7 @@ func (s CloudHsmInternalException) GoString() string {
 
 func newErrorCloudHsmInternalException(v protocol.ResponseMetadata) error {
 	return &CloudHsmInternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2064,18 +2064,18 @@ func (s CloudHsmInternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmInternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmInternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that an exception occurred in the AWS CloudHSM service.
 type CloudHsmServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Additional information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2096,7 +2096,7 @@ func (s CloudHsmServiceException) GoString() string {
 
 func newErrorCloudHsmServiceException(v protocol.ResponseMetadata) error {
 	return &CloudHsmServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2124,12 +2124,12 @@ func (s CloudHsmServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the inputs for the CreateHapgRequest action.
@@ -3196,7 +3196,7 @@ func (s *GetConfigOutput) SetConfigType(v string) *GetConfigOutput {
 // Indicates that one or more of the request parameters are not valid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3213,7 +3213,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3241,12 +3241,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the inputs for the ListAvailableZones action.

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -2018,8 +2018,8 @@ func (s *AddTagsToResourceOutput) SetStatus(v string) *AddTagsToResourceOutput {
 
 // Indicates that an internal error occurred.
 type CloudHsmInternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2074,8 +2074,8 @@ func (s CloudHsmInternalException) RequestID() string {
 
 // Indicates that an exception occurred in the AWS CloudHSM service.
 type CloudHsmServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Additional information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3195,8 +3195,8 @@ func (s *GetConfigOutput) SetConfigType(v string) *GetConfigOutput {
 
 // Indicates that one or more of the request parameters are not valid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/cloudhsmv2/api.go
+++ b/service/cloudhsmv2/api.go
@@ -1622,7 +1622,7 @@ func (s *Certificates) SetManufacturerHardwareCertificate(v string) *Certificate
 // perform the requested operation.
 type CloudHsmAccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1639,7 +1639,7 @@ func (s CloudHsmAccessDeniedException) GoString() string {
 
 func newErrorCloudHsmAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &CloudHsmAccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1667,19 +1667,19 @@ func (s CloudHsmAccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmAccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmAccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because of an AWS CloudHSM internal failure. The
 // request can be retried.
 type CloudHsmInternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1696,7 +1696,7 @@ func (s CloudHsmInternalFailureException) GoString() string {
 
 func newErrorCloudHsmInternalFailureException(v protocol.ResponseMetadata) error {
 	return &CloudHsmInternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1724,18 +1724,18 @@ func (s CloudHsmInternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmInternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmInternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because it is not a valid request.
 type CloudHsmInvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1752,7 +1752,7 @@ func (s CloudHsmInvalidRequestException) GoString() string {
 
 func newErrorCloudHsmInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &CloudHsmInvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1780,18 +1780,18 @@ func (s CloudHsmInvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmInvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmInvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because it refers to a resource that cannot be found.
 type CloudHsmResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1808,7 +1808,7 @@ func (s CloudHsmResourceNotFoundException) GoString() string {
 
 func newErrorCloudHsmResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &CloudHsmResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1836,18 +1836,18 @@ func (s CloudHsmResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because an error occurred.
 type CloudHsmServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1864,7 +1864,7 @@ func (s CloudHsmServiceException) GoString() string {
 
 func newErrorCloudHsmServiceException(v protocol.ResponseMetadata) error {
 	return &CloudHsmServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1892,17 +1892,17 @@ func (s CloudHsmServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CloudHsmTagException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1919,7 +1919,7 @@ func (s CloudHsmTagException) GoString() string {
 
 func newErrorCloudHsmTagException(v protocol.ResponseMetadata) error {
 	return &CloudHsmTagException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1947,12 +1947,12 @@ func (s CloudHsmTagException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmTagException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmTagException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about an AWS CloudHSM cluster.

--- a/service/cloudhsmv2/api.go
+++ b/service/cloudhsmv2/api.go
@@ -1621,8 +1621,8 @@ func (s *Certificates) SetManufacturerHardwareCertificate(v string) *Certificate
 // The request was rejected because the requester does not have permission to
 // perform the requested operation.
 type CloudHsmAccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1678,8 +1678,8 @@ func (s CloudHsmAccessDeniedException) RequestID() string {
 // The request was rejected because of an AWS CloudHSM internal failure. The
 // request can be retried.
 type CloudHsmInternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1734,8 +1734,8 @@ func (s CloudHsmInternalFailureException) RequestID() string {
 
 // The request was rejected because it is not a valid request.
 type CloudHsmInvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1790,8 +1790,8 @@ func (s CloudHsmInvalidRequestException) RequestID() string {
 
 // The request was rejected because it refers to a resource that cannot be found.
 type CloudHsmResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1846,8 +1846,8 @@ func (s CloudHsmResourceNotFoundException) RequestID() string {
 
 // The request was rejected because an error occurred.
 type CloudHsmServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1901,8 +1901,8 @@ func (s CloudHsmServiceException) RequestID() string {
 }
 
 type CloudHsmTagException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -360,8 +360,8 @@ func (s *BucketInfo) SetBuckets(v []*Bucket) *BucketInfo {
 
 // Information about any problems encountered while processing an upload request.
 type DocumentServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The description of the errors returned by the document service.
 	Message_ *string `locationName:"message" type:"string"`
@@ -657,8 +657,8 @@ func (s *Hits) SetStart(v int64) *Hits {
 
 // Information about any problems encountered while processing a search request.
 type SearchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description of the error returned by the search service.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -361,7 +361,7 @@ func (s *BucketInfo) SetBuckets(v []*Bucket) *BucketInfo {
 // Information about any problems encountered while processing an upload request.
 type DocumentServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The description of the errors returned by the document service.
 	Message_ *string `locationName:"message" type:"string"`
@@ -382,7 +382,7 @@ func (s DocumentServiceException) GoString() string {
 
 func newErrorDocumentServiceException(v protocol.ResponseMetadata) error {
 	return &DocumentServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -410,12 +410,12 @@ func (s DocumentServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DocumentServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DocumentServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A warning returned by the document service when an issue is discovered while
@@ -658,7 +658,7 @@ func (s *Hits) SetStart(v int64) *Hits {
 // Information about any problems encountered while processing a search request.
 type SearchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description of the error returned by the search service.
 	Message_ *string `locationName:"message" type:"string"`
@@ -676,7 +676,7 @@ func (s SearchException) GoString() string {
 
 func newErrorSearchException(v protocol.ResponseMetadata) error {
 	return &SearchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -704,12 +704,12 @@ func (s SearchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SearchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SearchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Container for the parameters to the Search request.

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -2524,8 +2524,8 @@ func (c *CloudTrail) UpdateTrailWithContext(ctx aws.Context, input *UpdateTrailI
 //
 // arn:aws:cloudtrail:us-east-2:123456789012:trail/MyTrail
 type ARNInvalidException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2583,8 +2583,8 @@ func (s ARNInvalidException) RequestID() string {
 // Trusted Access with Other AWS Services (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html)
 // and Prepare For Creating a Trail For Your Organization (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html).
 type AccessNotEnabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2716,8 +2716,8 @@ func (s AddTagsOutput) GoString() string {
 
 // Cannot set a CloudWatch Logs delivery for this region.
 type CloudWatchLogsDeliveryUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4026,8 +4026,8 @@ func (s *GetTrailStatusOutput) SetTimeLoggingStopped(v string) *GetTrailStatusOu
 // If you run GetInsightSelectors on a trail that does not have Insights events
 // enabled, the operation throws the exception InsightNotEnabledException.
 type InsightNotEnabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4111,8 +4111,8 @@ func (s *InsightSelector) SetInsightType(v string) *InsightSelector {
 // an organization trail in a required service. For more information, see Prepare
 // For Creating a Trail For Your Organization (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html).
 type InsufficientDependencyServiceAccessPermissionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4168,8 +4168,8 @@ func (s InsufficientDependencyServiceAccessPermissionException) RequestID() stri
 // This exception is thrown when the policy on the S3 bucket or KMS key is not
 // sufficient.
 type InsufficientEncryptionPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4224,8 +4224,8 @@ func (s InsufficientEncryptionPolicyException) RequestID() string {
 
 // This exception is thrown when the policy on the S3 bucket is not sufficient.
 type InsufficientS3BucketPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4280,8 +4280,8 @@ func (s InsufficientS3BucketPolicyException) RequestID() string {
 
 // This exception is thrown when the policy on the SNS topic is not sufficient.
 type InsufficientSnsTopicPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4336,8 +4336,8 @@ func (s InsufficientSnsTopicPolicyException) RequestID() string {
 
 // This exception is thrown when the provided CloudWatch log group is not valid.
 type InvalidCloudWatchLogsLogGroupArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4392,8 +4392,8 @@ func (s InvalidCloudWatchLogsLogGroupArnException) RequestID() string {
 
 // This exception is thrown when the provided role is not valid.
 type InvalidCloudWatchLogsRoleArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4449,8 +4449,8 @@ func (s InvalidCloudWatchLogsRoleArnException) RequestID() string {
 // Occurs if an event category that is not valid is specified as a value of
 // EventCategory.
 type InvalidEventCategoryException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4523,8 +4523,8 @@ func (s InvalidEventCategoryException) RequestID() string {
 //    * Specify a valid value for a parameter. For example, specifying the ReadWriteType
 //    parameter with a value of read-only is invalid.
 type InvalidEventSelectorsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4580,8 +4580,8 @@ func (s InvalidEventSelectorsException) RequestID() string {
 // This exception is thrown when an operation is called on a trail from a region
 // other than the region in which the trail was created.
 type InvalidHomeRegionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4638,8 +4638,8 @@ func (s InvalidHomeRegionException) RequestID() string {
 // or GetInsightSelectors request is not valid, or the specified insight type
 // in the InsightSelectors statement is not a valid insight type.
 type InvalidInsightSelectorsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4694,8 +4694,8 @@ func (s InvalidInsightSelectorsException) RequestID() string {
 
 // This exception is thrown when the KMS key ARN is invalid.
 type InvalidKmsKeyIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4750,8 +4750,8 @@ func (s InvalidKmsKeyIdException) RequestID() string {
 
 // Occurs when an invalid lookup attribute is specified.
 type InvalidLookupAttributesException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4806,8 +4806,8 @@ func (s InvalidLookupAttributesException) RequestID() string {
 
 // This exception is thrown if the limit specified is invalid.
 type InvalidMaxResultsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4863,8 +4863,8 @@ func (s InvalidMaxResultsException) RequestID() string {
 // Invalid token or token that was previously used in a request with different
 // parameters. This exception is thrown if the token is invalid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4920,8 +4920,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // This exception is thrown when the combination of parameters provided is not
 // valid.
 type InvalidParameterCombinationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4976,8 +4976,8 @@ func (s InvalidParameterCombinationException) RequestID() string {
 
 // This exception is thrown when the provided S3 bucket name is not valid.
 type InvalidS3BucketNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5032,8 +5032,8 @@ func (s InvalidS3BucketNameException) RequestID() string {
 
 // This exception is thrown when the provided S3 prefix is not valid.
 type InvalidS3PrefixException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5088,8 +5088,8 @@ func (s InvalidS3PrefixException) RequestID() string {
 
 // This exception is thrown when the provided SNS topic name is not valid.
 type InvalidSnsTopicNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5145,8 +5145,8 @@ func (s InvalidSnsTopicNameException) RequestID() string {
 // This exception is thrown when the specified tag key or values are not valid.
 // It can also occur if there are duplicate tags or too many tags on the resource.
 type InvalidTagParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5202,8 +5202,8 @@ func (s InvalidTagParameterException) RequestID() string {
 // Occurs if the timestamp values are invalid. Either the start time occurs
 // after the end time or the time range is outside the range of possible values.
 type InvalidTimeRangeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5258,8 +5258,8 @@ func (s InvalidTimeRangeException) RequestID() string {
 
 // Reserved for future use.
 type InvalidTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5327,8 +5327,8 @@ func (s InvalidTokenException) RequestID() string {
 //
 //    * Not be in IP address format (for example, 192.168.5.4)
 type InvalidTrailNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5384,8 +5384,8 @@ func (s InvalidTrailNameException) RequestID() string {
 // This exception is thrown when there is an issue with the specified KMS key
 // and the trail can’t be updated.
 type KmsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5442,8 +5442,8 @@ func (s KmsException) RequestID() string {
 //
 // Deprecated: KmsKeyDisabledException has been deprecated
 type KmsKeyDisabledException struct {
-	_            struct{} `deprecated:"true" type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `deprecated:"true" type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5499,8 +5499,8 @@ func (s KmsKeyDisabledException) RequestID() string {
 // This exception is thrown when the KMS key does not exist, or when the S3
 // bucket and the KMS key are not in the same region.
 type KmsKeyNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5981,8 +5981,8 @@ func (s *LookupEventsOutput) SetNextToken(v string) *LookupEventsOutput {
 
 // This exception is thrown when the maximum number of trails is reached.
 type MaximumNumberOfTrailsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6040,8 +6040,8 @@ func (s MaximumNumberOfTrailsExceededException) RequestID() string {
 // in AWS Organizations. For more information, see Prepare For Creating a Trail
 // For Your Organization (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html).
 type NotOrganizationMasterAccountException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6096,8 +6096,8 @@ func (s NotOrganizationMasterAccountException) RequestID() string {
 
 // This exception is thrown when the requested operation is not permitted.
 type OperationNotPermittedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6155,8 +6155,8 @@ func (s OperationNotPermittedException) RequestID() string {
 // creating an organization trail. For more information, see Prepare For Creating
 // a Trail For Your Organization (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html).
 type OrganizationNotInAllFeaturesModeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6213,8 +6213,8 @@ func (s OrganizationNotInAllFeaturesModeException) RequestID() string {
 // is not a member of an organization. To make this request, sign in using the
 // credentials of an account that belongs to an organization.
 type OrganizationsNotInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6632,8 +6632,8 @@ func (s *Resource) SetResourceType(v string) *Resource {
 
 // This exception is thrown when the specified resource is not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6722,8 +6722,8 @@ func (s *ResourceTag) SetTagsList(v []*Tag) *ResourceTag {
 // This exception is thrown when the specified resource type is not supported
 // by CloudTrail.
 type ResourceTypeNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6778,8 +6778,8 @@ func (s ResourceTypeNotSupportedException) RequestID() string {
 
 // This exception is thrown when the specified S3 bucket does not exist.
 type S3BucketDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7002,8 +7002,8 @@ func (s *Tag) SetValue(v string) *Tag {
 // The number of tags per trail has exceeded the permitted amount. Currently,
 // the limit is 50.
 type TagsLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7235,8 +7235,8 @@ func (s *Trail) SetTrailARN(v string) *Trail {
 
 // This exception is thrown when the specified trail already exists.
 type TrailAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7334,8 +7334,8 @@ func (s *TrailInfo) SetTrailARN(v string) *TrailInfo {
 
 // This exception is thrown when the trail with the given name is not found.
 type TrailNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7390,8 +7390,8 @@ func (s TrailNotFoundException) RequestID() string {
 
 // This exception is no longer in use.
 type TrailNotProvidedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7446,8 +7446,8 @@ func (s TrailNotProvidedException) RequestID() string {
 
 // This exception is thrown when the requested operation is not supported.
 type UnsupportedOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -2525,7 +2525,7 @@ func (c *CloudTrail) UpdateTrailWithContext(ctx aws.Context, input *UpdateTrailI
 // arn:aws:cloudtrail:us-east-2:123456789012:trail/MyTrail
 type ARNInvalidException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2542,7 +2542,7 @@ func (s ARNInvalidException) GoString() string {
 
 func newErrorARNInvalidException(v protocol.ResponseMetadata) error {
 	return &ARNInvalidException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2570,12 +2570,12 @@ func (s ARNInvalidException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ARNInvalidException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ARNInvalidException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when trusted access has not been enabled between
@@ -2584,7 +2584,7 @@ func (s ARNInvalidException) RequestID() string {
 // and Prepare For Creating a Trail For Your Organization (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html).
 type AccessNotEnabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2601,7 +2601,7 @@ func (s AccessNotEnabledException) GoString() string {
 
 func newErrorAccessNotEnabledException(v protocol.ResponseMetadata) error {
 	return &AccessNotEnabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2629,12 +2629,12 @@ func (s AccessNotEnabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessNotEnabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessNotEnabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the tags to add to a trail.
@@ -2717,7 +2717,7 @@ func (s AddTagsOutput) GoString() string {
 // Cannot set a CloudWatch Logs delivery for this region.
 type CloudWatchLogsDeliveryUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2734,7 +2734,7 @@ func (s CloudWatchLogsDeliveryUnavailableException) GoString() string {
 
 func newErrorCloudWatchLogsDeliveryUnavailableException(v protocol.ResponseMetadata) error {
 	return &CloudWatchLogsDeliveryUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2762,12 +2762,12 @@ func (s CloudWatchLogsDeliveryUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudWatchLogsDeliveryUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudWatchLogsDeliveryUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the settings for each trail.
@@ -4027,7 +4027,7 @@ func (s *GetTrailStatusOutput) SetTimeLoggingStopped(v string) *GetTrailStatusOu
 // enabled, the operation throws the exception InsightNotEnabledException.
 type InsightNotEnabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4044,7 +4044,7 @@ func (s InsightNotEnabledException) GoString() string {
 
 func newErrorInsightNotEnabledException(v protocol.ResponseMetadata) error {
 	return &InsightNotEnabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4072,12 +4072,12 @@ func (s InsightNotEnabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsightNotEnabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsightNotEnabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A JSON string that contains a list of insight types that are logged on a
@@ -4112,7 +4112,7 @@ func (s *InsightSelector) SetInsightType(v string) *InsightSelector {
 // For Creating a Trail For Your Organization (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html).
 type InsufficientDependencyServiceAccessPermissionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4129,7 +4129,7 @@ func (s InsufficientDependencyServiceAccessPermissionException) GoString() strin
 
 func newErrorInsufficientDependencyServiceAccessPermissionException(v protocol.ResponseMetadata) error {
 	return &InsufficientDependencyServiceAccessPermissionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4157,19 +4157,19 @@ func (s InsufficientDependencyServiceAccessPermissionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientDependencyServiceAccessPermissionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientDependencyServiceAccessPermissionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the policy on the S3 bucket or KMS key is not
 // sufficient.
 type InsufficientEncryptionPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4186,7 +4186,7 @@ func (s InsufficientEncryptionPolicyException) GoString() string {
 
 func newErrorInsufficientEncryptionPolicyException(v protocol.ResponseMetadata) error {
 	return &InsufficientEncryptionPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4214,18 +4214,18 @@ func (s InsufficientEncryptionPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientEncryptionPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientEncryptionPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the policy on the S3 bucket is not sufficient.
 type InsufficientS3BucketPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4242,7 +4242,7 @@ func (s InsufficientS3BucketPolicyException) GoString() string {
 
 func newErrorInsufficientS3BucketPolicyException(v protocol.ResponseMetadata) error {
 	return &InsufficientS3BucketPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4270,18 +4270,18 @@ func (s InsufficientS3BucketPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientS3BucketPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientS3BucketPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the policy on the SNS topic is not sufficient.
 type InsufficientSnsTopicPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4298,7 +4298,7 @@ func (s InsufficientSnsTopicPolicyException) GoString() string {
 
 func newErrorInsufficientSnsTopicPolicyException(v protocol.ResponseMetadata) error {
 	return &InsufficientSnsTopicPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4326,18 +4326,18 @@ func (s InsufficientSnsTopicPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientSnsTopicPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientSnsTopicPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the provided CloudWatch log group is not valid.
 type InvalidCloudWatchLogsLogGroupArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4354,7 +4354,7 @@ func (s InvalidCloudWatchLogsLogGroupArnException) GoString() string {
 
 func newErrorInvalidCloudWatchLogsLogGroupArnException(v protocol.ResponseMetadata) error {
 	return &InvalidCloudWatchLogsLogGroupArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4382,18 +4382,18 @@ func (s InvalidCloudWatchLogsLogGroupArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCloudWatchLogsLogGroupArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCloudWatchLogsLogGroupArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the provided role is not valid.
 type InvalidCloudWatchLogsRoleArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4410,7 +4410,7 @@ func (s InvalidCloudWatchLogsRoleArnException) GoString() string {
 
 func newErrorInvalidCloudWatchLogsRoleArnException(v protocol.ResponseMetadata) error {
 	return &InvalidCloudWatchLogsRoleArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4438,19 +4438,19 @@ func (s InvalidCloudWatchLogsRoleArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCloudWatchLogsRoleArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCloudWatchLogsRoleArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Occurs if an event category that is not valid is specified as a value of
 // EventCategory.
 type InvalidEventCategoryException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4467,7 +4467,7 @@ func (s InvalidEventCategoryException) GoString() string {
 
 func newErrorInvalidEventCategoryException(v protocol.ResponseMetadata) error {
 	return &InvalidEventCategoryException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4495,12 +4495,12 @@ func (s InvalidEventCategoryException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEventCategoryException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEventCategoryException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the PutEventSelectors operation is called with
@@ -4524,7 +4524,7 @@ func (s InvalidEventCategoryException) RequestID() string {
 //    parameter with a value of read-only is invalid.
 type InvalidEventSelectorsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4541,7 +4541,7 @@ func (s InvalidEventSelectorsException) GoString() string {
 
 func newErrorInvalidEventSelectorsException(v protocol.ResponseMetadata) error {
 	return &InvalidEventSelectorsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4569,19 +4569,19 @@ func (s InvalidEventSelectorsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEventSelectorsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEventSelectorsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when an operation is called on a trail from a region
 // other than the region in which the trail was created.
 type InvalidHomeRegionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4598,7 +4598,7 @@ func (s InvalidHomeRegionException) GoString() string {
 
 func newErrorInvalidHomeRegionException(v protocol.ResponseMetadata) error {
 	return &InvalidHomeRegionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4626,12 +4626,12 @@ func (s InvalidHomeRegionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidHomeRegionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidHomeRegionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The formatting or syntax of the InsightSelectors JSON statement in your PutInsightSelectors
@@ -4639,7 +4639,7 @@ func (s InvalidHomeRegionException) RequestID() string {
 // in the InsightSelectors statement is not a valid insight type.
 type InvalidInsightSelectorsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4656,7 +4656,7 @@ func (s InvalidInsightSelectorsException) GoString() string {
 
 func newErrorInvalidInsightSelectorsException(v protocol.ResponseMetadata) error {
 	return &InvalidInsightSelectorsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4684,18 +4684,18 @@ func (s InvalidInsightSelectorsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInsightSelectorsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInsightSelectorsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the KMS key ARN is invalid.
 type InvalidKmsKeyIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4712,7 +4712,7 @@ func (s InvalidKmsKeyIdException) GoString() string {
 
 func newErrorInvalidKmsKeyIdException(v protocol.ResponseMetadata) error {
 	return &InvalidKmsKeyIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4740,18 +4740,18 @@ func (s InvalidKmsKeyIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidKmsKeyIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidKmsKeyIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Occurs when an invalid lookup attribute is specified.
 type InvalidLookupAttributesException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4768,7 +4768,7 @@ func (s InvalidLookupAttributesException) GoString() string {
 
 func newErrorInvalidLookupAttributesException(v protocol.ResponseMetadata) error {
 	return &InvalidLookupAttributesException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4796,18 +4796,18 @@ func (s InvalidLookupAttributesException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLookupAttributesException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLookupAttributesException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown if the limit specified is invalid.
 type InvalidMaxResultsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4824,7 +4824,7 @@ func (s InvalidMaxResultsException) GoString() string {
 
 func newErrorInvalidMaxResultsException(v protocol.ResponseMetadata) error {
 	return &InvalidMaxResultsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4852,19 +4852,19 @@ func (s InvalidMaxResultsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidMaxResultsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidMaxResultsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Invalid token or token that was previously used in a request with different
 // parameters. This exception is thrown if the token is invalid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4881,7 +4881,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4909,19 +4909,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the combination of parameters provided is not
 // valid.
 type InvalidParameterCombinationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4938,7 +4938,7 @@ func (s InvalidParameterCombinationException) GoString() string {
 
 func newErrorInvalidParameterCombinationException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterCombinationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4966,18 +4966,18 @@ func (s InvalidParameterCombinationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterCombinationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterCombinationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the provided S3 bucket name is not valid.
 type InvalidS3BucketNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4994,7 +4994,7 @@ func (s InvalidS3BucketNameException) GoString() string {
 
 func newErrorInvalidS3BucketNameException(v protocol.ResponseMetadata) error {
 	return &InvalidS3BucketNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5022,18 +5022,18 @@ func (s InvalidS3BucketNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidS3BucketNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidS3BucketNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the provided S3 prefix is not valid.
 type InvalidS3PrefixException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5050,7 +5050,7 @@ func (s InvalidS3PrefixException) GoString() string {
 
 func newErrorInvalidS3PrefixException(v protocol.ResponseMetadata) error {
 	return &InvalidS3PrefixException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5078,18 +5078,18 @@ func (s InvalidS3PrefixException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidS3PrefixException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidS3PrefixException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the provided SNS topic name is not valid.
 type InvalidSnsTopicNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5106,7 +5106,7 @@ func (s InvalidSnsTopicNameException) GoString() string {
 
 func newErrorInvalidSnsTopicNameException(v protocol.ResponseMetadata) error {
 	return &InvalidSnsTopicNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5134,19 +5134,19 @@ func (s InvalidSnsTopicNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSnsTopicNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSnsTopicNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the specified tag key or values are not valid.
 // It can also occur if there are duplicate tags or too many tags on the resource.
 type InvalidTagParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5163,7 +5163,7 @@ func (s InvalidTagParameterException) GoString() string {
 
 func newErrorInvalidTagParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidTagParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5191,19 +5191,19 @@ func (s InvalidTagParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Occurs if the timestamp values are invalid. Either the start time occurs
 // after the end time or the time range is outside the range of possible values.
 type InvalidTimeRangeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5220,7 +5220,7 @@ func (s InvalidTimeRangeException) GoString() string {
 
 func newErrorInvalidTimeRangeException(v protocol.ResponseMetadata) error {
 	return &InvalidTimeRangeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5248,18 +5248,18 @@ func (s InvalidTimeRangeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTimeRangeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTimeRangeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Reserved for future use.
 type InvalidTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5276,7 +5276,7 @@ func (s InvalidTokenException) GoString() string {
 
 func newErrorInvalidTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5304,12 +5304,12 @@ func (s InvalidTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the provided trail name is not valid. Trail
@@ -5328,7 +5328,7 @@ func (s InvalidTokenException) RequestID() string {
 //    * Not be in IP address format (for example, 192.168.5.4)
 type InvalidTrailNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5345,7 +5345,7 @@ func (s InvalidTrailNameException) GoString() string {
 
 func newErrorInvalidTrailNameException(v protocol.ResponseMetadata) error {
 	return &InvalidTrailNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5373,19 +5373,19 @@ func (s InvalidTrailNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTrailNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTrailNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when there is an issue with the specified KMS key
 // and the trail can’t be updated.
 type KmsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5402,7 +5402,7 @@ func (s KmsException) GoString() string {
 
 func newErrorKmsException(v protocol.ResponseMetadata) error {
 	return &KmsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5430,12 +5430,12 @@ func (s KmsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KmsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KmsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is no longer in use.
@@ -5443,7 +5443,7 @@ func (s KmsException) RequestID() string {
 // Deprecated: KmsKeyDisabledException has been deprecated
 type KmsKeyDisabledException struct {
 	_            struct{} `deprecated:"true" type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5460,7 +5460,7 @@ func (s KmsKeyDisabledException) GoString() string {
 
 func newErrorKmsKeyDisabledException(v protocol.ResponseMetadata) error {
 	return &KmsKeyDisabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5488,19 +5488,19 @@ func (s KmsKeyDisabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KmsKeyDisabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KmsKeyDisabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the KMS key does not exist, or when the S3
 // bucket and the KMS key are not in the same region.
 type KmsKeyNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5517,7 +5517,7 @@ func (s KmsKeyNotFoundException) GoString() string {
 
 func newErrorKmsKeyNotFoundException(v protocol.ResponseMetadata) error {
 	return &KmsKeyNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5545,12 +5545,12 @@ func (s KmsKeyNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KmsKeyNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KmsKeyNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Requests the public keys for a specified time range.
@@ -5982,7 +5982,7 @@ func (s *LookupEventsOutput) SetNextToken(v string) *LookupEventsOutput {
 // This exception is thrown when the maximum number of trails is reached.
 type MaximumNumberOfTrailsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5999,7 +5999,7 @@ func (s MaximumNumberOfTrailsExceededException) GoString() string {
 
 func newErrorMaximumNumberOfTrailsExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumNumberOfTrailsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6027,12 +6027,12 @@ func (s MaximumNumberOfTrailsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumNumberOfTrailsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumNumberOfTrailsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the AWS account making the request to create
@@ -6041,7 +6041,7 @@ func (s MaximumNumberOfTrailsExceededException) RequestID() string {
 // For Your Organization (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html).
 type NotOrganizationMasterAccountException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6058,7 +6058,7 @@ func (s NotOrganizationMasterAccountException) GoString() string {
 
 func newErrorNotOrganizationMasterAccountException(v protocol.ResponseMetadata) error {
 	return &NotOrganizationMasterAccountException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6086,18 +6086,18 @@ func (s NotOrganizationMasterAccountException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotOrganizationMasterAccountException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotOrganizationMasterAccountException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the requested operation is not permitted.
 type OperationNotPermittedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6114,7 +6114,7 @@ func (s OperationNotPermittedException) GoString() string {
 
 func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 	return &OperationNotPermittedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6142,12 +6142,12 @@ func (s OperationNotPermittedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotPermittedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotPermittedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when AWS Organizations is not configured to support
@@ -6156,7 +6156,7 @@ func (s OperationNotPermittedException) RequestID() string {
 // a Trail For Your Organization (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-an-organizational-trail-prepare.html).
 type OrganizationNotInAllFeaturesModeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6173,7 +6173,7 @@ func (s OrganizationNotInAllFeaturesModeException) GoString() string {
 
 func newErrorOrganizationNotInAllFeaturesModeException(v protocol.ResponseMetadata) error {
 	return &OrganizationNotInAllFeaturesModeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6201,12 +6201,12 @@ func (s OrganizationNotInAllFeaturesModeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationNotInAllFeaturesModeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationNotInAllFeaturesModeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the request is made from an AWS account that
@@ -6214,7 +6214,7 @@ func (s OrganizationNotInAllFeaturesModeException) RequestID() string {
 // credentials of an account that belongs to an organization.
 type OrganizationsNotInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6231,7 +6231,7 @@ func (s OrganizationsNotInUseException) GoString() string {
 
 func newErrorOrganizationsNotInUseException(v protocol.ResponseMetadata) error {
 	return &OrganizationsNotInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6259,12 +6259,12 @@ func (s OrganizationsNotInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationsNotInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationsNotInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a returned public key.
@@ -6633,7 +6633,7 @@ func (s *Resource) SetResourceType(v string) *Resource {
 // This exception is thrown when the specified resource is not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6650,7 +6650,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6678,12 +6678,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A resource tag.
@@ -6723,7 +6723,7 @@ func (s *ResourceTag) SetTagsList(v []*Tag) *ResourceTag {
 // by CloudTrail.
 type ResourceTypeNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6740,7 +6740,7 @@ func (s ResourceTypeNotSupportedException) GoString() string {
 
 func newErrorResourceTypeNotSupportedException(v protocol.ResponseMetadata) error {
 	return &ResourceTypeNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6768,18 +6768,18 @@ func (s ResourceTypeNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceTypeNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceTypeNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the specified S3 bucket does not exist.
 type S3BucketDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6796,7 +6796,7 @@ func (s S3BucketDoesNotExistException) GoString() string {
 
 func newErrorS3BucketDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &S3BucketDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6824,12 +6824,12 @@ func (s S3BucketDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s S3BucketDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s S3BucketDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request to CloudTrail to start logging AWS API calls for an account.
@@ -7003,7 +7003,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // the limit is 50.
 type TagsLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7020,7 +7020,7 @@ func (s TagsLimitExceededException) GoString() string {
 
 func newErrorTagsLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TagsLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7048,12 +7048,12 @@ func (s TagsLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagsLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagsLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The settings for a trail.
@@ -7236,7 +7236,7 @@ func (s *Trail) SetTrailARN(v string) *Trail {
 // This exception is thrown when the specified trail already exists.
 type TrailAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7253,7 +7253,7 @@ func (s TrailAlreadyExistsException) GoString() string {
 
 func newErrorTrailAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &TrailAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7281,12 +7281,12 @@ func (s TrailAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TrailAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TrailAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a CloudTrail trail, including the trail's name, home region,
@@ -7335,7 +7335,7 @@ func (s *TrailInfo) SetTrailARN(v string) *TrailInfo {
 // This exception is thrown when the trail with the given name is not found.
 type TrailNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7352,7 +7352,7 @@ func (s TrailNotFoundException) GoString() string {
 
 func newErrorTrailNotFoundException(v protocol.ResponseMetadata) error {
 	return &TrailNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7380,18 +7380,18 @@ func (s TrailNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TrailNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TrailNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is no longer in use.
 type TrailNotProvidedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7408,7 +7408,7 @@ func (s TrailNotProvidedException) GoString() string {
 
 func newErrorTrailNotProvidedException(v protocol.ResponseMetadata) error {
 	return &TrailNotProvidedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7436,18 +7436,18 @@ func (s TrailNotProvidedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TrailNotProvidedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TrailNotProvidedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the requested operation is not supported.
 type UnsupportedOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7464,7 +7464,7 @@ func (s UnsupportedOperationException) GoString() string {
 
 func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 	return &UnsupportedOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7492,12 +7492,12 @@ func (s UnsupportedOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies settings to update for the trail.

--- a/service/cloudwatchevents/api.go
+++ b/service/cloudwatchevents/api.go
@@ -3243,7 +3243,7 @@ func (s *BatchRetryStrategy) SetAttempts(v int64) *BatchRetryStrategy {
 // There is concurrent modification on a rule or target.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3260,7 +3260,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3288,12 +3288,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A JSON string which you can use to limit the event bus permissions you are
@@ -4709,7 +4709,7 @@ func (s *InputTransformer) SetInputTemplate(v string) *InputTransformer {
 // This exception occurs due to unexpected causes.
 type InternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4726,7 +4726,7 @@ func (s InternalException) GoString() string {
 
 func newErrorInternalException(v protocol.ResponseMetadata) error {
 	return &InternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4754,18 +4754,18 @@ func (s InternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The event pattern is not valid.
 type InvalidEventPatternException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4782,7 +4782,7 @@ func (s InvalidEventPatternException) GoString() string {
 
 func newErrorInvalidEventPatternException(v protocol.ResponseMetadata) error {
 	return &InvalidEventPatternException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4810,18 +4810,18 @@ func (s InvalidEventPatternException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEventPatternException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEventPatternException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified state is not a valid state for an event source.
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4838,7 +4838,7 @@ func (s InvalidStateException) GoString() string {
 
 func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 	return &InvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4866,12 +4866,12 @@ func (s InvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This object enables you to specify a JSON path to extract from the event
@@ -4921,7 +4921,7 @@ func (s *KinesisParameters) SetPartitionKeyPath(v string) *KinesisParameters {
 // You tried to create more rules or add more targets to a rule than is allowed.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4938,7 +4938,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4966,12 +4966,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListEventBusesInput struct {
@@ -5769,7 +5769,7 @@ func (s *ListTargetsByRuleOutput) SetTargets(v []*Target) *ListTargetsByRuleOutp
 // or UntagResource.
 type ManagedRuleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5786,7 +5786,7 @@ func (s ManagedRuleException) GoString() string {
 
 func newErrorManagedRuleException(v protocol.ResponseMetadata) error {
 	return &ManagedRuleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5814,12 +5814,12 @@ func (s ManagedRuleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ManagedRuleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ManagedRuleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This structure specifies the network configuration for an ECS task.
@@ -5957,7 +5957,7 @@ func (s *PartnerEventSourceAccount) SetState(v string) *PartnerEventSourceAccoun
 // The event bus policy is too long. For more information, see the limits.
 type PolicyLengthExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5974,7 +5974,7 @@ func (s PolicyLengthExceededException) GoString() string {
 
 func newErrorPolicyLengthExceededException(v protocol.ResponseMetadata) error {
 	return &PolicyLengthExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6002,12 +6002,12 @@ func (s PolicyLengthExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyLengthExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyLengthExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutEventsInput struct {
@@ -7097,7 +7097,7 @@ func (s *RemoveTargetsResultEntry) SetTargetId(v string) *RemoveTargetsResultEnt
 // The resource you are trying to create already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7114,7 +7114,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7142,18 +7142,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An entity that you specified does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7170,7 +7170,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7198,12 +7198,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a rule in Amazon EventBridge.

--- a/service/cloudwatchevents/api.go
+++ b/service/cloudwatchevents/api.go
@@ -3242,8 +3242,8 @@ func (s *BatchRetryStrategy) SetAttempts(v int64) *BatchRetryStrategy {
 
 // There is concurrent modification on a rule or target.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4708,8 +4708,8 @@ func (s *InputTransformer) SetInputTemplate(v string) *InputTransformer {
 
 // This exception occurs due to unexpected causes.
 type InternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4764,8 +4764,8 @@ func (s InternalException) RequestID() string {
 
 // The event pattern is not valid.
 type InvalidEventPatternException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4820,8 +4820,8 @@ func (s InvalidEventPatternException) RequestID() string {
 
 // The specified state is not a valid state for an event source.
 type InvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4920,8 +4920,8 @@ func (s *KinesisParameters) SetPartitionKeyPath(v string) *KinesisParameters {
 
 // You tried to create more rules or add more targets to a rule than is allowed.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5768,8 +5768,8 @@ func (s *ListTargetsByRuleOutput) SetTargets(v []*Target) *ListTargetsByRuleOutp
 // rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
 // or UntagResource.
 type ManagedRuleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5956,8 +5956,8 @@ func (s *PartnerEventSourceAccount) SetState(v string) *PartnerEventSourceAccoun
 
 // The event bus policy is too long. For more information, see the limits.
 type PolicyLengthExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7096,8 +7096,8 @@ func (s *RemoveTargetsResultEntry) SetTargetId(v string) *RemoveTargetsResultEnt
 
 // The resource you are trying to create already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7152,8 +7152,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // An entity that you specified does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -4484,7 +4484,7 @@ func (s CreateLogStreamOutput) GoString() string {
 // The event was already logged.
 type DataAlreadyAcceptedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ExpectedSequenceToken *string `locationName:"expectedSequenceToken" min:"1" type:"string"`
 
@@ -4503,7 +4503,7 @@ func (s DataAlreadyAcceptedException) GoString() string {
 
 func newErrorDataAlreadyAcceptedException(v protocol.ResponseMetadata) error {
 	return &DataAlreadyAcceptedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4531,12 +4531,12 @@ func (s DataAlreadyAcceptedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DataAlreadyAcceptedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DataAlreadyAcceptedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteDestinationInput struct {
@@ -6839,7 +6839,7 @@ func (s *InputLogEvent) SetTimestamp(v int64) *InputLogEvent {
 // The operation is not valid on the specified resource.
 type InvalidOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6856,7 +6856,7 @@ func (s InvalidOperationException) GoString() string {
 
 func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 	return &InvalidOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6884,18 +6884,18 @@ func (s InvalidOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A parameter is specified incorrectly.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6912,7 +6912,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6940,19 +6940,19 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The sequence token is not valid. You can get the correct sequence token in
 // the expectedSequenceToken field in the InvalidSequenceTokenException message.
 type InvalidSequenceTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ExpectedSequenceToken *string `locationName:"expectedSequenceToken" min:"1" type:"string"`
 
@@ -6971,7 +6971,7 @@ func (s InvalidSequenceTokenException) GoString() string {
 
 func newErrorInvalidSequenceTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidSequenceTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6999,18 +6999,18 @@ func (s InvalidSequenceTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSequenceTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSequenceTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have reached the maximum number of resources that can be created.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7027,7 +7027,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7055,12 +7055,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTagsLogGroupInput struct {
@@ -7350,7 +7350,7 @@ func (s *LogStream) SetUploadSequenceToken(v string) *LogStream {
 // Query Syntax (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html).
 type MalformedQueryException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -7370,7 +7370,7 @@ func (s MalformedQueryException) GoString() string {
 
 func newErrorMalformedQueryException(v protocol.ResponseMetadata) error {
 	return &MalformedQueryException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7398,12 +7398,12 @@ func (s MalformedQueryException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MalformedQueryException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MalformedQueryException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Metric filters express how CloudWatch Logs would extract metric observations
@@ -7596,7 +7596,7 @@ func (s *MetricTransformation) SetMetricValue(v string) *MetricTransformation {
 // Multiple requests to update the same resource were in conflict.
 type OperationAbortedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7613,7 +7613,7 @@ func (s OperationAbortedException) GoString() string {
 
 func newErrorOperationAbortedException(v protocol.ResponseMetadata) error {
 	return &OperationAbortedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7641,12 +7641,12 @@ func (s OperationAbortedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationAbortedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationAbortedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a log event.
@@ -8623,7 +8623,7 @@ func (s *RejectedLogEventsInfo) SetTooOldLogEventEndIndex(v int64) *RejectedLogE
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8640,7 +8640,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8668,18 +8668,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8696,7 +8696,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8724,12 +8724,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A policy enabling one or more entities to put logs to a log group in this
@@ -8846,7 +8846,7 @@ func (s *SearchedLogStream) SetSearchedCompletely(v bool) *SearchedLogStream {
 // The service cannot complete the request.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8863,7 +8863,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8891,12 +8891,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartQueryInput struct {
@@ -9334,7 +9334,7 @@ func (s *TestMetricFilterOutput) SetMatches(v []*MetricFilterMatchRecord) *TestM
 // The most likely cause is an invalid AWS access key ID or secret key.
 type UnrecognizedClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9351,7 +9351,7 @@ func (s UnrecognizedClientException) GoString() string {
 
 func newErrorUnrecognizedClientException(v protocol.ResponseMetadata) error {
 	return &UnrecognizedClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9379,12 +9379,12 @@ func (s UnrecognizedClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnrecognizedClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnrecognizedClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagLogGroupInput struct {

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -4483,8 +4483,8 @@ func (s CreateLogStreamOutput) GoString() string {
 
 // The event was already logged.
 type DataAlreadyAcceptedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ExpectedSequenceToken *string `locationName:"expectedSequenceToken" min:"1" type:"string"`
 
@@ -6838,8 +6838,8 @@ func (s *InputLogEvent) SetTimestamp(v int64) *InputLogEvent {
 
 // The operation is not valid on the specified resource.
 type InvalidOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6894,8 +6894,8 @@ func (s InvalidOperationException) RequestID() string {
 
 // A parameter is specified incorrectly.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6951,8 +6951,8 @@ func (s InvalidParameterException) RequestID() string {
 // The sequence token is not valid. You can get the correct sequence token in
 // the expectedSequenceToken field in the InvalidSequenceTokenException message.
 type InvalidSequenceTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ExpectedSequenceToken *string `locationName:"expectedSequenceToken" min:"1" type:"string"`
 
@@ -7009,8 +7009,8 @@ func (s InvalidSequenceTokenException) RequestID() string {
 
 // You have reached the maximum number of resources that can be created.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7349,8 +7349,8 @@ func (s *LogStream) SetUploadSequenceToken(v string) *LogStream {
 // For more information about valid query syntax, see CloudWatch Logs Insights
 // Query Syntax (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html).
 type MalformedQueryException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -7595,8 +7595,8 @@ func (s *MetricTransformation) SetMetricValue(v string) *MetricTransformation {
 
 // Multiple requests to update the same resource were in conflict.
 type OperationAbortedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8622,8 +8622,8 @@ func (s *RejectedLogEventsInfo) SetTooOldLogEventEndIndex(v int64) *RejectedLogE
 
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8678,8 +8678,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8845,8 +8845,8 @@ func (s *SearchedLogStream) SetSearchedCompletely(v bool) *SearchedLogStream {
 
 // The service cannot complete the request.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9333,8 +9333,8 @@ func (s *TestMetricFilterOutput) SetMatches(v []*MetricFilterMatchRecord) *TestM
 
 // The most likely cause is an invalid AWS access key ID or secret key.
 type UnrecognizedClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/codebuild/api.go
+++ b/service/codebuild/api.go
@@ -2798,8 +2798,8 @@ func (c *CodeBuild) UpdateWebhookWithContext(ctx aws.Context, input *UpdateWebho
 
 // An AWS service limit was exceeded for the calling AWS account.
 type AccountLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5333,8 +5333,8 @@ func (s *ImportSourceCredentialsOutput) SetArn(v string) *ImportSourceCredential
 
 // The input value that was provided is not valid.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6588,8 +6588,8 @@ func (s *NetworkInterface) SetSubnetId(v string) *NetworkInterface {
 
 // There was a problem with the underlying OAuth provider.
 type OAuthProviderException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8266,8 +8266,8 @@ func (s *ReportGroup) SetType(v string) *ReportGroup {
 // The specified AWS resource cannot be created, because an AWS resource with
 // the same settings already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8322,8 +8322,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The specified AWS resource cannot be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/codebuild/api.go
+++ b/service/codebuild/api.go
@@ -2799,7 +2799,7 @@ func (c *CodeBuild) UpdateWebhookWithContext(ctx aws.Context, input *UpdateWebho
 // An AWS service limit was exceeded for the calling AWS account.
 type AccountLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2816,7 +2816,7 @@ func (s AccountLimitExceededException) GoString() string {
 
 func newErrorAccountLimitExceededException(v protocol.ResponseMetadata) error {
 	return &AccountLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2844,12 +2844,12 @@ func (s AccountLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccountLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccountLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type BatchDeleteBuildsInput struct {
@@ -5334,7 +5334,7 @@ func (s *ImportSourceCredentialsOutput) SetArn(v string) *ImportSourceCredential
 // The input value that was provided is not valid.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5351,7 +5351,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5379,12 +5379,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvalidateProjectCacheInput struct {
@@ -6589,7 +6589,7 @@ func (s *NetworkInterface) SetSubnetId(v string) *NetworkInterface {
 // There was a problem with the underlying OAuth provider.
 type OAuthProviderException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6606,7 +6606,7 @@ func (s OAuthProviderException) GoString() string {
 
 func newErrorOAuthProviderException(v protocol.ResponseMetadata) error {
 	return &OAuthProviderException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6634,12 +6634,12 @@ func (s OAuthProviderException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OAuthProviderException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OAuthProviderException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Additional information about a build phase that has an error. You can use
@@ -8267,7 +8267,7 @@ func (s *ReportGroup) SetType(v string) *ReportGroup {
 // the same settings already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8284,7 +8284,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8312,18 +8312,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified AWS resource cannot be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8340,7 +8340,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8368,12 +8368,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about S3 logs for a build project.

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -10355,7 +10355,7 @@ func (c *CodeCommit) UpdateRepositoryNameWithContext(ctx aws.Context, input *Upd
 // The specified Amazon Resource Name (ARN) does not exist in the AWS account.
 type ActorDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10372,7 +10372,7 @@ func (s ActorDoesNotExistException) GoString() string {
 
 func newErrorActorDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &ActorDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10400,12 +10400,12 @@ func (s ActorDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ActorDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ActorDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about a specific approval on a pull request.
@@ -10533,7 +10533,7 @@ func (s *ApprovalRule) SetRuleContentSha256(v string) *ApprovalRule {
 // for an approval rule. The content cannot be null.
 type ApprovalRuleContentRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10550,7 +10550,7 @@ func (s ApprovalRuleContentRequiredException) GoString() string {
 
 func newErrorApprovalRuleContentRequiredException(v protocol.ResponseMetadata) error {
 	return &ApprovalRuleContentRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10578,18 +10578,18 @@ func (s ApprovalRuleContentRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalRuleContentRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalRuleContentRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified approval rule does not exist.
 type ApprovalRuleDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10606,7 +10606,7 @@ func (s ApprovalRuleDoesNotExistException) GoString() string {
 
 func newErrorApprovalRuleDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &ApprovalRuleDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10634,12 +10634,12 @@ func (s ApprovalRuleDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalRuleDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalRuleDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about an event for an approval rule.
@@ -10688,7 +10688,7 @@ func (s *ApprovalRuleEventMetadata) SetApprovalRuleName(v string) *ApprovalRuleE
 // be unique within the scope of a pull request.
 type ApprovalRuleNameAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10705,7 +10705,7 @@ func (s ApprovalRuleNameAlreadyExistsException) GoString() string {
 
 func newErrorApprovalRuleNameAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ApprovalRuleNameAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10733,18 +10733,18 @@ func (s ApprovalRuleNameAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalRuleNameAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalRuleNameAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An approval rule name is required, but was not specified.
 type ApprovalRuleNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10761,7 +10761,7 @@ func (s ApprovalRuleNameRequiredException) GoString() string {
 
 func newErrorApprovalRuleNameRequiredException(v protocol.ResponseMetadata) error {
 	return &ApprovalRuleNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10789,12 +10789,12 @@ func (s ApprovalRuleNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalRuleNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalRuleNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about an override event for approval rules for a pull
@@ -10924,7 +10924,7 @@ func (s *ApprovalRuleTemplate) SetRuleContentSha256(v string) *ApprovalRuleTempl
 // content for an approval rule template. The content cannot be null.
 type ApprovalRuleTemplateContentRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10941,7 +10941,7 @@ func (s ApprovalRuleTemplateContentRequiredException) GoString() string {
 
 func newErrorApprovalRuleTemplateContentRequiredException(v protocol.ResponseMetadata) error {
 	return &ApprovalRuleTemplateContentRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10969,12 +10969,12 @@ func (s ApprovalRuleTemplateContentRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalRuleTemplateContentRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalRuleTemplateContentRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified approval rule template does not exist. Verify that the name
@@ -10982,7 +10982,7 @@ func (s ApprovalRuleTemplateContentRequiredException) RequestID() string {
 // was created, and then try again.
 type ApprovalRuleTemplateDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10999,7 +10999,7 @@ func (s ApprovalRuleTemplateDoesNotExistException) GoString() string {
 
 func newErrorApprovalRuleTemplateDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &ApprovalRuleTemplateDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11027,12 +11027,12 @@ func (s ApprovalRuleTemplateDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalRuleTemplateDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalRuleTemplateDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The approval rule template is associated with one or more repositories. You
@@ -11040,7 +11040,7 @@ func (s ApprovalRuleTemplateDoesNotExistException) RequestID() string {
 // associations, and then try again.
 type ApprovalRuleTemplateInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11057,7 +11057,7 @@ func (s ApprovalRuleTemplateInUseException) GoString() string {
 
 func newErrorApprovalRuleTemplateInUseException(v protocol.ResponseMetadata) error {
 	return &ApprovalRuleTemplateInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11085,12 +11085,12 @@ func (s ApprovalRuleTemplateInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalRuleTemplateInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalRuleTemplateInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You cannot create an approval rule template with that name because a template
@@ -11098,7 +11098,7 @@ func (s ApprovalRuleTemplateInUseException) RequestID() string {
 // rule template names must be unique.
 type ApprovalRuleTemplateNameAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11115,7 +11115,7 @@ func (s ApprovalRuleTemplateNameAlreadyExistsException) GoString() string {
 
 func newErrorApprovalRuleTemplateNameAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ApprovalRuleTemplateNameAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11143,18 +11143,18 @@ func (s ApprovalRuleTemplateNameAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalRuleTemplateNameAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalRuleTemplateNameAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An approval rule template name is required, but was not specified.
 type ApprovalRuleTemplateNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11171,7 +11171,7 @@ func (s ApprovalRuleTemplateNameRequiredException) GoString() string {
 
 func newErrorApprovalRuleTemplateNameRequiredException(v protocol.ResponseMetadata) error {
 	return &ApprovalRuleTemplateNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11199,12 +11199,12 @@ func (s ApprovalRuleTemplateNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalRuleTemplateNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalRuleTemplateNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about a change in the approval state for a pull request.
@@ -11243,7 +11243,7 @@ func (s *ApprovalStateChangedEventMetadata) SetRevisionId(v string) *ApprovalSta
 // An approval state is required, but was not specified.
 type ApprovalStateRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11260,7 +11260,7 @@ func (s ApprovalStateRequiredException) GoString() string {
 
 func newErrorApprovalStateRequiredException(v protocol.ResponseMetadata) error {
 	return &ApprovalStateRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11288,12 +11288,12 @@ func (s ApprovalStateRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalStateRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalStateRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AssociateApprovalRuleTemplateWithRepositoryInput struct {
@@ -11371,7 +11371,7 @@ func (s AssociateApprovalRuleTemplateWithRepositoryOutput) GoString() string {
 // The specified Amazon Resource Name (ARN) does not exist in the AWS account.
 type AuthorDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11388,7 +11388,7 @@ func (s AuthorDoesNotExistException) GoString() string {
 
 func newErrorAuthorDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &AuthorDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11416,12 +11416,12 @@ func (s AuthorDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AuthorDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AuthorDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about errors in a BatchAssociateApprovalRuleTemplateWithRepositories
@@ -12196,7 +12196,7 @@ func (s *BatchGetRepositoriesOutput) SetRepositoriesNotFound(v []*string) *Batch
 // The before commit ID and the after commit ID must be different commit IDs.
 type BeforeCommitIdAndAfterCommitIdAreSameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12213,7 +12213,7 @@ func (s BeforeCommitIdAndAfterCommitIdAreSameException) GoString() string {
 
 func newErrorBeforeCommitIdAndAfterCommitIdAreSameException(v protocol.ResponseMetadata) error {
 	return &BeforeCommitIdAndAfterCommitIdAreSameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12241,18 +12241,18 @@ func (s BeforeCommitIdAndAfterCommitIdAreSameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BeforeCommitIdAndAfterCommitIdAreSameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BeforeCommitIdAndAfterCommitIdAreSameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified blob does not exist.
 type BlobIdDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12269,7 +12269,7 @@ func (s BlobIdDoesNotExistException) GoString() string {
 
 func newErrorBlobIdDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &BlobIdDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12297,18 +12297,18 @@ func (s BlobIdDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BlobIdDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BlobIdDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A blob ID is required, but was not specified.
 type BlobIdRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12325,7 +12325,7 @@ func (s BlobIdRequiredException) GoString() string {
 
 func newErrorBlobIdRequiredException(v protocol.ResponseMetadata) error {
 	return &BlobIdRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12353,12 +12353,12 @@ func (s BlobIdRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BlobIdRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BlobIdRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about a specific Git blob object.
@@ -12414,7 +12414,7 @@ func (s *BlobMetadata) SetPath(v string) *BlobMetadata {
 // The specified branch does not exist.
 type BranchDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12431,7 +12431,7 @@ func (s BranchDoesNotExistException) GoString() string {
 
 func newErrorBranchDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &BranchDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12459,12 +12459,12 @@ func (s BranchDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BranchDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BranchDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about a branch.
@@ -12503,7 +12503,7 @@ func (s *BranchInfo) SetCommitId(v string) *BranchInfo {
 // The specified branch name already exists.
 type BranchNameExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12520,7 +12520,7 @@ func (s BranchNameExistsException) GoString() string {
 
 func newErrorBranchNameExistsException(v protocol.ResponseMetadata) error {
 	return &BranchNameExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12548,12 +12548,12 @@ func (s BranchNameExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BranchNameExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BranchNameExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified branch name is not valid because it is a tag name. Enter the
@@ -12561,7 +12561,7 @@ func (s BranchNameExistsException) RequestID() string {
 // ListBranches.
 type BranchNameIsTagNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12578,7 +12578,7 @@ func (s BranchNameIsTagNameException) GoString() string {
 
 func newErrorBranchNameIsTagNameException(v protocol.ResponseMetadata) error {
 	return &BranchNameIsTagNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12606,18 +12606,18 @@ func (s BranchNameIsTagNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BranchNameIsTagNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BranchNameIsTagNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A branch name is required, but was not specified.
 type BranchNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12634,7 +12634,7 @@ func (s BranchNameRequiredException) GoString() string {
 
 func newErrorBranchNameRequiredException(v protocol.ResponseMetadata) error {
 	return &BranchNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12662,19 +12662,19 @@ func (s BranchNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BranchNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BranchNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The approval rule cannot be deleted from the pull request because it was
 // created by an approval rule template and applied to the pull request automatically.
 type CannotDeleteApprovalRuleFromTemplateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12691,7 +12691,7 @@ func (s CannotDeleteApprovalRuleFromTemplateException) GoString() string {
 
 func newErrorCannotDeleteApprovalRuleFromTemplateException(v protocol.ResponseMetadata) error {
 	return &CannotDeleteApprovalRuleFromTemplateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12719,19 +12719,19 @@ func (s CannotDeleteApprovalRuleFromTemplateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CannotDeleteApprovalRuleFromTemplateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CannotDeleteApprovalRuleFromTemplateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The approval rule cannot be modified for the pull request because it was
 // created by an approval rule template and applied to the pull request automatically.
 type CannotModifyApprovalRuleFromTemplateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12748,7 +12748,7 @@ func (s CannotModifyApprovalRuleFromTemplateException) GoString() string {
 
 func newErrorCannotModifyApprovalRuleFromTemplateException(v protocol.ResponseMetadata) error {
 	return &CannotModifyApprovalRuleFromTemplateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12776,12 +12776,12 @@ func (s CannotModifyApprovalRuleFromTemplateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CannotModifyApprovalRuleFromTemplateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CannotModifyApprovalRuleFromTemplateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A client request token is required. A client request token is an unique,
@@ -12791,7 +12791,7 @@ func (s CannotModifyApprovalRuleFromTemplateException) RequestID() string {
 // information about the initial request that used that token.
 type ClientRequestTokenRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12808,7 +12808,7 @@ func (s ClientRequestTokenRequiredException) GoString() string {
 
 func newErrorClientRequestTokenRequiredException(v protocol.ResponseMetadata) error {
 	return &ClientRequestTokenRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12836,12 +12836,12 @@ func (s ClientRequestTokenRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientRequestTokenRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientRequestTokenRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about a specific comment.
@@ -12938,7 +12938,7 @@ func (s *Comment) SetLastModifiedDate(v time.Time) *Comment {
 // cannot be null.
 type CommentContentRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12955,7 +12955,7 @@ func (s CommentContentRequiredException) GoString() string {
 
 func newErrorCommentContentRequiredException(v protocol.ResponseMetadata) error {
 	return &CommentContentRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12983,18 +12983,18 @@ func (s CommentContentRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommentContentRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommentContentRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The comment is too large. Comments are limited to 1,000 characters.
 type CommentContentSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13011,7 +13011,7 @@ func (s CommentContentSizeLimitExceededException) GoString() string {
 
 func newErrorCommentContentSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &CommentContentSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13039,19 +13039,19 @@ func (s CommentContentSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommentContentSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommentContentSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This comment has already been deleted. You cannot edit or delete a deleted
 // comment.
 type CommentDeletedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13068,7 +13068,7 @@ func (s CommentDeletedException) GoString() string {
 
 func newErrorCommentDeletedException(v protocol.ResponseMetadata) error {
 	return &CommentDeletedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13096,19 +13096,19 @@ func (s CommentDeletedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommentDeletedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommentDeletedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // No comment exists with the provided ID. Verify that you have used the correct
 // ID, and then try again.
 type CommentDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13125,7 +13125,7 @@ func (s CommentDoesNotExistException) GoString() string {
 
 func newErrorCommentDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &CommentDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13153,18 +13153,18 @@ func (s CommentDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommentDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommentDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The comment ID is missing or null. A comment ID is required.
 type CommentIdRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13181,7 +13181,7 @@ func (s CommentIdRequiredException) GoString() string {
 
 func newErrorCommentIdRequiredException(v protocol.ResponseMetadata) error {
 	return &CommentIdRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13209,19 +13209,19 @@ func (s CommentIdRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommentIdRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommentIdRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You cannot modify or delete this comment. Only comment authors can modify
 // or delete their comments.
 type CommentNotCreatedByCallerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13238,7 +13238,7 @@ func (s CommentNotCreatedByCallerException) GoString() string {
 
 func newErrorCommentNotCreatedByCallerException(v protocol.ResponseMetadata) error {
 	return &CommentNotCreatedByCallerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13266,12 +13266,12 @@ func (s CommentNotCreatedByCallerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommentNotCreatedByCallerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommentNotCreatedByCallerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about comments on the comparison between two commits.
@@ -13542,7 +13542,7 @@ func (s *Commit) SetTreeId(v string) *Commit {
 // repository has no default branch.
 type CommitDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13559,7 +13559,7 @@ func (s CommitDoesNotExistException) GoString() string {
 
 func newErrorCommitDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &CommitDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13587,18 +13587,18 @@ func (s CommitDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommitDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommitDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified commit ID does not exist.
 type CommitIdDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13615,7 +13615,7 @@ func (s CommitIdDoesNotExistException) GoString() string {
 
 func newErrorCommitIdDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &CommitIdDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13643,18 +13643,18 @@ func (s CommitIdDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommitIdDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommitIdDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A commit ID was not specified.
 type CommitIdRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13671,7 +13671,7 @@ func (s CommitIdRequiredException) GoString() string {
 
 func newErrorCommitIdRequiredException(v protocol.ResponseMetadata) error {
 	return &CommitIdRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13699,12 +13699,12 @@ func (s CommitIdRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommitIdRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommitIdRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of allowed commit IDs in a batch request is 100. Verify
@@ -13712,7 +13712,7 @@ func (s CommitIdRequiredException) RequestID() string {
 // again.
 type CommitIdsLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13729,7 +13729,7 @@ func (s CommitIdsLimitExceededException) GoString() string {
 
 func newErrorCommitIdsLimitExceededException(v protocol.ResponseMetadata) error {
 	return &CommitIdsLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13757,19 +13757,19 @@ func (s CommitIdsLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommitIdsLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommitIdsLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A list of commit IDs is required, but was either not specified or the list
 // was empty.
 type CommitIdsListRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13786,7 +13786,7 @@ func (s CommitIdsListRequiredException) GoString() string {
 
 func newErrorCommitIdsListRequiredException(v protocol.ResponseMetadata) error {
 	return &CommitIdsListRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13814,18 +13814,18 @@ func (s CommitIdsListRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommitIdsListRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommitIdsListRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The commit message is too long. Provide a shorter string.
 type CommitMessageLengthExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13842,7 +13842,7 @@ func (s CommitMessageLengthExceededException) GoString() string {
 
 func newErrorCommitMessageLengthExceededException(v protocol.ResponseMetadata) error {
 	return &CommitMessageLengthExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13870,18 +13870,18 @@ func (s CommitMessageLengthExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommitMessageLengthExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommitMessageLengthExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A commit was not specified.
 type CommitRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13898,7 +13898,7 @@ func (s CommitRequiredException) GoString() string {
 
 func newErrorCommitRequiredException(v protocol.ResponseMetadata) error {
 	return &CommitRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13926,12 +13926,12 @@ func (s CommitRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CommitRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CommitRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The merge cannot be completed because the target branch has been modified.
@@ -13939,7 +13939,7 @@ func (s CommitRequiredException) RequestID() string {
 // progress. Wait a few minutes, and then try again.
 type ConcurrentReferenceUpdateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13956,7 +13956,7 @@ func (s ConcurrentReferenceUpdateException) GoString() string {
 
 func newErrorConcurrentReferenceUpdateException(v protocol.ResponseMetadata) error {
 	return &ConcurrentReferenceUpdateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13984,12 +13984,12 @@ func (s ConcurrentReferenceUpdateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentReferenceUpdateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentReferenceUpdateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about conflicts in a merge operation.
@@ -15187,7 +15187,7 @@ func (s *CreateUnreferencedMergeCommitOutput) SetTreeId(v string) *CreateUnrefer
 // default branch.
 type DefaultBranchCannotBeDeletedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15204,7 +15204,7 @@ func (s DefaultBranchCannotBeDeletedException) GoString() string {
 
 func newErrorDefaultBranchCannotBeDeletedException(v protocol.ResponseMetadata) error {
 	return &DefaultBranchCannotBeDeletedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15232,12 +15232,12 @@ func (s DefaultBranchCannotBeDeletedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DefaultBranchCannotBeDeletedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DefaultBranchCannotBeDeletedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteApprovalRuleTemplateInput struct {
@@ -16224,7 +16224,7 @@ func (s *Difference) SetChangeType(v string) *Difference {
 // file.
 type DirectoryNameConflictsWithFileNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16241,7 +16241,7 @@ func (s DirectoryNameConflictsWithFileNameException) GoString() string {
 
 func newErrorDirectoryNameConflictsWithFileNameException(v protocol.ResponseMetadata) error {
 	return &DirectoryNameConflictsWithFileNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16269,12 +16269,12 @@ func (s DirectoryNameConflictsWithFileNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryNameConflictsWithFileNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryNameConflictsWithFileNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DisassociateApprovalRuleTemplateFromRepositoryInput struct {
@@ -16352,7 +16352,7 @@ func (s DisassociateApprovalRuleTemplateFromRepositoryOutput) GoString() string 
 // An encryption integrity check failed.
 type EncryptionIntegrityChecksFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16369,7 +16369,7 @@ func (s EncryptionIntegrityChecksFailedException) GoString() string {
 
 func newErrorEncryptionIntegrityChecksFailedException(v protocol.ResponseMetadata) error {
 	return &EncryptionIntegrityChecksFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16397,18 +16397,18 @@ func (s EncryptionIntegrityChecksFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EncryptionIntegrityChecksFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EncryptionIntegrityChecksFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An encryption key could not be accessed.
 type EncryptionKeyAccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16425,7 +16425,7 @@ func (s EncryptionKeyAccessDeniedException) GoString() string {
 
 func newErrorEncryptionKeyAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &EncryptionKeyAccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16453,18 +16453,18 @@ func (s EncryptionKeyAccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EncryptionKeyAccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EncryptionKeyAccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The encryption key is disabled.
 type EncryptionKeyDisabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16481,7 +16481,7 @@ func (s EncryptionKeyDisabledException) GoString() string {
 
 func newErrorEncryptionKeyDisabledException(v protocol.ResponseMetadata) error {
 	return &EncryptionKeyDisabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16509,18 +16509,18 @@ func (s EncryptionKeyDisabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EncryptionKeyDisabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EncryptionKeyDisabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // No encryption key was found.
 type EncryptionKeyNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16537,7 +16537,7 @@ func (s EncryptionKeyNotFoundException) GoString() string {
 
 func newErrorEncryptionKeyNotFoundException(v protocol.ResponseMetadata) error {
 	return &EncryptionKeyNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16565,18 +16565,18 @@ func (s EncryptionKeyNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EncryptionKeyNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EncryptionKeyNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The encryption key is not available.
 type EncryptionKeyUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16593,7 +16593,7 @@ func (s EncryptionKeyUnavailableException) GoString() string {
 
 func newErrorEncryptionKeyUnavailableException(v protocol.ResponseMetadata) error {
 	return &EncryptionKeyUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16621,12 +16621,12 @@ func (s EncryptionKeyUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EncryptionKeyUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EncryptionKeyUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type EvaluatePullRequestApprovalRulesInput struct {
@@ -16820,7 +16820,7 @@ func (s *File) SetRelativePath(v string) *File {
 // a source file or provide the file content directly.
 type FileContentAndSourceFileSpecifiedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16837,7 +16837,7 @@ func (s FileContentAndSourceFileSpecifiedException) GoString() string {
 
 func newErrorFileContentAndSourceFileSpecifiedException(v protocol.ResponseMetadata) error {
 	return &FileContentAndSourceFileSpecifiedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16865,19 +16865,19 @@ func (s FileContentAndSourceFileSpecifiedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileContentAndSourceFileSpecifiedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileContentAndSourceFileSpecifiedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The file cannot be added because it is empty. Empty files cannot be added
 // to the repository with this API.
 type FileContentRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16894,7 +16894,7 @@ func (s FileContentRequiredException) GoString() string {
 
 func newErrorFileContentRequiredException(v protocol.ResponseMetadata) error {
 	return &FileContentRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16922,12 +16922,12 @@ func (s FileContentRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileContentRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileContentRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The file cannot be added because it is too large. The maximum file size is
@@ -16935,7 +16935,7 @@ func (s FileContentRequiredException) RequestID() string {
 // these changes using a Git client.
 type FileContentSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16952,7 +16952,7 @@ func (s FileContentSizeLimitExceededException) GoString() string {
 
 func newErrorFileContentSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &FileContentSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16980,19 +16980,19 @@ func (s FileContentSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileContentSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileContentSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified file does not exist. Verify that you have used the correct
 // file name, full path, and extension.
 type FileDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17009,7 +17009,7 @@ func (s FileDoesNotExistException) GoString() string {
 
 func newErrorFileDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &FileDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17037,19 +17037,19 @@ func (s FileDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The commit cannot be created because no files have been specified as added,
 // updated, or changed (PutFile or DeleteFile) for the commit.
 type FileEntryRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17066,7 +17066,7 @@ func (s FileEntryRequiredException) GoString() string {
 
 func newErrorFileEntryRequiredException(v protocol.ResponseMetadata) error {
 	return &FileEntryRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17094,12 +17094,12 @@ func (s FileEntryRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileEntryRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileEntryRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A file to be added, updated, or deleted as part of a commit.
@@ -17150,7 +17150,7 @@ func (s *FileMetadata) SetFileMode(v string) *FileMetadata {
 // mode is required to update mode permissions for a file.
 type FileModeRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17167,7 +17167,7 @@ func (s FileModeRequiredException) GoString() string {
 
 func newErrorFileModeRequiredException(v protocol.ResponseMetadata) error {
 	return &FileModeRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17195,12 +17195,12 @@ func (s FileModeRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileModeRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileModeRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about file modes in a merge or pull request.
@@ -17251,7 +17251,7 @@ func (s *FileModes) SetSource(v string) *FileModes {
 // file name.
 type FileNameConflictsWithDirectoryNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17268,7 +17268,7 @@ func (s FileNameConflictsWithDirectoryNameException) GoString() string {
 
 func newErrorFileNameConflictsWithDirectoryNameException(v protocol.ResponseMetadata) error {
 	return &FileNameConflictsWithDirectoryNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17296,12 +17296,12 @@ func (s FileNameConflictsWithDirectoryNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileNameConflictsWithDirectoryNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileNameConflictsWithDirectoryNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The commit cannot be created because a specified file path points to a submodule.
@@ -17309,7 +17309,7 @@ func (s FileNameConflictsWithDirectoryNameException) RequestID() string {
 // to a submodule.
 type FilePathConflictsWithSubmodulePathException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17326,7 +17326,7 @@ func (s FilePathConflictsWithSubmodulePathException) GoString() string {
 
 func newErrorFilePathConflictsWithSubmodulePathException(v protocol.ResponseMetadata) error {
 	return &FilePathConflictsWithSubmodulePathException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17354,12 +17354,12 @@ func (s FilePathConflictsWithSubmodulePathException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FilePathConflictsWithSubmodulePathException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FilePathConflictsWithSubmodulePathException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the size of files in a merge or pull request.
@@ -17409,7 +17409,7 @@ func (s *FileSizes) SetSource(v int64) *FileSizes {
 // (https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html).
 type FileTooLargeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17426,7 +17426,7 @@ func (s FileTooLargeException) GoString() string {
 
 func newErrorFileTooLargeException(v protocol.ResponseMetadata) error {
 	return &FileTooLargeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17454,12 +17454,12 @@ func (s FileTooLargeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileTooLargeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileTooLargeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about a folder in a repository.
@@ -17512,7 +17512,7 @@ func (s *Folder) SetTreeId(v string) *Folder {
 // multiple folders.
 type FolderContentSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17529,7 +17529,7 @@ func (s FolderContentSizeLimitExceededException) GoString() string {
 
 func newErrorFolderContentSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &FolderContentSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17557,19 +17557,19 @@ func (s FolderContentSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FolderContentSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FolderContentSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified folder does not exist. Either the folder name is not correct,
 // or you did not enter the full path to the folder.
 type FolderDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17586,7 +17586,7 @@ func (s FolderDoesNotExistException) GoString() string {
 
 func newErrorFolderDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &FolderDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17614,12 +17614,12 @@ func (s FolderDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FolderDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FolderDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetApprovalRuleTemplateInput struct {
@@ -19572,7 +19572,7 @@ func (s *GetRepositoryTriggersOutput) SetTriggers(v []*RepositoryTrigger) *GetRe
 // format, or the token has been used in a previous request and cannot be reused.
 type IdempotencyParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19589,7 +19589,7 @@ func (s IdempotencyParameterMismatchException) GoString() string {
 
 func newErrorIdempotencyParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotencyParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19617,12 +19617,12 @@ func (s IdempotencyParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotencyParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotencyParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon Resource Name (ARN) is not valid. Make sure that you have provided
@@ -19630,7 +19630,7 @@ func (s IdempotencyParameterMismatchException) RequestID() string {
 // and then try again.
 type InvalidActorArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19647,7 +19647,7 @@ func (s InvalidActorArnException) GoString() string {
 
 func newErrorInvalidActorArnException(v protocol.ResponseMetadata) error {
 	return &InvalidActorArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19675,18 +19675,18 @@ func (s InvalidActorArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidActorArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidActorArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The content for the approval rule is not valid.
 type InvalidApprovalRuleContentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19703,7 +19703,7 @@ func (s InvalidApprovalRuleContentException) GoString() string {
 
 func newErrorInvalidApprovalRuleContentException(v protocol.ResponseMetadata) error {
 	return &InvalidApprovalRuleContentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19731,18 +19731,18 @@ func (s InvalidApprovalRuleContentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApprovalRuleContentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApprovalRuleContentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The name for the approval rule is not valid.
 type InvalidApprovalRuleNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19759,7 +19759,7 @@ func (s InvalidApprovalRuleNameException) GoString() string {
 
 func newErrorInvalidApprovalRuleNameException(v protocol.ResponseMetadata) error {
 	return &InvalidApprovalRuleNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19787,18 +19787,18 @@ func (s InvalidApprovalRuleNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApprovalRuleNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApprovalRuleNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The content of the approval rule template is not valid.
 type InvalidApprovalRuleTemplateContentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19815,7 +19815,7 @@ func (s InvalidApprovalRuleTemplateContentException) GoString() string {
 
 func newErrorInvalidApprovalRuleTemplateContentException(v protocol.ResponseMetadata) error {
 	return &InvalidApprovalRuleTemplateContentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19843,12 +19843,12 @@ func (s InvalidApprovalRuleTemplateContentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApprovalRuleTemplateContentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApprovalRuleTemplateContentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The description for the approval rule template is not valid because it exceeds
@@ -19856,7 +19856,7 @@ func (s InvalidApprovalRuleTemplateContentException) RequestID() string {
 // limits in AWS CodeCommit, see AWS CodeCommit User Guide (https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html).
 type InvalidApprovalRuleTemplateDescriptionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19873,7 +19873,7 @@ func (s InvalidApprovalRuleTemplateDescriptionException) GoString() string {
 
 func newErrorInvalidApprovalRuleTemplateDescriptionException(v protocol.ResponseMetadata) error {
 	return &InvalidApprovalRuleTemplateDescriptionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19901,12 +19901,12 @@ func (s InvalidApprovalRuleTemplateDescriptionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApprovalRuleTemplateDescriptionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApprovalRuleTemplateDescriptionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The name of the approval rule template is not valid. Template names must
@@ -19914,7 +19914,7 @@ func (s InvalidApprovalRuleTemplateDescriptionException) RequestID() string {
 // limits in AWS CodeCommit, see AWS CodeCommit User Guide (https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html).
 type InvalidApprovalRuleTemplateNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19931,7 +19931,7 @@ func (s InvalidApprovalRuleTemplateNameException) GoString() string {
 
 func newErrorInvalidApprovalRuleTemplateNameException(v protocol.ResponseMetadata) error {
 	return &InvalidApprovalRuleTemplateNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19959,19 +19959,19 @@ func (s InvalidApprovalRuleTemplateNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApprovalRuleTemplateNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApprovalRuleTemplateNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The state for the approval is not valid. Valid values include APPROVE and
 // REVOKE.
 type InvalidApprovalStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19988,7 +19988,7 @@ func (s InvalidApprovalStateException) GoString() string {
 
 func newErrorInvalidApprovalStateException(v protocol.ResponseMetadata) error {
 	return &InvalidApprovalStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20016,19 +20016,19 @@ func (s InvalidApprovalStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApprovalStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApprovalStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon Resource Name (ARN) is not valid. Make sure that you have provided
 // the full ARN for the author of the pull request, and then try again.
 type InvalidAuthorArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20045,7 +20045,7 @@ func (s InvalidAuthorArnException) GoString() string {
 
 func newErrorInvalidAuthorArnException(v protocol.ResponseMetadata) error {
 	return &InvalidAuthorArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20073,18 +20073,18 @@ func (s InvalidAuthorArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAuthorArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAuthorArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified blob is not valid.
 type InvalidBlobIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20101,7 +20101,7 @@ func (s InvalidBlobIdException) GoString() string {
 
 func newErrorInvalidBlobIdException(v protocol.ResponseMetadata) error {
 	return &InvalidBlobIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20129,18 +20129,18 @@ func (s InvalidBlobIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidBlobIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidBlobIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified reference name is not valid.
 type InvalidBranchNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20157,7 +20157,7 @@ func (s InvalidBranchNameException) GoString() string {
 
 func newErrorInvalidBranchNameException(v protocol.ResponseMetadata) error {
 	return &InvalidBranchNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20185,18 +20185,18 @@ func (s InvalidBranchNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidBranchNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidBranchNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The client request token is not valid.
 type InvalidClientRequestTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20213,7 +20213,7 @@ func (s InvalidClientRequestTokenException) GoString() string {
 
 func newErrorInvalidClientRequestTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidClientRequestTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20241,19 +20241,19 @@ func (s InvalidClientRequestTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidClientRequestTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidClientRequestTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The comment ID is not in a valid format. Make sure that you have provided
 // the full comment ID.
 type InvalidCommentIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20270,7 +20270,7 @@ func (s InvalidCommentIdException) GoString() string {
 
 func newErrorInvalidCommentIdException(v protocol.ResponseMetadata) error {
 	return &InvalidCommentIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20298,18 +20298,18 @@ func (s InvalidCommentIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCommentIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCommentIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified commit is not valid.
 type InvalidCommitException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20326,7 +20326,7 @@ func (s InvalidCommitException) GoString() string {
 
 func newErrorInvalidCommitException(v protocol.ResponseMetadata) error {
 	return &InvalidCommitException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20354,18 +20354,18 @@ func (s InvalidCommitException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCommitException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCommitException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified commit ID is not valid.
 type InvalidCommitIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20382,7 +20382,7 @@ func (s InvalidCommitIdException) GoString() string {
 
 func newErrorInvalidCommitIdException(v protocol.ResponseMetadata) error {
 	return &InvalidCommitIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20410,18 +20410,18 @@ func (s InvalidCommitIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCommitIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCommitIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified conflict detail level is not valid.
 type InvalidConflictDetailLevelException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20438,7 +20438,7 @@ func (s InvalidConflictDetailLevelException) GoString() string {
 
 func newErrorInvalidConflictDetailLevelException(v protocol.ResponseMetadata) error {
 	return &InvalidConflictDetailLevelException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20466,18 +20466,18 @@ func (s InvalidConflictDetailLevelException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidConflictDetailLevelException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidConflictDetailLevelException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified conflict resolution list is not valid.
 type InvalidConflictResolutionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20494,7 +20494,7 @@ func (s InvalidConflictResolutionException) GoString() string {
 
 func newErrorInvalidConflictResolutionException(v protocol.ResponseMetadata) error {
 	return &InvalidConflictResolutionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20522,18 +20522,18 @@ func (s InvalidConflictResolutionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidConflictResolutionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidConflictResolutionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified conflict resolution strategy is not valid.
 type InvalidConflictResolutionStrategyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20550,7 +20550,7 @@ func (s InvalidConflictResolutionStrategyException) GoString() string {
 
 func newErrorInvalidConflictResolutionStrategyException(v protocol.ResponseMetadata) error {
 	return &InvalidConflictResolutionStrategyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20578,18 +20578,18 @@ func (s InvalidConflictResolutionStrategyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidConflictResolutionStrategyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidConflictResolutionStrategyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified continuation token is not valid.
 type InvalidContinuationTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20606,7 +20606,7 @@ func (s InvalidContinuationTokenException) GoString() string {
 
 func newErrorInvalidContinuationTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidContinuationTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20634,18 +20634,18 @@ func (s InvalidContinuationTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidContinuationTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidContinuationTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified deletion parameter is not valid.
 type InvalidDeletionParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20662,7 +20662,7 @@ func (s InvalidDeletionParameterException) GoString() string {
 
 func newErrorInvalidDeletionParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidDeletionParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20690,19 +20690,19 @@ func (s InvalidDeletionParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeletionParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeletionParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pull request description is not valid. Descriptions cannot be more than
 // 1,000 characters.
 type InvalidDescriptionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20719,7 +20719,7 @@ func (s InvalidDescriptionException) GoString() string {
 
 func newErrorInvalidDescriptionException(v protocol.ResponseMetadata) error {
 	return &InvalidDescriptionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20747,19 +20747,19 @@ func (s InvalidDescriptionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDescriptionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDescriptionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The destination commit specifier is not valid. You must provide a valid branch
 // name, tag, or full commit ID.
 type InvalidDestinationCommitSpecifierException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20776,7 +20776,7 @@ func (s InvalidDestinationCommitSpecifierException) GoString() string {
 
 func newErrorInvalidDestinationCommitSpecifierException(v protocol.ResponseMetadata) error {
 	return &InvalidDestinationCommitSpecifierException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20804,12 +20804,12 @@ func (s InvalidDestinationCommitSpecifierException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDestinationCommitSpecifierException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDestinationCommitSpecifierException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified email address either contains one or more characters that are
@@ -20817,7 +20817,7 @@ func (s InvalidDestinationCommitSpecifierException) RequestID() string {
 // email address.
 type InvalidEmailException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20834,7 +20834,7 @@ func (s InvalidEmailException) GoString() string {
 
 func newErrorInvalidEmailException(v protocol.ResponseMetadata) error {
 	return &InvalidEmailException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20862,19 +20862,19 @@ func (s InvalidEmailException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEmailException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEmailException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The location of the file is not valid. Make sure that you include the file
 // name and extension.
 type InvalidFileLocationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20891,7 +20891,7 @@ func (s InvalidFileLocationException) GoString() string {
 
 func newErrorInvalidFileLocationException(v protocol.ResponseMetadata) error {
 	return &InvalidFileLocationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20919,19 +20919,19 @@ func (s InvalidFileLocationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFileLocationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFileLocationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified file mode permission is not valid. For a list of valid file
 // mode permissions, see PutFile.
 type InvalidFileModeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20948,7 +20948,7 @@ func (s InvalidFileModeException) GoString() string {
 
 func newErrorInvalidFileModeException(v protocol.ResponseMetadata) error {
 	return &InvalidFileModeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20976,19 +20976,19 @@ func (s InvalidFileModeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFileModeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFileModeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The position is not valid. Make sure that the line number exists in the version
 // of the file you want to comment on.
 type InvalidFilePositionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21005,7 +21005,7 @@ func (s InvalidFilePositionException) GoString() string {
 
 func newErrorInvalidFilePositionException(v protocol.ResponseMetadata) error {
 	return &InvalidFilePositionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21033,18 +21033,18 @@ func (s InvalidFilePositionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFilePositionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFilePositionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified value for the number of conflict files to return is not valid.
 type InvalidMaxConflictFilesException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21061,7 +21061,7 @@ func (s InvalidMaxConflictFilesException) GoString() string {
 
 func newErrorInvalidMaxConflictFilesException(v protocol.ResponseMetadata) error {
 	return &InvalidMaxConflictFilesException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21089,18 +21089,18 @@ func (s InvalidMaxConflictFilesException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidMaxConflictFilesException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidMaxConflictFilesException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified value for the number of merge hunks to return is not valid.
 type InvalidMaxMergeHunksException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21117,7 +21117,7 @@ func (s InvalidMaxMergeHunksException) GoString() string {
 
 func newErrorInvalidMaxMergeHunksException(v protocol.ResponseMetadata) error {
 	return &InvalidMaxMergeHunksException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21145,18 +21145,18 @@ func (s InvalidMaxMergeHunksException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidMaxMergeHunksException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidMaxMergeHunksException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified number of maximum results is not valid.
 type InvalidMaxResultsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21173,7 +21173,7 @@ func (s InvalidMaxResultsException) GoString() string {
 
 func newErrorInvalidMaxResultsException(v protocol.ResponseMetadata) error {
 	return &InvalidMaxResultsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21201,19 +21201,19 @@ func (s InvalidMaxResultsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidMaxResultsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidMaxResultsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified merge option is not valid for this operation. Not all merge
 // strategies are supported for all operations.
 type InvalidMergeOptionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21230,7 +21230,7 @@ func (s InvalidMergeOptionException) GoString() string {
 
 func newErrorInvalidMergeOptionException(v protocol.ResponseMetadata) error {
 	return &InvalidMergeOptionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21258,18 +21258,18 @@ func (s InvalidMergeOptionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidMergeOptionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidMergeOptionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified sort order is not valid.
 type InvalidOrderException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21286,7 +21286,7 @@ func (s InvalidOrderException) GoString() string {
 
 func newErrorInvalidOrderException(v protocol.ResponseMetadata) error {
 	return &InvalidOrderException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21314,18 +21314,18 @@ func (s InvalidOrderException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOrderException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOrderException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The override status is not valid. Valid statuses are OVERRIDE and REVOKE.
 type InvalidOverrideStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21342,7 +21342,7 @@ func (s InvalidOverrideStatusException) GoString() string {
 
 func newErrorInvalidOverrideStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidOverrideStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21370,12 +21370,12 @@ func (s InvalidOverrideStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOverrideStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOverrideStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The parent commit ID is not valid. The commit ID cannot be empty, and must
@@ -21383,7 +21383,7 @@ func (s InvalidOverrideStatusException) RequestID() string {
 // to add or update a file.
 type InvalidParentCommitIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21400,7 +21400,7 @@ func (s InvalidParentCommitIdException) GoString() string {
 
 func newErrorInvalidParentCommitIdException(v protocol.ResponseMetadata) error {
 	return &InvalidParentCommitIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21428,18 +21428,18 @@ func (s InvalidParentCommitIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParentCommitIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParentCommitIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified path is not valid.
 type InvalidPathException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21456,7 +21456,7 @@ func (s InvalidPathException) GoString() string {
 
 func newErrorInvalidPathException(v protocol.ResponseMetadata) error {
 	return &InvalidPathException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21484,18 +21484,18 @@ func (s InvalidPathException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPathException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPathException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pull request event type is not valid.
 type InvalidPullRequestEventTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21512,7 +21512,7 @@ func (s InvalidPullRequestEventTypeException) GoString() string {
 
 func newErrorInvalidPullRequestEventTypeException(v protocol.ResponseMetadata) error {
 	return &InvalidPullRequestEventTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21540,12 +21540,12 @@ func (s InvalidPullRequestEventTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPullRequestEventTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPullRequestEventTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pull request ID is not valid. Make sure that you have provided the full
@@ -21553,7 +21553,7 @@ func (s InvalidPullRequestEventTypeException) RequestID() string {
 // again.
 type InvalidPullRequestIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21570,7 +21570,7 @@ func (s InvalidPullRequestIdException) GoString() string {
 
 func newErrorInvalidPullRequestIdException(v protocol.ResponseMetadata) error {
 	return &InvalidPullRequestIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21598,19 +21598,19 @@ func (s InvalidPullRequestIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPullRequestIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPullRequestIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pull request status is not valid. The only valid values are OPEN and
 // CLOSED.
 type InvalidPullRequestStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21627,7 +21627,7 @@ func (s InvalidPullRequestStatusException) GoString() string {
 
 func newErrorInvalidPullRequestStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidPullRequestStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21655,19 +21655,19 @@ func (s InvalidPullRequestStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPullRequestStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPullRequestStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pull request status update is not valid. The only valid update is from
 // OPEN to CLOSED.
 type InvalidPullRequestStatusUpdateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21684,7 +21684,7 @@ func (s InvalidPullRequestStatusUpdateException) GoString() string {
 
 func newErrorInvalidPullRequestStatusUpdateException(v protocol.ResponseMetadata) error {
 	return &InvalidPullRequestStatusUpdateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21712,12 +21712,12 @@ func (s InvalidPullRequestStatusUpdateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPullRequestStatusUpdateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPullRequestStatusUpdateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified reference name format is not valid. Reference names must conform
@@ -21726,7 +21726,7 @@ func (s InvalidPullRequestStatusUpdateException) RequestID() string {
 // or consult your Git documentation.
 type InvalidReferenceNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21743,7 +21743,7 @@ func (s InvalidReferenceNameException) GoString() string {
 
 func newErrorInvalidReferenceNameException(v protocol.ResponseMetadata) error {
 	return &InvalidReferenceNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21771,19 +21771,19 @@ func (s InvalidReferenceNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidReferenceNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidReferenceNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Either the enum is not in a valid format, or the specified file version enum
 // is not valid in respect to the current file version.
 type InvalidRelativeFileVersionEnumException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21800,7 +21800,7 @@ func (s InvalidRelativeFileVersionEnumException) GoString() string {
 
 func newErrorInvalidRelativeFileVersionEnumException(v protocol.ResponseMetadata) error {
 	return &InvalidRelativeFileVersionEnumException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21828,19 +21828,19 @@ func (s InvalidRelativeFileVersionEnumException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRelativeFileVersionEnumException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRelativeFileVersionEnumException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Automerge was specified for resolving the conflict, but the replacement type
 // is not valid or content is missing.
 type InvalidReplacementContentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21857,7 +21857,7 @@ func (s InvalidReplacementContentException) GoString() string {
 
 func newErrorInvalidReplacementContentException(v protocol.ResponseMetadata) error {
 	return &InvalidReplacementContentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21885,19 +21885,19 @@ func (s InvalidReplacementContentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidReplacementContentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidReplacementContentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Automerge was specified for resolving the conflict, but the specified replacement
 // type is not valid.
 type InvalidReplacementTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21914,7 +21914,7 @@ func (s InvalidReplacementTypeException) GoString() string {
 
 func newErrorInvalidReplacementTypeException(v protocol.ResponseMetadata) error {
 	return &InvalidReplacementTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21942,18 +21942,18 @@ func (s InvalidReplacementTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidReplacementTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidReplacementTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified repository description is not valid.
 type InvalidRepositoryDescriptionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21970,7 +21970,7 @@ func (s InvalidRepositoryDescriptionException) GoString() string {
 
 func newErrorInvalidRepositoryDescriptionException(v protocol.ResponseMetadata) error {
 	return &InvalidRepositoryDescriptionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21998,12 +21998,12 @@ func (s InvalidRepositoryDescriptionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRepositoryDescriptionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRepositoryDescriptionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A specified repository name is not valid.
@@ -22013,7 +22013,7 @@ func (s InvalidRepositoryDescriptionException) RequestID() string {
 // when a specified repository does not exist.
 type InvalidRepositoryNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22030,7 +22030,7 @@ func (s InvalidRepositoryNameException) GoString() string {
 
 func newErrorInvalidRepositoryNameException(v protocol.ResponseMetadata) error {
 	return &InvalidRepositoryNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22058,18 +22058,18 @@ func (s InvalidRepositoryNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRepositoryNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRepositoryNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more branch names specified for the trigger is not valid.
 type InvalidRepositoryTriggerBranchNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22086,7 +22086,7 @@ func (s InvalidRepositoryTriggerBranchNameException) GoString() string {
 
 func newErrorInvalidRepositoryTriggerBranchNameException(v protocol.ResponseMetadata) error {
 	return &InvalidRepositoryTriggerBranchNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22114,18 +22114,18 @@ func (s InvalidRepositoryTriggerBranchNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRepositoryTriggerBranchNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRepositoryTriggerBranchNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The custom data provided for the trigger is not valid.
 type InvalidRepositoryTriggerCustomDataException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22142,7 +22142,7 @@ func (s InvalidRepositoryTriggerCustomDataException) GoString() string {
 
 func newErrorInvalidRepositoryTriggerCustomDataException(v protocol.ResponseMetadata) error {
 	return &InvalidRepositoryTriggerCustomDataException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22170,12 +22170,12 @@ func (s InvalidRepositoryTriggerCustomDataException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRepositoryTriggerCustomDataException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRepositoryTriggerCustomDataException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon Resource Name (ARN) for the trigger is not valid for the specified
@@ -22183,7 +22183,7 @@ func (s InvalidRepositoryTriggerCustomDataException) RequestID() string {
 // meet the requirements for the service type.
 type InvalidRepositoryTriggerDestinationArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22200,7 +22200,7 @@ func (s InvalidRepositoryTriggerDestinationArnException) GoString() string {
 
 func newErrorInvalidRepositoryTriggerDestinationArnException(v protocol.ResponseMetadata) error {
 	return &InvalidRepositoryTriggerDestinationArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22228,19 +22228,19 @@ func (s InvalidRepositoryTriggerDestinationArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRepositoryTriggerDestinationArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRepositoryTriggerDestinationArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more events specified for the trigger is not valid. Check to make
 // sure that all events specified match the requirements for allowed events.
 type InvalidRepositoryTriggerEventsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22257,7 +22257,7 @@ func (s InvalidRepositoryTriggerEventsException) GoString() string {
 
 func newErrorInvalidRepositoryTriggerEventsException(v protocol.ResponseMetadata) error {
 	return &InvalidRepositoryTriggerEventsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22285,18 +22285,18 @@ func (s InvalidRepositoryTriggerEventsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRepositoryTriggerEventsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRepositoryTriggerEventsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The name of the trigger is not valid.
 type InvalidRepositoryTriggerNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22313,7 +22313,7 @@ func (s InvalidRepositoryTriggerNameException) GoString() string {
 
 func newErrorInvalidRepositoryTriggerNameException(v protocol.ResponseMetadata) error {
 	return &InvalidRepositoryTriggerNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22341,12 +22341,12 @@ func (s InvalidRepositoryTriggerNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRepositoryTriggerNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRepositoryTriggerNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The AWS Region for the trigger target does not match the AWS Region for the
@@ -22354,7 +22354,7 @@ func (s InvalidRepositoryTriggerNameException) RequestID() string {
 // the trigger.
 type InvalidRepositoryTriggerRegionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22371,7 +22371,7 @@ func (s InvalidRepositoryTriggerRegionException) GoString() string {
 
 func newErrorInvalidRepositoryTriggerRegionException(v protocol.ResponseMetadata) error {
 	return &InvalidRepositoryTriggerRegionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22399,12 +22399,12 @@ func (s InvalidRepositoryTriggerRegionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRepositoryTriggerRegionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRepositoryTriggerRegionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The value for the resource ARN is not valid. For more information about resources
@@ -22412,7 +22412,7 @@ func (s InvalidRepositoryTriggerRegionException) RequestID() string {
 // in the AWS CodeCommit User Guide.
 type InvalidResourceArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22429,7 +22429,7 @@ func (s InvalidResourceArnException) GoString() string {
 
 func newErrorInvalidResourceArnException(v protocol.ResponseMetadata) error {
 	return &InvalidResourceArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22457,18 +22457,18 @@ func (s InvalidResourceArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The revision ID is not valid. Use GetPullRequest to determine the value.
 type InvalidRevisionIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22485,7 +22485,7 @@ func (s InvalidRevisionIdException) GoString() string {
 
 func newErrorInvalidRevisionIdException(v protocol.ResponseMetadata) error {
 	return &InvalidRevisionIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22513,18 +22513,18 @@ func (s InvalidRevisionIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRevisionIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRevisionIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The SHA-256 hash signature for the rule content is not valid.
 type InvalidRuleContentSha256Exception struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22541,7 +22541,7 @@ func (s InvalidRuleContentSha256Exception) GoString() string {
 
 func newErrorInvalidRuleContentSha256Exception(v protocol.ResponseMetadata) error {
 	return &InvalidRuleContentSha256Exception{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22569,18 +22569,18 @@ func (s InvalidRuleContentSha256Exception) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRuleContentSha256Exception) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRuleContentSha256Exception) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified sort by value is not valid.
 type InvalidSortByException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22597,7 +22597,7 @@ func (s InvalidSortByException) GoString() string {
 
 func newErrorInvalidSortByException(v protocol.ResponseMetadata) error {
 	return &InvalidSortByException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22625,19 +22625,19 @@ func (s InvalidSortByException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSortByException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSortByException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The source commit specifier is not valid. You must provide a valid branch
 // name, tag, or full commit ID.
 type InvalidSourceCommitSpecifierException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22654,7 +22654,7 @@ func (s InvalidSourceCommitSpecifierException) GoString() string {
 
 func newErrorInvalidSourceCommitSpecifierException(v protocol.ResponseMetadata) error {
 	return &InvalidSourceCommitSpecifierException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22682,18 +22682,18 @@ func (s InvalidSourceCommitSpecifierException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSourceCommitSpecifierException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSourceCommitSpecifierException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified tag is not valid. Key names cannot be prefixed with aws:.
 type InvalidSystemTagUsageException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22710,7 +22710,7 @@ func (s InvalidSystemTagUsageException) GoString() string {
 
 func newErrorInvalidSystemTagUsageException(v protocol.ResponseMetadata) error {
 	return &InvalidSystemTagUsageException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22738,18 +22738,18 @@ func (s InvalidSystemTagUsageException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSystemTagUsageException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSystemTagUsageException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The list of tags is not valid.
 type InvalidTagKeysListException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22766,7 +22766,7 @@ func (s InvalidTagKeysListException) GoString() string {
 
 func newErrorInvalidTagKeysListException(v protocol.ResponseMetadata) error {
 	return &InvalidTagKeysListException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22794,18 +22794,18 @@ func (s InvalidTagKeysListException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagKeysListException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagKeysListException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The map of tags is not valid.
 type InvalidTagsMapException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22822,7 +22822,7 @@ func (s InvalidTagsMapException) GoString() string {
 
 func newErrorInvalidTagsMapException(v protocol.ResponseMetadata) error {
 	return &InvalidTagsMapException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22850,18 +22850,18 @@ func (s InvalidTagsMapException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagsMapException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagsMapException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified target branch is not valid.
 type InvalidTargetBranchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22878,7 +22878,7 @@ func (s InvalidTargetBranchException) GoString() string {
 
 func newErrorInvalidTargetBranchException(v protocol.ResponseMetadata) error {
 	return &InvalidTargetBranchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22906,12 +22906,12 @@ func (s InvalidTargetBranchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTargetBranchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTargetBranchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The target for the pull request is not valid. A target must contain the full
@@ -22919,7 +22919,7 @@ func (s InvalidTargetBranchException) RequestID() string {
 // the pull request.
 type InvalidTargetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22936,7 +22936,7 @@ func (s InvalidTargetException) GoString() string {
 
 func newErrorInvalidTargetException(v protocol.ResponseMetadata) error {
 	return &InvalidTargetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22964,12 +22964,12 @@ func (s InvalidTargetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTargetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTargetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The targets for the pull request is not valid or not in a valid format. Targets
@@ -22978,7 +22978,7 @@ func (s InvalidTargetException) RequestID() string {
 // request.
 type InvalidTargetsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22995,7 +22995,7 @@ func (s InvalidTargetsException) GoString() string {
 
 func newErrorInvalidTargetsException(v protocol.ResponseMetadata) error {
 	return &InvalidTargetsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23023,19 +23023,19 @@ func (s InvalidTargetsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTargetsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTargetsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The title of the pull request is not valid. Pull request titles cannot exceed
 // 100 characters in length.
 type InvalidTitleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23052,7 +23052,7 @@ func (s InvalidTitleException) GoString() string {
 
 func newErrorInvalidTitleException(v protocol.ResponseMetadata) error {
 	return &InvalidTitleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23080,12 +23080,12 @@ func (s InvalidTitleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTitleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTitleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about whether a file is binary or textual in a merge or pull
@@ -23802,7 +23802,7 @@ func (s *Location) SetRelativeFileVersion(v string) *Location {
 // You must manually merge the branches and resolve any conflicts.
 type ManualMergeRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23819,7 +23819,7 @@ func (s ManualMergeRequiredException) GoString() string {
 
 func newErrorManualMergeRequiredException(v protocol.ResponseMetadata) error {
 	return &ManualMergeRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23847,18 +23847,18 @@ func (s ManualMergeRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ManualMergeRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ManualMergeRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of branches for the trigger was exceeded.
 type MaximumBranchesExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23875,7 +23875,7 @@ func (s MaximumBranchesExceededException) GoString() string {
 
 func newErrorMaximumBranchesExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumBranchesExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23903,18 +23903,18 @@ func (s MaximumBranchesExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumBranchesExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumBranchesExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of allowed conflict resolution entries was exceeded.
 type MaximumConflictResolutionEntriesExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23931,7 +23931,7 @@ func (s MaximumConflictResolutionEntriesExceededException) GoString() string {
 
 func newErrorMaximumConflictResolutionEntriesExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumConflictResolutionEntriesExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23959,18 +23959,18 @@ func (s MaximumConflictResolutionEntriesExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumConflictResolutionEntriesExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumConflictResolutionEntriesExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of files to load exceeds the allowed limit.
 type MaximumFileContentToLoadExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23987,7 +23987,7 @@ func (s MaximumFileContentToLoadExceededException) GoString() string {
 
 func newErrorMaximumFileContentToLoadExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumFileContentToLoadExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24015,12 +24015,12 @@ func (s MaximumFileContentToLoadExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumFileContentToLoadExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumFileContentToLoadExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of specified files to change as part of this commit exceeds the
@@ -24028,7 +24028,7 @@ func (s MaximumFileContentToLoadExceededException) RequestID() string {
 // using a Git client for these changes.
 type MaximumFileEntriesExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24045,7 +24045,7 @@ func (s MaximumFileEntriesExceededException) GoString() string {
 
 func newErrorMaximumFileEntriesExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumFileEntriesExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24073,19 +24073,19 @@ func (s MaximumFileEntriesExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumFileEntriesExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumFileEntriesExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of items to compare between the source or destination branches
 // and the merge base has exceeded the maximum allowed.
 type MaximumItemsToCompareExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24102,7 +24102,7 @@ func (s MaximumItemsToCompareExceededException) GoString() string {
 
 func newErrorMaximumItemsToCompareExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumItemsToCompareExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24130,19 +24130,19 @@ func (s MaximumItemsToCompareExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumItemsToCompareExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumItemsToCompareExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of approvals required for the approval rule exceeds the maximum
 // number allowed.
 type MaximumNumberOfApprovalsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24159,7 +24159,7 @@ func (s MaximumNumberOfApprovalsExceededException) GoString() string {
 
 func newErrorMaximumNumberOfApprovalsExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumNumberOfApprovalsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24187,12 +24187,12 @@ func (s MaximumNumberOfApprovalsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumNumberOfApprovalsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumNumberOfApprovalsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You cannot create the pull request because the repository has too many open
@@ -24200,7 +24200,7 @@ func (s MaximumNumberOfApprovalsExceededException) RequestID() string {
 // is 1,000. Close one or more open pull requests, and then try again.
 type MaximumOpenPullRequestsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24217,7 +24217,7 @@ func (s MaximumOpenPullRequestsExceededException) GoString() string {
 
 func newErrorMaximumOpenPullRequestsExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumOpenPullRequestsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24245,19 +24245,19 @@ func (s MaximumOpenPullRequestsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumOpenPullRequestsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumOpenPullRequestsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of allowed repository names was exceeded. Currently, this
 // number is 100.
 type MaximumRepositoryNamesExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24274,7 +24274,7 @@ func (s MaximumRepositoryNamesExceededException) GoString() string {
 
 func newErrorMaximumRepositoryNamesExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumRepositoryNamesExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24302,18 +24302,18 @@ func (s MaximumRepositoryNamesExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumRepositoryNamesExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumRepositoryNamesExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of triggers allowed for the repository was exceeded.
 type MaximumRepositoryTriggersExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24330,7 +24330,7 @@ func (s MaximumRepositoryTriggersExceededException) GoString() string {
 
 func newErrorMaximumRepositoryTriggersExceededException(v protocol.ResponseMetadata) error {
 	return &MaximumRepositoryTriggersExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24358,19 +24358,19 @@ func (s MaximumRepositoryTriggersExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumRepositoryTriggersExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumRepositoryTriggersExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of approval rule templates for a repository has been exceeded.
 // You cannot associate more than 25 approval rule templates with a repository.
 type MaximumRuleTemplatesAssociatedWithRepositoryException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24387,7 +24387,7 @@ func (s MaximumRuleTemplatesAssociatedWithRepositoryException) GoString() string
 
 func newErrorMaximumRuleTemplatesAssociatedWithRepositoryException(v protocol.ResponseMetadata) error {
 	return &MaximumRuleTemplatesAssociatedWithRepositoryException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24415,12 +24415,12 @@ func (s MaximumRuleTemplatesAssociatedWithRepositoryException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaximumRuleTemplatesAssociatedWithRepositoryException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaximumRuleTemplatesAssociatedWithRepositoryException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type MergeBranchesByFastForwardInput struct {
@@ -25115,7 +25115,7 @@ func (s *MergeOperations) SetSource(v string) *MergeOperations {
 // A merge option or stategy is required, and none was provided.
 type MergeOptionRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25132,7 +25132,7 @@ func (s MergeOptionRequiredException) GoString() string {
 
 func newErrorMergeOptionRequiredException(v protocol.ResponseMetadata) error {
 	return &MergeOptionRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25160,12 +25160,12 @@ func (s MergeOptionRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MergeOptionRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MergeOptionRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type MergePullRequestByFastForwardInput struct {
@@ -25597,7 +25597,7 @@ func (s *MergePullRequestByThreeWayOutput) SetPullRequest(v *PullRequest) *Merge
 // can have only one conflict resolution entry.
 type MultipleConflictResolutionEntriesException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25614,7 +25614,7 @@ func (s MultipleConflictResolutionEntriesException) GoString() string {
 
 func newErrorMultipleConflictResolutionEntriesException(v protocol.ResponseMetadata) error {
 	return &MultipleConflictResolutionEntriesException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25642,12 +25642,12 @@ func (s MultipleConflictResolutionEntriesException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MultipleConflictResolutionEntriesException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MultipleConflictResolutionEntriesException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You cannot include more than one repository in a pull request. Make sure
@@ -25655,7 +25655,7 @@ func (s MultipleConflictResolutionEntriesException) RequestID() string {
 // again.
 type MultipleRepositoriesInPullRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25672,7 +25672,7 @@ func (s MultipleRepositoriesInPullRequestException) GoString() string {
 
 func newErrorMultipleRepositoriesInPullRequestException(v protocol.ResponseMetadata) error {
 	return &MultipleRepositoriesInPullRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25700,19 +25700,19 @@ func (s MultipleRepositoriesInPullRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MultipleRepositoriesInPullRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MultipleRepositoriesInPullRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The user name is not valid because it has exceeded the character limit for
 // author names.
 type NameLengthExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25729,7 +25729,7 @@ func (s NameLengthExceededException) GoString() string {
 
 func newErrorNameLengthExceededException(v protocol.ResponseMetadata) error {
 	return &NameLengthExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25757,19 +25757,19 @@ func (s NameLengthExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NameLengthExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NameLengthExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The commit cannot be created because no changes will be made to the repository
 // as a result of this commit. A commit must contain at least one change.
 type NoChangeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25786,7 +25786,7 @@ func (s NoChangeException) GoString() string {
 
 func newErrorNoChangeException(v protocol.ResponseMetadata) error {
 	return &NoChangeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25814,19 +25814,19 @@ func (s NoChangeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoChangeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoChangeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of approval rule templates has been exceeded for this
 // AWS Region.
 type NumberOfRuleTemplatesExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25843,7 +25843,7 @@ func (s NumberOfRuleTemplatesExceededException) GoString() string {
 
 func newErrorNumberOfRuleTemplatesExceededException(v protocol.ResponseMetadata) error {
 	return &NumberOfRuleTemplatesExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25871,19 +25871,19 @@ func (s NumberOfRuleTemplatesExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NumberOfRuleTemplatesExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NumberOfRuleTemplatesExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The approval rule cannot be added. The pull request has the maximum number
 // of approval rules associated with it.
 type NumberOfRulesExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25900,7 +25900,7 @@ func (s NumberOfRulesExceededException) GoString() string {
 
 func newErrorNumberOfRulesExceededException(v protocol.ResponseMetadata) error {
 	return &NumberOfRulesExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25928,12 +25928,12 @@ func (s NumberOfRulesExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NumberOfRulesExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NumberOfRulesExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the type of an object in a merge operation.
@@ -26015,7 +26015,7 @@ func (s *OriginApprovalRuleTemplate) SetApprovalRuleTemplateName(v string) *Orig
 // The pull request has already had its approval rules set to override.
 type OverrideAlreadySetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26032,7 +26032,7 @@ func (s OverrideAlreadySetException) GoString() string {
 
 func newErrorOverrideAlreadySetException(v protocol.ResponseMetadata) error {
 	return &OverrideAlreadySetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26060,12 +26060,12 @@ func (s OverrideAlreadySetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OverrideAlreadySetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OverrideAlreadySetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type OverridePullRequestApprovalRulesInput struct {
@@ -26157,7 +26157,7 @@ func (s OverridePullRequestApprovalRulesOutput) GoString() string {
 // OVERRIDE and REVOKE.
 type OverrideStatusRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26174,7 +26174,7 @@ func (s OverrideStatusRequiredException) GoString() string {
 
 func newErrorOverrideStatusRequiredException(v protocol.ResponseMetadata) error {
 	return &OverrideStatusRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26202,19 +26202,19 @@ func (s OverrideStatusRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OverrideStatusRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OverrideStatusRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The parent commit ID is not valid because it does not exist. The specified
 // parent commit ID does not exist in the specified branch of the repository.
 type ParentCommitDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26231,7 +26231,7 @@ func (s ParentCommitDoesNotExistException) GoString() string {
 
 func newErrorParentCommitDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &ParentCommitDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26259,12 +26259,12 @@ func (s ParentCommitDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParentCommitDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParentCommitDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The file could not be added because the provided parent commit ID is not
@@ -26272,7 +26272,7 @@ func (s ParentCommitDoesNotExistException) RequestID() string {
 // current head of the branch, use GetBranch.
 type ParentCommitIdOutdatedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26289,7 +26289,7 @@ func (s ParentCommitIdOutdatedException) GoString() string {
 
 func newErrorParentCommitIdOutdatedException(v protocol.ResponseMetadata) error {
 	return &ParentCommitIdOutdatedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26317,12 +26317,12 @@ func (s ParentCommitIdOutdatedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParentCommitIdOutdatedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParentCommitIdOutdatedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A parent commit ID is required. To view the full commit ID of a branch in
@@ -26330,7 +26330,7 @@ func (s ParentCommitIdOutdatedException) RequestID() string {
 // log).
 type ParentCommitIdRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26347,7 +26347,7 @@ func (s ParentCommitIdRequiredException) GoString() string {
 
 func newErrorParentCommitIdRequiredException(v protocol.ResponseMetadata) error {
 	return &ParentCommitIdRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26375,18 +26375,18 @@ func (s ParentCommitIdRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParentCommitIdRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParentCommitIdRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified path does not exist.
 type PathDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26403,7 +26403,7 @@ func (s PathDoesNotExistException) GoString() string {
 
 func newErrorPathDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &PathDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26431,18 +26431,18 @@ func (s PathDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PathDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PathDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The folderPath for a location cannot be null.
 type PathRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26459,7 +26459,7 @@ func (s PathRequiredException) GoString() string {
 
 func newErrorPathRequiredException(v protocol.ResponseMetadata) error {
 	return &PathRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26487,12 +26487,12 @@ func (s PathRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PathRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PathRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PostCommentForComparedCommitInput struct {
@@ -27100,7 +27100,7 @@ func (s *PullRequest) SetTitle(v string) *PullRequest {
 // The pull request status cannot be updated because it is already closed.
 type PullRequestAlreadyClosedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27117,7 +27117,7 @@ func (s PullRequestAlreadyClosedException) GoString() string {
 
 func newErrorPullRequestAlreadyClosedException(v protocol.ResponseMetadata) error {
 	return &PullRequestAlreadyClosedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27145,19 +27145,19 @@ func (s PullRequestAlreadyClosedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PullRequestAlreadyClosedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PullRequestAlreadyClosedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pull request cannot be merged because one or more approval rules applied
 // to the pull request have conditions that have not been met.
 type PullRequestApprovalRulesNotSatisfiedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27174,7 +27174,7 @@ func (s PullRequestApprovalRulesNotSatisfiedException) GoString() string {
 
 func newErrorPullRequestApprovalRulesNotSatisfiedException(v protocol.ResponseMetadata) error {
 	return &PullRequestApprovalRulesNotSatisfiedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27202,12 +27202,12 @@ func (s PullRequestApprovalRulesNotSatisfiedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PullRequestApprovalRulesNotSatisfiedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PullRequestApprovalRulesNotSatisfiedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The approval cannot be applied because the user approving the pull request
@@ -27215,7 +27215,7 @@ func (s PullRequestApprovalRulesNotSatisfiedException) RequestID() string {
 // request that you created.
 type PullRequestCannotBeApprovedByAuthorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27232,7 +27232,7 @@ func (s PullRequestCannotBeApprovedByAuthorException) GoString() string {
 
 func newErrorPullRequestCannotBeApprovedByAuthorException(v protocol.ResponseMetadata) error {
 	return &PullRequestCannotBeApprovedByAuthorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27260,12 +27260,12 @@ func (s PullRequestCannotBeApprovedByAuthorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PullRequestCannotBeApprovedByAuthorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PullRequestCannotBeApprovedByAuthorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Metadata about the pull request that is used when comparing the pull request
@@ -27326,7 +27326,7 @@ func (s *PullRequestCreatedEventMetadata) SetSourceCommitId(v string) *PullReque
 // the correct repository name and pull request ID, and then try again.
 type PullRequestDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27343,7 +27343,7 @@ func (s PullRequestDoesNotExistException) GoString() string {
 
 func newErrorPullRequestDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &PullRequestDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27371,12 +27371,12 @@ func (s PullRequestDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PullRequestDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PullRequestDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about a pull request event.
@@ -27499,7 +27499,7 @@ func (s *PullRequestEvent) SetPullRequestStatusChangedEventMetadata(v *PullReque
 // A pull request ID is required, but none was provided.
 type PullRequestIdRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27516,7 +27516,7 @@ func (s PullRequestIdRequiredException) GoString() string {
 
 func newErrorPullRequestIdRequiredException(v protocol.ResponseMetadata) error {
 	return &PullRequestIdRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27544,12 +27544,12 @@ func (s PullRequestIdRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PullRequestIdRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PullRequestIdRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about the change in the merge state for a pull request
@@ -27676,7 +27676,7 @@ func (s *PullRequestStatusChangedEventMetadata) SetPullRequestStatus(v string) *
 // A pull request status is required, but none was provided.
 type PullRequestStatusRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27693,7 +27693,7 @@ func (s PullRequestStatusRequiredException) GoString() string {
 
 func newErrorPullRequestStatusRequiredException(v protocol.ResponseMetadata) error {
 	return &PullRequestStatusRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27721,12 +27721,12 @@ func (s PullRequestStatusRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PullRequestStatusRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PullRequestStatusRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about a pull request target.
@@ -27894,7 +27894,7 @@ func (s *PutFileEntry) SetSourceFile(v *SourceFileSpecifier) *PutFileEntry {
 // reference both a file and a folder.
 type PutFileEntryConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27911,7 +27911,7 @@ func (s PutFileEntryConflictException) GoString() string {
 
 func newErrorPutFileEntryConflictException(v protocol.ResponseMetadata) error {
 	return &PutFileEntryConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27939,12 +27939,12 @@ func (s PutFileEntryConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PutFileEntryConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PutFileEntryConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutFileInput struct {
@@ -28234,7 +28234,7 @@ func (s *PutRepositoryTriggersOutput) SetConfigurationId(v string) *PutRepositor
 // The specified reference does not exist. You must provide a full commit ID.
 type ReferenceDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28251,7 +28251,7 @@ func (s ReferenceDoesNotExistException) GoString() string {
 
 func newErrorReferenceDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &ReferenceDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28279,18 +28279,18 @@ func (s ReferenceDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReferenceDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReferenceDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A reference name is required, but none was provided.
 type ReferenceNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28307,7 +28307,7 @@ func (s ReferenceNameRequiredException) GoString() string {
 
 func newErrorReferenceNameRequiredException(v protocol.ResponseMetadata) error {
 	return &ReferenceNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28335,18 +28335,18 @@ func (s ReferenceNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReferenceNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReferenceNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified reference is not a supported type.
 type ReferenceTypeNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28363,7 +28363,7 @@ func (s ReferenceTypeNotSupportedException) GoString() string {
 
 func newErrorReferenceTypeNotSupportedException(v protocol.ResponseMetadata) error {
 	return &ReferenceTypeNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28391,12 +28391,12 @@ func (s ReferenceTypeNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReferenceTypeNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReferenceTypeNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a replacement content entry in the conflict of a merge
@@ -28476,7 +28476,7 @@ func (s *ReplaceContentEntry) SetReplacementType(v string) *ReplaceContentEntry 
 // USE_NEW_CONTENT was specified, but no replacement content has been provided.
 type ReplacementContentRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28493,7 +28493,7 @@ func (s ReplacementContentRequiredException) GoString() string {
 
 func newErrorReplacementContentRequiredException(v protocol.ResponseMetadata) error {
 	return &ReplacementContentRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28521,18 +28521,18 @@ func (s ReplacementContentRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReplacementContentRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReplacementContentRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A replacement type is required.
 type ReplacementTypeRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28549,7 +28549,7 @@ func (s ReplacementTypeRequiredException) GoString() string {
 
 func newErrorReplacementTypeRequiredException(v protocol.ResponseMetadata) error {
 	return &ReplacementTypeRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28577,18 +28577,18 @@ func (s ReplacementTypeRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReplacementTypeRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReplacementTypeRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified repository does not exist.
 type RepositoryDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28605,7 +28605,7 @@ func (s RepositoryDoesNotExistException) GoString() string {
 
 func newErrorRepositoryDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &RepositoryDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28633,18 +28633,18 @@ func (s RepositoryDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A repository resource limit was exceeded.
 type RepositoryLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28661,7 +28661,7 @@ func (s RepositoryLimitExceededException) GoString() string {
 
 func newErrorRepositoryLimitExceededException(v protocol.ResponseMetadata) error {
 	return &RepositoryLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28689,12 +28689,12 @@ func (s RepositoryLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a repository.
@@ -28805,7 +28805,7 @@ func (s *RepositoryMetadata) SetRepositoryName(v string) *RepositoryMetadata {
 // The specified repository name already exists.
 type RepositoryNameExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28822,7 +28822,7 @@ func (s RepositoryNameExistsException) GoString() string {
 
 func newErrorRepositoryNameExistsException(v protocol.ResponseMetadata) error {
 	return &RepositoryNameExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28850,12 +28850,12 @@ func (s RepositoryNameExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryNameExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryNameExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a repository name and ID.
@@ -28894,7 +28894,7 @@ func (s *RepositoryNameIdPair) SetRepositoryName(v string) *RepositoryNameIdPair
 // A repository name is required, but was not specified.
 type RepositoryNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28911,7 +28911,7 @@ func (s RepositoryNameRequiredException) GoString() string {
 
 func newErrorRepositoryNameRequiredException(v protocol.ResponseMetadata) error {
 	return &RepositoryNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28939,18 +28939,18 @@ func (s RepositoryNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // At least one repository name object is required, but was not specified.
 type RepositoryNamesRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28967,7 +28967,7 @@ func (s RepositoryNamesRequiredException) GoString() string {
 
 func newErrorRepositoryNamesRequiredException(v protocol.ResponseMetadata) error {
 	return &RepositoryNamesRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28995,12 +28995,12 @@ func (s RepositoryNamesRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryNamesRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryNamesRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The repository does not contain any pull requests with that pull request
@@ -29008,7 +29008,7 @@ func (s RepositoryNamesRequiredException) RequestID() string {
 // request ID.
 type RepositoryNotAssociatedWithPullRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29025,7 +29025,7 @@ func (s RepositoryNotAssociatedWithPullRequestException) GoString() string {
 
 func newErrorRepositoryNotAssociatedWithPullRequestException(v protocol.ResponseMetadata) error {
 	return &RepositoryNotAssociatedWithPullRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29053,12 +29053,12 @@ func (s RepositoryNotAssociatedWithPullRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryNotAssociatedWithPullRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryNotAssociatedWithPullRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a trigger for a repository.
@@ -29159,7 +29159,7 @@ func (s *RepositoryTrigger) SetName(v string) *RepositoryTrigger {
 // configuration.
 type RepositoryTriggerBranchNameListRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29176,7 +29176,7 @@ func (s RepositoryTriggerBranchNameListRequiredException) GoString() string {
 
 func newErrorRepositoryTriggerBranchNameListRequiredException(v protocol.ResponseMetadata) error {
 	return &RepositoryTriggerBranchNameListRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29204,19 +29204,19 @@ func (s RepositoryTriggerBranchNameListRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryTriggerBranchNameListRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryTriggerBranchNameListRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A destination ARN for the target service for the trigger is required, but
 // was not specified.
 type RepositoryTriggerDestinationArnRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29233,7 +29233,7 @@ func (s RepositoryTriggerDestinationArnRequiredException) GoString() string {
 
 func newErrorRepositoryTriggerDestinationArnRequiredException(v protocol.ResponseMetadata) error {
 	return &RepositoryTriggerDestinationArnRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29261,18 +29261,18 @@ func (s RepositoryTriggerDestinationArnRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryTriggerDestinationArnRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryTriggerDestinationArnRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // At least one event for the trigger is required, but was not specified.
 type RepositoryTriggerEventsListRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29289,7 +29289,7 @@ func (s RepositoryTriggerEventsListRequiredException) GoString() string {
 
 func newErrorRepositoryTriggerEventsListRequiredException(v protocol.ResponseMetadata) error {
 	return &RepositoryTriggerEventsListRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29317,12 +29317,12 @@ func (s RepositoryTriggerEventsListRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryTriggerEventsListRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryTriggerEventsListRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A trigger failed to run.
@@ -29361,7 +29361,7 @@ func (s *RepositoryTriggerExecutionFailure) SetTrigger(v string) *RepositoryTrig
 // A name for the trigger is required, but was not specified.
 type RepositoryTriggerNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29378,7 +29378,7 @@ func (s RepositoryTriggerNameRequiredException) GoString() string {
 
 func newErrorRepositoryTriggerNameRequiredException(v protocol.ResponseMetadata) error {
 	return &RepositoryTriggerNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29406,18 +29406,18 @@ func (s RepositoryTriggerNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryTriggerNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryTriggerNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The list of triggers for the repository is required, but was not specified.
 type RepositoryTriggersListRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29434,7 +29434,7 @@ func (s RepositoryTriggersListRequiredException) GoString() string {
 
 func newErrorRepositoryTriggersListRequiredException(v protocol.ResponseMetadata) error {
 	return &RepositoryTriggersListRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29462,12 +29462,12 @@ func (s RepositoryTriggersListRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryTriggersListRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryTriggersListRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A valid Amazon Resource Name (ARN) for an AWS CodeCommit resource is required.
@@ -29476,7 +29476,7 @@ func (s RepositoryTriggersListRequiredException) RequestID() string {
 // in the AWS CodeCommit User Guide.
 type ResourceArnRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29493,7 +29493,7 @@ func (s ResourceArnRequiredException) GoString() string {
 
 func newErrorResourceArnRequiredException(v protocol.ResponseMetadata) error {
 	return &ResourceArnRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29521,19 +29521,19 @@ func (s ResourceArnRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceArnRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceArnRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The commit cannot be created because one of the changes specifies copying
 // or moving a .gitkeep file.
 type RestrictedSourceFileException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29550,7 +29550,7 @@ func (s RestrictedSourceFileException) GoString() string {
 
 func newErrorRestrictedSourceFileException(v protocol.ResponseMetadata) error {
 	return &RestrictedSourceFileException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29578,18 +29578,18 @@ func (s RestrictedSourceFileException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RestrictedSourceFileException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RestrictedSourceFileException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A revision ID is required, but was not provided.
 type RevisionIdRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29606,7 +29606,7 @@ func (s RevisionIdRequiredException) GoString() string {
 
 func newErrorRevisionIdRequiredException(v protocol.ResponseMetadata) error {
 	return &RevisionIdRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29634,19 +29634,19 @@ func (s RevisionIdRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RevisionIdRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RevisionIdRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The revision ID provided in the request does not match the current revision
 // ID. Use GetPullRequest to retrieve the current revision ID.
 type RevisionNotCurrentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29663,7 +29663,7 @@ func (s RevisionNotCurrentException) GoString() string {
 
 func newErrorRevisionNotCurrentException(v protocol.ResponseMetadata) error {
 	return &RevisionNotCurrentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29691,12 +29691,12 @@ func (s RevisionNotCurrentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RevisionNotCurrentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RevisionNotCurrentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The file was not added or updated because the content of the file is exactly
@@ -29704,7 +29704,7 @@ func (s RevisionNotCurrentException) RequestID() string {
 // specified.
 type SameFileContentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29721,7 +29721,7 @@ func (s SameFileContentException) GoString() string {
 
 func newErrorSameFileContentException(v protocol.ResponseMetadata) error {
 	return &SameFileContentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29749,12 +29749,12 @@ func (s SameFileContentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SameFileContentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SameFileContentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The commit cannot be created because one or more changes in this commit duplicate
@@ -29763,7 +29763,7 @@ func (s SameFileContentException) RequestID() string {
 // and a move request to the same file as part of the same commit.
 type SamePathRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29780,7 +29780,7 @@ func (s SamePathRequestException) GoString() string {
 
 func newErrorSamePathRequestException(v protocol.ResponseMetadata) error {
 	return &SamePathRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29808,12 +29808,12 @@ func (s SamePathRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SamePathRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SamePathRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the file mode changes.
@@ -29873,7 +29873,7 @@ func (s *SetFileModeEntry) SetFilePath(v string) *SetFileModeEntry {
 // You must specify different branches for the source and destination.
 type SourceAndDestinationAreSameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29890,7 +29890,7 @@ func (s SourceAndDestinationAreSameException) GoString() string {
 
 func newErrorSourceAndDestinationAreSameException(v protocol.ResponseMetadata) error {
 	return &SourceAndDestinationAreSameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29918,19 +29918,19 @@ func (s SourceAndDestinationAreSameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SourceAndDestinationAreSameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SourceAndDestinationAreSameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The commit cannot be created because no source files or file content have
 // been specified for the commit.
 type SourceFileOrContentRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29947,7 +29947,7 @@ func (s SourceFileOrContentRequiredException) GoString() string {
 
 func newErrorSourceFileOrContentRequiredException(v protocol.ResponseMetadata) error {
 	return &SourceFileOrContentRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29975,12 +29975,12 @@ func (s SourceFileOrContentRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SourceFileOrContentRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SourceFileOrContentRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a source file that is part of changes made in a commit.
@@ -30129,7 +30129,7 @@ func (s *SymbolicLink) SetRelativePath(v string) *SymbolicLink {
 // A list of tag keys is required. The list cannot be empty or null.
 type TagKeysListRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30146,7 +30146,7 @@ func (s TagKeysListRequiredException) GoString() string {
 
 func newErrorTagKeysListRequiredException(v protocol.ResponseMetadata) error {
 	return &TagKeysListRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30174,18 +30174,18 @@ func (s TagKeysListRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagKeysListRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagKeysListRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The tag policy is not valid.
 type TagPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30202,7 +30202,7 @@ func (s TagPolicyException) GoString() string {
 
 func newErrorTagPolicyException(v protocol.ResponseMetadata) error {
 	return &TagPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30230,12 +30230,12 @@ func (s TagPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {
@@ -30308,7 +30308,7 @@ func (s TagResourceOutput) GoString() string {
 // A map of tags is required.
 type TagsMapRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30325,7 +30325,7 @@ func (s TagsMapRequiredException) GoString() string {
 
 func newErrorTagsMapRequiredException(v protocol.ResponseMetadata) error {
 	return &TagsMapRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30353,12 +30353,12 @@ func (s TagsMapRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagsMapRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagsMapRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about a target for a pull request.
@@ -30433,7 +30433,7 @@ func (s *Target) SetSourceReference(v string) *Target {
 // and destination branch for the pull request.
 type TargetRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30450,7 +30450,7 @@ func (s TargetRequiredException) GoString() string {
 
 func newErrorTargetRequiredException(v protocol.ResponseMetadata) error {
 	return &TargetRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30478,18 +30478,18 @@ func (s TargetRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TargetRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TargetRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An array of target objects is required. It cannot be empty or null.
 type TargetsRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30506,7 +30506,7 @@ func (s TargetsRequiredException) GoString() string {
 
 func newErrorTargetsRequiredException(v protocol.ResponseMetadata) error {
 	return &TargetsRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30534,12 +30534,12 @@ func (s TargetsRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TargetsRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TargetsRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of a test repository triggers operation.
@@ -30648,7 +30648,7 @@ func (s *TestRepositoryTriggersOutput) SetSuccessfulExecutions(v []*string) *Tes
 // might have been updated. Make sure that you have the latest changes.
 type TipOfSourceReferenceIsDifferentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30665,7 +30665,7 @@ func (s TipOfSourceReferenceIsDifferentException) GoString() string {
 
 func newErrorTipOfSourceReferenceIsDifferentException(v protocol.ResponseMetadata) error {
 	return &TipOfSourceReferenceIsDifferentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30693,12 +30693,12 @@ func (s TipOfSourceReferenceIsDifferentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TipOfSourceReferenceIsDifferentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TipOfSourceReferenceIsDifferentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The divergence between the tips of the provided commit specifiers is too
@@ -30706,7 +30706,7 @@ func (s TipOfSourceReferenceIsDifferentException) RequestID() string {
 // the specifiers using git diff or a diff tool.
 type TipsDivergenceExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30723,7 +30723,7 @@ func (s TipsDivergenceExceededException) GoString() string {
 
 func newErrorTipsDivergenceExceededException(v protocol.ResponseMetadata) error {
 	return &TipsDivergenceExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30751,18 +30751,18 @@ func (s TipsDivergenceExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TipsDivergenceExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TipsDivergenceExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A pull request title is required. It cannot be empty or null.
 type TitleRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30779,7 +30779,7 @@ func (s TitleRequiredException) GoString() string {
 
 func newErrorTitleRequiredException(v protocol.ResponseMetadata) error {
 	return &TitleRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30807,18 +30807,18 @@ func (s TitleRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TitleRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TitleRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of tags for an AWS CodeCommit resource has been exceeded.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30835,7 +30835,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30863,12 +30863,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -10354,8 +10354,8 @@ func (c *CodeCommit) UpdateRepositoryNameWithContext(ctx aws.Context, input *Upd
 
 // The specified Amazon Resource Name (ARN) does not exist in the AWS account.
 type ActorDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10532,8 +10532,8 @@ func (s *ApprovalRule) SetRuleContentSha256(v string) *ApprovalRule {
 // The content for the approval rule is empty. You must provide some content
 // for an approval rule. The content cannot be null.
 type ApprovalRuleContentRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10588,8 +10588,8 @@ func (s ApprovalRuleContentRequiredException) RequestID() string {
 
 // The specified approval rule does not exist.
 type ApprovalRuleDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10687,8 +10687,8 @@ func (s *ApprovalRuleEventMetadata) SetApprovalRuleName(v string) *ApprovalRuleE
 // An approval rule with that name already exists. Approval rule names must
 // be unique within the scope of a pull request.
 type ApprovalRuleNameAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10743,8 +10743,8 @@ func (s ApprovalRuleNameAlreadyExistsException) RequestID() string {
 
 // An approval rule name is required, but was not specified.
 type ApprovalRuleNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10923,8 +10923,8 @@ func (s *ApprovalRuleTemplate) SetRuleContentSha256(v string) *ApprovalRuleTempl
 // The content for the approval rule template is empty. You must provide some
 // content for an approval rule template. The content cannot be null.
 type ApprovalRuleTemplateContentRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10981,8 +10981,8 @@ func (s ApprovalRuleTemplateContentRequiredException) RequestID() string {
 // is correct and that you are signed in to the AWS Region where the template
 // was created, and then try again.
 type ApprovalRuleTemplateDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11039,8 +11039,8 @@ func (s ApprovalRuleTemplateDoesNotExistException) RequestID() string {
 // cannot delete a template that is associated with a repository. Remove all
 // associations, and then try again.
 type ApprovalRuleTemplateInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11097,8 +11097,8 @@ func (s ApprovalRuleTemplateInUseException) RequestID() string {
 // with that name already exists in this AWS Region for your AWS account. Approval
 // rule template names must be unique.
 type ApprovalRuleTemplateNameAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11153,8 +11153,8 @@ func (s ApprovalRuleTemplateNameAlreadyExistsException) RequestID() string {
 
 // An approval rule template name is required, but was not specified.
 type ApprovalRuleTemplateNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11242,8 +11242,8 @@ func (s *ApprovalStateChangedEventMetadata) SetRevisionId(v string) *ApprovalSta
 
 // An approval state is required, but was not specified.
 type ApprovalStateRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11370,8 +11370,8 @@ func (s AssociateApprovalRuleTemplateWithRepositoryOutput) GoString() string {
 
 // The specified Amazon Resource Name (ARN) does not exist in the AWS account.
 type AuthorDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12195,8 +12195,8 @@ func (s *BatchGetRepositoriesOutput) SetRepositoriesNotFound(v []*string) *Batch
 // The before commit ID and the after commit ID are the same, which is not valid.
 // The before commit ID and the after commit ID must be different commit IDs.
 type BeforeCommitIdAndAfterCommitIdAreSameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12251,8 +12251,8 @@ func (s BeforeCommitIdAndAfterCommitIdAreSameException) RequestID() string {
 
 // The specified blob does not exist.
 type BlobIdDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12307,8 +12307,8 @@ func (s BlobIdDoesNotExistException) RequestID() string {
 
 // A blob ID is required, but was not specified.
 type BlobIdRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12413,8 +12413,8 @@ func (s *BlobMetadata) SetPath(v string) *BlobMetadata {
 
 // The specified branch does not exist.
 type BranchDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12502,8 +12502,8 @@ func (s *BranchInfo) SetCommitId(v string) *BranchInfo {
 
 // The specified branch name already exists.
 type BranchNameExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12560,8 +12560,8 @@ func (s BranchNameExistsException) RequestID() string {
 // name of a branch in the repository. For a list of valid branch names, use
 // ListBranches.
 type BranchNameIsTagNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12616,8 +12616,8 @@ func (s BranchNameIsTagNameException) RequestID() string {
 
 // A branch name is required, but was not specified.
 type BranchNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12673,8 +12673,8 @@ func (s BranchNameRequiredException) RequestID() string {
 // The approval rule cannot be deleted from the pull request because it was
 // created by an approval rule template and applied to the pull request automatically.
 type CannotDeleteApprovalRuleFromTemplateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12730,8 +12730,8 @@ func (s CannotDeleteApprovalRuleFromTemplateException) RequestID() string {
 // The approval rule cannot be modified for the pull request because it was
 // created by an approval rule template and applied to the pull request automatically.
 type CannotModifyApprovalRuleFromTemplateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12790,8 +12790,8 @@ func (s CannotModifyApprovalRuleFromTemplateException) RequestID() string {
 // received with the same parameters and a token is included, the request returns
 // information about the initial request that used that token.
 type ClientRequestTokenRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12937,8 +12937,8 @@ func (s *Comment) SetLastModifiedDate(v time.Time) *Comment {
 // The comment is empty. You must provide some content for a comment. The content
 // cannot be null.
 type CommentContentRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12993,8 +12993,8 @@ func (s CommentContentRequiredException) RequestID() string {
 
 // The comment is too large. Comments are limited to 1,000 characters.
 type CommentContentSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13050,8 +13050,8 @@ func (s CommentContentSizeLimitExceededException) RequestID() string {
 // This comment has already been deleted. You cannot edit or delete a deleted
 // comment.
 type CommentDeletedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13107,8 +13107,8 @@ func (s CommentDeletedException) RequestID() string {
 // No comment exists with the provided ID. Verify that you have used the correct
 // ID, and then try again.
 type CommentDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13163,8 +13163,8 @@ func (s CommentDoesNotExistException) RequestID() string {
 
 // The comment ID is missing or null. A comment ID is required.
 type CommentIdRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13220,8 +13220,8 @@ func (s CommentIdRequiredException) RequestID() string {
 // You cannot modify or delete this comment. Only comment authors can modify
 // or delete their comments.
 type CommentNotCreatedByCallerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13541,8 +13541,8 @@ func (s *Commit) SetTreeId(v string) *Commit {
 // The specified commit does not exist or no commit was specified, and the specified
 // repository has no default branch.
 type CommitDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13597,8 +13597,8 @@ func (s CommitDoesNotExistException) RequestID() string {
 
 // The specified commit ID does not exist.
 type CommitIdDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13653,8 +13653,8 @@ func (s CommitIdDoesNotExistException) RequestID() string {
 
 // A commit ID was not specified.
 type CommitIdRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13711,8 +13711,8 @@ func (s CommitIdRequiredException) RequestID() string {
 // that your batch requests contains no more than 100 commit IDs, and then try
 // again.
 type CommitIdsLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13768,8 +13768,8 @@ func (s CommitIdsLimitExceededException) RequestID() string {
 // A list of commit IDs is required, but was either not specified or the list
 // was empty.
 type CommitIdsListRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13824,8 +13824,8 @@ func (s CommitIdsListRequiredException) RequestID() string {
 
 // The commit message is too long. Provide a shorter string.
 type CommitMessageLengthExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13880,8 +13880,8 @@ func (s CommitMessageLengthExceededException) RequestID() string {
 
 // A commit was not specified.
 type CommitRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13938,8 +13938,8 @@ func (s CommitRequiredException) RequestID() string {
 // Another user might have modified the target branch while the merge was in
 // progress. Wait a few minutes, and then try again.
 type ConcurrentReferenceUpdateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15186,8 +15186,8 @@ func (s *CreateUnreferencedMergeCommitOutput) SetTreeId(v string) *CreateUnrefer
 // be deleted. To delete this branch, you must first set another branch as the
 // default branch.
 type DefaultBranchCannotBeDeletedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16223,8 +16223,8 @@ func (s *Difference) SetChangeType(v string) *Difference {
 // provide a different name for the file, or specify a different path for the
 // file.
 type DirectoryNameConflictsWithFileNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16351,8 +16351,8 @@ func (s DisassociateApprovalRuleTemplateFromRepositoryOutput) GoString() string 
 
 // An encryption integrity check failed.
 type EncryptionIntegrityChecksFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16407,8 +16407,8 @@ func (s EncryptionIntegrityChecksFailedException) RequestID() string {
 
 // An encryption key could not be accessed.
 type EncryptionKeyAccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16463,8 +16463,8 @@ func (s EncryptionKeyAccessDeniedException) RequestID() string {
 
 // The encryption key is disabled.
 type EncryptionKeyDisabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16519,8 +16519,8 @@ func (s EncryptionKeyDisabledException) RequestID() string {
 
 // No encryption key was found.
 type EncryptionKeyNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16575,8 +16575,8 @@ func (s EncryptionKeyNotFoundException) RequestID() string {
 
 // The encryption key is not available.
 type EncryptionKeyUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16819,8 +16819,8 @@ func (s *File) SetRelativePath(v string) *File {
 // have been specified for the same file. You cannot provide both. Either specify
 // a source file or provide the file content directly.
 type FileContentAndSourceFileSpecifiedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16876,8 +16876,8 @@ func (s FileContentAndSourceFileSpecifiedException) RequestID() string {
 // The file cannot be added because it is empty. Empty files cannot be added
 // to the repository with this API.
 type FileContentRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16934,8 +16934,8 @@ func (s FileContentRequiredException) RequestID() string {
 // 6 MB, and the combined file content change size is 7 MB. Consider making
 // these changes using a Git client.
 type FileContentSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16991,8 +16991,8 @@ func (s FileContentSizeLimitExceededException) RequestID() string {
 // The specified file does not exist. Verify that you have used the correct
 // file name, full path, and extension.
 type FileDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17048,8 +17048,8 @@ func (s FileDoesNotExistException) RequestID() string {
 // The commit cannot be created because no files have been specified as added,
 // updated, or changed (PutFile or DeleteFile) for the commit.
 type FileEntryRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17149,8 +17149,8 @@ func (s *FileMetadata) SetFileMode(v string) *FileMetadata {
 // The commit cannot be created because no file mode has been specified. A file
 // mode is required to update mode permissions for a file.
 type FileModeRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17250,8 +17250,8 @@ func (s *FileModes) SetSource(v string) *FileModes {
 // name for the file, or add the file in a directory that does not match the
 // file name.
 type FileNameConflictsWithDirectoryNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17308,8 +17308,8 @@ func (s FileNameConflictsWithDirectoryNameException) RequestID() string {
 // Verify that the destination files have valid file paths that do not point
 // to a submodule.
 type FilePathConflictsWithSubmodulePathException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17408,8 +17408,8 @@ func (s *FileSizes) SetSource(v int64) *FileSizes {
 // information about limits in AWS CodeCommit, see AWS CodeCommit User Guide
 // (https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html).
 type FileTooLargeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17511,8 +17511,8 @@ func (s *Folder) SetTreeId(v string) *Folder {
 // Either reduce the number and size of your changes, or split the changes across
 // multiple folders.
 type FolderContentSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17568,8 +17568,8 @@ func (s FolderContentSizeLimitExceededException) RequestID() string {
 // The specified folder does not exist. Either the folder name is not correct,
 // or you did not enter the full path to the folder.
 type FolderDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19571,8 +19571,8 @@ func (s *GetRepositoryTriggersOutput) SetTriggers(v []*RepositoryTrigger) *GetRe
 // The client request token is not valid. Either the token is not in a valid
 // format, or the token has been used in a previous request and cannot be reused.
 type IdempotencyParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19629,8 +19629,8 @@ func (s IdempotencyParameterMismatchException) RequestID() string {
 // the full ARN for the user who initiated the change for the pull request,
 // and then try again.
 type InvalidActorArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19685,8 +19685,8 @@ func (s InvalidActorArnException) RequestID() string {
 
 // The content for the approval rule is not valid.
 type InvalidApprovalRuleContentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19741,8 +19741,8 @@ func (s InvalidApprovalRuleContentException) RequestID() string {
 
 // The name for the approval rule is not valid.
 type InvalidApprovalRuleNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19797,8 +19797,8 @@ func (s InvalidApprovalRuleNameException) RequestID() string {
 
 // The content of the approval rule template is not valid.
 type InvalidApprovalRuleTemplateContentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19855,8 +19855,8 @@ func (s InvalidApprovalRuleTemplateContentException) RequestID() string {
 // the maximum characters allowed for a description. For more information about
 // limits in AWS CodeCommit, see AWS CodeCommit User Guide (https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html).
 type InvalidApprovalRuleTemplateDescriptionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19913,8 +19913,8 @@ func (s InvalidApprovalRuleTemplateDescriptionException) RequestID() string {
 // be between 1 and 100 valid characters in length. For more information about
 // limits in AWS CodeCommit, see AWS CodeCommit User Guide (https://docs.aws.amazon.com/codecommit/latest/userguide/limits.html).
 type InvalidApprovalRuleTemplateNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19970,8 +19970,8 @@ func (s InvalidApprovalRuleTemplateNameException) RequestID() string {
 // The state for the approval is not valid. Valid values include APPROVE and
 // REVOKE.
 type InvalidApprovalStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20027,8 +20027,8 @@ func (s InvalidApprovalStateException) RequestID() string {
 // The Amazon Resource Name (ARN) is not valid. Make sure that you have provided
 // the full ARN for the author of the pull request, and then try again.
 type InvalidAuthorArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20083,8 +20083,8 @@ func (s InvalidAuthorArnException) RequestID() string {
 
 // The specified blob is not valid.
 type InvalidBlobIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20139,8 +20139,8 @@ func (s InvalidBlobIdException) RequestID() string {
 
 // The specified reference name is not valid.
 type InvalidBranchNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20195,8 +20195,8 @@ func (s InvalidBranchNameException) RequestID() string {
 
 // The client request token is not valid.
 type InvalidClientRequestTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20252,8 +20252,8 @@ func (s InvalidClientRequestTokenException) RequestID() string {
 // The comment ID is not in a valid format. Make sure that you have provided
 // the full comment ID.
 type InvalidCommentIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20308,8 +20308,8 @@ func (s InvalidCommentIdException) RequestID() string {
 
 // The specified commit is not valid.
 type InvalidCommitException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20364,8 +20364,8 @@ func (s InvalidCommitException) RequestID() string {
 
 // The specified commit ID is not valid.
 type InvalidCommitIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20420,8 +20420,8 @@ func (s InvalidCommitIdException) RequestID() string {
 
 // The specified conflict detail level is not valid.
 type InvalidConflictDetailLevelException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20476,8 +20476,8 @@ func (s InvalidConflictDetailLevelException) RequestID() string {
 
 // The specified conflict resolution list is not valid.
 type InvalidConflictResolutionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20532,8 +20532,8 @@ func (s InvalidConflictResolutionException) RequestID() string {
 
 // The specified conflict resolution strategy is not valid.
 type InvalidConflictResolutionStrategyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20588,8 +20588,8 @@ func (s InvalidConflictResolutionStrategyException) RequestID() string {
 
 // The specified continuation token is not valid.
 type InvalidContinuationTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20644,8 +20644,8 @@ func (s InvalidContinuationTokenException) RequestID() string {
 
 // The specified deletion parameter is not valid.
 type InvalidDeletionParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20701,8 +20701,8 @@ func (s InvalidDeletionParameterException) RequestID() string {
 // The pull request description is not valid. Descriptions cannot be more than
 // 1,000 characters.
 type InvalidDescriptionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20758,8 +20758,8 @@ func (s InvalidDescriptionException) RequestID() string {
 // The destination commit specifier is not valid. You must provide a valid branch
 // name, tag, or full commit ID.
 type InvalidDestinationCommitSpecifierException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20816,8 +20816,8 @@ func (s InvalidDestinationCommitSpecifierException) RequestID() string {
 // not allowed, or it exceeds the maximum number of characters allowed for an
 // email address.
 type InvalidEmailException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20873,8 +20873,8 @@ func (s InvalidEmailException) RequestID() string {
 // The location of the file is not valid. Make sure that you include the file
 // name and extension.
 type InvalidFileLocationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20930,8 +20930,8 @@ func (s InvalidFileLocationException) RequestID() string {
 // The specified file mode permission is not valid. For a list of valid file
 // mode permissions, see PutFile.
 type InvalidFileModeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20987,8 +20987,8 @@ func (s InvalidFileModeException) RequestID() string {
 // The position is not valid. Make sure that the line number exists in the version
 // of the file you want to comment on.
 type InvalidFilePositionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21043,8 +21043,8 @@ func (s InvalidFilePositionException) RequestID() string {
 
 // The specified value for the number of conflict files to return is not valid.
 type InvalidMaxConflictFilesException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21099,8 +21099,8 @@ func (s InvalidMaxConflictFilesException) RequestID() string {
 
 // The specified value for the number of merge hunks to return is not valid.
 type InvalidMaxMergeHunksException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21155,8 +21155,8 @@ func (s InvalidMaxMergeHunksException) RequestID() string {
 
 // The specified number of maximum results is not valid.
 type InvalidMaxResultsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21212,8 +21212,8 @@ func (s InvalidMaxResultsException) RequestID() string {
 // The specified merge option is not valid for this operation. Not all merge
 // strategies are supported for all operations.
 type InvalidMergeOptionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21268,8 +21268,8 @@ func (s InvalidMergeOptionException) RequestID() string {
 
 // The specified sort order is not valid.
 type InvalidOrderException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21324,8 +21324,8 @@ func (s InvalidOrderException) RequestID() string {
 
 // The override status is not valid. Valid statuses are OVERRIDE and REVOKE.
 type InvalidOverrideStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21382,8 +21382,8 @@ func (s InvalidOverrideStatusException) RequestID() string {
 // match the head commit ID for the branch of the repository where you want
 // to add or update a file.
 type InvalidParentCommitIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21438,8 +21438,8 @@ func (s InvalidParentCommitIdException) RequestID() string {
 
 // The specified path is not valid.
 type InvalidPathException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21494,8 +21494,8 @@ func (s InvalidPathException) RequestID() string {
 
 // The pull request event type is not valid.
 type InvalidPullRequestEventTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21552,8 +21552,8 @@ func (s InvalidPullRequestEventTypeException) RequestID() string {
 // ID and that the pull request is in the specified repository, and then try
 // again.
 type InvalidPullRequestIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21609,8 +21609,8 @@ func (s InvalidPullRequestIdException) RequestID() string {
 // The pull request status is not valid. The only valid values are OPEN and
 // CLOSED.
 type InvalidPullRequestStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21666,8 +21666,8 @@ func (s InvalidPullRequestStatusException) RequestID() string {
 // The pull request status update is not valid. The only valid update is from
 // OPEN to CLOSED.
 type InvalidPullRequestStatusUpdateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21725,8 +21725,8 @@ func (s InvalidPullRequestStatusUpdateException) RequestID() string {
 // see Git Internals - Git References (https://git-scm.com/book/en/v2/Git-Internals-Git-References)
 // or consult your Git documentation.
 type InvalidReferenceNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21782,8 +21782,8 @@ func (s InvalidReferenceNameException) RequestID() string {
 // Either the enum is not in a valid format, or the specified file version enum
 // is not valid in respect to the current file version.
 type InvalidRelativeFileVersionEnumException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21839,8 +21839,8 @@ func (s InvalidRelativeFileVersionEnumException) RequestID() string {
 // Automerge was specified for resolving the conflict, but the replacement type
 // is not valid or content is missing.
 type InvalidReplacementContentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21896,8 +21896,8 @@ func (s InvalidReplacementContentException) RequestID() string {
 // Automerge was specified for resolving the conflict, but the specified replacement
 // type is not valid.
 type InvalidReplacementTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21952,8 +21952,8 @@ func (s InvalidReplacementTypeException) RequestID() string {
 
 // The specified repository description is not valid.
 type InvalidRepositoryDescriptionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22012,8 +22012,8 @@ func (s InvalidRepositoryDescriptionException) RequestID() string {
 // Other exceptions occur when a required repository parameter is missing, or
 // when a specified repository does not exist.
 type InvalidRepositoryNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22068,8 +22068,8 @@ func (s InvalidRepositoryNameException) RequestID() string {
 
 // One or more branch names specified for the trigger is not valid.
 type InvalidRepositoryTriggerBranchNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22124,8 +22124,8 @@ func (s InvalidRepositoryTriggerBranchNameException) RequestID() string {
 
 // The custom data provided for the trigger is not valid.
 type InvalidRepositoryTriggerCustomDataException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22182,8 +22182,8 @@ func (s InvalidRepositoryTriggerCustomDataException) RequestID() string {
 // destination. The most common reason for this error is that the ARN does not
 // meet the requirements for the service type.
 type InvalidRepositoryTriggerDestinationArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22239,8 +22239,8 @@ func (s InvalidRepositoryTriggerDestinationArnException) RequestID() string {
 // One or more events specified for the trigger is not valid. Check to make
 // sure that all events specified match the requirements for allowed events.
 type InvalidRepositoryTriggerEventsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22295,8 +22295,8 @@ func (s InvalidRepositoryTriggerEventsException) RequestID() string {
 
 // The name of the trigger is not valid.
 type InvalidRepositoryTriggerNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22353,8 +22353,8 @@ func (s InvalidRepositoryTriggerNameException) RequestID() string {
 // repository. Triggers must be created in the same Region as the target for
 // the trigger.
 type InvalidRepositoryTriggerRegionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22411,8 +22411,8 @@ func (s InvalidRepositoryTriggerRegionException) RequestID() string {
 // in AWS CodeCommit, see CodeCommit Resources and Operations (https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-iam-access-control-identity-based.html#arn-formats)
 // in the AWS CodeCommit User Guide.
 type InvalidResourceArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22467,8 +22467,8 @@ func (s InvalidResourceArnException) RequestID() string {
 
 // The revision ID is not valid. Use GetPullRequest to determine the value.
 type InvalidRevisionIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22523,8 +22523,8 @@ func (s InvalidRevisionIdException) RequestID() string {
 
 // The SHA-256 hash signature for the rule content is not valid.
 type InvalidRuleContentSha256Exception struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22579,8 +22579,8 @@ func (s InvalidRuleContentSha256Exception) RequestID() string {
 
 // The specified sort by value is not valid.
 type InvalidSortByException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22636,8 +22636,8 @@ func (s InvalidSortByException) RequestID() string {
 // The source commit specifier is not valid. You must provide a valid branch
 // name, tag, or full commit ID.
 type InvalidSourceCommitSpecifierException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22692,8 +22692,8 @@ func (s InvalidSourceCommitSpecifierException) RequestID() string {
 
 // The specified tag is not valid. Key names cannot be prefixed with aws:.
 type InvalidSystemTagUsageException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22748,8 +22748,8 @@ func (s InvalidSystemTagUsageException) RequestID() string {
 
 // The list of tags is not valid.
 type InvalidTagKeysListException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22804,8 +22804,8 @@ func (s InvalidTagKeysListException) RequestID() string {
 
 // The map of tags is not valid.
 type InvalidTagsMapException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22860,8 +22860,8 @@ func (s InvalidTagsMapException) RequestID() string {
 
 // The specified target branch is not valid.
 type InvalidTargetBranchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22918,8 +22918,8 @@ func (s InvalidTargetBranchException) RequestID() string {
 // values for the repository name, source branch, and destination branch for
 // the pull request.
 type InvalidTargetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -22977,8 +22977,8 @@ func (s InvalidTargetException) RequestID() string {
 // for the repository name, source branch, and destination branch for a pull
 // request.
 type InvalidTargetsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23034,8 +23034,8 @@ func (s InvalidTargetsException) RequestID() string {
 // The title of the pull request is not valid. Pull request titles cannot exceed
 // 100 characters in length.
 type InvalidTitleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23801,8 +23801,8 @@ func (s *Location) SetRelativeFileVersion(v string) *Location {
 // The pull request cannot be merged automatically into the destination branch.
 // You must manually merge the branches and resolve any conflicts.
 type ManualMergeRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23857,8 +23857,8 @@ func (s ManualMergeRequiredException) RequestID() string {
 
 // The number of branches for the trigger was exceeded.
 type MaximumBranchesExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23913,8 +23913,8 @@ func (s MaximumBranchesExceededException) RequestID() string {
 
 // The number of allowed conflict resolution entries was exceeded.
 type MaximumConflictResolutionEntriesExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23969,8 +23969,8 @@ func (s MaximumConflictResolutionEntriesExceededException) RequestID() string {
 
 // The number of files to load exceeds the allowed limit.
 type MaximumFileContentToLoadExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24027,8 +24027,8 @@ func (s MaximumFileContentToLoadExceededException) RequestID() string {
 // maximum number of files that can be changed in a single commit. Consider
 // using a Git client for these changes.
 type MaximumFileEntriesExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24084,8 +24084,8 @@ func (s MaximumFileEntriesExceededException) RequestID() string {
 // The number of items to compare between the source or destination branches
 // and the merge base has exceeded the maximum allowed.
 type MaximumItemsToCompareExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24141,8 +24141,8 @@ func (s MaximumItemsToCompareExceededException) RequestID() string {
 // The number of approvals required for the approval rule exceeds the maximum
 // number allowed.
 type MaximumNumberOfApprovalsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24199,8 +24199,8 @@ func (s MaximumNumberOfApprovalsExceededException) RequestID() string {
 // pull requests. The maximum number of open pull requests for a repository
 // is 1,000. Close one or more open pull requests, and then try again.
 type MaximumOpenPullRequestsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24256,8 +24256,8 @@ func (s MaximumOpenPullRequestsExceededException) RequestID() string {
 // The maximum number of allowed repository names was exceeded. Currently, this
 // number is 100.
 type MaximumRepositoryNamesExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24312,8 +24312,8 @@ func (s MaximumRepositoryNamesExceededException) RequestID() string {
 
 // The number of triggers allowed for the repository was exceeded.
 type MaximumRepositoryTriggersExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24369,8 +24369,8 @@ func (s MaximumRepositoryTriggersExceededException) RequestID() string {
 // The maximum number of approval rule templates for a repository has been exceeded.
 // You cannot associate more than 25 approval rule templates with a repository.
 type MaximumRuleTemplatesAssociatedWithRepositoryException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25114,8 +25114,8 @@ func (s *MergeOperations) SetSource(v string) *MergeOperations {
 
 // A merge option or stategy is required, and none was provided.
 type MergeOptionRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25596,8 +25596,8 @@ func (s *MergePullRequestByThreeWayOutput) SetPullRequest(v *PullRequest) *Merge
 // More than one conflict resolution entries exists for the conflict. A conflict
 // can have only one conflict resolution entry.
 type MultipleConflictResolutionEntriesException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25654,8 +25654,8 @@ func (s MultipleConflictResolutionEntriesException) RequestID() string {
 // you have specified only one repository name in your request, and then try
 // again.
 type MultipleRepositoriesInPullRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25711,8 +25711,8 @@ func (s MultipleRepositoriesInPullRequestException) RequestID() string {
 // The user name is not valid because it has exceeded the character limit for
 // author names.
 type NameLengthExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25768,8 +25768,8 @@ func (s NameLengthExceededException) RequestID() string {
 // The commit cannot be created because no changes will be made to the repository
 // as a result of this commit. A commit must contain at least one change.
 type NoChangeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25825,8 +25825,8 @@ func (s NoChangeException) RequestID() string {
 // The maximum number of approval rule templates has been exceeded for this
 // AWS Region.
 type NumberOfRuleTemplatesExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25882,8 +25882,8 @@ func (s NumberOfRuleTemplatesExceededException) RequestID() string {
 // The approval rule cannot be added. The pull request has the maximum number
 // of approval rules associated with it.
 type NumberOfRulesExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26014,8 +26014,8 @@ func (s *OriginApprovalRuleTemplate) SetApprovalRuleTemplateName(v string) *Orig
 
 // The pull request has already had its approval rules set to override.
 type OverrideAlreadySetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26156,8 +26156,8 @@ func (s OverridePullRequestApprovalRulesOutput) GoString() string {
 // An override status is required, but no value was provided. Valid values include
 // OVERRIDE and REVOKE.
 type OverrideStatusRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26213,8 +26213,8 @@ func (s OverrideStatusRequiredException) RequestID() string {
 // The parent commit ID is not valid because it does not exist. The specified
 // parent commit ID does not exist in the specified branch of the repository.
 type ParentCommitDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26271,8 +26271,8 @@ func (s ParentCommitDoesNotExistException) RequestID() string {
 // the current tip of the specified branch. To view the full commit ID of the
 // current head of the branch, use GetBranch.
 type ParentCommitIdOutdatedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26329,8 +26329,8 @@ func (s ParentCommitIdOutdatedException) RequestID() string {
 // a repository, use GetBranch or a Git command (for example, git pull or git
 // log).
 type ParentCommitIdRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26385,8 +26385,8 @@ func (s ParentCommitIdRequiredException) RequestID() string {
 
 // The specified path does not exist.
 type PathDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26441,8 +26441,8 @@ func (s PathDoesNotExistException) RequestID() string {
 
 // The folderPath for a location cannot be null.
 type PathRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27099,8 +27099,8 @@ func (s *PullRequest) SetTitle(v string) *PullRequest {
 
 // The pull request status cannot be updated because it is already closed.
 type PullRequestAlreadyClosedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27156,8 +27156,8 @@ func (s PullRequestAlreadyClosedException) RequestID() string {
 // The pull request cannot be merged because one or more approval rules applied
 // to the pull request have conditions that have not been met.
 type PullRequestApprovalRulesNotSatisfiedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27214,8 +27214,8 @@ func (s PullRequestApprovalRulesNotSatisfiedException) RequestID() string {
 // matches the user who created the pull request. You cannot approve a pull
 // request that you created.
 type PullRequestCannotBeApprovedByAuthorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27325,8 +27325,8 @@ func (s *PullRequestCreatedEventMetadata) SetSourceCommitId(v string) *PullReque
 // The pull request ID could not be found. Make sure that you have specified
 // the correct repository name and pull request ID, and then try again.
 type PullRequestDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27498,8 +27498,8 @@ func (s *PullRequestEvent) SetPullRequestStatusChangedEventMetadata(v *PullReque
 
 // A pull request ID is required, but none was provided.
 type PullRequestIdRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27675,8 +27675,8 @@ func (s *PullRequestStatusChangedEventMetadata) SetPullRequestStatus(v string) *
 
 // A pull request status is required, but none was provided.
 type PullRequestStatusRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27893,8 +27893,8 @@ func (s *PutFileEntry) SetSourceFile(v *SourceFileSpecifier) *PutFileEntry {
 // The commit cannot be created because one or more files specified in the commit
 // reference both a file and a folder.
 type PutFileEntryConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28233,8 +28233,8 @@ func (s *PutRepositoryTriggersOutput) SetConfigurationId(v string) *PutRepositor
 
 // The specified reference does not exist. You must provide a full commit ID.
 type ReferenceDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28289,8 +28289,8 @@ func (s ReferenceDoesNotExistException) RequestID() string {
 
 // A reference name is required, but none was provided.
 type ReferenceNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28345,8 +28345,8 @@ func (s ReferenceNameRequiredException) RequestID() string {
 
 // The specified reference is not a supported type.
 type ReferenceTypeNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28475,8 +28475,8 @@ func (s *ReplaceContentEntry) SetReplacementType(v string) *ReplaceContentEntry 
 
 // USE_NEW_CONTENT was specified, but no replacement content has been provided.
 type ReplacementContentRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28531,8 +28531,8 @@ func (s ReplacementContentRequiredException) RequestID() string {
 
 // A replacement type is required.
 type ReplacementTypeRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28587,8 +28587,8 @@ func (s ReplacementTypeRequiredException) RequestID() string {
 
 // The specified repository does not exist.
 type RepositoryDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28643,8 +28643,8 @@ func (s RepositoryDoesNotExistException) RequestID() string {
 
 // A repository resource limit was exceeded.
 type RepositoryLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28804,8 +28804,8 @@ func (s *RepositoryMetadata) SetRepositoryName(v string) *RepositoryMetadata {
 
 // The specified repository name already exists.
 type RepositoryNameExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28893,8 +28893,8 @@ func (s *RepositoryNameIdPair) SetRepositoryName(v string) *RepositoryNameIdPair
 
 // A repository name is required, but was not specified.
 type RepositoryNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28949,8 +28949,8 @@ func (s RepositoryNameRequiredException) RequestID() string {
 
 // At least one repository name object is required, but was not specified.
 type RepositoryNamesRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29007,8 +29007,8 @@ func (s RepositoryNamesRequiredException) RequestID() string {
 // ID. Use GetPullRequest to verify the correct repository name for the pull
 // request ID.
 type RepositoryNotAssociatedWithPullRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29158,8 +29158,8 @@ func (s *RepositoryTrigger) SetName(v string) *RepositoryTrigger {
 // At least one branch name is required, but was not specified in the trigger
 // configuration.
 type RepositoryTriggerBranchNameListRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29215,8 +29215,8 @@ func (s RepositoryTriggerBranchNameListRequiredException) RequestID() string {
 // A destination ARN for the target service for the trigger is required, but
 // was not specified.
 type RepositoryTriggerDestinationArnRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29271,8 +29271,8 @@ func (s RepositoryTriggerDestinationArnRequiredException) RequestID() string {
 
 // At least one event for the trigger is required, but was not specified.
 type RepositoryTriggerEventsListRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29360,8 +29360,8 @@ func (s *RepositoryTriggerExecutionFailure) SetTrigger(v string) *RepositoryTrig
 
 // A name for the trigger is required, but was not specified.
 type RepositoryTriggerNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29416,8 +29416,8 @@ func (s RepositoryTriggerNameRequiredException) RequestID() string {
 
 // The list of triggers for the repository is required, but was not specified.
 type RepositoryTriggersListRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29475,8 +29475,8 @@ func (s RepositoryTriggersListRequiredException) RequestID() string {
 // and Operations (https://docs.aws.amazon.com/codecommit/latest/userguide/auth-and-access-control-iam-access-control-identity-based.html#arn-formats)
 // in the AWS CodeCommit User Guide.
 type ResourceArnRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29532,8 +29532,8 @@ func (s ResourceArnRequiredException) RequestID() string {
 // The commit cannot be created because one of the changes specifies copying
 // or moving a .gitkeep file.
 type RestrictedSourceFileException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29588,8 +29588,8 @@ func (s RestrictedSourceFileException) RequestID() string {
 
 // A revision ID is required, but was not provided.
 type RevisionIdRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29645,8 +29645,8 @@ func (s RevisionIdRequiredException) RequestID() string {
 // The revision ID provided in the request does not match the current revision
 // ID. Use GetPullRequest to retrieve the current revision ID.
 type RevisionNotCurrentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29703,8 +29703,8 @@ func (s RevisionNotCurrentException) RequestID() string {
 // the same as the content of that file in the repository and branch that you
 // specified.
 type SameFileContentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29762,8 +29762,8 @@ func (s SameFileContentException) RequestID() string {
 // request to the same file in the same file path twice, or make a delete request
 // and a move request to the same file as part of the same commit.
 type SamePathRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29872,8 +29872,8 @@ func (s *SetFileModeEntry) SetFilePath(v string) *SetFileModeEntry {
 // The source branch and destination branch for the pull request are the same.
 // You must specify different branches for the source and destination.
 type SourceAndDestinationAreSameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29929,8 +29929,8 @@ func (s SourceAndDestinationAreSameException) RequestID() string {
 // The commit cannot be created because no source files or file content have
 // been specified for the commit.
 type SourceFileOrContentRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30128,8 +30128,8 @@ func (s *SymbolicLink) SetRelativePath(v string) *SymbolicLink {
 
 // A list of tag keys is required. The list cannot be empty or null.
 type TagKeysListRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30184,8 +30184,8 @@ func (s TagKeysListRequiredException) RequestID() string {
 
 // The tag policy is not valid.
 type TagPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30307,8 +30307,8 @@ func (s TagResourceOutput) GoString() string {
 
 // A map of tags is required.
 type TagsMapRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30432,8 +30432,8 @@ func (s *Target) SetSourceReference(v string) *Target {
 // target must contain the full values for the repository name, source branch,
 // and destination branch for the pull request.
 type TargetRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30488,8 +30488,8 @@ func (s TargetRequiredException) RequestID() string {
 
 // An array of target objects is required. It cannot be empty or null.
 type TargetsRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30647,8 +30647,8 @@ func (s *TestRepositoryTriggersOutput) SetSuccessfulExecutions(v []*string) *Tes
 // the tip of the source branch specified in your request. The pull request
 // might have been updated. Make sure that you have the latest changes.
 type TipOfSourceReferenceIsDifferentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30705,8 +30705,8 @@ func (s TipOfSourceReferenceIsDifferentException) RequestID() string {
 // great to determine whether there might be any merge conflicts. Locally compare
 // the specifiers using git diff or a diff tool.
 type TipsDivergenceExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30761,8 +30761,8 @@ func (s TipsDivergenceExceededException) RequestID() string {
 
 // A pull request title is required. It cannot be empty or null.
 type TitleRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30817,8 +30817,8 @@ func (s TitleRequiredException) RequestID() string {
 
 // The maximum number of tags for an AWS CodeCommit resource has been exceeded.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -5177,7 +5177,7 @@ func (s *AlarmConfiguration) SetIgnorePollAlarmFailure(v bool) *AlarmConfigurati
 // The maximum number of alarms for a deployment group (10) was exceeded.
 type AlarmsLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5194,7 +5194,7 @@ func (s AlarmsLimitExceededException) GoString() string {
 
 func newErrorAlarmsLimitExceededException(v protocol.ResponseMetadata) error {
 	return &AlarmsLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5222,12 +5222,12 @@ func (s AlarmsLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlarmsLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlarmsLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A revision for an AWS Lambda or Amazon ECS deployment that is a YAML-formatted
@@ -5281,7 +5281,7 @@ func (s *AppSpecContent) SetSha256(v string) *AppSpecContent {
 // exists.
 type ApplicationAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5298,7 +5298,7 @@ func (s ApplicationAlreadyExistsException) GoString() string {
 
 func newErrorApplicationAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ApplicationAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5326,18 +5326,18 @@ func (s ApplicationAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApplicationAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApplicationAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The application does not exist with the IAM user or AWS account.
 type ApplicationDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5354,7 +5354,7 @@ func (s ApplicationDoesNotExistException) GoString() string {
 
 func newErrorApplicationDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &ApplicationDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5382,12 +5382,12 @@ func (s ApplicationDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApplicationDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApplicationDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about an application.
@@ -5464,7 +5464,7 @@ func (s *ApplicationInfo) SetLinkedToGitHub(v bool) *ApplicationInfo {
 // More applications were attempted to be created than are allowed.
 type ApplicationLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5481,7 +5481,7 @@ func (s ApplicationLimitExceededException) GoString() string {
 
 func newErrorApplicationLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ApplicationLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5509,18 +5509,18 @@ func (s ApplicationLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApplicationLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApplicationLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The minimum number of required application names was not specified.
 type ApplicationNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5537,7 +5537,7 @@ func (s ApplicationNameRequiredException) GoString() string {
 
 func newErrorApplicationNameRequiredException(v protocol.ResponseMetadata) error {
 	return &ApplicationNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5565,19 +5565,19 @@ func (s ApplicationNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApplicationNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApplicationNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified ARN is not supported. For example, it might be an ARN for a
 // resource that is not expected.
 type ArnNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5594,7 +5594,7 @@ func (s ArnNotSupportedException) GoString() string {
 
 func newErrorArnNotSupportedException(v protocol.ResponseMetadata) error {
 	return &ArnNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5622,12 +5622,12 @@ func (s ArnNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ArnNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ArnNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a configuration for automatically rolling back to a previous
@@ -6246,7 +6246,7 @@ func (s *BatchGetOnPremisesInstancesOutput) SetInstanceInfos(v []*InstanceInfo) 
 // The maximum number of names or IDs allowed for this request (100) was exceeded.
 type BatchLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6263,7 +6263,7 @@ func (s BatchLimitExceededException) GoString() string {
 
 func newErrorBatchLimitExceededException(v protocol.ResponseMetadata) error {
 	return &BatchLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6291,12 +6291,12 @@ func (s BatchLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BatchLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BatchLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about blue/green deployment options for a deployment group.
@@ -6395,7 +6395,7 @@ func (s *BlueInstanceTerminationOption) SetTerminationWaitTimeInMinutes(v int64)
 // A bucket name is required, but was not provided.
 type BucketNameFilterRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6412,7 +6412,7 @@ func (s BucketNameFilterRequiredException) GoString() string {
 
 func newErrorBucketNameFilterRequiredException(v protocol.ResponseMetadata) error {
 	return &BucketNameFilterRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6440,12 +6440,12 @@ func (s BucketNameFilterRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BucketNameFilterRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BucketNameFilterRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ContinueDeploymentInput struct {
@@ -7403,7 +7403,7 @@ func (s *DeleteGitHubAccountTokenOutput) SetTokenName(v string) *DeleteGitHubAcc
 // The deployment is already complete.
 type DeploymentAlreadyCompletedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7420,7 +7420,7 @@ func (s DeploymentAlreadyCompletedException) GoString() string {
 
 func newErrorDeploymentAlreadyCompletedException(v protocol.ResponseMetadata) error {
 	return &DeploymentAlreadyCompletedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7448,19 +7448,19 @@ func (s DeploymentAlreadyCompletedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentAlreadyCompletedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentAlreadyCompletedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A deployment configuration with the specified name with the IAM user or AWS
 // account already exists .
 type DeploymentConfigAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7477,7 +7477,7 @@ func (s DeploymentConfigAlreadyExistsException) GoString() string {
 
 func newErrorDeploymentConfigAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &DeploymentConfigAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7505,18 +7505,18 @@ func (s DeploymentConfigAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentConfigAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentConfigAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The deployment configuration does not exist with the IAM user or AWS account.
 type DeploymentConfigDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7533,7 +7533,7 @@ func (s DeploymentConfigDoesNotExistException) GoString() string {
 
 func newErrorDeploymentConfigDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &DeploymentConfigDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7561,18 +7561,18 @@ func (s DeploymentConfigDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentConfigDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentConfigDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The deployment configuration is still in use.
 type DeploymentConfigInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7589,7 +7589,7 @@ func (s DeploymentConfigInUseException) GoString() string {
 
 func newErrorDeploymentConfigInUseException(v protocol.ResponseMetadata) error {
 	return &DeploymentConfigInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7617,12 +7617,12 @@ func (s DeploymentConfigInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentConfigInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentConfigInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a deployment configuration.
@@ -7698,7 +7698,7 @@ func (s *DeploymentConfigInfo) SetTrafficRoutingConfig(v *TrafficRoutingConfig) 
 // The deployment configurations limit was exceeded.
 type DeploymentConfigLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7715,7 +7715,7 @@ func (s DeploymentConfigLimitExceededException) GoString() string {
 
 func newErrorDeploymentConfigLimitExceededException(v protocol.ResponseMetadata) error {
 	return &DeploymentConfigLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7743,18 +7743,18 @@ func (s DeploymentConfigLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentConfigLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentConfigLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The deployment configuration name was not specified.
 type DeploymentConfigNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7771,7 +7771,7 @@ func (s DeploymentConfigNameRequiredException) GoString() string {
 
 func newErrorDeploymentConfigNameRequiredException(v protocol.ResponseMetadata) error {
 	return &DeploymentConfigNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7799,18 +7799,18 @@ func (s DeploymentConfigNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentConfigNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentConfigNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The deployment with the IAM user or AWS account does not exist.
 type DeploymentDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7827,7 +7827,7 @@ func (s DeploymentDoesNotExistException) GoString() string {
 
 func newErrorDeploymentDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &DeploymentDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7855,19 +7855,19 @@ func (s DeploymentDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A deployment group with the specified name with the IAM user or AWS account
 // already exists.
 type DeploymentGroupAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7884,7 +7884,7 @@ func (s DeploymentGroupAlreadyExistsException) GoString() string {
 
 func newErrorDeploymentGroupAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &DeploymentGroupAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7912,18 +7912,18 @@ func (s DeploymentGroupAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentGroupAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentGroupAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The named deployment group with the IAM user or AWS account does not exist.
 type DeploymentGroupDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7940,7 +7940,7 @@ func (s DeploymentGroupDoesNotExistException) GoString() string {
 
 func newErrorDeploymentGroupDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &DeploymentGroupDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7968,12 +7968,12 @@ func (s DeploymentGroupDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentGroupDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentGroupDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a deployment group.
@@ -8200,7 +8200,7 @@ func (s *DeploymentGroupInfo) SetTriggerConfigurations(v []*TriggerConfig) *Depl
 // The deployment groups limit was exceeded.
 type DeploymentGroupLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8217,7 +8217,7 @@ func (s DeploymentGroupLimitExceededException) GoString() string {
 
 func newErrorDeploymentGroupLimitExceededException(v protocol.ResponseMetadata) error {
 	return &DeploymentGroupLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8245,18 +8245,18 @@ func (s DeploymentGroupLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentGroupLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentGroupLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The deployment group name was not specified.
 type DeploymentGroupNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8273,7 +8273,7 @@ func (s DeploymentGroupNameRequiredException) GoString() string {
 
 func newErrorDeploymentGroupNameRequiredException(v protocol.ResponseMetadata) error {
 	return &DeploymentGroupNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8301,18 +8301,18 @@ func (s DeploymentGroupNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentGroupNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentGroupNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // At least one deployment ID must be specified.
 type DeploymentIdRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8329,7 +8329,7 @@ func (s DeploymentIdRequiredException) GoString() string {
 
 func newErrorDeploymentIdRequiredException(v protocol.ResponseMetadata) error {
 	return &DeploymentIdRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8357,12 +8357,12 @@ func (s DeploymentIdRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentIdRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentIdRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a deployment.
@@ -8680,7 +8680,7 @@ func (s *DeploymentInfo) SetUpdateOutdatedInstancesOnly(v bool) *DeploymentInfo 
 // The deployment does not have a status of Ready and can't continue yet.
 type DeploymentIsNotInReadyStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8697,7 +8697,7 @@ func (s DeploymentIsNotInReadyStateException) GoString() string {
 
 func newErrorDeploymentIsNotInReadyStateException(v protocol.ResponseMetadata) error {
 	return &DeploymentIsNotInReadyStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8725,18 +8725,18 @@ func (s DeploymentIsNotInReadyStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentIsNotInReadyStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentIsNotInReadyStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of allowed deployments was exceeded.
 type DeploymentLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8753,7 +8753,7 @@ func (s DeploymentLimitExceededException) GoString() string {
 
 func newErrorDeploymentLimitExceededException(v protocol.ResponseMetadata) error {
 	return &DeploymentLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8781,18 +8781,18 @@ func (s DeploymentLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified deployment has not started.
 type DeploymentNotStartedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8809,7 +8809,7 @@ func (s DeploymentNotStartedException) GoString() string {
 
 func newErrorDeploymentNotStartedException(v protocol.ResponseMetadata) error {
 	return &DeploymentNotStartedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8837,12 +8837,12 @@ func (s DeploymentNotStartedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentNotStartedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentNotStartedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the deployment status of the instances in the deployment.
@@ -9053,7 +9053,7 @@ func (s *DeploymentTarget) SetLambdaTarget(v *LambdaTarget) *DeploymentTarget {
 // The provided target ID does not belong to the attempted deployment.
 type DeploymentTargetDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9070,7 +9070,7 @@ func (s DeploymentTargetDoesNotExistException) GoString() string {
 
 func newErrorDeploymentTargetDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &DeploymentTargetDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9098,18 +9098,18 @@ func (s DeploymentTargetDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentTargetDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentTargetDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A deployment target ID was not provided.
 type DeploymentTargetIdRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9126,7 +9126,7 @@ func (s DeploymentTargetIdRequiredException) GoString() string {
 
 func newErrorDeploymentTargetIdRequiredException(v protocol.ResponseMetadata) error {
 	return &DeploymentTargetIdRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9154,12 +9154,12 @@ func (s DeploymentTargetIdRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentTargetIdRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentTargetIdRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of targets that can be associated with an Amazon ECS or
@@ -9168,7 +9168,7 @@ func (s DeploymentTargetIdRequiredException) RequestID() string {
 // deployments.
 type DeploymentTargetListSizeExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9185,7 +9185,7 @@ func (s DeploymentTargetListSizeExceededException) GoString() string {
 
 func newErrorDeploymentTargetListSizeExceededException(v protocol.ResponseMetadata) error {
 	return &DeploymentTargetListSizeExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9213,12 +9213,12 @@ func (s DeploymentTargetListSizeExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeploymentTargetListSizeExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeploymentTargetListSizeExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of a DeregisterOnPremisesInstance operation.
@@ -9277,7 +9277,7 @@ func (s DeregisterOnPremisesInstanceOutput) GoString() string {
 // The description is too long.
 type DescriptionTooLongException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9294,7 +9294,7 @@ func (s DescriptionTooLongException) GoString() string {
 
 func newErrorDescriptionTooLongException(v protocol.ResponseMetadata) error {
 	return &DescriptionTooLongException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9322,12 +9322,12 @@ func (s DescriptionTooLongException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DescriptionTooLongException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DescriptionTooLongException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Diagnostic information about executable scripts that are part of a deployment.
@@ -9510,7 +9510,7 @@ func (s *ECSService) SetServiceName(v string) *ECSService {
 // An Amazon ECS service can be associated with only one deployment group.
 type ECSServiceMappingLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9527,7 +9527,7 @@ func (s ECSServiceMappingLimitExceededException) GoString() string {
 
 func newErrorECSServiceMappingLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ECSServiceMappingLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9555,12 +9555,12 @@ func (s ECSServiceMappingLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ECSServiceMappingLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ECSServiceMappingLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the target of an Amazon ECS deployment.
@@ -10492,7 +10492,7 @@ func (s *GetOnPremisesInstanceOutput) SetInstanceInfo(v *InstanceInfo) *GetOnPre
 // No GitHub account connection exists with the named specified in the call.
 type GitHubAccountTokenDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10509,7 +10509,7 @@ func (s GitHubAccountTokenDoesNotExistException) GoString() string {
 
 func newErrorGitHubAccountTokenDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &GitHubAccountTokenDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10537,18 +10537,18 @@ func (s GitHubAccountTokenDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GitHubAccountTokenDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GitHubAccountTokenDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The call is missing a required GitHub account connection name.
 type GitHubAccountTokenNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10565,7 +10565,7 @@ func (s GitHubAccountTokenNameRequiredException) GoString() string {
 
 func newErrorGitHubAccountTokenNameRequiredException(v protocol.ResponseMetadata) error {
 	return &GitHubAccountTokenNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10593,12 +10593,12 @@ func (s GitHubAccountTokenNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GitHubAccountTokenNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GitHubAccountTokenNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the location of application artifacts stored in GitHub.
@@ -10673,7 +10673,7 @@ func (s *GreenFleetProvisioningOption) SetAction(v string) *GreenFleetProvisioni
 // IAM user ARN in the request.
 type IamArnRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10690,7 +10690,7 @@ func (s IamArnRequiredException) GoString() string {
 
 func newErrorIamArnRequiredException(v protocol.ResponseMetadata) error {
 	return &IamArnRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10718,19 +10718,19 @@ func (s IamArnRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IamArnRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IamArnRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request included an IAM session ARN that has already been used to register
 // a different instance.
 type IamSessionArnAlreadyRegisteredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10747,7 +10747,7 @@ func (s IamSessionArnAlreadyRegisteredException) GoString() string {
 
 func newErrorIamSessionArnAlreadyRegisteredException(v protocol.ResponseMetadata) error {
 	return &IamSessionArnAlreadyRegisteredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10775,18 +10775,18 @@ func (s IamSessionArnAlreadyRegisteredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IamSessionArnAlreadyRegisteredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IamSessionArnAlreadyRegisteredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified IAM user ARN is already registered with an on-premises instance.
 type IamUserArnAlreadyRegisteredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10803,7 +10803,7 @@ func (s IamUserArnAlreadyRegisteredException) GoString() string {
 
 func newErrorIamUserArnAlreadyRegisteredException(v protocol.ResponseMetadata) error {
 	return &IamUserArnAlreadyRegisteredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10831,18 +10831,18 @@ func (s IamUserArnAlreadyRegisteredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IamUserArnAlreadyRegisteredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IamUserArnAlreadyRegisteredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An IAM user ARN was not specified.
 type IamUserArnRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10859,7 +10859,7 @@ func (s IamUserArnRequiredException) GoString() string {
 
 func newErrorIamUserArnRequiredException(v protocol.ResponseMetadata) error {
 	return &IamUserArnRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10887,12 +10887,12 @@ func (s IamUserArnRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IamUserArnRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IamUserArnRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified instance does not exist in the deployment group.
@@ -10900,7 +10900,7 @@ func (s IamUserArnRequiredException) RequestID() string {
 // Deprecated: This exception is deprecated, use DeploymentTargetDoesNotExistException instead.
 type InstanceDoesNotExistException struct {
 	_            struct{} `deprecated:"true" type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10917,7 +10917,7 @@ func (s InstanceDoesNotExistException) GoString() string {
 
 func newErrorInstanceDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &InstanceDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10945,12 +10945,12 @@ func (s InstanceDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InstanceDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InstanceDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The instance ID was not specified.
@@ -10958,7 +10958,7 @@ func (s InstanceDoesNotExistException) RequestID() string {
 // Deprecated: This exception is deprecated, use DeploymentTargetIdRequiredException instead.
 type InstanceIdRequiredException struct {
 	_            struct{} `deprecated:"true" type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10975,7 +10975,7 @@ func (s InstanceIdRequiredException) GoString() string {
 
 func newErrorInstanceIdRequiredException(v protocol.ResponseMetadata) error {
 	return &InstanceIdRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11003,12 +11003,12 @@ func (s InstanceIdRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InstanceIdRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InstanceIdRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about an on-premises instance.
@@ -11094,7 +11094,7 @@ func (s *InstanceInfo) SetTags(v []*Tag) *InstanceInfo {
 // exceeded.
 type InstanceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11111,7 +11111,7 @@ func (s InstanceLimitExceededException) GoString() string {
 
 func newErrorInstanceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &InstanceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11139,18 +11139,18 @@ func (s InstanceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InstanceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InstanceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified on-premises instance name is already registered.
 type InstanceNameAlreadyRegisteredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11167,7 +11167,7 @@ func (s InstanceNameAlreadyRegisteredException) GoString() string {
 
 func newErrorInstanceNameAlreadyRegisteredException(v protocol.ResponseMetadata) error {
 	return &InstanceNameAlreadyRegisteredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11195,18 +11195,18 @@ func (s InstanceNameAlreadyRegisteredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InstanceNameAlreadyRegisteredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InstanceNameAlreadyRegisteredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An on-premises instance name was not specified.
 type InstanceNameRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11223,7 +11223,7 @@ func (s InstanceNameRequiredException) GoString() string {
 
 func newErrorInstanceNameRequiredException(v protocol.ResponseMetadata) error {
 	return &InstanceNameRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11251,18 +11251,18 @@ func (s InstanceNameRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InstanceNameRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InstanceNameRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified on-premises instance is not registered.
 type InstanceNotRegisteredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11279,7 +11279,7 @@ func (s InstanceNotRegisteredException) GoString() string {
 
 func newErrorInstanceNotRegisteredException(v protocol.ResponseMetadata) error {
 	return &InstanceNotRegisteredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11307,12 +11307,12 @@ func (s InstanceNotRegisteredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InstanceNotRegisteredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InstanceNotRegisteredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about an instance in a deployment.
@@ -11496,7 +11496,7 @@ func (s *InstanceTarget) SetTargetId(v string) *InstanceTarget {
 //    * The alarm configuration is enabled, but the alarm list is empty.
 type InvalidAlarmConfigException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11513,7 +11513,7 @@ func (s InvalidAlarmConfigException) GoString() string {
 
 func newErrorInvalidAlarmConfigException(v protocol.ResponseMetadata) error {
 	return &InvalidAlarmConfigException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11541,18 +11541,18 @@ func (s InvalidAlarmConfigException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAlarmConfigException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAlarmConfigException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The application name was specified in an invalid format.
 type InvalidApplicationNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11569,7 +11569,7 @@ func (s InvalidApplicationNameException) GoString() string {
 
 func newErrorInvalidApplicationNameException(v protocol.ResponseMetadata) error {
 	return &InvalidApplicationNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11597,18 +11597,18 @@ func (s InvalidApplicationNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApplicationNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApplicationNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified ARN is not in a valid format.
 type InvalidArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11625,7 +11625,7 @@ func (s InvalidArnException) GoString() string {
 
 func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 	return &InvalidArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11653,12 +11653,12 @@ func (s InvalidArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The automatic rollback configuration was specified in an invalid format.
@@ -11666,7 +11666,7 @@ func (s InvalidArnException) RequestID() string {
 // type or no event types were listed.
 type InvalidAutoRollbackConfigException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11683,7 +11683,7 @@ func (s InvalidAutoRollbackConfigException) GoString() string {
 
 func newErrorInvalidAutoRollbackConfigException(v protocol.ResponseMetadata) error {
 	return &InvalidAutoRollbackConfigException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11711,18 +11711,18 @@ func (s InvalidAutoRollbackConfigException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAutoRollbackConfigException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAutoRollbackConfigException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Auto Scaling group was specified in an invalid format or does not exist.
 type InvalidAutoScalingGroupException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11739,7 +11739,7 @@ func (s InvalidAutoScalingGroupException) GoString() string {
 
 func newErrorInvalidAutoScalingGroupException(v protocol.ResponseMetadata) error {
 	return &InvalidAutoScalingGroupException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11767,12 +11767,12 @@ func (s InvalidAutoScalingGroupException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAutoScalingGroupException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAutoScalingGroupException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The configuration for the blue/green deployment group was provided in an
@@ -11780,7 +11780,7 @@ func (s InvalidAutoScalingGroupException) RequestID() string {
 // CreateDeploymentConfig.
 type InvalidBlueGreenDeploymentConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11797,7 +11797,7 @@ func (s InvalidBlueGreenDeploymentConfigurationException) GoString() string {
 
 func newErrorInvalidBlueGreenDeploymentConfigurationException(v protocol.ResponseMetadata) error {
 	return &InvalidBlueGreenDeploymentConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11825,18 +11825,18 @@ func (s InvalidBlueGreenDeploymentConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidBlueGreenDeploymentConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidBlueGreenDeploymentConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The bucket name either doesn't exist or was specified in an invalid format.
 type InvalidBucketNameFilterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11853,7 +11853,7 @@ func (s InvalidBucketNameFilterException) GoString() string {
 
 func newErrorInvalidBucketNameFilterException(v protocol.ResponseMetadata) error {
 	return &InvalidBucketNameFilterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11881,18 +11881,18 @@ func (s InvalidBucketNameFilterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidBucketNameFilterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidBucketNameFilterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The computePlatform is invalid. The computePlatform should be Lambda or Server.
 type InvalidComputePlatformException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11909,7 +11909,7 @@ func (s InvalidComputePlatformException) GoString() string {
 
 func newErrorInvalidComputePlatformException(v protocol.ResponseMetadata) error {
 	return &InvalidComputePlatformException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11937,18 +11937,18 @@ func (s InvalidComputePlatformException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidComputePlatformException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidComputePlatformException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The deployed state filter was specified in an invalid format.
 type InvalidDeployedStateFilterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11965,7 +11965,7 @@ func (s InvalidDeployedStateFilterException) GoString() string {
 
 func newErrorInvalidDeployedStateFilterException(v protocol.ResponseMetadata) error {
 	return &InvalidDeployedStateFilterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11993,18 +11993,18 @@ func (s InvalidDeployedStateFilterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeployedStateFilterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeployedStateFilterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The deployment configuration name was specified in an invalid format.
 type InvalidDeploymentConfigNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12021,7 +12021,7 @@ func (s InvalidDeploymentConfigNameException) GoString() string {
 
 func newErrorInvalidDeploymentConfigNameException(v protocol.ResponseMetadata) error {
 	return &InvalidDeploymentConfigNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12049,18 +12049,18 @@ func (s InvalidDeploymentConfigNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeploymentConfigNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeploymentConfigNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The deployment group name was specified in an invalid format.
 type InvalidDeploymentGroupNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12077,7 +12077,7 @@ func (s InvalidDeploymentGroupNameException) GoString() string {
 
 func newErrorInvalidDeploymentGroupNameException(v protocol.ResponseMetadata) error {
 	return &InvalidDeploymentGroupNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12105,18 +12105,18 @@ func (s InvalidDeploymentGroupNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeploymentGroupNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeploymentGroupNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // At least one of the deployment IDs was specified in an invalid format.
 type InvalidDeploymentIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12133,7 +12133,7 @@ func (s InvalidDeploymentIdException) GoString() string {
 
 func newErrorInvalidDeploymentIdException(v protocol.ResponseMetadata) error {
 	return &InvalidDeploymentIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12161,19 +12161,19 @@ func (s InvalidDeploymentIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeploymentIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeploymentIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An instance type was specified for an in-place deployment. Instance types
 // are supported for blue/green deployments only.
 type InvalidDeploymentInstanceTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12190,7 +12190,7 @@ func (s InvalidDeploymentInstanceTypeException) GoString() string {
 
 func newErrorInvalidDeploymentInstanceTypeException(v protocol.ResponseMetadata) error {
 	return &InvalidDeploymentInstanceTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12218,18 +12218,18 @@ func (s InvalidDeploymentInstanceTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeploymentInstanceTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeploymentInstanceTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified deployment status doesn't exist or cannot be determined.
 type InvalidDeploymentStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12246,7 +12246,7 @@ func (s InvalidDeploymentStatusException) GoString() string {
 
 func newErrorInvalidDeploymentStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidDeploymentStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12274,12 +12274,12 @@ func (s InvalidDeploymentStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeploymentStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeploymentStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid deployment style was specified. Valid deployment types include
@@ -12287,7 +12287,7 @@ func (s InvalidDeploymentStatusException) RequestID() string {
 // and "WITHOUT_TRAFFIC_CONTROL."
 type InvalidDeploymentStyleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12304,7 +12304,7 @@ func (s InvalidDeploymentStyleException) GoString() string {
 
 func newErrorInvalidDeploymentStyleException(v protocol.ResponseMetadata) error {
 	return &InvalidDeploymentStyleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12332,18 +12332,18 @@ func (s InvalidDeploymentStyleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeploymentStyleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeploymentStyleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The target ID provided was not valid.
 type InvalidDeploymentTargetIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12360,7 +12360,7 @@ func (s InvalidDeploymentTargetIdException) GoString() string {
 
 func newErrorInvalidDeploymentTargetIdException(v protocol.ResponseMetadata) error {
 	return &InvalidDeploymentTargetIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12388,18 +12388,18 @@ func (s InvalidDeploymentTargetIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeploymentTargetIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeploymentTargetIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The wait type is invalid.
 type InvalidDeploymentWaitTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12416,7 +12416,7 @@ func (s InvalidDeploymentWaitTypeException) GoString() string {
 
 func newErrorInvalidDeploymentWaitTypeException(v protocol.ResponseMetadata) error {
 	return &InvalidDeploymentWaitTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12444,19 +12444,19 @@ func (s InvalidDeploymentWaitTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeploymentWaitTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeploymentWaitTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A call was submitted that specified both Ec2TagFilters and Ec2TagSet, but
 // only one of these data types can be used in a single call.
 type InvalidEC2TagCombinationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12473,7 +12473,7 @@ func (s InvalidEC2TagCombinationException) GoString() string {
 
 func newErrorInvalidEC2TagCombinationException(v protocol.ResponseMetadata) error {
 	return &InvalidEC2TagCombinationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12501,18 +12501,18 @@ func (s InvalidEC2TagCombinationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEC2TagCombinationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEC2TagCombinationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The tag was specified in an invalid format.
 type InvalidEC2TagException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12529,7 +12529,7 @@ func (s InvalidEC2TagException) GoString() string {
 
 func newErrorInvalidEC2TagException(v protocol.ResponseMetadata) error {
 	return &InvalidEC2TagException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12557,18 +12557,18 @@ func (s InvalidEC2TagException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEC2TagException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEC2TagException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon ECS service identifier is not valid.
 type InvalidECSServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12585,7 +12585,7 @@ func (s InvalidECSServiceException) GoString() string {
 
 func newErrorInvalidECSServiceException(v protocol.ResponseMetadata) error {
 	return &InvalidECSServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12613,12 +12613,12 @@ func (s InvalidECSServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidECSServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidECSServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid fileExistsBehavior option was specified to determine how AWS CodeDeploy
@@ -12627,7 +12627,7 @@ func (s InvalidECSServiceException) RequestID() string {
 // "DISALLOW," "OVERWRITE," and "RETAIN."
 type InvalidFileExistsBehaviorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12644,7 +12644,7 @@ func (s InvalidFileExistsBehaviorException) GoString() string {
 
 func newErrorInvalidFileExistsBehaviorException(v protocol.ResponseMetadata) error {
 	return &InvalidFileExistsBehaviorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12672,18 +12672,18 @@ func (s InvalidFileExistsBehaviorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFileExistsBehaviorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFileExistsBehaviorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The GitHub token is not valid.
 type InvalidGitHubAccountTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12700,7 +12700,7 @@ func (s InvalidGitHubAccountTokenException) GoString() string {
 
 func newErrorInvalidGitHubAccountTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidGitHubAccountTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12728,18 +12728,18 @@ func (s InvalidGitHubAccountTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidGitHubAccountTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidGitHubAccountTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The format of the specified GitHub account connection name is invalid.
 type InvalidGitHubAccountTokenNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12756,7 +12756,7 @@ func (s InvalidGitHubAccountTokenNameException) GoString() string {
 
 func newErrorInvalidGitHubAccountTokenNameException(v protocol.ResponseMetadata) error {
 	return &InvalidGitHubAccountTokenNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12784,18 +12784,18 @@ func (s InvalidGitHubAccountTokenNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidGitHubAccountTokenNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidGitHubAccountTokenNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The IAM session ARN was specified in an invalid format.
 type InvalidIamSessionArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12812,7 +12812,7 @@ func (s InvalidIamSessionArnException) GoString() string {
 
 func newErrorInvalidIamSessionArnException(v protocol.ResponseMetadata) error {
 	return &InvalidIamSessionArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12840,18 +12840,18 @@ func (s InvalidIamSessionArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidIamSessionArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidIamSessionArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The IAM user ARN was specified in an invalid format.
 type InvalidIamUserArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12868,7 +12868,7 @@ func (s InvalidIamUserArnException) GoString() string {
 
 func newErrorInvalidIamUserArnException(v protocol.ResponseMetadata) error {
 	return &InvalidIamUserArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12896,19 +12896,19 @@ func (s InvalidIamUserArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidIamUserArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidIamUserArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The IgnoreApplicationStopFailures value is invalid. For AWS Lambda deployments,
 // false is expected. For EC2/On-premises deployments, true or false is expected.
 type InvalidIgnoreApplicationStopFailuresValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12925,7 +12925,7 @@ func (s InvalidIgnoreApplicationStopFailuresValueException) GoString() string {
 
 func newErrorInvalidIgnoreApplicationStopFailuresValueException(v protocol.ResponseMetadata) error {
 	return &InvalidIgnoreApplicationStopFailuresValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12953,18 +12953,18 @@ func (s InvalidIgnoreApplicationStopFailuresValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidIgnoreApplicationStopFailuresValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidIgnoreApplicationStopFailuresValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input was specified in an invalid format.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12981,7 +12981,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13009,18 +13009,18 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The on-premises instance name was specified in an invalid format.
 type InvalidInstanceNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13037,7 +13037,7 @@ func (s InvalidInstanceNameException) GoString() string {
 
 func newErrorInvalidInstanceNameException(v protocol.ResponseMetadata) error {
 	return &InvalidInstanceNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13065,18 +13065,18 @@ func (s InvalidInstanceNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInstanceNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInstanceNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified instance status does not exist.
 type InvalidInstanceStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13093,7 +13093,7 @@ func (s InvalidInstanceStatusException) GoString() string {
 
 func newErrorInvalidInstanceStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidInstanceStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13121,12 +13121,12 @@ func (s InvalidInstanceStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInstanceStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInstanceStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid instance type was specified for instances in a blue/green deployment.
@@ -13134,7 +13134,7 @@ func (s InvalidInstanceStatusException) RequestID() string {
 // replacement environment.
 type InvalidInstanceTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13151,7 +13151,7 @@ func (s InvalidInstanceTypeException) GoString() string {
 
 func newErrorInvalidInstanceTypeException(v protocol.ResponseMetadata) error {
 	return &InvalidInstanceTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13179,18 +13179,18 @@ func (s InvalidInstanceTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInstanceTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInstanceTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified key prefix filter was specified in an invalid format.
 type InvalidKeyPrefixFilterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13207,7 +13207,7 @@ func (s InvalidKeyPrefixFilterException) GoString() string {
 
 func newErrorInvalidKeyPrefixFilterException(v protocol.ResponseMetadata) error {
 	return &InvalidKeyPrefixFilterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13235,19 +13235,19 @@ func (s InvalidKeyPrefixFilterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidKeyPrefixFilterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidKeyPrefixFilterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A lifecycle event hook is invalid. Review the hooks section in your AppSpec
 // file to ensure the lifecycle events and hooks functions are valid.
 type InvalidLifecycleEventHookExecutionIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13264,7 +13264,7 @@ func (s InvalidLifecycleEventHookExecutionIdException) GoString() string {
 
 func newErrorInvalidLifecycleEventHookExecutionIdException(v protocol.ResponseMetadata) error {
 	return &InvalidLifecycleEventHookExecutionIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13292,19 +13292,19 @@ func (s InvalidLifecycleEventHookExecutionIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLifecycleEventHookExecutionIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLifecycleEventHookExecutionIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The result of a Lambda validation function that verifies a lifecycle event
 // is invalid. It should return Succeeded or Failed.
 type InvalidLifecycleEventHookExecutionStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13321,7 +13321,7 @@ func (s InvalidLifecycleEventHookExecutionStatusException) GoString() string {
 
 func newErrorInvalidLifecycleEventHookExecutionStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidLifecycleEventHookExecutionStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13349,18 +13349,18 @@ func (s InvalidLifecycleEventHookExecutionStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLifecycleEventHookExecutionStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLifecycleEventHookExecutionStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid load balancer name, or no load balancer name, was specified.
 type InvalidLoadBalancerInfoException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13377,7 +13377,7 @@ func (s InvalidLoadBalancerInfoException) GoString() string {
 
 func newErrorInvalidLoadBalancerInfoException(v protocol.ResponseMetadata) error {
 	return &InvalidLoadBalancerInfoException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13405,18 +13405,18 @@ func (s InvalidLoadBalancerInfoException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLoadBalancerInfoException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLoadBalancerInfoException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The minimum healthy instance value was specified in an invalid format.
 type InvalidMinimumHealthyHostValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13433,7 +13433,7 @@ func (s InvalidMinimumHealthyHostValueException) GoString() string {
 
 func newErrorInvalidMinimumHealthyHostValueException(v protocol.ResponseMetadata) error {
 	return &InvalidMinimumHealthyHostValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13461,18 +13461,18 @@ func (s InvalidMinimumHealthyHostValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidMinimumHealthyHostValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidMinimumHealthyHostValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The next token was specified in an invalid format.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13489,7 +13489,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13517,19 +13517,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A call was submitted that specified both OnPremisesTagFilters and OnPremisesTagSet,
 // but only one of these data types can be used in a single call.
 type InvalidOnPremisesTagCombinationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13546,7 +13546,7 @@ func (s InvalidOnPremisesTagCombinationException) GoString() string {
 
 func newErrorInvalidOnPremisesTagCombinationException(v protocol.ResponseMetadata) error {
 	return &InvalidOnPremisesTagCombinationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13574,18 +13574,18 @@ func (s InvalidOnPremisesTagCombinationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOnPremisesTagCombinationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOnPremisesTagCombinationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid operation was detected.
 type InvalidOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13602,7 +13602,7 @@ func (s InvalidOperationException) GoString() string {
 
 func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 	return &InvalidOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13630,18 +13630,18 @@ func (s InvalidOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The registration status was specified in an invalid format.
 type InvalidRegistrationStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13658,7 +13658,7 @@ func (s InvalidRegistrationStatusException) GoString() string {
 
 func newErrorInvalidRegistrationStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidRegistrationStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13686,18 +13686,18 @@ func (s InvalidRegistrationStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRegistrationStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRegistrationStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The revision was specified in an invalid format.
 type InvalidRevisionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13714,7 +13714,7 @@ func (s InvalidRevisionException) GoString() string {
 
 func newErrorInvalidRevisionException(v protocol.ResponseMetadata) error {
 	return &InvalidRevisionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13742,12 +13742,12 @@ func (s InvalidRevisionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRevisionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRevisionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service role ARN was specified in an invalid format. Or, if an Auto Scaling
@@ -13755,7 +13755,7 @@ func (s InvalidRevisionException) RequestID() string {
 // permissions to Amazon EC2 Auto Scaling.
 type InvalidRoleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13772,7 +13772,7 @@ func (s InvalidRoleException) GoString() string {
 
 func newErrorInvalidRoleException(v protocol.ResponseMetadata) error {
 	return &InvalidRoleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13800,19 +13800,19 @@ func (s InvalidRoleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRoleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRoleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The column name to sort by is either not present or was specified in an invalid
 // format.
 type InvalidSortByException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13829,7 +13829,7 @@ func (s InvalidSortByException) GoString() string {
 
 func newErrorInvalidSortByException(v protocol.ResponseMetadata) error {
 	return &InvalidSortByException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13857,18 +13857,18 @@ func (s InvalidSortByException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSortByException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSortByException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The sort order was specified in an invalid format.
 type InvalidSortOrderException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13885,7 +13885,7 @@ func (s InvalidSortOrderException) GoString() string {
 
 func newErrorInvalidSortOrderException(v protocol.ResponseMetadata) error {
 	return &InvalidSortOrderException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13913,18 +13913,18 @@ func (s InvalidSortOrderException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSortOrderException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSortOrderException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The tag was specified in an invalid format.
 type InvalidTagException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13941,7 +13941,7 @@ func (s InvalidTagException) GoString() string {
 
 func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 	return &InvalidTagException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13969,18 +13969,18 @@ func (s InvalidTagException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The tag filter was specified in an invalid format.
 type InvalidTagFilterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13997,7 +13997,7 @@ func (s InvalidTagFilterException) GoString() string {
 
 func newErrorInvalidTagFilterException(v protocol.ResponseMetadata) error {
 	return &InvalidTagFilterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14025,18 +14025,18 @@ func (s InvalidTagFilterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagFilterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagFilterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified tags are not valid.
 type InvalidTagsToAddException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14053,7 +14053,7 @@ func (s InvalidTagsToAddException) GoString() string {
 
 func newErrorInvalidTagsToAddException(v protocol.ResponseMetadata) error {
 	return &InvalidTagsToAddException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14081,18 +14081,18 @@ func (s InvalidTagsToAddException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagsToAddException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagsToAddException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The target filter name is invalid.
 type InvalidTargetFilterNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14109,7 +14109,7 @@ func (s InvalidTargetFilterNameException) GoString() string {
 
 func newErrorInvalidTargetFilterNameException(v protocol.ResponseMetadata) error {
 	return &InvalidTargetFilterNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14137,18 +14137,18 @@ func (s InvalidTargetFilterNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTargetFilterNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTargetFilterNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A target group pair associated with this deployment is not valid.
 type InvalidTargetGroupPairException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14165,7 +14165,7 @@ func (s InvalidTargetGroupPairException) GoString() string {
 
 func newErrorInvalidTargetGroupPairException(v protocol.ResponseMetadata) error {
 	return &InvalidTargetGroupPairException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14193,12 +14193,12 @@ func (s InvalidTargetGroupPairException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTargetGroupPairException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTargetGroupPairException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The target instance configuration is invalid. Possible causes include:
@@ -14213,7 +14213,7 @@ func (s InvalidTargetGroupPairException) RequestID() string {
 //    * A specified tag is not currently applied to any instances.
 type InvalidTargetInstancesException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14230,7 +14230,7 @@ func (s InvalidTargetInstancesException) GoString() string {
 
 func newErrorInvalidTargetInstancesException(v protocol.ResponseMetadata) error {
 	return &InvalidTargetInstancesException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14258,18 +14258,18 @@ func (s InvalidTargetInstancesException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTargetInstancesException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTargetInstancesException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified time range was specified in an invalid format.
 type InvalidTimeRangeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14286,7 +14286,7 @@ func (s InvalidTimeRangeException) GoString() string {
 
 func newErrorInvalidTimeRangeException(v protocol.ResponseMetadata) error {
 	return &InvalidTimeRangeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14314,19 +14314,19 @@ func (s InvalidTimeRangeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTimeRangeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTimeRangeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The configuration that specifies how traffic is routed during a deployment
 // is invalid.
 type InvalidTrafficRoutingConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14343,7 +14343,7 @@ func (s InvalidTrafficRoutingConfigurationException) GoString() string {
 
 func newErrorInvalidTrafficRoutingConfigurationException(v protocol.ResponseMetadata) error {
 	return &InvalidTrafficRoutingConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14371,18 +14371,18 @@ func (s InvalidTrafficRoutingConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTrafficRoutingConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTrafficRoutingConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The trigger was specified in an invalid format.
 type InvalidTriggerConfigException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14399,7 +14399,7 @@ func (s InvalidTriggerConfigException) GoString() string {
 
 func newErrorInvalidTriggerConfigException(v protocol.ResponseMetadata) error {
 	return &InvalidTriggerConfigException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14427,19 +14427,19 @@ func (s InvalidTriggerConfigException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTriggerConfigException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTriggerConfigException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The UpdateOutdatedInstancesOnly value is invalid. For AWS Lambda deployments,
 // false is expected. For EC2/On-premises deployments, true or false is expected.
 type InvalidUpdateOutdatedInstancesOnlyValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14456,7 +14456,7 @@ func (s InvalidUpdateOutdatedInstancesOnlyValueException) GoString() string {
 
 func newErrorInvalidUpdateOutdatedInstancesOnlyValueException(v protocol.ResponseMetadata) error {
 	return &InvalidUpdateOutdatedInstancesOnlyValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14484,12 +14484,12 @@ func (s InvalidUpdateOutdatedInstancesOnlyValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidUpdateOutdatedInstancesOnlyValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidUpdateOutdatedInstancesOnlyValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a Lambda function specified in a deployment.
@@ -14763,7 +14763,7 @@ func (s *LifecycleEvent) SetStatus(v string) *LifecycleEvent {
 // An attempt to return the status of an already completed lifecycle event occurred.
 type LifecycleEventAlreadyCompletedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14780,7 +14780,7 @@ func (s LifecycleEventAlreadyCompletedException) GoString() string {
 
 func newErrorLifecycleEventAlreadyCompletedException(v protocol.ResponseMetadata) error {
 	return &LifecycleEventAlreadyCompletedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14808,18 +14808,18 @@ func (s LifecycleEventAlreadyCompletedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LifecycleEventAlreadyCompletedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LifecycleEventAlreadyCompletedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The limit for lifecycle hooks was exceeded.
 type LifecycleHookLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14836,7 +14836,7 @@ func (s LifecycleHookLimitExceededException) GoString() string {
 
 func newErrorLifecycleHookLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LifecycleHookLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14864,12 +14864,12 @@ func (s LifecycleHookLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LifecycleHookLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LifecycleHookLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of a ListApplicationRevisions operation.
@@ -15926,7 +15926,7 @@ func (s *MinimumHealthyHosts) SetValue(v int64) *MinimumHealthyHosts {
 // Use only one ARN type.
 type MultipleIamArnsProvidedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15943,7 +15943,7 @@ func (s MultipleIamArnsProvidedException) GoString() string {
 
 func newErrorMultipleIamArnsProvidedException(v protocol.ResponseMetadata) error {
 	return &MultipleIamArnsProvidedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15971,12 +15971,12 @@ func (s MultipleIamArnsProvidedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MultipleIamArnsProvidedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MultipleIamArnsProvidedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about groups of on-premises instance tags.
@@ -16008,7 +16008,7 @@ func (s *OnPremisesTagSet) SetOnPremisesTagSetList(v [][]*TagFilter) *OnPremises
 // The API used does not support the deployment.
 type OperationNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16025,7 +16025,7 @@ func (s OperationNotSupportedException) GoString() string {
 
 func newErrorOperationNotSupportedException(v protocol.ResponseMetadata) error {
 	return &OperationNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16053,12 +16053,12 @@ func (s OperationNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutLifecycleEventHookExecutionStatusInput struct {
@@ -16390,7 +16390,7 @@ func (s RemoveTagsFromOnPremisesInstancesOutput) GoString() string {
 // The ARN of a resource is required, but was not found.
 type ResourceArnRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16407,7 +16407,7 @@ func (s ResourceArnRequiredException) GoString() string {
 
 func newErrorResourceArnRequiredException(v protocol.ResponseMetadata) error {
 	return &ResourceArnRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16435,18 +16435,18 @@ func (s ResourceArnRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceArnRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceArnRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource could not be validated.
 type ResourceValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16463,7 +16463,7 @@ func (s ResourceValidationException) GoString() string {
 
 func newErrorResourceValidationException(v protocol.ResponseMetadata) error {
 	return &ResourceValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16491,18 +16491,18 @@ func (s ResourceValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The named revision does not exist with the IAM user or AWS account.
 type RevisionDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16519,7 +16519,7 @@ func (s RevisionDoesNotExistException) GoString() string {
 
 func newErrorRevisionDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &RevisionDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16547,12 +16547,12 @@ func (s RevisionDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RevisionDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RevisionDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about an application revision.
@@ -16662,7 +16662,7 @@ func (s *RevisionLocation) SetString_(v *RawString) *RevisionLocation {
 // The revision ID was not specified.
 type RevisionRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16679,7 +16679,7 @@ func (s RevisionRequiredException) GoString() string {
 
 func newErrorRevisionRequiredException(v protocol.ResponseMetadata) error {
 	return &RevisionRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16707,18 +16707,18 @@ func (s RevisionRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RevisionRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RevisionRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The role ID was not specified.
 type RoleRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16735,7 +16735,7 @@ func (s RoleRequiredException) GoString() string {
 
 func newErrorRoleRequiredException(v protocol.ResponseMetadata) error {
 	return &RoleRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16763,12 +16763,12 @@ func (s RoleRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RoleRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RoleRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a deployment rollback.
@@ -17100,7 +17100,7 @@ func (s *TagFilter) SetValue(v string) *TagFilter {
 // The maximum allowed number of tags was exceeded.
 type TagLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17117,7 +17117,7 @@ func (s TagLimitExceededException) GoString() string {
 
 func newErrorTagLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TagLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17145,18 +17145,18 @@ func (s TagLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A tag was not specified.
 type TagRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17173,7 +17173,7 @@ func (s TagRequiredException) GoString() string {
 
 func newErrorTagRequiredException(v protocol.ResponseMetadata) error {
 	return &TagRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17201,12 +17201,12 @@ func (s TagRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {
@@ -17283,7 +17283,7 @@ func (s TagResourceOutput) GoString() string {
 // allowed limit of 3.
 type TagSetListLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17300,7 +17300,7 @@ func (s TagSetListLimitExceededException) GoString() string {
 
 func newErrorTagSetListLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TagSetListLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17328,12 +17328,12 @@ func (s TagSetListLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagSetListLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagSetListLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a target group in Elastic Load Balancing to use in a deployment.
@@ -17466,7 +17466,7 @@ func (s *TargetInstances) SetTagFilters(v []*EC2TagFilter) *TargetInstances {
 // An API function was called too frequently.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17483,7 +17483,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17511,12 +17511,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A configuration that shifts traffic from one version of a Lambda function
@@ -17753,7 +17753,7 @@ func (s *TriggerConfig) SetTriggerTargetArn(v string) *TriggerConfig {
 // The maximum allowed number of triggers was exceeded.
 type TriggerTargetsLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17770,7 +17770,7 @@ func (s TriggerTargetsLimitExceededException) GoString() string {
 
 func newErrorTriggerTargetsLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TriggerTargetsLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17798,18 +17798,18 @@ func (s TriggerTargetsLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TriggerTargetsLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TriggerTargetsLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A call was submitted that is not supported for the specified deployment type.
 type UnsupportedActionForDeploymentTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17826,7 +17826,7 @@ func (s UnsupportedActionForDeploymentTypeException) GoString() string {
 
 func newErrorUnsupportedActionForDeploymentTypeException(v protocol.ResponseMetadata) error {
 	return &UnsupportedActionForDeploymentTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17854,12 +17854,12 @@ func (s UnsupportedActionForDeploymentTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedActionForDeploymentTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedActionForDeploymentTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -5176,8 +5176,8 @@ func (s *AlarmConfiguration) SetIgnorePollAlarmFailure(v bool) *AlarmConfigurati
 
 // The maximum number of alarms for a deployment group (10) was exceeded.
 type AlarmsLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5280,8 +5280,8 @@ func (s *AppSpecContent) SetSha256(v string) *AppSpecContent {
 // An application with the specified name with the IAM user or AWS account already
 // exists.
 type ApplicationAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5336,8 +5336,8 @@ func (s ApplicationAlreadyExistsException) RequestID() string {
 
 // The application does not exist with the IAM user or AWS account.
 type ApplicationDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5463,8 +5463,8 @@ func (s *ApplicationInfo) SetLinkedToGitHub(v bool) *ApplicationInfo {
 
 // More applications were attempted to be created than are allowed.
 type ApplicationLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5519,8 +5519,8 @@ func (s ApplicationLimitExceededException) RequestID() string {
 
 // The minimum number of required application names was not specified.
 type ApplicationNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5576,8 +5576,8 @@ func (s ApplicationNameRequiredException) RequestID() string {
 // The specified ARN is not supported. For example, it might be an ARN for a
 // resource that is not expected.
 type ArnNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6245,8 +6245,8 @@ func (s *BatchGetOnPremisesInstancesOutput) SetInstanceInfos(v []*InstanceInfo) 
 
 // The maximum number of names or IDs allowed for this request (100) was exceeded.
 type BatchLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6394,8 +6394,8 @@ func (s *BlueInstanceTerminationOption) SetTerminationWaitTimeInMinutes(v int64)
 
 // A bucket name is required, but was not provided.
 type BucketNameFilterRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7402,8 +7402,8 @@ func (s *DeleteGitHubAccountTokenOutput) SetTokenName(v string) *DeleteGitHubAcc
 
 // The deployment is already complete.
 type DeploymentAlreadyCompletedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7459,8 +7459,8 @@ func (s DeploymentAlreadyCompletedException) RequestID() string {
 // A deployment configuration with the specified name with the IAM user or AWS
 // account already exists .
 type DeploymentConfigAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7515,8 +7515,8 @@ func (s DeploymentConfigAlreadyExistsException) RequestID() string {
 
 // The deployment configuration does not exist with the IAM user or AWS account.
 type DeploymentConfigDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7571,8 +7571,8 @@ func (s DeploymentConfigDoesNotExistException) RequestID() string {
 
 // The deployment configuration is still in use.
 type DeploymentConfigInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7697,8 +7697,8 @@ func (s *DeploymentConfigInfo) SetTrafficRoutingConfig(v *TrafficRoutingConfig) 
 
 // The deployment configurations limit was exceeded.
 type DeploymentConfigLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7753,8 +7753,8 @@ func (s DeploymentConfigLimitExceededException) RequestID() string {
 
 // The deployment configuration name was not specified.
 type DeploymentConfigNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7809,8 +7809,8 @@ func (s DeploymentConfigNameRequiredException) RequestID() string {
 
 // The deployment with the IAM user or AWS account does not exist.
 type DeploymentDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7866,8 +7866,8 @@ func (s DeploymentDoesNotExistException) RequestID() string {
 // A deployment group with the specified name with the IAM user or AWS account
 // already exists.
 type DeploymentGroupAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7922,8 +7922,8 @@ func (s DeploymentGroupAlreadyExistsException) RequestID() string {
 
 // The named deployment group with the IAM user or AWS account does not exist.
 type DeploymentGroupDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8199,8 +8199,8 @@ func (s *DeploymentGroupInfo) SetTriggerConfigurations(v []*TriggerConfig) *Depl
 
 // The deployment groups limit was exceeded.
 type DeploymentGroupLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8255,8 +8255,8 @@ func (s DeploymentGroupLimitExceededException) RequestID() string {
 
 // The deployment group name was not specified.
 type DeploymentGroupNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8311,8 +8311,8 @@ func (s DeploymentGroupNameRequiredException) RequestID() string {
 
 // At least one deployment ID must be specified.
 type DeploymentIdRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8679,8 +8679,8 @@ func (s *DeploymentInfo) SetUpdateOutdatedInstancesOnly(v bool) *DeploymentInfo 
 
 // The deployment does not have a status of Ready and can't continue yet.
 type DeploymentIsNotInReadyStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8735,8 +8735,8 @@ func (s DeploymentIsNotInReadyStateException) RequestID() string {
 
 // The number of allowed deployments was exceeded.
 type DeploymentLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8791,8 +8791,8 @@ func (s DeploymentLimitExceededException) RequestID() string {
 
 // The specified deployment has not started.
 type DeploymentNotStartedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9052,8 +9052,8 @@ func (s *DeploymentTarget) SetLambdaTarget(v *LambdaTarget) *DeploymentTarget {
 
 // The provided target ID does not belong to the attempted deployment.
 type DeploymentTargetDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9108,8 +9108,8 @@ func (s DeploymentTargetDoesNotExistException) RequestID() string {
 
 // A deployment target ID was not provided.
 type DeploymentTargetIdRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9167,8 +9167,8 @@ func (s DeploymentTargetIdRequiredException) RequestID() string {
 // must have exactly one item. This exception does not apply to EC2/On-premises
 // deployments.
 type DeploymentTargetListSizeExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9276,8 +9276,8 @@ func (s DeregisterOnPremisesInstanceOutput) GoString() string {
 
 // The description is too long.
 type DescriptionTooLongException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9509,8 +9509,8 @@ func (s *ECSService) SetServiceName(v string) *ECSService {
 // The Amazon ECS service is associated with more than one deployment groups.
 // An Amazon ECS service can be associated with only one deployment group.
 type ECSServiceMappingLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10491,8 +10491,8 @@ func (s *GetOnPremisesInstanceOutput) SetInstanceInfo(v *InstanceInfo) *GetOnPre
 
 // No GitHub account connection exists with the named specified in the call.
 type GitHubAccountTokenDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10547,8 +10547,8 @@ func (s GitHubAccountTokenDoesNotExistException) RequestID() string {
 
 // The call is missing a required GitHub account connection name.
 type GitHubAccountTokenNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10672,8 +10672,8 @@ func (s *GreenFleetProvisioningOption) SetAction(v string) *GreenFleetProvisioni
 // No IAM ARN was included in the request. You must use an IAM session ARN or
 // IAM user ARN in the request.
 type IamArnRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10729,8 +10729,8 @@ func (s IamArnRequiredException) RequestID() string {
 // The request included an IAM session ARN that has already been used to register
 // a different instance.
 type IamSessionArnAlreadyRegisteredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10785,8 +10785,8 @@ func (s IamSessionArnAlreadyRegisteredException) RequestID() string {
 
 // The specified IAM user ARN is already registered with an on-premises instance.
 type IamUserArnAlreadyRegisteredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10841,8 +10841,8 @@ func (s IamUserArnAlreadyRegisteredException) RequestID() string {
 
 // An IAM user ARN was not specified.
 type IamUserArnRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10899,8 +10899,8 @@ func (s IamUserArnRequiredException) RequestID() string {
 //
 // Deprecated: This exception is deprecated, use DeploymentTargetDoesNotExistException instead.
 type InstanceDoesNotExistException struct {
-	_            struct{} `deprecated:"true" type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `deprecated:"true" type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10957,8 +10957,8 @@ func (s InstanceDoesNotExistException) RequestID() string {
 //
 // Deprecated: This exception is deprecated, use DeploymentTargetIdRequiredException instead.
 type InstanceIdRequiredException struct {
-	_            struct{} `deprecated:"true" type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `deprecated:"true" type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11093,8 +11093,8 @@ func (s *InstanceInfo) SetTags(v []*Tag) *InstanceInfo {
 // The maximum number of allowed on-premises instances in a single call was
 // exceeded.
 type InstanceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11149,8 +11149,8 @@ func (s InstanceLimitExceededException) RequestID() string {
 
 // The specified on-premises instance name is already registered.
 type InstanceNameAlreadyRegisteredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11205,8 +11205,8 @@ func (s InstanceNameAlreadyRegisteredException) RequestID() string {
 
 // An on-premises instance name was not specified.
 type InstanceNameRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11261,8 +11261,8 @@ func (s InstanceNameRequiredException) RequestID() string {
 
 // The specified on-premises instance is not registered.
 type InstanceNotRegisteredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11495,8 +11495,8 @@ func (s *InstanceTarget) SetTargetId(v string) *InstanceTarget {
 //
 //    * The alarm configuration is enabled, but the alarm list is empty.
 type InvalidAlarmConfigException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11551,8 +11551,8 @@ func (s InvalidAlarmConfigException) RequestID() string {
 
 // The application name was specified in an invalid format.
 type InvalidApplicationNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11607,8 +11607,8 @@ func (s InvalidApplicationNameException) RequestID() string {
 
 // The specified ARN is not in a valid format.
 type InvalidArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11665,8 +11665,8 @@ func (s InvalidArnException) RequestID() string {
 // For example, automatic rollback is enabled, but an invalid triggering event
 // type or no event types were listed.
 type InvalidAutoRollbackConfigException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11721,8 +11721,8 @@ func (s InvalidAutoRollbackConfigException) RequestID() string {
 
 // The Auto Scaling group was specified in an invalid format or does not exist.
 type InvalidAutoScalingGroupException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11779,8 +11779,8 @@ func (s InvalidAutoScalingGroupException) RequestID() string {
 // invalid format. For information about deployment configuration format, see
 // CreateDeploymentConfig.
 type InvalidBlueGreenDeploymentConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11835,8 +11835,8 @@ func (s InvalidBlueGreenDeploymentConfigurationException) RequestID() string {
 
 // The bucket name either doesn't exist or was specified in an invalid format.
 type InvalidBucketNameFilterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11891,8 +11891,8 @@ func (s InvalidBucketNameFilterException) RequestID() string {
 
 // The computePlatform is invalid. The computePlatform should be Lambda or Server.
 type InvalidComputePlatformException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11947,8 +11947,8 @@ func (s InvalidComputePlatformException) RequestID() string {
 
 // The deployed state filter was specified in an invalid format.
 type InvalidDeployedStateFilterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12003,8 +12003,8 @@ func (s InvalidDeployedStateFilterException) RequestID() string {
 
 // The deployment configuration name was specified in an invalid format.
 type InvalidDeploymentConfigNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12059,8 +12059,8 @@ func (s InvalidDeploymentConfigNameException) RequestID() string {
 
 // The deployment group name was specified in an invalid format.
 type InvalidDeploymentGroupNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12115,8 +12115,8 @@ func (s InvalidDeploymentGroupNameException) RequestID() string {
 
 // At least one of the deployment IDs was specified in an invalid format.
 type InvalidDeploymentIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12172,8 +12172,8 @@ func (s InvalidDeploymentIdException) RequestID() string {
 // An instance type was specified for an in-place deployment. Instance types
 // are supported for blue/green deployments only.
 type InvalidDeploymentInstanceTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12228,8 +12228,8 @@ func (s InvalidDeploymentInstanceTypeException) RequestID() string {
 
 // The specified deployment status doesn't exist or cannot be determined.
 type InvalidDeploymentStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12286,8 +12286,8 @@ func (s InvalidDeploymentStatusException) RequestID() string {
 // "IN_PLACE" and "BLUE_GREEN." Valid deployment options include "WITH_TRAFFIC_CONTROL"
 // and "WITHOUT_TRAFFIC_CONTROL."
 type InvalidDeploymentStyleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12342,8 +12342,8 @@ func (s InvalidDeploymentStyleException) RequestID() string {
 
 // The target ID provided was not valid.
 type InvalidDeploymentTargetIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12398,8 +12398,8 @@ func (s InvalidDeploymentTargetIdException) RequestID() string {
 
 // The wait type is invalid.
 type InvalidDeploymentWaitTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12455,8 +12455,8 @@ func (s InvalidDeploymentWaitTypeException) RequestID() string {
 // A call was submitted that specified both Ec2TagFilters and Ec2TagSet, but
 // only one of these data types can be used in a single call.
 type InvalidEC2TagCombinationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12511,8 +12511,8 @@ func (s InvalidEC2TagCombinationException) RequestID() string {
 
 // The tag was specified in an invalid format.
 type InvalidEC2TagException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12567,8 +12567,8 @@ func (s InvalidEC2TagException) RequestID() string {
 
 // The Amazon ECS service identifier is not valid.
 type InvalidECSServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12626,8 +12626,8 @@ func (s InvalidECSServiceException) RequestID() string {
 // but weren't part of the previous successful deployment. Valid values include
 // "DISALLOW," "OVERWRITE," and "RETAIN."
 type InvalidFileExistsBehaviorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12682,8 +12682,8 @@ func (s InvalidFileExistsBehaviorException) RequestID() string {
 
 // The GitHub token is not valid.
 type InvalidGitHubAccountTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12738,8 +12738,8 @@ func (s InvalidGitHubAccountTokenException) RequestID() string {
 
 // The format of the specified GitHub account connection name is invalid.
 type InvalidGitHubAccountTokenNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12794,8 +12794,8 @@ func (s InvalidGitHubAccountTokenNameException) RequestID() string {
 
 // The IAM session ARN was specified in an invalid format.
 type InvalidIamSessionArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12850,8 +12850,8 @@ func (s InvalidIamSessionArnException) RequestID() string {
 
 // The IAM user ARN was specified in an invalid format.
 type InvalidIamUserArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12907,8 +12907,8 @@ func (s InvalidIamUserArnException) RequestID() string {
 // The IgnoreApplicationStopFailures value is invalid. For AWS Lambda deployments,
 // false is expected. For EC2/On-premises deployments, true or false is expected.
 type InvalidIgnoreApplicationStopFailuresValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12963,8 +12963,8 @@ func (s InvalidIgnoreApplicationStopFailuresValueException) RequestID() string {
 
 // The input was specified in an invalid format.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13019,8 +13019,8 @@ func (s InvalidInputException) RequestID() string {
 
 // The on-premises instance name was specified in an invalid format.
 type InvalidInstanceNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13075,8 +13075,8 @@ func (s InvalidInstanceNameException) RequestID() string {
 
 // The specified instance status does not exist.
 type InvalidInstanceStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13133,8 +13133,8 @@ func (s InvalidInstanceStatusException) RequestID() string {
 // Valid values include "Blue" for an original environment and "Green" for a
 // replacement environment.
 type InvalidInstanceTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13189,8 +13189,8 @@ func (s InvalidInstanceTypeException) RequestID() string {
 
 // The specified key prefix filter was specified in an invalid format.
 type InvalidKeyPrefixFilterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13246,8 +13246,8 @@ func (s InvalidKeyPrefixFilterException) RequestID() string {
 // A lifecycle event hook is invalid. Review the hooks section in your AppSpec
 // file to ensure the lifecycle events and hooks functions are valid.
 type InvalidLifecycleEventHookExecutionIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13303,8 +13303,8 @@ func (s InvalidLifecycleEventHookExecutionIdException) RequestID() string {
 // The result of a Lambda validation function that verifies a lifecycle event
 // is invalid. It should return Succeeded or Failed.
 type InvalidLifecycleEventHookExecutionStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13359,8 +13359,8 @@ func (s InvalidLifecycleEventHookExecutionStatusException) RequestID() string {
 
 // An invalid load balancer name, or no load balancer name, was specified.
 type InvalidLoadBalancerInfoException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13415,8 +13415,8 @@ func (s InvalidLoadBalancerInfoException) RequestID() string {
 
 // The minimum healthy instance value was specified in an invalid format.
 type InvalidMinimumHealthyHostValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13471,8 +13471,8 @@ func (s InvalidMinimumHealthyHostValueException) RequestID() string {
 
 // The next token was specified in an invalid format.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13528,8 +13528,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // A call was submitted that specified both OnPremisesTagFilters and OnPremisesTagSet,
 // but only one of these data types can be used in a single call.
 type InvalidOnPremisesTagCombinationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13584,8 +13584,8 @@ func (s InvalidOnPremisesTagCombinationException) RequestID() string {
 
 // An invalid operation was detected.
 type InvalidOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13640,8 +13640,8 @@ func (s InvalidOperationException) RequestID() string {
 
 // The registration status was specified in an invalid format.
 type InvalidRegistrationStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13696,8 +13696,8 @@ func (s InvalidRegistrationStatusException) RequestID() string {
 
 // The revision was specified in an invalid format.
 type InvalidRevisionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13754,8 +13754,8 @@ func (s InvalidRevisionException) RequestID() string {
 // group was specified, the specified service role does not grant the appropriate
 // permissions to Amazon EC2 Auto Scaling.
 type InvalidRoleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13811,8 +13811,8 @@ func (s InvalidRoleException) RequestID() string {
 // The column name to sort by is either not present or was specified in an invalid
 // format.
 type InvalidSortByException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13867,8 +13867,8 @@ func (s InvalidSortByException) RequestID() string {
 
 // The sort order was specified in an invalid format.
 type InvalidSortOrderException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13923,8 +13923,8 @@ func (s InvalidSortOrderException) RequestID() string {
 
 // The tag was specified in an invalid format.
 type InvalidTagException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13979,8 +13979,8 @@ func (s InvalidTagException) RequestID() string {
 
 // The tag filter was specified in an invalid format.
 type InvalidTagFilterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14035,8 +14035,8 @@ func (s InvalidTagFilterException) RequestID() string {
 
 // The specified tags are not valid.
 type InvalidTagsToAddException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14091,8 +14091,8 @@ func (s InvalidTagsToAddException) RequestID() string {
 
 // The target filter name is invalid.
 type InvalidTargetFilterNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14147,8 +14147,8 @@ func (s InvalidTargetFilterNameException) RequestID() string {
 
 // A target group pair associated with this deployment is not valid.
 type InvalidTargetGroupPairException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14212,8 +14212,8 @@ func (s InvalidTargetGroupPairException) RequestID() string {
 //
 //    * A specified tag is not currently applied to any instances.
 type InvalidTargetInstancesException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14268,8 +14268,8 @@ func (s InvalidTargetInstancesException) RequestID() string {
 
 // The specified time range was specified in an invalid format.
 type InvalidTimeRangeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14325,8 +14325,8 @@ func (s InvalidTimeRangeException) RequestID() string {
 // The configuration that specifies how traffic is routed during a deployment
 // is invalid.
 type InvalidTrafficRoutingConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14381,8 +14381,8 @@ func (s InvalidTrafficRoutingConfigurationException) RequestID() string {
 
 // The trigger was specified in an invalid format.
 type InvalidTriggerConfigException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14438,8 +14438,8 @@ func (s InvalidTriggerConfigException) RequestID() string {
 // The UpdateOutdatedInstancesOnly value is invalid. For AWS Lambda deployments,
 // false is expected. For EC2/On-premises deployments, true or false is expected.
 type InvalidUpdateOutdatedInstancesOnlyValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14762,8 +14762,8 @@ func (s *LifecycleEvent) SetStatus(v string) *LifecycleEvent {
 
 // An attempt to return the status of an already completed lifecycle event occurred.
 type LifecycleEventAlreadyCompletedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14818,8 +14818,8 @@ func (s LifecycleEventAlreadyCompletedException) RequestID() string {
 
 // The limit for lifecycle hooks was exceeded.
 type LifecycleHookLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15925,8 +15925,8 @@ func (s *MinimumHealthyHosts) SetValue(v int64) *MinimumHealthyHosts {
 // Both an IAM user ARN and an IAM session ARN were included in the request.
 // Use only one ARN type.
 type MultipleIamArnsProvidedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16007,8 +16007,8 @@ func (s *OnPremisesTagSet) SetOnPremisesTagSetList(v [][]*TagFilter) *OnPremises
 
 // The API used does not support the deployment.
 type OperationNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16389,8 +16389,8 @@ func (s RemoveTagsFromOnPremisesInstancesOutput) GoString() string {
 
 // The ARN of a resource is required, but was not found.
 type ResourceArnRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16445,8 +16445,8 @@ func (s ResourceArnRequiredException) RequestID() string {
 
 // The specified resource could not be validated.
 type ResourceValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16501,8 +16501,8 @@ func (s ResourceValidationException) RequestID() string {
 
 // The named revision does not exist with the IAM user or AWS account.
 type RevisionDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16661,8 +16661,8 @@ func (s *RevisionLocation) SetString_(v *RawString) *RevisionLocation {
 
 // The revision ID was not specified.
 type RevisionRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16717,8 +16717,8 @@ func (s RevisionRequiredException) RequestID() string {
 
 // The role ID was not specified.
 type RoleRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17099,8 +17099,8 @@ func (s *TagFilter) SetValue(v string) *TagFilter {
 
 // The maximum allowed number of tags was exceeded.
 type TagLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17155,8 +17155,8 @@ func (s TagLimitExceededException) RequestID() string {
 
 // A tag was not specified.
 type TagRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17282,8 +17282,8 @@ func (s TagResourceOutput) GoString() string {
 // The number of tag groups included in the tag set list exceeded the maximum
 // allowed limit of 3.
 type TagSetListLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17465,8 +17465,8 @@ func (s *TargetInstances) SetTagFilters(v []*EC2TagFilter) *TargetInstances {
 
 // An API function was called too frequently.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17752,8 +17752,8 @@ func (s *TriggerConfig) SetTriggerTargetArn(v string) *TriggerConfig {
 
 // The maximum allowed number of triggers was exceeded.
 type TriggerTargetsLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17808,8 +17808,8 @@ func (s TriggerTargetsLimitExceededException) RequestID() string {
 
 // A call was submitted that is not supported for the specified deployment type.
 type UnsupportedActionForDeploymentTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/codeguruprofiler/api.go
+++ b/service/codeguruprofiler/api.go
@@ -1118,7 +1118,7 @@ func (s *ConfigureAgentOutput) SetConfiguration(v *AgentConfiguration) *Configur
 // retrying this request.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1135,7 +1135,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1163,12 +1163,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The structure representing the createProfiliingGroupRequest.
@@ -1546,7 +1546,7 @@ func (s *GetProfileOutput) SetProfile(v []byte) *GetProfileOutput {
 // The server encountered an internal error and is unable to complete the request.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1563,7 +1563,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1591,12 +1591,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The structure representing the listProfileTimesRequest.
@@ -2109,7 +2109,7 @@ func (s *ProfilingStatus) SetLatestAggregatedProfile(v *AggregatedProfileTime) *
 // The resource specified in the request does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2126,7 +2126,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2154,12 +2154,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have exceeded your service quota. To perform the requested action, remove
@@ -2167,7 +2167,7 @@ func (s ResourceNotFoundException) RequestID() string {
 // to request a service quota increase.
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2184,7 +2184,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2212,18 +2212,18 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was denied due to request throttling.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2240,7 +2240,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2268,12 +2268,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The structure representing the updateProfilingGroupRequest.
@@ -2364,7 +2364,7 @@ func (s *UpdateProfilingGroupOutput) SetProfilingGroup(v *ProfilingGroupDescript
 // The parameter is not valid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2381,7 +2381,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2409,12 +2409,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/codeguruprofiler/api.go
+++ b/service/codeguruprofiler/api.go
@@ -1117,8 +1117,8 @@ func (s *ConfigureAgentOutput) SetConfiguration(v *AgentConfiguration) *Configur
 // a service resource associated with the request. Resolve the conflict before
 // retrying this request.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1545,8 +1545,8 @@ func (s *GetProfileOutput) SetProfile(v []byte) *GetProfileOutput {
 
 // The server encountered an internal error and is unable to complete the request.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2108,8 +2108,8 @@ func (s *ProfilingStatus) SetLatestAggregatedProfile(v *AggregatedProfileTime) *
 
 // The resource specified in the request does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2166,8 +2166,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // some of the relevant resources, or use Service Quotas (https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html)
 // to request a service quota increase.
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2222,8 +2222,8 @@ func (s ServiceQuotaExceededException) RequestID() string {
 
 // The request was denied due to request throttling.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2363,8 +2363,8 @@ func (s *UpdateProfilingGroupOutput) SetProfilingGroup(v *ProfilingGroupDescript
 
 // The parameter is not valid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/codegurureviewer/api.go
+++ b/service/codegurureviewer/api.go
@@ -446,7 +446,7 @@ func (c *CodeGuruReviewer) ListRepositoryAssociationsPagesWithContext(ctx aws.Co
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -463,7 +463,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -491,12 +491,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AssociateRepositoryInput struct {
@@ -644,7 +644,7 @@ func (s *CodeCommitRepository) SetName(v string) *CodeCommitRepository {
 // retrying this request.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -661,7 +661,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -689,12 +689,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DescribeRepositoryAssociationInput struct {
@@ -828,7 +828,7 @@ func (s *DisassociateRepositoryOutput) SetRepositoryAssociation(v *RepositoryAss
 // The server encountered an internal error and is unable to complete the request.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -845,7 +845,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -873,12 +873,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListRepositoryAssociationsInput struct {
@@ -1029,7 +1029,7 @@ func (s *ListRepositoryAssociationsOutput) SetRepositoryAssociationSummaries(v [
 // The resource specified in the request was not found.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1046,7 +1046,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1074,12 +1074,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a repository.
@@ -1318,7 +1318,7 @@ func (s *RepositoryAssociationSummary) SetState(v string) *RepositoryAssociation
 // The request was denied due to request throttling.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1335,7 +1335,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1363,18 +1363,18 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input fails to satisfy the specified constraints.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1391,7 +1391,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1419,12 +1419,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/codegurureviewer/api.go
+++ b/service/codegurureviewer/api.go
@@ -445,8 +445,8 @@ func (c *CodeGuruReviewer) ListRepositoryAssociationsPagesWithContext(ctx aws.Co
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -643,8 +643,8 @@ func (s *CodeCommitRepository) SetName(v string) *CodeCommitRepository {
 // a service resource associated with the request. Resolve the conflict before
 // retrying this request.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -827,8 +827,8 @@ func (s *DisassociateRepositoryOutput) SetRepositoryAssociation(v *RepositoryAss
 
 // The server encountered an internal error and is unable to complete the request.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1028,8 +1028,8 @@ func (s *ListRepositoryAssociationsOutput) SetRepositoryAssociationSummaries(v [
 
 // The resource specified in the request was not found.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1317,8 +1317,8 @@ func (s *RepositoryAssociationSummary) SetState(v string) *RepositoryAssociation
 
 // The request was denied due to request throttling.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1373,8 +1373,8 @@ func (s ThrottlingException) RequestID() string {
 
 // The input fails to satisfy the specified constraints.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -4685,7 +4685,7 @@ func (s *ActionExecutionResult) SetExternalExecutionUrl(v string) *ActionExecuti
 // The specified action cannot be found.
 type ActionNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4702,7 +4702,7 @@ func (s ActionNotFoundException) GoString() string {
 
 func newErrorActionNotFoundException(v protocol.ResponseMetadata) error {
 	return &ActionNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4730,12 +4730,12 @@ func (s ActionNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ActionNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ActionNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents information about the version (or revision) of an action.
@@ -5038,7 +5038,7 @@ func (s *ActionTypeId) SetVersion(v string) *ActionTypeId {
 // The specified action type cannot be found.
 type ActionTypeNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5055,7 +5055,7 @@ func (s ActionTypeNotFoundException) GoString() string {
 
 func newErrorActionTypeNotFoundException(v protocol.ResponseMetadata) error {
 	return &ActionTypeNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5083,12 +5083,12 @@ func (s ActionTypeNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ActionTypeNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ActionTypeNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about the settings for an action type.
@@ -5177,7 +5177,7 @@ func (s *ActionTypeSettings) SetThirdPartyConfigurationUrl(v string) *ActionType
 // The approval action has already been approved or rejected.
 type ApprovalAlreadyCompletedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5194,7 +5194,7 @@ func (s ApprovalAlreadyCompletedException) GoString() string {
 
 func newErrorApprovalAlreadyCompletedException(v protocol.ResponseMetadata) error {
 	return &ApprovalAlreadyCompletedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5222,12 +5222,12 @@ func (s ApprovalAlreadyCompletedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ApprovalAlreadyCompletedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ApprovalAlreadyCompletedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents information about the result of an approval request.
@@ -5662,7 +5662,7 @@ func (s *BlockerDeclaration) SetType(v string) *BlockerDeclaration {
 // Unable to modify the tag due to a simultaneous update request.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -5679,7 +5679,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5707,12 +5707,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of a CreateCustomActionType operation.
@@ -6466,7 +6466,7 @@ func (s DisableStageTransitionOutput) GoString() string {
 // make that request again.
 type DuplicatedStopRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -6483,7 +6483,7 @@ func (s DuplicatedStopRequestException) GoString() string {
 
 func newErrorDuplicatedStopRequestException(v protocol.ResponseMetadata) error {
 	return &DuplicatedStopRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6511,12 +6511,12 @@ func (s DuplicatedStopRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicatedStopRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicatedStopRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of an EnableStageTransition action.
@@ -7348,7 +7348,7 @@ func (s *InputArtifact) SetName(v string) *InputArtifact {
 // The action declaration was specified in an invalid format.
 type InvalidActionDeclarationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7365,7 +7365,7 @@ func (s InvalidActionDeclarationException) GoString() string {
 
 func newErrorInvalidActionDeclarationException(v protocol.ResponseMetadata) error {
 	return &InvalidActionDeclarationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7393,18 +7393,18 @@ func (s InvalidActionDeclarationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidActionDeclarationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidActionDeclarationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The approval request already received a response or has expired.
 type InvalidApprovalTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7421,7 +7421,7 @@ func (s InvalidApprovalTokenException) GoString() string {
 
 func newErrorInvalidApprovalTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidApprovalTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7449,18 +7449,18 @@ func (s InvalidApprovalTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApprovalTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApprovalTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource ARN is invalid.
 type InvalidArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -7477,7 +7477,7 @@ func (s InvalidArnException) GoString() string {
 
 func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 	return &InvalidArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7505,18 +7505,18 @@ func (s InvalidArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Reserved for future use.
 type InvalidBlockerDeclarationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7533,7 +7533,7 @@ func (s InvalidBlockerDeclarationException) GoString() string {
 
 func newErrorInvalidBlockerDeclarationException(v protocol.ResponseMetadata) error {
 	return &InvalidBlockerDeclarationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7561,18 +7561,18 @@ func (s InvalidBlockerDeclarationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidBlockerDeclarationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidBlockerDeclarationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The client token was specified in an invalid format
 type InvalidClientTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7589,7 +7589,7 @@ func (s InvalidClientTokenException) GoString() string {
 
 func newErrorInvalidClientTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidClientTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7617,18 +7617,18 @@ func (s InvalidClientTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidClientTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidClientTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The job was specified in an invalid format or cannot be found.
 type InvalidJobException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7645,7 +7645,7 @@ func (s InvalidJobException) GoString() string {
 
 func newErrorInvalidJobException(v protocol.ResponseMetadata) error {
 	return &InvalidJobException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7673,18 +7673,18 @@ func (s InvalidJobException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidJobException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidJobException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The job state was specified in an invalid format.
 type InvalidJobStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7701,7 +7701,7 @@ func (s InvalidJobStateException) GoString() string {
 
 func newErrorInvalidJobStateException(v protocol.ResponseMetadata) error {
 	return &InvalidJobStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7729,19 +7729,19 @@ func (s InvalidJobStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidJobStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidJobStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The next token was specified in an invalid format. Make sure that the next
 // token you provide is the token returned by a previous call.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7758,7 +7758,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7786,18 +7786,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The nonce was specified in an invalid format.
 type InvalidNonceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7814,7 +7814,7 @@ func (s InvalidNonceException) GoString() string {
 
 func newErrorInvalidNonceException(v protocol.ResponseMetadata) error {
 	return &InvalidNonceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7842,18 +7842,18 @@ func (s InvalidNonceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNonceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNonceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The stage declaration was specified in an invalid format.
 type InvalidStageDeclarationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7870,7 +7870,7 @@ func (s InvalidStageDeclarationException) GoString() string {
 
 func newErrorInvalidStageDeclarationException(v protocol.ResponseMetadata) error {
 	return &InvalidStageDeclarationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7898,18 +7898,18 @@ func (s InvalidStageDeclarationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStageDeclarationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStageDeclarationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The structure was specified in an invalid format.
 type InvalidStructureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7926,7 +7926,7 @@ func (s InvalidStructureException) GoString() string {
 
 func newErrorInvalidStructureException(v protocol.ResponseMetadata) error {
 	return &InvalidStructureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7954,18 +7954,18 @@ func (s InvalidStructureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStructureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStructureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource tags are invalid.
 type InvalidTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -7982,7 +7982,7 @@ func (s InvalidTagsException) GoString() string {
 
 func newErrorInvalidTagsException(v protocol.ResponseMetadata) error {
 	return &InvalidTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8010,18 +8010,18 @@ func (s InvalidTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified authentication type is in an invalid format.
 type InvalidWebhookAuthenticationParametersException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8038,7 +8038,7 @@ func (s InvalidWebhookAuthenticationParametersException) GoString() string {
 
 func newErrorInvalidWebhookAuthenticationParametersException(v protocol.ResponseMetadata) error {
 	return &InvalidWebhookAuthenticationParametersException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8066,18 +8066,18 @@ func (s InvalidWebhookAuthenticationParametersException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidWebhookAuthenticationParametersException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidWebhookAuthenticationParametersException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified event filter rule is in an invalid format.
 type InvalidWebhookFilterPatternException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8094,7 +8094,7 @@ func (s InvalidWebhookFilterPatternException) GoString() string {
 
 func newErrorInvalidWebhookFilterPatternException(v protocol.ResponseMetadata) error {
 	return &InvalidWebhookFilterPatternException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8122,12 +8122,12 @@ func (s InvalidWebhookFilterPatternException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidWebhookFilterPatternException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidWebhookFilterPatternException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents information about a job.
@@ -8324,7 +8324,7 @@ func (s *JobDetails) SetId(v string) *JobDetails {
 // The job was specified in an invalid format or cannot be found.
 type JobNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8341,7 +8341,7 @@ func (s JobNotFoundException) GoString() string {
 
 func newErrorJobNotFoundException(v protocol.ResponseMetadata) error {
 	return &JobNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8369,19 +8369,19 @@ func (s JobNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s JobNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s JobNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of pipelines associated with the AWS account has exceeded the
 // limit allowed for the account.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8398,7 +8398,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8426,12 +8426,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListActionExecutionsInput struct {
@@ -9087,7 +9087,7 @@ func (s *ListWebhooksOutput) SetWebhooks(v []*ListWebhookItem) *ListWebhooksOutp
 // associated with the request is out of date.
 type NotLatestPipelineExecutionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9104,7 +9104,7 @@ func (s NotLatestPipelineExecutionException) GoString() string {
 
 func newErrorNotLatestPipelineExecutionException(v protocol.ResponseMetadata) error {
 	return &NotLatestPipelineExecutionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9132,12 +9132,12 @@ func (s NotLatestPipelineExecutionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotLatestPipelineExecutionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotLatestPipelineExecutionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents information about the output of an action.
@@ -9193,7 +9193,7 @@ func (s *OutputArtifact) SetName(v string) *OutputArtifact {
 // Exceeded the total size limit for all variables in the pipeline.
 type OutputVariablesSizeExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -9210,7 +9210,7 @@ func (s OutputVariablesSizeExceededException) GoString() string {
 
 func newErrorOutputVariablesSizeExceededException(v protocol.ResponseMetadata) error {
 	return &OutputVariablesSizeExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9238,12 +9238,12 @@ func (s OutputVariablesSizeExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OutputVariablesSizeExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OutputVariablesSizeExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents information about a pipeline to a job worker.
@@ -9533,7 +9533,7 @@ func (s *PipelineExecution) SetStatus(v string) *PipelineExecution {
 // or an execution ID does not belong to the specified pipeline.
 type PipelineExecutionNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9550,7 +9550,7 @@ func (s PipelineExecutionNotFoundException) GoString() string {
 
 func newErrorPipelineExecutionNotFoundException(v protocol.ResponseMetadata) error {
 	return &PipelineExecutionNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9578,19 +9578,19 @@ func (s PipelineExecutionNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PipelineExecutionNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PipelineExecutionNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Unable to stop the pipeline execution. The execution might already be in
 // a Stopped state, or it might no longer be in progress.
 type PipelineExecutionNotStoppableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -9607,7 +9607,7 @@ func (s PipelineExecutionNotStoppableException) GoString() string {
 
 func newErrorPipelineExecutionNotStoppableException(v protocol.ResponseMetadata) error {
 	return &PipelineExecutionNotStoppableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9635,12 +9635,12 @@ func (s PipelineExecutionNotStoppableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PipelineExecutionNotStoppableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PipelineExecutionNotStoppableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Summary information about a pipeline execution.
@@ -9787,7 +9787,7 @@ func (s *PipelineMetadata) SetUpdated(v time.Time) *PipelineMetadata {
 // The specified pipeline name is already in use.
 type PipelineNameInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9804,7 +9804,7 @@ func (s PipelineNameInUseException) GoString() string {
 
 func newErrorPipelineNameInUseException(v protocol.ResponseMetadata) error {
 	return &PipelineNameInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9832,18 +9832,18 @@ func (s PipelineNameInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PipelineNameInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PipelineNameInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pipeline was specified in an invalid format or cannot be found.
 type PipelineNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9860,7 +9860,7 @@ func (s PipelineNotFoundException) GoString() string {
 
 func newErrorPipelineNotFoundException(v protocol.ResponseMetadata) error {
 	return &PipelineNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9888,12 +9888,12 @@ func (s PipelineNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PipelineNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PipelineNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns a summary of a pipeline.
@@ -9950,7 +9950,7 @@ func (s *PipelineSummary) SetVersion(v int64) *PipelineSummary {
 // The pipeline version was specified in an invalid format or cannot be found.
 type PipelineVersionNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9967,7 +9967,7 @@ func (s PipelineVersionNotFoundException) GoString() string {
 
 func newErrorPipelineVersionNotFoundException(v protocol.ResponseMetadata) error {
 	return &PipelineVersionNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9995,12 +9995,12 @@ func (s PipelineVersionNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PipelineVersionNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PipelineVersionNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of a PollForJobs action.
@@ -10981,7 +10981,7 @@ func (s RegisterWebhookWithThirdPartyOutput) GoString() string {
 // The resource was specified in an invalid format.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10998,7 +10998,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11026,12 +11026,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of a RetryStageExecution action.
@@ -11428,7 +11428,7 @@ func (s *StageExecution) SetStatus(v string) *StageExecution {
 // The stage was specified in an invalid format or cannot be found.
 type StageNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11445,7 +11445,7 @@ func (s StageNotFoundException) GoString() string {
 
 func newErrorStageNotFoundException(v protocol.ResponseMetadata) error {
 	return &StageNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11473,19 +11473,19 @@ func (s StageNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StageNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StageNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Unable to retry. The pipeline structure or stage state might have changed
 // while actions awaited retry, or the stage contains no failed actions.
 type StageNotRetryableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11502,7 +11502,7 @@ func (s StageNotRetryableException) GoString() string {
 
 func newErrorStageNotRetryableException(v protocol.ResponseMetadata) error {
 	return &StageNotRetryableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11530,12 +11530,12 @@ func (s StageNotRetryableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StageNotRetryableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StageNotRetryableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents information about the state of the stage.
@@ -12107,7 +12107,7 @@ func (s *ThirdPartyJobDetails) SetNonce(v string) *ThirdPartyJobDetails {
 // The tags limit for a resource has been exceeded.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -12124,7 +12124,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12152,12 +12152,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents information about the state of transitions between one stage and
@@ -12350,7 +12350,7 @@ func (s *UpdatePipelineOutput) SetPipeline(v *PipelineDeclaration) *UpdatePipeli
 // The validation was specified in an invalid format.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12367,7 +12367,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12395,12 +12395,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The authentication applied to incoming webhook trigger requests.
@@ -12674,7 +12674,7 @@ func (s *WebhookFilterRule) SetMatchEquals(v string) *WebhookFilterRule {
 // The specified webhook was entered in an invalid format or cannot be found.
 type WebhookNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12691,7 +12691,7 @@ func (s WebhookNotFoundException) GoString() string {
 
 func newErrorWebhookNotFoundException(v protocol.ResponseMetadata) error {
 	return &WebhookNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12719,12 +12719,12 @@ func (s WebhookNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WebhookNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WebhookNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -4684,8 +4684,8 @@ func (s *ActionExecutionResult) SetExternalExecutionUrl(v string) *ActionExecuti
 
 // The specified action cannot be found.
 type ActionNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5037,8 +5037,8 @@ func (s *ActionTypeId) SetVersion(v string) *ActionTypeId {
 
 // The specified action type cannot be found.
 type ActionTypeNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5176,8 +5176,8 @@ func (s *ActionTypeSettings) SetThirdPartyConfigurationUrl(v string) *ActionType
 
 // The approval action has already been approved or rejected.
 type ApprovalAlreadyCompletedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5661,8 +5661,8 @@ func (s *BlockerDeclaration) SetType(v string) *BlockerDeclaration {
 
 // Unable to modify the tag due to a simultaneous update request.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -6465,8 +6465,8 @@ func (s DisableStageTransitionOutput) GoString() string {
 // out of sequence tasks. If you already chose to stop and abandon, you cannot
 // make that request again.
 type DuplicatedStopRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -7347,8 +7347,8 @@ func (s *InputArtifact) SetName(v string) *InputArtifact {
 
 // The action declaration was specified in an invalid format.
 type InvalidActionDeclarationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7403,8 +7403,8 @@ func (s InvalidActionDeclarationException) RequestID() string {
 
 // The approval request already received a response or has expired.
 type InvalidApprovalTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7459,8 +7459,8 @@ func (s InvalidApprovalTokenException) RequestID() string {
 
 // The specified resource ARN is invalid.
 type InvalidArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -7515,8 +7515,8 @@ func (s InvalidArnException) RequestID() string {
 
 // Reserved for future use.
 type InvalidBlockerDeclarationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7571,8 +7571,8 @@ func (s InvalidBlockerDeclarationException) RequestID() string {
 
 // The client token was specified in an invalid format
 type InvalidClientTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7627,8 +7627,8 @@ func (s InvalidClientTokenException) RequestID() string {
 
 // The job was specified in an invalid format or cannot be found.
 type InvalidJobException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7683,8 +7683,8 @@ func (s InvalidJobException) RequestID() string {
 
 // The job state was specified in an invalid format.
 type InvalidJobStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7740,8 +7740,8 @@ func (s InvalidJobStateException) RequestID() string {
 // The next token was specified in an invalid format. Make sure that the next
 // token you provide is the token returned by a previous call.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7796,8 +7796,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // The nonce was specified in an invalid format.
 type InvalidNonceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7852,8 +7852,8 @@ func (s InvalidNonceException) RequestID() string {
 
 // The stage declaration was specified in an invalid format.
 type InvalidStageDeclarationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7908,8 +7908,8 @@ func (s InvalidStageDeclarationException) RequestID() string {
 
 // The structure was specified in an invalid format.
 type InvalidStructureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7964,8 +7964,8 @@ func (s InvalidStructureException) RequestID() string {
 
 // The specified resource tags are invalid.
 type InvalidTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -8020,8 +8020,8 @@ func (s InvalidTagsException) RequestID() string {
 
 // The specified authentication type is in an invalid format.
 type InvalidWebhookAuthenticationParametersException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8076,8 +8076,8 @@ func (s InvalidWebhookAuthenticationParametersException) RequestID() string {
 
 // The specified event filter rule is in an invalid format.
 type InvalidWebhookFilterPatternException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8323,8 +8323,8 @@ func (s *JobDetails) SetId(v string) *JobDetails {
 
 // The job was specified in an invalid format or cannot be found.
 type JobNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8380,8 +8380,8 @@ func (s JobNotFoundException) RequestID() string {
 // The number of pipelines associated with the AWS account has exceeded the
 // limit allowed for the account.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9086,8 +9086,8 @@ func (s *ListWebhooksOutput) SetWebhooks(v []*ListWebhookItem) *ListWebhooksOutp
 // The stage has failed in a later run of the pipeline and the pipelineExecutionId
 // associated with the request is out of date.
 type NotLatestPipelineExecutionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9192,8 +9192,8 @@ func (s *OutputArtifact) SetName(v string) *OutputArtifact {
 
 // Exceeded the total size limit for all variables in the pipeline.
 type OutputVariablesSizeExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -9532,8 +9532,8 @@ func (s *PipelineExecution) SetStatus(v string) *PipelineExecution {
 // The pipeline execution was specified in an invalid format or cannot be found,
 // or an execution ID does not belong to the specified pipeline.
 type PipelineExecutionNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9589,8 +9589,8 @@ func (s PipelineExecutionNotFoundException) RequestID() string {
 // Unable to stop the pipeline execution. The execution might already be in
 // a Stopped state, or it might no longer be in progress.
 type PipelineExecutionNotStoppableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -9786,8 +9786,8 @@ func (s *PipelineMetadata) SetUpdated(v time.Time) *PipelineMetadata {
 
 // The specified pipeline name is already in use.
 type PipelineNameInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9842,8 +9842,8 @@ func (s PipelineNameInUseException) RequestID() string {
 
 // The pipeline was specified in an invalid format or cannot be found.
 type PipelineNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9949,8 +9949,8 @@ func (s *PipelineSummary) SetVersion(v int64) *PipelineSummary {
 
 // The pipeline version was specified in an invalid format or cannot be found.
 type PipelineVersionNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10980,8 +10980,8 @@ func (s RegisterWebhookWithThirdPartyOutput) GoString() string {
 
 // The resource was specified in an invalid format.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11427,8 +11427,8 @@ func (s *StageExecution) SetStatus(v string) *StageExecution {
 
 // The stage was specified in an invalid format or cannot be found.
 type StageNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11484,8 +11484,8 @@ func (s StageNotFoundException) RequestID() string {
 // Unable to retry. The pipeline structure or stage state might have changed
 // while actions awaited retry, or the stage contains no failed actions.
 type StageNotRetryableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12106,8 +12106,8 @@ func (s *ThirdPartyJobDetails) SetNonce(v string) *ThirdPartyJobDetails {
 
 // The tags limit for a resource has been exceeded.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" min:"1" type:"string"`
 }
@@ -12349,8 +12349,8 @@ func (s *UpdatePipelineOutput) SetPipeline(v *PipelineDeclaration) *UpdatePipeli
 
 // The validation was specified in an invalid format.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12673,8 +12673,8 @@ func (s *WebhookFilterRule) SetMatchEquals(v string) *WebhookFilterRule {
 
 // The specified webhook was entered in an invalid format or cannot be found.
 type WebhookNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/codestar/api.go
+++ b/service/codestar/api.go
@@ -1948,8 +1948,8 @@ func (s *CodeSource) SetS3(v *S3Location) *CodeSource {
 // Another modification is being made. That modification must complete before
 // you can make your change.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2984,8 +2984,8 @@ func (s *GitHubCodeDestination) SetType(v string) *GitHubCodeDestination {
 
 // The next token is not valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3040,8 +3040,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // The service role is not valid.
 type InvalidServiceRoleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3096,8 +3096,8 @@ func (s InvalidServiceRoleException) RequestID() string {
 
 // A resource limit has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3619,8 +3619,8 @@ func (s *ListUserProfilesOutput) SetUserProfiles(v []*UserProfileSummary) *ListU
 // the AWS account. AWS CodeStar project IDs must be unique within a region
 // for the AWS account.
 type ProjectAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3675,8 +3675,8 @@ func (s ProjectAlreadyExistsException) RequestID() string {
 
 // Project configuration information is required but not specified.
 type ProjectConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3733,8 +3733,8 @@ func (s ProjectConfigurationException) RequestID() string {
 // occurred during project creation. The project could not be created in AWS
 // CodeStar.
 type ProjectCreationFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3789,8 +3789,8 @@ func (s ProjectCreationFailedException) RequestID() string {
 
 // The specified AWS CodeStar project was not found.
 type ProjectNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4115,8 +4115,8 @@ func (s *TeamMember) SetUserArn(v string) *TeamMember {
 
 // The team member is already associated with a role in this project.
 type TeamMemberAlreadyAssociatedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4171,8 +4171,8 @@ func (s TeamMemberAlreadyAssociatedException) RequestID() string {
 
 // The specified team member was not found.
 type TeamMemberNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4767,8 +4767,8 @@ func (s *UpdateUserProfileOutput) SetUserArn(v string) *UpdateUserProfileOutput 
 // AWS CodeStar user profile names must be unique within a region for the AWS
 // account.
 type UserProfileAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4823,8 +4823,8 @@ func (s UserProfileAlreadyExistsException) RequestID() string {
 
 // The user profile was not found.
 type UserProfileNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4940,8 +4940,8 @@ func (s *UserProfileSummary) SetUserArn(v string) *UserProfileSummary {
 
 // The specified input is either not valid, or it could not be validated.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/codestar/api.go
+++ b/service/codestar/api.go
@@ -1949,7 +1949,7 @@ func (s *CodeSource) SetS3(v *S3Location) *CodeSource {
 // you can make your change.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1966,7 +1966,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1994,12 +1994,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateProjectInput struct {
@@ -2985,7 +2985,7 @@ func (s *GitHubCodeDestination) SetType(v string) *GitHubCodeDestination {
 // The next token is not valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3002,7 +3002,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3030,18 +3030,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service role is not valid.
 type InvalidServiceRoleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3058,7 +3058,7 @@ func (s InvalidServiceRoleException) GoString() string {
 
 func newErrorInvalidServiceRoleException(v protocol.ResponseMetadata) error {
 	return &InvalidServiceRoleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3086,18 +3086,18 @@ func (s InvalidServiceRoleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidServiceRoleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidServiceRoleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A resource limit has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3114,7 +3114,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3142,12 +3142,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListProjectsInput struct {
@@ -3620,7 +3620,7 @@ func (s *ListUserProfilesOutput) SetUserProfiles(v []*UserProfileSummary) *ListU
 // for the AWS account.
 type ProjectAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3637,7 +3637,7 @@ func (s ProjectAlreadyExistsException) GoString() string {
 
 func newErrorProjectAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ProjectAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3665,18 +3665,18 @@ func (s ProjectAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProjectAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProjectAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Project configuration information is required but not specified.
 type ProjectConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3693,7 +3693,7 @@ func (s ProjectConfigurationException) GoString() string {
 
 func newErrorProjectConfigurationException(v protocol.ResponseMetadata) error {
 	return &ProjectConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3721,12 +3721,12 @@ func (s ProjectConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProjectConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProjectConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The project creation request was valid, but a nonspecific exception or error
@@ -3734,7 +3734,7 @@ func (s ProjectConfigurationException) RequestID() string {
 // CodeStar.
 type ProjectCreationFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3751,7 +3751,7 @@ func (s ProjectCreationFailedException) GoString() string {
 
 func newErrorProjectCreationFailedException(v protocol.ResponseMetadata) error {
 	return &ProjectCreationFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3779,18 +3779,18 @@ func (s ProjectCreationFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProjectCreationFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProjectCreationFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified AWS CodeStar project was not found.
 type ProjectNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3807,7 +3807,7 @@ func (s ProjectNotFoundException) GoString() string {
 
 func newErrorProjectNotFoundException(v protocol.ResponseMetadata) error {
 	return &ProjectNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3835,12 +3835,12 @@ func (s ProjectNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProjectNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProjectNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An indication of whether a project creation or deletion is failed or successful.
@@ -4116,7 +4116,7 @@ func (s *TeamMember) SetUserArn(v string) *TeamMember {
 // The team member is already associated with a role in this project.
 type TeamMemberAlreadyAssociatedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4133,7 +4133,7 @@ func (s TeamMemberAlreadyAssociatedException) GoString() string {
 
 func newErrorTeamMemberAlreadyAssociatedException(v protocol.ResponseMetadata) error {
 	return &TeamMemberAlreadyAssociatedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4161,18 +4161,18 @@ func (s TeamMemberAlreadyAssociatedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TeamMemberAlreadyAssociatedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TeamMemberAlreadyAssociatedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified team member was not found.
 type TeamMemberNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4189,7 +4189,7 @@ func (s TeamMemberNotFoundException) GoString() string {
 
 func newErrorTeamMemberNotFoundException(v protocol.ResponseMetadata) error {
 	return &TeamMemberNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4217,12 +4217,12 @@ func (s TeamMemberNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TeamMemberNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TeamMemberNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The toolchain template file provided with the project request. AWS CodeStar
@@ -4768,7 +4768,7 @@ func (s *UpdateUserProfileOutput) SetUserArn(v string) *UpdateUserProfileOutput 
 // account.
 type UserProfileAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4785,7 +4785,7 @@ func (s UserProfileAlreadyExistsException) GoString() string {
 
 func newErrorUserProfileAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &UserProfileAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4813,18 +4813,18 @@ func (s UserProfileAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserProfileAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserProfileAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The user profile was not found.
 type UserProfileNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4841,7 +4841,7 @@ func (s UserProfileNotFoundException) GoString() string {
 
 func newErrorUserProfileNotFoundException(v protocol.ResponseMetadata) error {
 	return &UserProfileNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4869,12 +4869,12 @@ func (s UserProfileNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserProfileNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserProfileNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a user's profile in AWS CodeStar.
@@ -4941,7 +4941,7 @@ func (s *UserProfileSummary) SetUserArn(v string) *UserProfileSummary {
 // The specified input is either not valid, or it could not be validated.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4958,7 +4958,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4986,10 +4986,10 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }

--- a/service/codestarconnections/api.go
+++ b/service/codestarconnections/api.go
@@ -658,7 +658,7 @@ func (s *GetConnectionOutput) SetConnection(v *Connection) *GetConnectionOutput 
 // Exceeded the maximum limit for connections.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -675,7 +675,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -703,12 +703,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListConnectionsInput struct {
@@ -809,7 +809,7 @@ func (s *ListConnectionsOutput) SetNextToken(v string) *ListConnectionsOutput {
 // Resource not found. Verify the connection resource ARN and try again.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -826,7 +826,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -854,12 +854,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/codestarconnections/api.go
+++ b/service/codestarconnections/api.go
@@ -657,8 +657,8 @@ func (s *GetConnectionOutput) SetConnection(v *Connection) *GetConnectionOutput 
 
 // Exceeded the maximum limit for connections.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -808,8 +808,8 @@ func (s *ListConnectionsOutput) SetNextToken(v string) *ListConnectionsOutput {
 
 // Resource not found. Verify the connection resource ARN and try again.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/codestarnotifications/api.go
+++ b/service/codestarnotifications/api.go
@@ -1306,7 +1306,7 @@ func (c *CodeStarNotifications) UpdateNotificationRuleWithContext(ctx aws.Contex
 // do not have sufficient permissions.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1323,7 +1323,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1351,19 +1351,19 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS CodeStar Notifications can't complete the request because the resource
 // is being modified by another process. Wait a few minutes and try again.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1380,7 +1380,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1408,18 +1408,18 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Some or all of the configuration is incomplete, missing, or not valid.
 type ConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1436,7 +1436,7 @@ func (s ConfigurationException) GoString() string {
 
 func newErrorConfigurationException(v protocol.ResponseMetadata) error {
 	return &ConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1464,12 +1464,12 @@ func (s ConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateNotificationRuleInput struct {
@@ -1990,7 +1990,7 @@ func (s *EventTypeSummary) SetServiceName(v string) *EventTypeSummary {
 // batch of the results is not valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2007,7 +2007,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2035,12 +2035,12 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One of the AWS CodeStar Notifications limits has been exceeded. Limits apply
@@ -2048,7 +2048,7 @@ func (s InvalidNextTokenException) RequestID() string {
 // more information, see Limits.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2065,7 +2065,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2093,12 +2093,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a filter to apply to the list of returned event types.
@@ -2678,7 +2678,7 @@ func (s *NotificationRuleSummary) SetId(v string) *NotificationRuleSummary {
 // must be unique in your AWS account.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2695,7 +2695,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2723,19 +2723,19 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS CodeStar Notifications can't find a resource that matches the provided
 // ARN.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2752,7 +2752,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2780,12 +2780,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SubscribeInput struct {
@@ -3313,7 +3313,7 @@ func (s UpdateNotificationRuleOutput) GoString() string {
 // One or more parameter values are not valid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3330,7 +3330,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3358,12 +3358,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/codestarnotifications/api.go
+++ b/service/codestarnotifications/api.go
@@ -1305,8 +1305,8 @@ func (c *CodeStarNotifications) UpdateNotificationRuleWithContext(ctx aws.Contex
 // AWS CodeStar Notifications can't create the notification rule because you
 // do not have sufficient permissions.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1362,8 +1362,8 @@ func (s AccessDeniedException) RequestID() string {
 // AWS CodeStar Notifications can't complete the request because the resource
 // is being modified by another process. Wait a few minutes and try again.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1418,8 +1418,8 @@ func (s ConcurrentModificationException) RequestID() string {
 
 // Some or all of the configuration is incomplete, missing, or not valid.
 type ConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1989,8 +1989,8 @@ func (s *EventTypeSummary) SetServiceName(v string) *EventTypeSummary {
 // The value for the enumeration token used in the request to return the next
 // batch of the results is not valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2047,8 +2047,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // to accounts, notification rules, notifications, resources, and targets. For
 // more information, see Limits.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2677,8 +2677,8 @@ func (s *NotificationRuleSummary) SetId(v string) *NotificationRuleSummary {
 // A resource with the same name or ID already exists. Notification rule names
 // must be unique in your AWS account.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2734,8 +2734,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 // AWS CodeStar Notifications can't find a resource that matches the provided
 // ARN.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3312,8 +3312,8 @@ func (s UpdateNotificationRuleOutput) GoString() string {
 
 // One or more parameter values are not valid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -2162,7 +2162,7 @@ func (c *CognitoIdentity) UpdateIdentityPoolWithContext(ctx aws.Context, input *
 // Thrown if there are parallel requests to modify a resource.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by a ConcurrentModificationException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2180,7 +2180,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2208,12 +2208,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Input to the CreateIdentityPool action.
@@ -2621,7 +2621,7 @@ func (s *DescribeIdentityPoolInput) SetIdentityPoolId(v string) *DescribeIdentit
 // under a different identity ID.
 type DeveloperUserAlreadyRegisteredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// This developer user identifier is already registered with Cognito.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2639,7 +2639,7 @@ func (s DeveloperUserAlreadyRegisteredException) GoString() string {
 
 func newErrorDeveloperUserAlreadyRegisteredException(v protocol.ResponseMetadata) error {
 	return &DeveloperUserAlreadyRegisteredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2667,19 +2667,19 @@ func (s DeveloperUserAlreadyRegisteredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeveloperUserAlreadyRegisteredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeveloperUserAlreadyRegisteredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An exception thrown when a dependent service such as Facebook or Twitter
 // is not responding
 type ExternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by an ExternalServiceException
 	Message_ *string `locationName:"message" type:"string"`
@@ -2697,7 +2697,7 @@ func (s ExternalServiceException) GoString() string {
 
 func newErrorExternalServiceException(v protocol.ResponseMetadata) error {
 	return &ExternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2725,12 +2725,12 @@ func (s ExternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Input to the GetCredentialsForIdentity action.
@@ -3490,7 +3490,7 @@ func (s *IdentityPoolShortDescription) SetIdentityPoolName(v string) *IdentityPo
 // Thrown when the service encounters an error during processing the request.
 type InternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by an InternalErrorException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3508,7 +3508,7 @@ func (s InternalErrorException) GoString() string {
 
 func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 	return &InternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3536,19 +3536,19 @@ func (s InternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Thrown if the identity pool has no role associated for the given auth type
 // (auth/unauth) or if the AssumeRole fails.
 type InvalidIdentityPoolConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned for an InvalidIdentityPoolConfigurationException
 	Message_ *string `locationName:"message" type:"string"`
@@ -3566,7 +3566,7 @@ func (s InvalidIdentityPoolConfigurationException) GoString() string {
 
 func newErrorInvalidIdentityPoolConfigurationException(v protocol.ResponseMetadata) error {
 	return &InvalidIdentityPoolConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3594,18 +3594,18 @@ func (s InvalidIdentityPoolConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidIdentityPoolConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidIdentityPoolConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Thrown for missing or bad input parameter(s).
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by an InvalidParameterException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3623,7 +3623,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3651,18 +3651,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Thrown when the total number of user pools has exceeded a preset limit.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by a LimitExceededException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3680,7 +3680,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3708,12 +3708,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Input to the ListIdentities action.
@@ -4355,7 +4355,7 @@ func (s *MergeDeveloperIdentitiesOutput) SetIdentityId(v string) *MergeDeveloper
 // Thrown when a user is not authorized to access the requested resource.
 type NotAuthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by a NotAuthorizedException
 	Message_ *string `locationName:"message" type:"string"`
@@ -4373,7 +4373,7 @@ func (s NotAuthorizedException) GoString() string {
 
 func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 	return &NotAuthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4401,12 +4401,12 @@ func (s NotAuthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotAuthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotAuthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A provider representing an Amazon Cognito user pool and its client ID.
@@ -4480,7 +4480,7 @@ func (s *Provider) SetServerSideTokenCheck(v bool) *Provider {
 // account.
 type ResourceConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by a ResourceConflictException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4498,7 +4498,7 @@ func (s ResourceConflictException) GoString() string {
 
 func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 	return &ResourceConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4526,19 +4526,19 @@ func (s ResourceConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Thrown when the requested resource (for example, a dataset or record) does
 // not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by a ResourceNotFoundException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4556,7 +4556,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4584,12 +4584,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A role mapping.
@@ -4883,7 +4883,7 @@ func (s TagResourceOutput) GoString() string {
 // Thrown when a request is throttled.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Message returned by a TooManyRequestsException
 	Message_ *string `locationName:"message" type:"string"`
@@ -4901,7 +4901,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4929,12 +4929,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Input to the UnlinkDeveloperIdentity action.

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -2161,8 +2161,8 @@ func (c *CognitoIdentity) UpdateIdentityPoolWithContext(ctx aws.Context, input *
 
 // Thrown if there are parallel requests to modify a resource.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by a ConcurrentModificationException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2620,8 +2620,8 @@ func (s *DescribeIdentityPoolInput) SetIdentityPoolId(v string) *DescribeIdentit
 // The provided developer user identifier is already registered with Cognito
 // under a different identity ID.
 type DeveloperUserAlreadyRegisteredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// This developer user identifier is already registered with Cognito.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2678,8 +2678,8 @@ func (s DeveloperUserAlreadyRegisteredException) RequestID() string {
 // An exception thrown when a dependent service such as Facebook or Twitter
 // is not responding
 type ExternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by an ExternalServiceException
 	Message_ *string `locationName:"message" type:"string"`
@@ -3489,8 +3489,8 @@ func (s *IdentityPoolShortDescription) SetIdentityPoolName(v string) *IdentityPo
 
 // Thrown when the service encounters an error during processing the request.
 type InternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by an InternalErrorException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3547,8 +3547,8 @@ func (s InternalErrorException) RequestID() string {
 // Thrown if the identity pool has no role associated for the given auth type
 // (auth/unauth) or if the AssumeRole fails.
 type InvalidIdentityPoolConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned for an InvalidIdentityPoolConfigurationException
 	Message_ *string `locationName:"message" type:"string"`
@@ -3604,8 +3604,8 @@ func (s InvalidIdentityPoolConfigurationException) RequestID() string {
 
 // Thrown for missing or bad input parameter(s).
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by an InvalidParameterException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3661,8 +3661,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // Thrown when the total number of user pools has exceeded a preset limit.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by a LimitExceededException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4354,8 +4354,8 @@ func (s *MergeDeveloperIdentitiesOutput) SetIdentityId(v string) *MergeDeveloper
 
 // Thrown when a user is not authorized to access the requested resource.
 type NotAuthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by a NotAuthorizedException
 	Message_ *string `locationName:"message" type:"string"`
@@ -4479,8 +4479,8 @@ func (s *Provider) SetServerSideTokenCheck(v bool) *Provider {
 // Thrown when a user tries to use a login which is already linked to another
 // account.
 type ResourceConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by a ResourceConflictException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4537,8 +4537,8 @@ func (s ResourceConflictException) RequestID() string {
 // Thrown when the requested resource (for example, a dataset or record) does
 // not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by a ResourceNotFoundException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4882,8 +4882,8 @@ func (s TagResourceOutput) GoString() string {
 
 // Thrown when a request is throttled.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Message returned by a TooManyRequestsException
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/cognitoidentityprovider/api.go
+++ b/service/cognitoidentityprovider/api.go
@@ -14773,8 +14773,8 @@ func (s AdminUserGlobalSignOutOutput) GoString() string {
 // account. This exception tells user that an account with this email or phone
 // already exists.
 type AliasExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message sent to the user when an alias exists.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15401,8 +15401,8 @@ func (s *CodeDeliveryDetailsType) SetDestination(v string) *CodeDeliveryDetailsT
 
 // This exception is thrown when a verification code fails to deliver successfully.
 type CodeDeliveryFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message sent when a verification code fails to deliver successfully.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15459,8 +15459,8 @@ func (s CodeDeliveryFailureException) RequestID() string {
 // This exception is thrown if the provided code does not match what the server
 // was expecting.
 type CodeMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message provided when the code mismatch exception is thrown.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15609,8 +15609,8 @@ func (s *CompromisedCredentialsRiskConfigurationType) SetEventFilter(v []*string
 
 // This exception is thrown if two or more modifications are happening concurrently.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message provided when the concurrent exception is thrown.
 	Message_ *string `locationName:"message" type:"string"`
@@ -18834,8 +18834,8 @@ func (s *DomainDescriptionType) SetVersion(v string) *DomainDescriptionType {
 // This exception is thrown when the provider is already supported by the user
 // pool.
 type DuplicateProviderException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19030,8 +19030,8 @@ func (s *EmailConfigurationType) SetSourceArn(v string) *EmailConfigurationType 
 // This exception is thrown when there is a code mismatch and the service fails
 // to configure the software token TOTP multi-factor authentication (MFA).
 type EnableSoftwareTokenMFAException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19235,8 +19235,8 @@ func (s *EventRiskType) SetRiskLevel(v string) *EventRiskType {
 
 // This exception is thrown if a code has expired.
 type ExpiredCodeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the expired code exception is thrown.
 	Message_ *string `locationName:"message" type:"string"`
@@ -20354,8 +20354,8 @@ func (s GlobalSignOutOutput) GoString() string {
 // This exception is thrown when Amazon Cognito encounters a group that already
 // exists in the user pool.
 type GroupExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20914,8 +20914,8 @@ func (s *InitiateAuthOutput) SetSession(v string) *InitiateAuthOutput {
 
 // This exception is thrown when Amazon Cognito encounters an internal error.
 type InternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when Amazon Cognito throws an internal error exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -20972,8 +20972,8 @@ func (s InternalErrorException) RequestID() string {
 // This exception is thrown when Amazon Cognito is not allowed to use your email
 // identity. HTTP status code: 400.
 type InvalidEmailRoleAccessPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when you have an unverified email address or the identity
 	// policy is not set on an email address that Amazon Cognito can access.
@@ -21031,8 +21031,8 @@ func (s InvalidEmailRoleAccessPolicyException) RequestID() string {
 // This exception is thrown when the Amazon Cognito service encounters an invalid
 // AWS Lambda response.
 type InvalidLambdaResponseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the Amazon Cognito service throws an invalid AWS
 	// Lambda response exception.
@@ -21089,8 +21089,8 @@ func (s InvalidLambdaResponseException) RequestID() string {
 
 // This exception is thrown when the specified OAuth flow is invalid.
 type InvalidOAuthFlowException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21146,8 +21146,8 @@ func (s InvalidOAuthFlowException) RequestID() string {
 // This exception is thrown when the Amazon Cognito service encounters an invalid
 // parameter.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the Amazon Cognito service throws an invalid parameter
 	// exception.
@@ -21205,8 +21205,8 @@ func (s InvalidParameterException) RequestID() string {
 // This exception is thrown when the Amazon Cognito service encounters an invalid
 // password.
 type InvalidPasswordException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the Amazon Cognito service throws an invalid user
 	// password exception.
@@ -21264,8 +21264,8 @@ func (s InvalidPasswordException) RequestID() string {
 // This exception is returned when the role provided for SMS configuration does
 // not have permission to publish using Amazon SNS.
 type InvalidSmsRoleAccessPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message retuned when the invalid SMS role access policy exception is
 	// thrown.
@@ -21325,8 +21325,8 @@ func (s InvalidSmsRoleAccessPolicyException) RequestID() string {
 // or the external ID provided in the role does not match what is provided in
 // the SMS configuration for the user pool.
 type InvalidSmsRoleTrustRelationshipException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the role trust relationship for the SMS message
 	// is invalid.
@@ -21383,8 +21383,8 @@ func (s InvalidSmsRoleTrustRelationshipException) RequestID() string {
 
 // This exception is thrown when the user pool configuration is invalid.
 type InvalidUserPoolConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the user pool configuration is invalid.
 	Message_ *string `locationName:"message" type:"string"`
@@ -21586,8 +21586,8 @@ func (s *LambdaConfigType) SetVerifyAuthChallengeResponse(v string) *LambdaConfi
 // This exception is thrown when a user exceeds the limit for a requested AWS
 // resource.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when Amazon Cognito throws a limit exceeded exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -22664,8 +22664,8 @@ func (s *ListUsersOutput) SetUsers(v []*UserType) *ListUsersOutput {
 // This exception is thrown when Amazon Cognito cannot find a multi-factor authentication
 // (MFA) method.
 type MFAMethodNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when Amazon Cognito throws an MFA method not found exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -22869,8 +22869,8 @@ func (s *NewDeviceMetadataType) SetDeviceKey(v string) *NewDeviceMetadataType {
 
 // This exception is thrown when a user is not authorized.
 type NotAuthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the Amazon Cognito service returns a not authorized
 	// exception.
@@ -23227,8 +23227,8 @@ func (s *PasswordPolicyType) SetTemporaryPasswordValidityDays(v int64) *Password
 
 // This exception is thrown when a password reset is required.
 type PasswordResetRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when a password reset is required.
 	Message_ *string `locationName:"message" type:"string"`
@@ -23284,8 +23284,8 @@ func (s PasswordResetRequiredException) RequestID() string {
 
 // This exception is thrown when a precondition is not met.
 type PreconditionNotMetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when a precondition is not met.
 	Message_ *string `locationName:"message" type:"string"`
@@ -23661,8 +23661,8 @@ func (s *ResendConfirmationCodeOutput) SetCodeDeliveryDetails(v *CodeDeliveryDet
 // This exception is thrown when the Amazon Cognito service cannot find the
 // requested resource.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the Amazon Cognito service returns a resource not
 	// found exception.
@@ -24295,8 +24295,8 @@ func (s *SchemaAttributeType) SetStringAttributeConstraints(v *StringAttributeCo
 
 // This exception is thrown when the specified scope does not exist.
 type ScopeDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25199,8 +25199,8 @@ func (s *SmsMfaConfigType) SetSmsConfiguration(v *SmsConfigurationType) *SmsMfaC
 // This exception is thrown when the software token TOTP multi-factor authentication
 // (MFA) is not enabled for the user pool.
 type SoftwareTokenMFANotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25583,8 +25583,8 @@ func (s TagResourceOutput) GoString() string {
 // This exception is thrown when the user has made too many failed attempts
 // for a given action (e.g., sign in).
 type TooManyFailedAttemptsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the Amazon Cognito service returns a too many failed
 	// attempts exception.
@@ -25642,8 +25642,8 @@ func (s TooManyFailedAttemptsException) RequestID() string {
 // This exception is thrown when the user has made too many requests for a given
 // operation.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the Amazon Cognito service returns a too many requests
 	// exception.
@@ -25780,8 +25780,8 @@ func (s *UICustomizationType) SetUserPoolId(v string) *UICustomizationType {
 // This exception is thrown when the Amazon Cognito service encounters an unexpected
 // exception with the AWS Lambda service.
 type UnexpectedLambdaException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the Amazon Cognito service returns an unexpected
 	// AWS Lambda exception.
@@ -25838,8 +25838,8 @@ func (s UnexpectedLambdaException) RequestID() string {
 
 // This exception is thrown when the specified identifier is not supported.
 type UnsupportedIdentityProviderException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25894,8 +25894,8 @@ func (s UnsupportedIdentityProviderException) RequestID() string {
 
 // The request failed because the user is in an unsupported state.
 type UnsupportedUserStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the user is in an unsupported state.
 	Message_ *string `locationName:"message" type:"string"`
@@ -27431,8 +27431,8 @@ func (s *UserContextDataType) SetEncodedData(v string) *UserContextDataType {
 // This exception is thrown when you are trying to modify a user pool while
 // a user import job is in progress for that pool.
 type UserImportInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the user pool has an import job running.
 	Message_ *string `locationName:"message" type:"string"`
@@ -27644,8 +27644,8 @@ func (s *UserImportJobType) SetUserPoolId(v string) *UserImportJobType {
 // This exception is thrown when the Amazon Cognito service encounters a user
 // validation exception with the AWS Lambda service.
 type UserLambdaValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when the Amazon Cognito service returns a user validation
 	// exception with the AWS Lambda service.
@@ -27702,8 +27702,8 @@ func (s UserLambdaValidationException) RequestID() string {
 
 // This exception is thrown when a user is not confirmed successfully.
 type UserNotConfirmedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when a user is not confirmed successfully.
 	Message_ *string `locationName:"message" type:"string"`
@@ -27759,8 +27759,8 @@ func (s UserNotConfirmedException) RequestID() string {
 
 // This exception is thrown when a user is not found.
 type UserNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when a user is not found.
 	Message_ *string `locationName:"message" type:"string"`
@@ -27816,8 +27816,8 @@ func (s UserNotFoundException) RequestID() string {
 
 // This exception is thrown when user pool add-ons are not enabled.
 type UserPoolAddOnNotEnabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28354,8 +28354,8 @@ func (s *UserPoolPolicyType) SetPasswordPolicy(v *PasswordPolicyType) *UserPoolP
 
 // This exception is thrown when a user pool tag cannot be set or updated.
 type UserPoolTaggingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28876,8 +28876,8 @@ func (s *UsernameConfigurationType) SetCaseSensitive(v bool) *UsernameConfigurat
 // This exception is thrown when Amazon Cognito encounters a user name that
 // already exists in the user pool.
 type UsernameExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned when Amazon Cognito throws a user name exists exception.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/cognitoidentityprovider/api.go
+++ b/service/cognitoidentityprovider/api.go
@@ -14774,7 +14774,7 @@ func (s AdminUserGlobalSignOutOutput) GoString() string {
 // already exists.
 type AliasExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message sent to the user when an alias exists.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14792,7 +14792,7 @@ func (s AliasExistsException) GoString() string {
 
 func newErrorAliasExistsException(v protocol.ResponseMetadata) error {
 	return &AliasExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14820,12 +14820,12 @@ func (s AliasExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AliasExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AliasExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon Pinpoint analytics configuration for collecting metrics for a
@@ -15402,7 +15402,7 @@ func (s *CodeDeliveryDetailsType) SetDestination(v string) *CodeDeliveryDetailsT
 // This exception is thrown when a verification code fails to deliver successfully.
 type CodeDeliveryFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message sent when a verification code fails to deliver successfully.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15420,7 +15420,7 @@ func (s CodeDeliveryFailureException) GoString() string {
 
 func newErrorCodeDeliveryFailureException(v protocol.ResponseMetadata) error {
 	return &CodeDeliveryFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15448,19 +15448,19 @@ func (s CodeDeliveryFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CodeDeliveryFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CodeDeliveryFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown if the provided code does not match what the server
 // was expecting.
 type CodeMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message provided when the code mismatch exception is thrown.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15478,7 +15478,7 @@ func (s CodeMismatchException) GoString() string {
 
 func newErrorCodeMismatchException(v protocol.ResponseMetadata) error {
 	return &CodeMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15506,12 +15506,12 @@ func (s CodeMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CodeMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CodeMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The compromised credentials actions type
@@ -15610,7 +15610,7 @@ func (s *CompromisedCredentialsRiskConfigurationType) SetEventFilter(v []*string
 // This exception is thrown if two or more modifications are happening concurrently.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message provided when the concurrent exception is thrown.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15628,7 +15628,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15656,12 +15656,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Confirms the device request.
@@ -18835,7 +18835,7 @@ func (s *DomainDescriptionType) SetVersion(v string) *DomainDescriptionType {
 // pool.
 type DuplicateProviderException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18852,7 +18852,7 @@ func (s DuplicateProviderException) GoString() string {
 
 func newErrorDuplicateProviderException(v protocol.ResponseMetadata) error {
 	return &DuplicateProviderException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18880,12 +18880,12 @@ func (s DuplicateProviderException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateProviderException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateProviderException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The email configuration type.
@@ -19031,7 +19031,7 @@ func (s *EmailConfigurationType) SetSourceArn(v string) *EmailConfigurationType 
 // to configure the software token TOTP multi-factor authentication (MFA).
 type EnableSoftwareTokenMFAException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19048,7 +19048,7 @@ func (s EnableSoftwareTokenMFAException) GoString() string {
 
 func newErrorEnableSoftwareTokenMFAException(v protocol.ResponseMetadata) error {
 	return &EnableSoftwareTokenMFAException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19076,12 +19076,12 @@ func (s EnableSoftwareTokenMFAException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EnableSoftwareTokenMFAException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EnableSoftwareTokenMFAException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the user context data captured at the time of an event request.
@@ -19236,7 +19236,7 @@ func (s *EventRiskType) SetRiskLevel(v string) *EventRiskType {
 // This exception is thrown if a code has expired.
 type ExpiredCodeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the expired code exception is thrown.
 	Message_ *string `locationName:"message" type:"string"`
@@ -19254,7 +19254,7 @@ func (s ExpiredCodeException) GoString() string {
 
 func newErrorExpiredCodeException(v protocol.ResponseMetadata) error {
 	return &ExpiredCodeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19282,12 +19282,12 @@ func (s ExpiredCodeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExpiredCodeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExpiredCodeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the request to forget the device.
@@ -20355,7 +20355,7 @@ func (s GlobalSignOutOutput) GoString() string {
 // exists in the user pool.
 type GroupExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20372,7 +20372,7 @@ func (s GroupExistsException) GoString() string {
 
 func newErrorGroupExistsException(v protocol.ResponseMetadata) error {
 	return &GroupExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20400,12 +20400,12 @@ func (s GroupExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GroupExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GroupExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The group type.
@@ -20915,7 +20915,7 @@ func (s *InitiateAuthOutput) SetSession(v string) *InitiateAuthOutput {
 // This exception is thrown when Amazon Cognito encounters an internal error.
 type InternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when Amazon Cognito throws an internal error exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -20933,7 +20933,7 @@ func (s InternalErrorException) GoString() string {
 
 func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 	return &InternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20961,19 +20961,19 @@ func (s InternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when Amazon Cognito is not allowed to use your email
 // identity. HTTP status code: 400.
 type InvalidEmailRoleAccessPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when you have an unverified email address or the identity
 	// policy is not set on an email address that Amazon Cognito can access.
@@ -20992,7 +20992,7 @@ func (s InvalidEmailRoleAccessPolicyException) GoString() string {
 
 func newErrorInvalidEmailRoleAccessPolicyException(v protocol.ResponseMetadata) error {
 	return &InvalidEmailRoleAccessPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21020,19 +21020,19 @@ func (s InvalidEmailRoleAccessPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEmailRoleAccessPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEmailRoleAccessPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the Amazon Cognito service encounters an invalid
 // AWS Lambda response.
 type InvalidLambdaResponseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the Amazon Cognito service throws an invalid AWS
 	// Lambda response exception.
@@ -21051,7 +21051,7 @@ func (s InvalidLambdaResponseException) GoString() string {
 
 func newErrorInvalidLambdaResponseException(v protocol.ResponseMetadata) error {
 	return &InvalidLambdaResponseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21079,18 +21079,18 @@ func (s InvalidLambdaResponseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLambdaResponseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLambdaResponseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the specified OAuth flow is invalid.
 type InvalidOAuthFlowException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21107,7 +21107,7 @@ func (s InvalidOAuthFlowException) GoString() string {
 
 func newErrorInvalidOAuthFlowException(v protocol.ResponseMetadata) error {
 	return &InvalidOAuthFlowException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21135,19 +21135,19 @@ func (s InvalidOAuthFlowException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOAuthFlowException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOAuthFlowException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the Amazon Cognito service encounters an invalid
 // parameter.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the Amazon Cognito service throws an invalid parameter
 	// exception.
@@ -21166,7 +21166,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21194,19 +21194,19 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the Amazon Cognito service encounters an invalid
 // password.
 type InvalidPasswordException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the Amazon Cognito service throws an invalid user
 	// password exception.
@@ -21225,7 +21225,7 @@ func (s InvalidPasswordException) GoString() string {
 
 func newErrorInvalidPasswordException(v protocol.ResponseMetadata) error {
 	return &InvalidPasswordException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21253,19 +21253,19 @@ func (s InvalidPasswordException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPasswordException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPasswordException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is returned when the role provided for SMS configuration does
 // not have permission to publish using Amazon SNS.
 type InvalidSmsRoleAccessPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message retuned when the invalid SMS role access policy exception is
 	// thrown.
@@ -21284,7 +21284,7 @@ func (s InvalidSmsRoleAccessPolicyException) GoString() string {
 
 func newErrorInvalidSmsRoleAccessPolicyException(v protocol.ResponseMetadata) error {
 	return &InvalidSmsRoleAccessPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21312,12 +21312,12 @@ func (s InvalidSmsRoleAccessPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSmsRoleAccessPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSmsRoleAccessPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the trust relationship is invalid for the role
@@ -21326,7 +21326,7 @@ func (s InvalidSmsRoleAccessPolicyException) RequestID() string {
 // the SMS configuration for the user pool.
 type InvalidSmsRoleTrustRelationshipException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the role trust relationship for the SMS message
 	// is invalid.
@@ -21345,7 +21345,7 @@ func (s InvalidSmsRoleTrustRelationshipException) GoString() string {
 
 func newErrorInvalidSmsRoleTrustRelationshipException(v protocol.ResponseMetadata) error {
 	return &InvalidSmsRoleTrustRelationshipException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21373,18 +21373,18 @@ func (s InvalidSmsRoleTrustRelationshipException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSmsRoleTrustRelationshipException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSmsRoleTrustRelationshipException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the user pool configuration is invalid.
 type InvalidUserPoolConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the user pool configuration is invalid.
 	Message_ *string `locationName:"message" type:"string"`
@@ -21402,7 +21402,7 @@ func (s InvalidUserPoolConfigurationException) GoString() string {
 
 func newErrorInvalidUserPoolConfigurationException(v protocol.ResponseMetadata) error {
 	return &InvalidUserPoolConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21430,12 +21430,12 @@ func (s InvalidUserPoolConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidUserPoolConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidUserPoolConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the configuration for AWS Lambda triggers.
@@ -21587,7 +21587,7 @@ func (s *LambdaConfigType) SetVerifyAuthChallengeResponse(v string) *LambdaConfi
 // resource.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when Amazon Cognito throws a limit exceeded exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -21605,7 +21605,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21633,12 +21633,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the request to list the devices.
@@ -22665,7 +22665,7 @@ func (s *ListUsersOutput) SetUsers(v []*UserType) *ListUsersOutput {
 // (MFA) method.
 type MFAMethodNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when Amazon Cognito throws an MFA method not found exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -22683,7 +22683,7 @@ func (s MFAMethodNotFoundException) GoString() string {
 
 func newErrorMFAMethodNotFoundException(v protocol.ResponseMetadata) error {
 	return &MFAMethodNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22711,12 +22711,12 @@ func (s MFAMethodNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MFAMethodNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MFAMethodNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This data type is no longer supported. You can use it only for SMS MFA configurations.
@@ -22870,7 +22870,7 @@ func (s *NewDeviceMetadataType) SetDeviceKey(v string) *NewDeviceMetadataType {
 // This exception is thrown when a user is not authorized.
 type NotAuthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the Amazon Cognito service returns a not authorized
 	// exception.
@@ -22889,7 +22889,7 @@ func (s NotAuthorizedException) GoString() string {
 
 func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 	return &NotAuthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22917,12 +22917,12 @@ func (s NotAuthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotAuthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotAuthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The notify configuration type.
@@ -23228,7 +23228,7 @@ func (s *PasswordPolicyType) SetTemporaryPasswordValidityDays(v int64) *Password
 // This exception is thrown when a password reset is required.
 type PasswordResetRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when a password reset is required.
 	Message_ *string `locationName:"message" type:"string"`
@@ -23246,7 +23246,7 @@ func (s PasswordResetRequiredException) GoString() string {
 
 func newErrorPasswordResetRequiredException(v protocol.ResponseMetadata) error {
 	return &PasswordResetRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23274,18 +23274,18 @@ func (s PasswordResetRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PasswordResetRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PasswordResetRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when a precondition is not met.
 type PreconditionNotMetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when a precondition is not met.
 	Message_ *string `locationName:"message" type:"string"`
@@ -23303,7 +23303,7 @@ func (s PreconditionNotMetException) GoString() string {
 
 func newErrorPreconditionNotMetException(v protocol.ResponseMetadata) error {
 	return &PreconditionNotMetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23331,12 +23331,12 @@ func (s PreconditionNotMetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PreconditionNotMetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PreconditionNotMetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A container for identity provider details.
@@ -23662,7 +23662,7 @@ func (s *ResendConfirmationCodeOutput) SetCodeDeliveryDetails(v *CodeDeliveryDet
 // requested resource.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the Amazon Cognito service returns a resource not
 	// found exception.
@@ -23681,7 +23681,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23709,12 +23709,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A resource server scope.
@@ -24296,7 +24296,7 @@ func (s *SchemaAttributeType) SetStringAttributeConstraints(v *StringAttributeCo
 // This exception is thrown when the specified scope does not exist.
 type ScopeDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -24313,7 +24313,7 @@ func (s ScopeDoesNotExistException) GoString() string {
 
 func newErrorScopeDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &ScopeDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24341,12 +24341,12 @@ func (s ScopeDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ScopeDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ScopeDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SetRiskConfigurationInput struct {
@@ -25200,7 +25200,7 @@ func (s *SmsMfaConfigType) SetSmsConfiguration(v *SmsConfigurationType) *SmsMfaC
 // (MFA) is not enabled for the user pool.
 type SoftwareTokenMFANotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25217,7 +25217,7 @@ func (s SoftwareTokenMFANotFoundException) GoString() string {
 
 func newErrorSoftwareTokenMFANotFoundException(v protocol.ResponseMetadata) error {
 	return &SoftwareTokenMFANotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25245,12 +25245,12 @@ func (s SoftwareTokenMFANotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SoftwareTokenMFANotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SoftwareTokenMFANotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The type used for enabling software token MFA at the user pool level.
@@ -25584,7 +25584,7 @@ func (s TagResourceOutput) GoString() string {
 // for a given action (e.g., sign in).
 type TooManyFailedAttemptsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the Amazon Cognito service returns a too many failed
 	// attempts exception.
@@ -25603,7 +25603,7 @@ func (s TooManyFailedAttemptsException) GoString() string {
 
 func newErrorTooManyFailedAttemptsException(v protocol.ResponseMetadata) error {
 	return &TooManyFailedAttemptsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25631,19 +25631,19 @@ func (s TooManyFailedAttemptsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyFailedAttemptsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyFailedAttemptsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the user has made too many requests for a given
 // operation.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the Amazon Cognito service returns a too many requests
 	// exception.
@@ -25662,7 +25662,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25690,12 +25690,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A container for the UI customization information for a user pool's built-in
@@ -25781,7 +25781,7 @@ func (s *UICustomizationType) SetUserPoolId(v string) *UICustomizationType {
 // exception with the AWS Lambda service.
 type UnexpectedLambdaException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the Amazon Cognito service returns an unexpected
 	// AWS Lambda exception.
@@ -25800,7 +25800,7 @@ func (s UnexpectedLambdaException) GoString() string {
 
 func newErrorUnexpectedLambdaException(v protocol.ResponseMetadata) error {
 	return &UnexpectedLambdaException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25828,18 +25828,18 @@ func (s UnexpectedLambdaException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnexpectedLambdaException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnexpectedLambdaException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the specified identifier is not supported.
 type UnsupportedIdentityProviderException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -25856,7 +25856,7 @@ func (s UnsupportedIdentityProviderException) GoString() string {
 
 func newErrorUnsupportedIdentityProviderException(v protocol.ResponseMetadata) error {
 	return &UnsupportedIdentityProviderException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25884,18 +25884,18 @@ func (s UnsupportedIdentityProviderException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedIdentityProviderException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedIdentityProviderException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request failed because the user is in an unsupported state.
 type UnsupportedUserStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the user is in an unsupported state.
 	Message_ *string `locationName:"message" type:"string"`
@@ -25913,7 +25913,7 @@ func (s UnsupportedUserStateException) GoString() string {
 
 func newErrorUnsupportedUserStateException(v protocol.ResponseMetadata) error {
 	return &UnsupportedUserStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25941,12 +25941,12 @@ func (s UnsupportedUserStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedUserStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedUserStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -27432,7 +27432,7 @@ func (s *UserContextDataType) SetEncodedData(v string) *UserContextDataType {
 // a user import job is in progress for that pool.
 type UserImportInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the user pool has an import job running.
 	Message_ *string `locationName:"message" type:"string"`
@@ -27450,7 +27450,7 @@ func (s UserImportInProgressException) GoString() string {
 
 func newErrorUserImportInProgressException(v protocol.ResponseMetadata) error {
 	return &UserImportInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27478,12 +27478,12 @@ func (s UserImportInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserImportInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserImportInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The user import job type.
@@ -27645,7 +27645,7 @@ func (s *UserImportJobType) SetUserPoolId(v string) *UserImportJobType {
 // validation exception with the AWS Lambda service.
 type UserLambdaValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when the Amazon Cognito service returns a user validation
 	// exception with the AWS Lambda service.
@@ -27664,7 +27664,7 @@ func (s UserLambdaValidationException) GoString() string {
 
 func newErrorUserLambdaValidationException(v protocol.ResponseMetadata) error {
 	return &UserLambdaValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27692,18 +27692,18 @@ func (s UserLambdaValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserLambdaValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserLambdaValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when a user is not confirmed successfully.
 type UserNotConfirmedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when a user is not confirmed successfully.
 	Message_ *string `locationName:"message" type:"string"`
@@ -27721,7 +27721,7 @@ func (s UserNotConfirmedException) GoString() string {
 
 func newErrorUserNotConfirmedException(v protocol.ResponseMetadata) error {
 	return &UserNotConfirmedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27749,18 +27749,18 @@ func (s UserNotConfirmedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserNotConfirmedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserNotConfirmedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when a user is not found.
 type UserNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when a user is not found.
 	Message_ *string `locationName:"message" type:"string"`
@@ -27778,7 +27778,7 @@ func (s UserNotFoundException) GoString() string {
 
 func newErrorUserNotFoundException(v protocol.ResponseMetadata) error {
 	return &UserNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27806,18 +27806,18 @@ func (s UserNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when user pool add-ons are not enabled.
 type UserPoolAddOnNotEnabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27834,7 +27834,7 @@ func (s UserPoolAddOnNotEnabledException) GoString() string {
 
 func newErrorUserPoolAddOnNotEnabledException(v protocol.ResponseMetadata) error {
 	return &UserPoolAddOnNotEnabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27862,12 +27862,12 @@ func (s UserPoolAddOnNotEnabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserPoolAddOnNotEnabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserPoolAddOnNotEnabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The user pool add-ons type.
@@ -28355,7 +28355,7 @@ func (s *UserPoolPolicyType) SetPasswordPolicy(v *PasswordPolicyType) *UserPoolP
 // This exception is thrown when a user pool tag cannot be set or updated.
 type UserPoolTaggingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28372,7 +28372,7 @@ func (s UserPoolTaggingException) GoString() string {
 
 func newErrorUserPoolTaggingException(v protocol.ResponseMetadata) error {
 	return &UserPoolTaggingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28400,12 +28400,12 @@ func (s UserPoolTaggingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserPoolTaggingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserPoolTaggingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A container for information about the user pool.
@@ -28877,7 +28877,7 @@ func (s *UsernameConfigurationType) SetCaseSensitive(v bool) *UsernameConfigurat
 // already exists in the user pool.
 type UsernameExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned when Amazon Cognito throws a user name exists exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -28895,7 +28895,7 @@ func (s UsernameExistsException) GoString() string {
 
 func newErrorUsernameExistsException(v protocol.ResponseMetadata) error {
 	return &UsernameExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28923,12 +28923,12 @@ func (s UsernameExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UsernameExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UsernameExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The template for verification messages.

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -1674,7 +1674,7 @@ func (c *CognitoSync) UpdateRecordsWithContext(ctx aws.Context, input *UpdateRec
 // 24 hours after a previous bulk publish operation completed successfully.
 type AlreadyStreamedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message associated with the AlreadyStreamedException exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1692,7 +1692,7 @@ func (s AlreadyStreamedException) GoString() string {
 
 func newErrorAlreadyStreamedException(v protocol.ResponseMetadata) error {
 	return &AlreadyStreamedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1720,12 +1720,12 @@ func (s AlreadyStreamedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyStreamedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyStreamedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input for the BulkPublish operation.
@@ -1864,7 +1864,7 @@ func (s *CognitoStreams) SetStreamingStatus(v string) *CognitoStreams {
 // Thrown if there are parallel requests to modify a resource.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by a ConcurrentModicationException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1882,7 +1882,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1910,12 +1910,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A collection of data for an identity pool. An identity pool can have multiple
@@ -2373,7 +2373,7 @@ func (s *DescribeIdentityUsageOutput) SetIdentityUsage(v *IdentityUsage) *Descri
 // the given identity pool.
 type DuplicateRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message associated with the DuplicateRequestException exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2391,7 +2391,7 @@ func (s DuplicateRequestException) GoString() string {
 
 func newErrorDuplicateRequestException(v protocol.ResponseMetadata) error {
 	return &DuplicateRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2419,12 +2419,12 @@ func (s DuplicateRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input for the GetBulkPublishDetails operation.
@@ -2812,7 +2812,7 @@ func (s *IdentityUsage) SetLastModifiedDate(v time.Time) *IdentityUsage {
 // Indicates an internal service error.
 type InternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Message returned by InternalErrorException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2830,7 +2830,7 @@ func (s InternalErrorException) GoString() string {
 
 func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 	return &InternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2858,17 +2858,17 @@ func (s InternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvalidConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Message returned by InvalidConfigurationException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2886,7 +2886,7 @@ func (s InvalidConfigurationException) GoString() string {
 
 func newErrorInvalidConfigurationException(v protocol.ResponseMetadata) error {
 	return &InvalidConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2914,18 +2914,18 @@ func (s InvalidConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The AWS Lambda function returned invalid output or an exception.
 type InvalidLambdaFunctionOutputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message returned when an InvalidLambdaFunctionOutputException occurs
 	Message_ *string `locationName:"message" type:"string"`
@@ -2943,7 +2943,7 @@ func (s InvalidLambdaFunctionOutputException) GoString() string {
 
 func newErrorInvalidLambdaFunctionOutputException(v protocol.ResponseMetadata) error {
 	return &InvalidLambdaFunctionOutputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2971,18 +2971,18 @@ func (s InvalidLambdaFunctionOutputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLambdaFunctionOutputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLambdaFunctionOutputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Thrown when a request parameter does not comply with the associated constraints.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Message returned by InvalidParameterException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3000,7 +3000,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3028,18 +3028,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Lambda throttled your account, please contact AWS Support
 type LambdaThrottledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message returned when an LambdaThrottledException is thrown
 	Message_ *string `locationName:"message" type:"string"`
@@ -3057,7 +3057,7 @@ func (s LambdaThrottledException) GoString() string {
 
 func newErrorLambdaThrottledException(v protocol.ResponseMetadata) error {
 	return &LambdaThrottledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3085,18 +3085,18 @@ func (s LambdaThrottledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LambdaThrottledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LambdaThrottledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Thrown when the limit on the number of objects or operations has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Message returned by LimitExceededException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3114,7 +3114,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3142,12 +3142,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Request for a list of datasets for an identity.
@@ -3569,7 +3569,7 @@ func (s *ListRecordsOutput) SetSyncSessionToken(v string) *ListRecordsOutput {
 // Thrown when a user is not authorized to access the requested resource.
 type NotAuthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by a NotAuthorizedException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3587,7 +3587,7 @@ func (s NotAuthorizedException) GoString() string {
 
 func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 	return &NotAuthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3615,12 +3615,12 @@ func (s NotAuthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotAuthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotAuthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Configuration options to be applied to the identity pool.
@@ -3943,7 +3943,7 @@ func (s *RegisterDeviceOutput) SetDeviceId(v string) *RegisterDeviceOutput {
 // another call and this would result in a conflict.
 type ResourceConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message returned by a ResourceConflictException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3961,7 +3961,7 @@ func (s ResourceConflictException) GoString() string {
 
 func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 	return &ResourceConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3989,18 +3989,18 @@ func (s ResourceConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Thrown if the resource doesn't exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Message returned by a ResourceNotFoundException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4018,7 +4018,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4046,12 +4046,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A request to configure Cognito Events"
@@ -4351,7 +4351,7 @@ func (s SubscribeToDatasetOutput) GoString() string {
 // Thrown if the request is throttled.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Message returned by a TooManyRequestsException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4369,7 +4369,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4397,12 +4397,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A request to UnsubscribeFromDataset.

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -1673,8 +1673,8 @@ func (c *CognitoSync) UpdateRecordsWithContext(ctx aws.Context, input *UpdateRec
 // An exception thrown when a bulk publish operation is requested less than
 // 24 hours after a previous bulk publish operation completed successfully.
 type AlreadyStreamedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message associated with the AlreadyStreamedException exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1863,8 +1863,8 @@ func (s *CognitoStreams) SetStreamingStatus(v string) *CognitoStreams {
 
 // Thrown if there are parallel requests to modify a resource.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by a ConcurrentModicationException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2372,8 +2372,8 @@ func (s *DescribeIdentityUsageOutput) SetIdentityUsage(v *IdentityUsage) *Descri
 // An exception thrown when there is an IN_PROGRESS bulk publish operation for
 // the given identity pool.
 type DuplicateRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message associated with the DuplicateRequestException exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2811,8 +2811,8 @@ func (s *IdentityUsage) SetLastModifiedDate(v time.Time) *IdentityUsage {
 
 // Indicates an internal service error.
 type InternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Message returned by InternalErrorException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2867,8 +2867,8 @@ func (s InternalErrorException) RequestID() string {
 }
 
 type InvalidConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Message returned by InvalidConfigurationException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2924,8 +2924,8 @@ func (s InvalidConfigurationException) RequestID() string {
 
 // The AWS Lambda function returned invalid output or an exception.
 type InvalidLambdaFunctionOutputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message returned when an InvalidLambdaFunctionOutputException occurs
 	Message_ *string `locationName:"message" type:"string"`
@@ -2981,8 +2981,8 @@ func (s InvalidLambdaFunctionOutputException) RequestID() string {
 
 // Thrown when a request parameter does not comply with the associated constraints.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Message returned by InvalidParameterException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3038,8 +3038,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // AWS Lambda throttled your account, please contact AWS Support
 type LambdaThrottledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message returned when an LambdaThrottledException is thrown
 	Message_ *string `locationName:"message" type:"string"`
@@ -3095,8 +3095,8 @@ func (s LambdaThrottledException) RequestID() string {
 
 // Thrown when the limit on the number of objects or operations has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Message returned by LimitExceededException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3568,8 +3568,8 @@ func (s *ListRecordsOutput) SetSyncSessionToken(v string) *ListRecordsOutput {
 
 // Thrown when a user is not authorized to access the requested resource.
 type NotAuthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by a NotAuthorizedException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3942,8 +3942,8 @@ func (s *RegisterDeviceOutput) SetDeviceId(v string) *RegisterDeviceOutput {
 // Thrown if an update can't be applied because the resource was changed by
 // another call and this would result in a conflict.
 type ResourceConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message returned by a ResourceConflictException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3999,8 +3999,8 @@ func (s ResourceConflictException) RequestID() string {
 
 // Thrown if the resource doesn't exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Message returned by a ResourceNotFoundException.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4350,8 +4350,8 @@ func (s SubscribeToDatasetOutput) GoString() string {
 
 // Thrown if the request is throttled.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Message returned by a TooManyRequestsException.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/comprehend/api.go
+++ b/service/comprehend/api.go
@@ -5961,7 +5961,7 @@ func (s *BatchItemError) SetIndex(v int64) *BatchItemError {
 // request again with fewer documents.
 type BatchSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -5978,7 +5978,7 @@ func (s BatchSizeLimitExceededException) GoString() string {
 
 func newErrorBatchSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &BatchSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6006,12 +6006,12 @@ func (s BatchSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BatchSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BatchSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the result metrics for the test data associated with an documentation
@@ -6276,7 +6276,7 @@ func (s *ClassifyDocumentOutput) SetLabels(v []*DocumentLabel) *ClassifyDocument
 // resource is not supported.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6293,7 +6293,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6321,12 +6321,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateDocumentClassifierInput struct {
@@ -9974,7 +9974,7 @@ func (s *InputDataConfig) SetS3Uri(v string) *InputDataConfig {
 // An internal server error occurred. Retry your request.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -9991,7 +9991,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10019,18 +10019,18 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The filter specified for the operation is invalid. Specify a different filter.
 type InvalidFilterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -10047,7 +10047,7 @@ func (s InvalidFilterException) GoString() string {
 
 func newErrorInvalidFilterException(v protocol.ResponseMetadata) error {
 	return &InvalidFilterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10075,18 +10075,18 @@ func (s InvalidFilterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFilterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFilterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request is invalid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -10103,7 +10103,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10131,18 +10131,18 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified job was not found. Check the job ID and try again.
 type JobNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -10159,7 +10159,7 @@ func (s JobNotFoundException) GoString() string {
 
 func newErrorJobNotFoundException(v protocol.ResponseMetadata) error {
 	return &JobNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10187,12 +10187,12 @@ func (s JobNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s JobNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s JobNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a key noun phrase.
@@ -10464,7 +10464,7 @@ func (s *KeyPhrasesDetectionJobProperties) SetVpcConfig(v *VpcConfig) *KeyPhrase
 // key and re-enter it.
 type KmsKeyValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -10481,7 +10481,7 @@ func (s KmsKeyValidationException) GoString() string {
 
 func newErrorKmsKeyValidationException(v protocol.ResponseMetadata) error {
 	return &KmsKeyValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10509,12 +10509,12 @@ func (s KmsKeyValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KmsKeyValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KmsKeyValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDocumentClassificationJobsInput struct {
@@ -11549,7 +11549,7 @@ func (s *PartOfSpeechTag) SetTag(v string) *PartOfSpeechTag {
 // again.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -11566,7 +11566,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11594,19 +11594,19 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of recognizers per account has been exceeded. Review the
 // recognizers, perform cleanup, and then try your request again.
 type ResourceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -11623,7 +11623,7 @@ func (s ResourceLimitExceededException) GoString() string {
 
 func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11651,19 +11651,19 @@ func (s ResourceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource ARN was not found. Check the ARN and try your request
 // again.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -11680,7 +11680,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11708,19 +11708,19 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource is not available. Check to see if the resource is
 // in the TRAINED state and try your request again.
 type ResourceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -11737,7 +11737,7 @@ func (s ResourceUnavailableException) GoString() string {
 
 func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ResourceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11765,12 +11765,12 @@ func (s ResourceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information for filtering a list of dominant language detection
@@ -13819,7 +13819,7 @@ func (s TagResourceOutput) GoString() string {
 // The size of the input text exceeds the limit. Use a smaller document.
 type TextSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -13836,7 +13836,7 @@ func (s TextSizeLimitExceededException) GoString() string {
 
 func newErrorTextSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TextSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13864,18 +13864,18 @@ func (s TextSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TextSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TextSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of requests exceeds the limit. Resubmit your request later.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -13892,7 +13892,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13920,19 +13920,19 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request contains more tag keys than can be associated with a resource
 // (50 tag keys per resource).
 type TooManyTagKeysException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -13949,7 +13949,7 @@ func (s TooManyTagKeysException) GoString() string {
 
 func newErrorTooManyTagKeysException(v protocol.ResponseMetadata) error {
 	return &TooManyTagKeysException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13977,12 +13977,12 @@ func (s TooManyTagKeysException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagKeysException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagKeysException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request contains more tags than can be associated with a resource (50
@@ -13990,7 +13990,7 @@ func (s TooManyTagKeysException) RequestID() string {
 // and those included in your current request.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -14007,7 +14007,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14035,12 +14035,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information for filtering topic detection jobs. For more information,
@@ -14256,7 +14256,7 @@ func (s *TopicsDetectionJobProperties) SetVpcConfig(v *VpcConfig) *TopicsDetecti
 // languages, see supported-languages.
 type UnsupportedLanguageException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -14273,7 +14273,7 @@ func (s UnsupportedLanguageException) GoString() string {
 
 func newErrorUnsupportedLanguageException(v protocol.ResponseMetadata) error {
 	return &UnsupportedLanguageException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14301,12 +14301,12 @@ func (s UnsupportedLanguageException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedLanguageException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedLanguageException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/comprehend/api.go
+++ b/service/comprehend/api.go
@@ -5960,8 +5960,8 @@ func (s *BatchItemError) SetIndex(v int64) *BatchItemError {
 // The number of documents in the request exceeds the limit of 25. Try your
 // request again with fewer documents.
 type BatchSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6275,8 +6275,8 @@ func (s *ClassifyDocumentOutput) SetLabels(v []*DocumentLabel) *ClassifyDocument
 // Concurrent modification of the tags associated with an Amazon Comprehend
 // resource is not supported.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -9973,8 +9973,8 @@ func (s *InputDataConfig) SetS3Uri(v string) *InputDataConfig {
 
 // An internal server error occurred. Retry your request.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -10029,8 +10029,8 @@ func (s InternalServerException) RequestID() string {
 
 // The filter specified for the operation is invalid. Specify a different filter.
 type InvalidFilterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -10085,8 +10085,8 @@ func (s InvalidFilterException) RequestID() string {
 
 // The request is invalid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -10141,8 +10141,8 @@ func (s InvalidRequestException) RequestID() string {
 
 // The specified job was not found. Check the job ID and try again.
 type JobNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -10463,8 +10463,8 @@ func (s *KeyPhrasesDetectionJobProperties) SetVpcConfig(v *VpcConfig) *KeyPhrase
 // The KMS customer managed key (CMK) entered cannot be validated. Verify the
 // key and re-enter it.
 type KmsKeyValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -11548,8 +11548,8 @@ func (s *PartOfSpeechTag) SetTag(v string) *PartOfSpeechTag {
 // The specified name is already in use. Use a different name and try your request
 // again.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -11605,8 +11605,8 @@ func (s ResourceInUseException) RequestID() string {
 // The maximum number of recognizers per account has been exceeded. Review the
 // recognizers, perform cleanup, and then try your request again.
 type ResourceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -11662,8 +11662,8 @@ func (s ResourceLimitExceededException) RequestID() string {
 // The specified resource ARN was not found. Check the ARN and try your request
 // again.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -11719,8 +11719,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // The specified resource is not available. Check to see if the resource is
 // in the TRAINED state and try your request again.
 type ResourceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -13818,8 +13818,8 @@ func (s TagResourceOutput) GoString() string {
 
 // The size of the input text exceeds the limit. Use a smaller document.
 type TextSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -13874,8 +13874,8 @@ func (s TextSizeLimitExceededException) RequestID() string {
 
 // The number of requests exceeds the limit. Resubmit your request later.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -13931,8 +13931,8 @@ func (s TooManyRequestsException) RequestID() string {
 // The request contains more tag keys than can be associated with a resource
 // (50 tag keys per resource).
 type TooManyTagKeysException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -13989,8 +13989,8 @@ func (s TooManyTagKeysException) RequestID() string {
 // tags per resource). The maximum number of tags includes both existing tags
 // and those included in your current request.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -14255,8 +14255,8 @@ func (s *TopicsDetectionJobProperties) SetVpcConfig(v *VpcConfig) *TopicsDetecti
 // Comprehend accepts text in all supported languages. For a list of supported
 // languages, see supported-languages.
 type UnsupportedLanguageException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/comprehendmedical/api.go
+++ b/service/comprehendmedical/api.go
@@ -2673,8 +2673,8 @@ func (s *InputDataConfig) SetS3Key(v string) *InputDataConfig {
 
 // An internal server error occurred. Retry your request.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2730,8 +2730,8 @@ func (s InternalServerException) RequestID() string {
 // The input text was not in valid UTF-8 character encoding. Check your text
 // then retry your request.
 type InvalidEncodingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2787,8 +2787,8 @@ func (s InvalidEncodingException) RequestID() string {
 // The request that you made is invalid. Check your request to determine why
 // it's invalid and then retry the request.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3092,8 +3092,8 @@ func (s *OutputDataConfig) SetS3Key(v string) *OutputDataConfig {
 // The resource identified by the specified Amazon Resource Name (ARN) was not
 // found. Check the ARN and try your request again.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3441,8 +3441,8 @@ func (s *RxNormTrait) SetScore(v float64) *RxNormTrait {
 // The Amazon Comprehend Medical service is temporarily unavailable. Please
 // wait and then retry your request.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3942,8 +3942,8 @@ func (s *StopPHIDetectionJobOutput) SetJobId(v string) *StopPHIDetectionJobOutpu
 // The size of the text you submitted exceeds the size limit. Reduce the size
 // of the text or use a smaller document and then retry your request.
 type TextSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -4000,8 +4000,8 @@ func (s TextSizeLimitExceededException) RequestID() string {
 // short time and then try your request again. Contact customer support for
 // more information about a service limit increase.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -4125,8 +4125,8 @@ func (s *UnmappedAttribute) SetType(v string) *UnmappedAttribute {
 // The filter that you specified for the operation is invalid. Check the filter
 // values that you entered and try your request again.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/comprehendmedical/api.go
+++ b/service/comprehendmedical/api.go
@@ -2674,7 +2674,7 @@ func (s *InputDataConfig) SetS3Key(v string) *InputDataConfig {
 // An internal server error occurred. Retry your request.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2691,7 +2691,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2719,19 +2719,19 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input text was not in valid UTF-8 character encoding. Check your text
 // then retry your request.
 type InvalidEncodingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2748,7 +2748,7 @@ func (s InvalidEncodingException) GoString() string {
 
 func newErrorInvalidEncodingException(v protocol.ResponseMetadata) error {
 	return &InvalidEncodingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2776,19 +2776,19 @@ func (s InvalidEncodingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEncodingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEncodingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request that you made is invalid. Check your request to determine why
 // it's invalid and then retry the request.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2805,7 +2805,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2833,12 +2833,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListEntitiesDetectionV2JobsInput struct {
@@ -3093,7 +3093,7 @@ func (s *OutputDataConfig) SetS3Key(v string) *OutputDataConfig {
 // found. Check the ARN and try your request again.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3110,7 +3110,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3138,12 +3138,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The extracted attributes that relate to this entity. The attributes recognized
@@ -3442,7 +3442,7 @@ func (s *RxNormTrait) SetScore(v float64) *RxNormTrait {
 // wait and then retry your request.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3459,7 +3459,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3487,12 +3487,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartEntitiesDetectionV2JobInput struct {
@@ -3943,7 +3943,7 @@ func (s *StopPHIDetectionJobOutput) SetJobId(v string) *StopPHIDetectionJobOutpu
 // of the text or use a smaller document and then retry your request.
 type TextSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3960,7 +3960,7 @@ func (s TextSizeLimitExceededException) GoString() string {
 
 func newErrorTextSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TextSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3988,12 +3988,12 @@ func (s TextSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TextSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TextSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have made too many requests within a short period of time. Wait for a
@@ -4001,7 +4001,7 @@ func (s TextSizeLimitExceededException) RequestID() string {
 // more information about a service limit increase.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -4018,7 +4018,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4046,12 +4046,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides contextual information about the extracted entity.
@@ -4126,7 +4126,7 @@ func (s *UnmappedAttribute) SetType(v string) *UnmappedAttribute {
 // values that you entered and try your request again.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -4143,7 +4143,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4171,12 +4171,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/computeoptimizer/api.go
+++ b/service/computeoptimizer/api.go
@@ -638,7 +638,7 @@ func (c *ComputeOptimizer) UpdateEnrollmentStatusWithContext(ctx aws.Context, in
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -655,7 +655,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -683,12 +683,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the configuration of an Auto Scaling group.
@@ -1683,7 +1683,7 @@ func (s *InstanceRecommendationOption) SetRank(v int64) *InstanceRecommendationO
 // or failure.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1700,7 +1700,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1728,18 +1728,18 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid or out-of-range value was supplied for the input parameter.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1756,7 +1756,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1784,19 +1784,19 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request must contain either a valid (registered) AWS access key ID or
 // X.509 certificate.
 type MissingAuthenticationToken struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1813,7 +1813,7 @@ func (s MissingAuthenticationToken) GoString() string {
 
 func newErrorMissingAuthenticationToken(v protocol.ResponseMetadata) error {
 	return &MissingAuthenticationToken{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1841,18 +1841,18 @@ func (s MissingAuthenticationToken) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MissingAuthenticationToken) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MissingAuthenticationToken) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You must opt in to the service to perform this action.
 type OptInRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1869,7 +1869,7 @@ func (s OptInRequiredException) GoString() string {
 
 func newErrorOptInRequiredException(v protocol.ResponseMetadata) error {
 	return &OptInRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1897,12 +1897,12 @@ func (s OptInRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OptInRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OptInRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a projected utilization metric of a recommendation option, such
@@ -2079,7 +2079,7 @@ func (s *RecommendedOptionProjectedMetric) SetRecommendedInstanceType(v string) 
 // The specified resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2096,7 +2096,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2124,18 +2124,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request has failed due to a temporary failure of the server.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2152,7 +2152,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2180,12 +2180,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The summary of a recommendation.
@@ -2224,7 +2224,7 @@ func (s *Summary) SetValue(v float64) *Summary {
 // The limit on the number of requests per second was exceeded.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2241,7 +2241,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2269,12 +2269,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateEnrollmentStatusInput struct {

--- a/service/computeoptimizer/api.go
+++ b/service/computeoptimizer/api.go
@@ -637,8 +637,8 @@ func (c *ComputeOptimizer) UpdateEnrollmentStatusWithContext(ctx aws.Context, in
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1682,8 +1682,8 @@ func (s *InstanceRecommendationOption) SetRank(v int64) *InstanceRecommendationO
 // The request processing has failed because of an unknown error, exception,
 // or failure.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1738,8 +1738,8 @@ func (s InternalServerException) RequestID() string {
 
 // An invalid or out-of-range value was supplied for the input parameter.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1795,8 +1795,8 @@ func (s InvalidParameterValueException) RequestID() string {
 // The request must contain either a valid (registered) AWS access key ID or
 // X.509 certificate.
 type MissingAuthenticationToken struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1851,8 +1851,8 @@ func (s MissingAuthenticationToken) RequestID() string {
 
 // You must opt in to the service to perform this action.
 type OptInRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2078,8 +2078,8 @@ func (s *RecommendedOptionProjectedMetric) SetRecommendedInstanceType(v string) 
 
 // The specified resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2134,8 +2134,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The request has failed due to a temporary failure of the server.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2223,8 +2223,8 @@ func (s *Summary) SetValue(v float64) *Summary {
 
 // The limit on the number of requests per second was exceeded.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -10602,8 +10602,8 @@ func (s *ConformancePackStatusDetail) SetStackArn(v string) *ConformancePackStat
 
 // You have specified a template that is not valid or supported.
 type ConformancePackTemplateValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15624,8 +15624,8 @@ func (s *GroupedResourceCount) SetResourceCount(v int64) *GroupedResourceCount {
 
 // Your Amazon S3 bucket policy does not permit AWS Config to write to it.
 type InsufficientDeliveryPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15694,8 +15694,8 @@ func (s InsufficientDeliveryPolicyException) RequestID() string {
 //    pack cannot be created because you do not have permissions: To call IAM
 //    GetRole action or create a service linked role. To read Amazon S3 bucket.
 type InsufficientPermissionsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15750,8 +15750,8 @@ func (s InsufficientPermissionsException) RequestID() string {
 
 // You have provided a configuration recorder name that is not valid.
 type InvalidConfigurationRecorderNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15806,8 +15806,8 @@ func (s InvalidConfigurationRecorderNameException) RequestID() string {
 
 // The specified delivery channel name is not valid.
 type InvalidDeliveryChannelNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15862,8 +15862,8 @@ func (s InvalidDeliveryChannelNameException) RequestID() string {
 
 // The syntax of the query is incorrect.
 type InvalidExpressionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15918,8 +15918,8 @@ func (s InvalidExpressionException) RequestID() string {
 
 // The specified limit is outside the allowable range.
 type InvalidLimitException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15975,8 +15975,8 @@ func (s InvalidLimitException) RequestID() string {
 // The specified next token is invalid. Specify the nextToken string that was
 // returned in the previous response to get the next page of results.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16032,8 +16032,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // One or more of the specified parameters are invalid. Verify that your parameters
 // are valid and try again.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16089,8 +16089,8 @@ func (s InvalidParameterValueException) RequestID() string {
 // AWS Config throws an exception if the recording group does not contain a
 // valid list of resource types. Invalid values might also be incorrectly formatted.
 type InvalidRecordingGroupException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16145,8 +16145,8 @@ func (s InvalidRecordingGroupException) RequestID() string {
 
 // The specified ResultToken is invalid.
 type InvalidResultTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16201,8 +16201,8 @@ func (s InvalidResultTokenException) RequestID() string {
 
 // You have provided a null or empty role ARN.
 type InvalidRoleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16257,8 +16257,8 @@ func (s InvalidRoleException) RequestID() string {
 
 // The specified Amazon S3 key prefix is not valid.
 type InvalidS3KeyPrefixException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16313,8 +16313,8 @@ func (s InvalidS3KeyPrefixException) RequestID() string {
 
 // The specified Amazon SNS topic does not exist.
 type InvalidSNSTopicARNException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16370,8 +16370,8 @@ func (s InvalidSNSTopicARNException) RequestID() string {
 // The specified time range is not valid. The earlier time is not chronologically
 // before the later time.
 type InvalidTimeRangeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16427,8 +16427,8 @@ func (s InvalidTimeRangeException) RequestID() string {
 // You cannot delete the delivery channel you specified because the configuration
 // recorder is running.
 type LastDeliveryChannelDeleteFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16488,8 +16488,8 @@ func (s LastDeliveryChannelDeleteFailedException) RequestID() string {
 // For PutConfigurationAggregator API, this exception is thrown if the number
 // of accounts and aggregators exceeds the limit.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16890,8 +16890,8 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 // You have reached the limit (100,000) of active custom resource types in your
 // account. Delete unused resources using DeleteResourceConfig.
 type MaxActiveResourcesExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16948,8 +16948,8 @@ func (s MaxActiveResourcesExceededException) RequestID() string {
 // maximum number of 150 rules. Consider deleting any deactivated rules before
 // you add new rules.
 type MaxNumberOfConfigRulesExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17004,8 +17004,8 @@ func (s MaxNumberOfConfigRulesExceededException) RequestID() string {
 
 // You have reached the limit of the number of recorders you can create.
 type MaxNumberOfConfigurationRecordersExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17061,8 +17061,8 @@ func (s MaxNumberOfConfigurationRecordersExceededException) RequestID() string {
 // You have reached the limit (6) of the number of conformance packs in an account
 // (6 conformance pack with 25 AWS Config rules per pack).
 type MaxNumberOfConformancePacksExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17117,8 +17117,8 @@ func (s MaxNumberOfConformancePacksExceededException) RequestID() string {
 
 // You have reached the limit of the number of delivery channels you can create.
 type MaxNumberOfDeliveryChannelsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17174,8 +17174,8 @@ func (s MaxNumberOfDeliveryChannelsExceededException) RequestID() string {
 // You have reached the limit of the number of organization config rules you
 // can create.
 type MaxNumberOfOrganizationConfigRulesExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17232,8 +17232,8 @@ func (s MaxNumberOfOrganizationConfigRulesExceededException) RequestID() string 
 // packs in an account (6 conformance pack with 25 AWS Config rules per pack
 // per account).
 type MaxNumberOfOrganizationConformancePacksExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17289,8 +17289,8 @@ func (s MaxNumberOfOrganizationConformancePacksExceededException) RequestID() st
 // Failed to add the retention configuration because a retention configuration
 // with that name already exists.
 type MaxNumberOfRetentionConfigurationsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17450,8 +17450,8 @@ func (s *MemberAccountStatus) SetMemberAccountRuleStatus(v string) *MemberAccoun
 // There are no configuration recorders available to provide the role needed
 // to describe your resources. Create a configuration recorder.
 type NoAvailableConfigurationRecorderException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17506,8 +17506,8 @@ func (s NoAvailableConfigurationRecorderException) RequestID() string {
 
 // There is no delivery channel available to record configurations.
 type NoAvailableDeliveryChannelException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17562,8 +17562,8 @@ func (s NoAvailableDeliveryChannelException) RequestID() string {
 
 // Organization is no longer available.
 type NoAvailableOrganizationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17618,8 +17618,8 @@ func (s NoAvailableOrganizationException) RequestID() string {
 
 // There is no configuration recorder running.
 type NoRunningConfigurationRecorderException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17674,8 +17674,8 @@ func (s NoRunningConfigurationRecorderException) RequestID() string {
 
 // The specified Amazon S3 bucket does not exist.
 type NoSuchBucketException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17731,8 +17731,8 @@ func (s NoSuchBucketException) RequestID() string {
 // One or more AWS Config rules in the request are invalid. Verify that the
 // rule names are correct and try again.
 type NoSuchConfigRuleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17787,8 +17787,8 @@ func (s NoSuchConfigRuleException) RequestID() string {
 
 // AWS Config rule that you passed in the filter does not exist.
 type NoSuchConfigRuleInConformancePackException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17843,8 +17843,8 @@ func (s NoSuchConfigRuleInConformancePackException) RequestID() string {
 
 // You have specified a configuration aggregator that does not exist.
 type NoSuchConfigurationAggregatorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17899,8 +17899,8 @@ func (s NoSuchConfigurationAggregatorException) RequestID() string {
 
 // You have specified a configuration recorder that does not exist.
 type NoSuchConfigurationRecorderException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17955,8 +17955,8 @@ func (s NoSuchConfigurationRecorderException) RequestID() string {
 
 // You specified one or more conformance packs that do not exist.
 type NoSuchConformancePackException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18011,8 +18011,8 @@ func (s NoSuchConformancePackException) RequestID() string {
 
 // You have specified a delivery channel that does not exist.
 type NoSuchDeliveryChannelException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18067,8 +18067,8 @@ func (s NoSuchDeliveryChannelException) RequestID() string {
 
 // You specified one or more organization config rules that do not exist.
 type NoSuchOrganizationConfigRuleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18127,8 +18127,8 @@ func (s NoSuchOrganizationConfigRuleException) RequestID() string {
 // For DeleteOrganizationConformancePack, you tried to delete an organization
 // conformance pack that does not exist.
 type NoSuchOrganizationConformancePackException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18183,8 +18183,8 @@ func (s NoSuchOrganizationConformancePackException) RequestID() string {
 
 // You specified an AWS Config rule without a remediation configuration.
 type NoSuchRemediationConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18239,8 +18239,8 @@ func (s NoSuchRemediationConfigurationException) RequestID() string {
 
 // You tried to delete a remediation exception that does not exist.
 type NoSuchRemediationExceptionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18295,8 +18295,8 @@ func (s NoSuchRemediationExceptionException) RequestID() string {
 
 // You have specified a retention configuration that does not exist.
 type NoSuchRetentionConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18356,8 +18356,8 @@ func (s NoSuchRetentionConfigurationException) RequestID() string {
 // Config throws an exception if APIs are called from member accounts. All APIs
 // must be called from organization master account.
 type OrganizationAccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18475,8 +18475,8 @@ func (s *OrganizationAggregationSource) SetRoleArn(v string) *OrganizationAggreg
 // AWS Config resource cannot be created because your organization does not
 // have all features enabled.
 type OrganizationAllFeaturesNotEnabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19009,8 +19009,8 @@ func (s *OrganizationConformancePackStatus) SetStatus(v string) *OrganizationCon
 
 // You have specified a template that is not valid or supported.
 type OrganizationConformancePackTemplateValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19420,8 +19420,8 @@ func (s *OrganizationResourceDetailedStatusFilters) SetStatus(v string) *Organiz
 
 // The configuration item size is outside the allowable range.
 type OversizedConfigurationItemException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21409,8 +21409,8 @@ func (s *RemediationExecutionStep) SetStopTime(v time.Time) *RemediationExecutio
 // Remediation action is in progress. You can either cancel execution in AWS
 // Systems Manager or wait and try again later.
 type RemediationInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21751,8 +21751,8 @@ func (s *ResourceIdentifier) SetResourceType(v string) *ResourceIdentifier {
 //    * For DeleteConformancePack, a conformance pack creation, update, and
 //    deletion is in progress. Try your request again later.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21864,8 +21864,8 @@ func (s *ResourceKey) SetResourceType(v string) *ResourceKey {
 
 // You have specified a resource that is either unknown or has not been discovered.
 type ResourceNotDiscoveredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21920,8 +21920,8 @@ func (s ResourceNotDiscoveredException) RequestID() string {
 
 // You have specified a resource that does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23074,8 +23074,8 @@ func (s TagResourceOutput) GoString() string {
 // You have reached the limit of the number of tags you can use. You have more
 // than 50 tags.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23204,8 +23204,8 @@ func (s UntagResourceOutput) GoString() string {
 
 // The requested action is not valid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -10603,7 +10603,7 @@ func (s *ConformancePackStatusDetail) SetStackArn(v string) *ConformancePackStat
 // You have specified a template that is not valid or supported.
 type ConformancePackTemplateValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10620,7 +10620,7 @@ func (s ConformancePackTemplateValidationException) GoString() string {
 
 func newErrorConformancePackTemplateValidationException(v protocol.ResponseMetadata) error {
 	return &ConformancePackTemplateValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10648,12 +10648,12 @@ func (s ConformancePackTemplateValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConformancePackTemplateValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConformancePackTemplateValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteAggregationAuthorizationInput struct {
@@ -15625,7 +15625,7 @@ func (s *GroupedResourceCount) SetResourceCount(v int64) *GroupedResourceCount {
 // Your Amazon S3 bucket policy does not permit AWS Config to write to it.
 type InsufficientDeliveryPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15642,7 +15642,7 @@ func (s InsufficientDeliveryPolicyException) GoString() string {
 
 func newErrorInsufficientDeliveryPolicyException(v protocol.ResponseMetadata) error {
 	return &InsufficientDeliveryPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15670,12 +15670,12 @@ func (s InsufficientDeliveryPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientDeliveryPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientDeliveryPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates one of the following errors:
@@ -15695,7 +15695,7 @@ func (s InsufficientDeliveryPolicyException) RequestID() string {
 //    GetRole action or create a service linked role. To read Amazon S3 bucket.
 type InsufficientPermissionsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15712,7 +15712,7 @@ func (s InsufficientPermissionsException) GoString() string {
 
 func newErrorInsufficientPermissionsException(v protocol.ResponseMetadata) error {
 	return &InsufficientPermissionsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15740,18 +15740,18 @@ func (s InsufficientPermissionsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientPermissionsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientPermissionsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have provided a configuration recorder name that is not valid.
 type InvalidConfigurationRecorderNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15768,7 +15768,7 @@ func (s InvalidConfigurationRecorderNameException) GoString() string {
 
 func newErrorInvalidConfigurationRecorderNameException(v protocol.ResponseMetadata) error {
 	return &InvalidConfigurationRecorderNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15796,18 +15796,18 @@ func (s InvalidConfigurationRecorderNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidConfigurationRecorderNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidConfigurationRecorderNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified delivery channel name is not valid.
 type InvalidDeliveryChannelNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15824,7 +15824,7 @@ func (s InvalidDeliveryChannelNameException) GoString() string {
 
 func newErrorInvalidDeliveryChannelNameException(v protocol.ResponseMetadata) error {
 	return &InvalidDeliveryChannelNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15852,18 +15852,18 @@ func (s InvalidDeliveryChannelNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeliveryChannelNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeliveryChannelNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The syntax of the query is incorrect.
 type InvalidExpressionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15880,7 +15880,7 @@ func (s InvalidExpressionException) GoString() string {
 
 func newErrorInvalidExpressionException(v protocol.ResponseMetadata) error {
 	return &InvalidExpressionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15908,18 +15908,18 @@ func (s InvalidExpressionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidExpressionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidExpressionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified limit is outside the allowable range.
 type InvalidLimitException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15936,7 +15936,7 @@ func (s InvalidLimitException) GoString() string {
 
 func newErrorInvalidLimitException(v protocol.ResponseMetadata) error {
 	return &InvalidLimitException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15964,19 +15964,19 @@ func (s InvalidLimitException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLimitException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLimitException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified next token is invalid. Specify the nextToken string that was
 // returned in the previous response to get the next page of results.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15993,7 +15993,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16021,19 +16021,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more of the specified parameters are invalid. Verify that your parameters
 // are valid and try again.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16050,7 +16050,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16078,19 +16078,19 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Config throws an exception if the recording group does not contain a
 // valid list of resource types. Invalid values might also be incorrectly formatted.
 type InvalidRecordingGroupException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16107,7 +16107,7 @@ func (s InvalidRecordingGroupException) GoString() string {
 
 func newErrorInvalidRecordingGroupException(v protocol.ResponseMetadata) error {
 	return &InvalidRecordingGroupException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16135,18 +16135,18 @@ func (s InvalidRecordingGroupException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRecordingGroupException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRecordingGroupException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified ResultToken is invalid.
 type InvalidResultTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16163,7 +16163,7 @@ func (s InvalidResultTokenException) GoString() string {
 
 func newErrorInvalidResultTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidResultTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16191,18 +16191,18 @@ func (s InvalidResultTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResultTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResultTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have provided a null or empty role ARN.
 type InvalidRoleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16219,7 +16219,7 @@ func (s InvalidRoleException) GoString() string {
 
 func newErrorInvalidRoleException(v protocol.ResponseMetadata) error {
 	return &InvalidRoleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16247,18 +16247,18 @@ func (s InvalidRoleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRoleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRoleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified Amazon S3 key prefix is not valid.
 type InvalidS3KeyPrefixException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16275,7 +16275,7 @@ func (s InvalidS3KeyPrefixException) GoString() string {
 
 func newErrorInvalidS3KeyPrefixException(v protocol.ResponseMetadata) error {
 	return &InvalidS3KeyPrefixException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16303,18 +16303,18 @@ func (s InvalidS3KeyPrefixException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidS3KeyPrefixException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidS3KeyPrefixException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified Amazon SNS topic does not exist.
 type InvalidSNSTopicARNException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16331,7 +16331,7 @@ func (s InvalidSNSTopicARNException) GoString() string {
 
 func newErrorInvalidSNSTopicARNException(v protocol.ResponseMetadata) error {
 	return &InvalidSNSTopicARNException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16359,19 +16359,19 @@ func (s InvalidSNSTopicARNException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSNSTopicARNException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSNSTopicARNException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified time range is not valid. The earlier time is not chronologically
 // before the later time.
 type InvalidTimeRangeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16388,7 +16388,7 @@ func (s InvalidTimeRangeException) GoString() string {
 
 func newErrorInvalidTimeRangeException(v protocol.ResponseMetadata) error {
 	return &InvalidTimeRangeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16416,19 +16416,19 @@ func (s InvalidTimeRangeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTimeRangeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTimeRangeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You cannot delete the delivery channel you specified because the configuration
 // recorder is running.
 type LastDeliveryChannelDeleteFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16445,7 +16445,7 @@ func (s LastDeliveryChannelDeleteFailedException) GoString() string {
 
 func newErrorLastDeliveryChannelDeleteFailedException(v protocol.ResponseMetadata) error {
 	return &LastDeliveryChannelDeleteFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16473,12 +16473,12 @@ func (s LastDeliveryChannelDeleteFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LastDeliveryChannelDeleteFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LastDeliveryChannelDeleteFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // For StartConfigRulesEvaluation API, this exception is thrown if an evaluation
@@ -16489,7 +16489,7 @@ func (s LastDeliveryChannelDeleteFailedException) RequestID() string {
 // of accounts and aggregators exceeds the limit.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16506,7 +16506,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16534,12 +16534,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAggregateDiscoveredResourcesInput struct {
@@ -16891,7 +16891,7 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 // account. Delete unused resources using DeleteResourceConfig.
 type MaxActiveResourcesExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16908,7 +16908,7 @@ func (s MaxActiveResourcesExceededException) GoString() string {
 
 func newErrorMaxActiveResourcesExceededException(v protocol.ResponseMetadata) error {
 	return &MaxActiveResourcesExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16936,12 +16936,12 @@ func (s MaxActiveResourcesExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxActiveResourcesExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxActiveResourcesExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Failed to add the AWS Config rule because the account already contains the
@@ -16949,7 +16949,7 @@ func (s MaxActiveResourcesExceededException) RequestID() string {
 // you add new rules.
 type MaxNumberOfConfigRulesExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16966,7 +16966,7 @@ func (s MaxNumberOfConfigRulesExceededException) GoString() string {
 
 func newErrorMaxNumberOfConfigRulesExceededException(v protocol.ResponseMetadata) error {
 	return &MaxNumberOfConfigRulesExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16994,18 +16994,18 @@ func (s MaxNumberOfConfigRulesExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxNumberOfConfigRulesExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxNumberOfConfigRulesExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have reached the limit of the number of recorders you can create.
 type MaxNumberOfConfigurationRecordersExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17022,7 +17022,7 @@ func (s MaxNumberOfConfigurationRecordersExceededException) GoString() string {
 
 func newErrorMaxNumberOfConfigurationRecordersExceededException(v protocol.ResponseMetadata) error {
 	return &MaxNumberOfConfigurationRecordersExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17050,19 +17050,19 @@ func (s MaxNumberOfConfigurationRecordersExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxNumberOfConfigurationRecordersExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxNumberOfConfigurationRecordersExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have reached the limit (6) of the number of conformance packs in an account
 // (6 conformance pack with 25 AWS Config rules per pack).
 type MaxNumberOfConformancePacksExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17079,7 +17079,7 @@ func (s MaxNumberOfConformancePacksExceededException) GoString() string {
 
 func newErrorMaxNumberOfConformancePacksExceededException(v protocol.ResponseMetadata) error {
 	return &MaxNumberOfConformancePacksExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17107,18 +17107,18 @@ func (s MaxNumberOfConformancePacksExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxNumberOfConformancePacksExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxNumberOfConformancePacksExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have reached the limit of the number of delivery channels you can create.
 type MaxNumberOfDeliveryChannelsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17135,7 +17135,7 @@ func (s MaxNumberOfDeliveryChannelsExceededException) GoString() string {
 
 func newErrorMaxNumberOfDeliveryChannelsExceededException(v protocol.ResponseMetadata) error {
 	return &MaxNumberOfDeliveryChannelsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17163,19 +17163,19 @@ func (s MaxNumberOfDeliveryChannelsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxNumberOfDeliveryChannelsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxNumberOfDeliveryChannelsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have reached the limit of the number of organization config rules you
 // can create.
 type MaxNumberOfOrganizationConfigRulesExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17192,7 +17192,7 @@ func (s MaxNumberOfOrganizationConfigRulesExceededException) GoString() string {
 
 func newErrorMaxNumberOfOrganizationConfigRulesExceededException(v protocol.ResponseMetadata) error {
 	return &MaxNumberOfOrganizationConfigRulesExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17220,12 +17220,12 @@ func (s MaxNumberOfOrganizationConfigRulesExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxNumberOfOrganizationConfigRulesExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxNumberOfOrganizationConfigRulesExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have reached the limit (6) of the number of organization conformance
@@ -17233,7 +17233,7 @@ func (s MaxNumberOfOrganizationConfigRulesExceededException) RequestID() string 
 // per account).
 type MaxNumberOfOrganizationConformancePacksExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17250,7 +17250,7 @@ func (s MaxNumberOfOrganizationConformancePacksExceededException) GoString() str
 
 func newErrorMaxNumberOfOrganizationConformancePacksExceededException(v protocol.ResponseMetadata) error {
 	return &MaxNumberOfOrganizationConformancePacksExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17278,19 +17278,19 @@ func (s MaxNumberOfOrganizationConformancePacksExceededException) Error() string
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxNumberOfOrganizationConformancePacksExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxNumberOfOrganizationConformancePacksExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Failed to add the retention configuration because a retention configuration
 // with that name already exists.
 type MaxNumberOfRetentionConfigurationsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17307,7 +17307,7 @@ func (s MaxNumberOfRetentionConfigurationsExceededException) GoString() string {
 
 func newErrorMaxNumberOfRetentionConfigurationsExceededException(v protocol.ResponseMetadata) error {
 	return &MaxNumberOfRetentionConfigurationsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17335,12 +17335,12 @@ func (s MaxNumberOfRetentionConfigurationsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxNumberOfRetentionConfigurationsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxNumberOfRetentionConfigurationsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Organization config rule creation or deletion status in each member account.
@@ -17451,7 +17451,7 @@ func (s *MemberAccountStatus) SetMemberAccountRuleStatus(v string) *MemberAccoun
 // to describe your resources. Create a configuration recorder.
 type NoAvailableConfigurationRecorderException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17468,7 +17468,7 @@ func (s NoAvailableConfigurationRecorderException) GoString() string {
 
 func newErrorNoAvailableConfigurationRecorderException(v protocol.ResponseMetadata) error {
 	return &NoAvailableConfigurationRecorderException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17496,18 +17496,18 @@ func (s NoAvailableConfigurationRecorderException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoAvailableConfigurationRecorderException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoAvailableConfigurationRecorderException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There is no delivery channel available to record configurations.
 type NoAvailableDeliveryChannelException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17524,7 +17524,7 @@ func (s NoAvailableDeliveryChannelException) GoString() string {
 
 func newErrorNoAvailableDeliveryChannelException(v protocol.ResponseMetadata) error {
 	return &NoAvailableDeliveryChannelException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17552,18 +17552,18 @@ func (s NoAvailableDeliveryChannelException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoAvailableDeliveryChannelException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoAvailableDeliveryChannelException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Organization is no longer available.
 type NoAvailableOrganizationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17580,7 +17580,7 @@ func (s NoAvailableOrganizationException) GoString() string {
 
 func newErrorNoAvailableOrganizationException(v protocol.ResponseMetadata) error {
 	return &NoAvailableOrganizationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17608,18 +17608,18 @@ func (s NoAvailableOrganizationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoAvailableOrganizationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoAvailableOrganizationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There is no configuration recorder running.
 type NoRunningConfigurationRecorderException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17636,7 +17636,7 @@ func (s NoRunningConfigurationRecorderException) GoString() string {
 
 func newErrorNoRunningConfigurationRecorderException(v protocol.ResponseMetadata) error {
 	return &NoRunningConfigurationRecorderException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17664,18 +17664,18 @@ func (s NoRunningConfigurationRecorderException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoRunningConfigurationRecorderException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoRunningConfigurationRecorderException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified Amazon S3 bucket does not exist.
 type NoSuchBucketException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17692,7 +17692,7 @@ func (s NoSuchBucketException) GoString() string {
 
 func newErrorNoSuchBucketException(v protocol.ResponseMetadata) error {
 	return &NoSuchBucketException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17720,19 +17720,19 @@ func (s NoSuchBucketException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchBucketException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchBucketException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more AWS Config rules in the request are invalid. Verify that the
 // rule names are correct and try again.
 type NoSuchConfigRuleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17749,7 +17749,7 @@ func (s NoSuchConfigRuleException) GoString() string {
 
 func newErrorNoSuchConfigRuleException(v protocol.ResponseMetadata) error {
 	return &NoSuchConfigRuleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17777,18 +17777,18 @@ func (s NoSuchConfigRuleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchConfigRuleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchConfigRuleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Config rule that you passed in the filter does not exist.
 type NoSuchConfigRuleInConformancePackException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17805,7 +17805,7 @@ func (s NoSuchConfigRuleInConformancePackException) GoString() string {
 
 func newErrorNoSuchConfigRuleInConformancePackException(v protocol.ResponseMetadata) error {
 	return &NoSuchConfigRuleInConformancePackException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17833,18 +17833,18 @@ func (s NoSuchConfigRuleInConformancePackException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchConfigRuleInConformancePackException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchConfigRuleInConformancePackException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have specified a configuration aggregator that does not exist.
 type NoSuchConfigurationAggregatorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17861,7 +17861,7 @@ func (s NoSuchConfigurationAggregatorException) GoString() string {
 
 func newErrorNoSuchConfigurationAggregatorException(v protocol.ResponseMetadata) error {
 	return &NoSuchConfigurationAggregatorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17889,18 +17889,18 @@ func (s NoSuchConfigurationAggregatorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchConfigurationAggregatorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchConfigurationAggregatorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have specified a configuration recorder that does not exist.
 type NoSuchConfigurationRecorderException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17917,7 +17917,7 @@ func (s NoSuchConfigurationRecorderException) GoString() string {
 
 func newErrorNoSuchConfigurationRecorderException(v protocol.ResponseMetadata) error {
 	return &NoSuchConfigurationRecorderException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17945,18 +17945,18 @@ func (s NoSuchConfigurationRecorderException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchConfigurationRecorderException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchConfigurationRecorderException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You specified one or more conformance packs that do not exist.
 type NoSuchConformancePackException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17973,7 +17973,7 @@ func (s NoSuchConformancePackException) GoString() string {
 
 func newErrorNoSuchConformancePackException(v protocol.ResponseMetadata) error {
 	return &NoSuchConformancePackException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18001,18 +18001,18 @@ func (s NoSuchConformancePackException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchConformancePackException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchConformancePackException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have specified a delivery channel that does not exist.
 type NoSuchDeliveryChannelException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18029,7 +18029,7 @@ func (s NoSuchDeliveryChannelException) GoString() string {
 
 func newErrorNoSuchDeliveryChannelException(v protocol.ResponseMetadata) error {
 	return &NoSuchDeliveryChannelException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18057,18 +18057,18 @@ func (s NoSuchDeliveryChannelException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchDeliveryChannelException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchDeliveryChannelException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You specified one or more organization config rules that do not exist.
 type NoSuchOrganizationConfigRuleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18085,7 +18085,7 @@ func (s NoSuchOrganizationConfigRuleException) GoString() string {
 
 func newErrorNoSuchOrganizationConfigRuleException(v protocol.ResponseMetadata) error {
 	return &NoSuchOrganizationConfigRuleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18113,12 +18113,12 @@ func (s NoSuchOrganizationConfigRuleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchOrganizationConfigRuleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchOrganizationConfigRuleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Config organization conformance pack that you passed in the filter does
@@ -18128,7 +18128,7 @@ func (s NoSuchOrganizationConfigRuleException) RequestID() string {
 // conformance pack that does not exist.
 type NoSuchOrganizationConformancePackException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18145,7 +18145,7 @@ func (s NoSuchOrganizationConformancePackException) GoString() string {
 
 func newErrorNoSuchOrganizationConformancePackException(v protocol.ResponseMetadata) error {
 	return &NoSuchOrganizationConformancePackException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18173,18 +18173,18 @@ func (s NoSuchOrganizationConformancePackException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchOrganizationConformancePackException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchOrganizationConformancePackException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You specified an AWS Config rule without a remediation configuration.
 type NoSuchRemediationConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18201,7 +18201,7 @@ func (s NoSuchRemediationConfigurationException) GoString() string {
 
 func newErrorNoSuchRemediationConfigurationException(v protocol.ResponseMetadata) error {
 	return &NoSuchRemediationConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18229,18 +18229,18 @@ func (s NoSuchRemediationConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchRemediationConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchRemediationConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You tried to delete a remediation exception that does not exist.
 type NoSuchRemediationExceptionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18257,7 +18257,7 @@ func (s NoSuchRemediationExceptionException) GoString() string {
 
 func newErrorNoSuchRemediationExceptionException(v protocol.ResponseMetadata) error {
 	return &NoSuchRemediationExceptionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18285,18 +18285,18 @@ func (s NoSuchRemediationExceptionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchRemediationExceptionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchRemediationExceptionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have specified a retention configuration that does not exist.
 type NoSuchRetentionConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18313,7 +18313,7 @@ func (s NoSuchRetentionConfigurationException) GoString() string {
 
 func newErrorNoSuchRetentionConfigurationException(v protocol.ResponseMetadata) error {
 	return &NoSuchRetentionConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18341,12 +18341,12 @@ func (s NoSuchRetentionConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchRetentionConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchRetentionConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // For PutConfigAggregator API, no permission to call EnableAWSServiceAccess
@@ -18357,7 +18357,7 @@ func (s NoSuchRetentionConfigurationException) RequestID() string {
 // must be called from organization master account.
 type OrganizationAccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18374,7 +18374,7 @@ func (s OrganizationAccessDeniedException) GoString() string {
 
 func newErrorOrganizationAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &OrganizationAccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18402,12 +18402,12 @@ func (s OrganizationAccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationAccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationAccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This object contains regions to set up the aggregator and an IAM role to
@@ -18476,7 +18476,7 @@ func (s *OrganizationAggregationSource) SetRoleArn(v string) *OrganizationAggreg
 // have all features enabled.
 type OrganizationAllFeaturesNotEnabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18493,7 +18493,7 @@ func (s OrganizationAllFeaturesNotEnabledException) GoString() string {
 
 func newErrorOrganizationAllFeaturesNotEnabledException(v protocol.ResponseMetadata) error {
 	return &OrganizationAllFeaturesNotEnabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18521,12 +18521,12 @@ func (s OrganizationAllFeaturesNotEnabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationAllFeaturesNotEnabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationAllFeaturesNotEnabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An organization config rule that has information about config rules that
@@ -19010,7 +19010,7 @@ func (s *OrganizationConformancePackStatus) SetStatus(v string) *OrganizationCon
 // You have specified a template that is not valid or supported.
 type OrganizationConformancePackTemplateValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19027,7 +19027,7 @@ func (s OrganizationConformancePackTemplateValidationException) GoString() strin
 
 func newErrorOrganizationConformancePackTemplateValidationException(v protocol.ResponseMetadata) error {
 	return &OrganizationConformancePackTemplateValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19055,12 +19055,12 @@ func (s OrganizationConformancePackTemplateValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationConformancePackTemplateValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationConformancePackTemplateValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that specifies organization custom rule metadata such as resource
@@ -19421,7 +19421,7 @@ func (s *OrganizationResourceDetailedStatusFilters) SetStatus(v string) *Organiz
 // The configuration item size is outside the allowable range.
 type OversizedConfigurationItemException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19438,7 +19438,7 @@ func (s OversizedConfigurationItemException) GoString() string {
 
 func newErrorOversizedConfigurationItemException(v protocol.ResponseMetadata) error {
 	return &OversizedConfigurationItemException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19466,12 +19466,12 @@ func (s OversizedConfigurationItemException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OversizedConfigurationItemException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OversizedConfigurationItemException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that represents the account ID and region of an aggregator account
@@ -21410,7 +21410,7 @@ func (s *RemediationExecutionStep) SetStopTime(v time.Time) *RemediationExecutio
 // Systems Manager or wait and try again later.
 type RemediationInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21427,7 +21427,7 @@ func (s RemediationInProgressException) GoString() string {
 
 func newErrorRemediationInProgressException(v protocol.ResponseMetadata) error {
 	return &RemediationInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21455,12 +21455,12 @@ func (s RemediationInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RemediationInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RemediationInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The value is either a dynamic (resource) value or a static value. You must
@@ -21752,7 +21752,7 @@ func (s *ResourceIdentifier) SetResourceType(v string) *ResourceIdentifier {
 //    deletion is in progress. Try your request again later.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21769,7 +21769,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21797,12 +21797,12 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The details that identify a resource within AWS Config, including the resource
@@ -21865,7 +21865,7 @@ func (s *ResourceKey) SetResourceType(v string) *ResourceKey {
 // You have specified a resource that is either unknown or has not been discovered.
 type ResourceNotDiscoveredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21882,7 +21882,7 @@ func (s ResourceNotDiscoveredException) GoString() string {
 
 func newErrorResourceNotDiscoveredException(v protocol.ResponseMetadata) error {
 	return &ResourceNotDiscoveredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21910,18 +21910,18 @@ func (s ResourceNotDiscoveredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotDiscoveredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotDiscoveredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have specified a resource that does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21938,7 +21938,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21966,12 +21966,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The dynamic value of the resource.
@@ -23075,7 +23075,7 @@ func (s TagResourceOutput) GoString() string {
 // than 50 tags.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23092,7 +23092,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23120,12 +23120,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -23205,7 +23205,7 @@ func (s UntagResourceOutput) GoString() string {
 // The requested action is not valid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23222,7 +23222,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23250,12 +23250,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/connect/api.go
+++ b/service/connect/api.go
@@ -3409,7 +3409,7 @@ func (s *ContactFlowSummary) SetName(v string) *ContactFlowSummary {
 // The contact with the specified ID is not active or does not exist.
 type ContactNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -3427,7 +3427,7 @@ func (s ContactNotFoundException) GoString() string {
 
 func newErrorContactNotFoundException(v protocol.ResponseMetadata) error {
 	return &ContactNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3455,12 +3455,12 @@ func (s ContactNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ContactNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ContactNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateUserInput struct {
@@ -4122,7 +4122,7 @@ func (s *DescribeUserOutput) SetUser(v *User) *DescribeUserOutput {
 // Outbound calls to the destination number are not allowed.
 type DestinationNotAllowedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -4140,7 +4140,7 @@ func (s DestinationNotAllowedException) GoString() string {
 
 func newErrorDestinationNotAllowedException(v protocol.ResponseMetadata) error {
 	return &DestinationNotAllowedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4168,12 +4168,12 @@ func (s DestinationNotAllowedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DestinationNotAllowedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DestinationNotAllowedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about the dimensions for a set of metrics.
@@ -4212,7 +4212,7 @@ func (s *Dimensions) SetQueue(v *QueueReference) *Dimensions {
 // A resource with the specified name already exists.
 type DuplicateResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4229,7 +4229,7 @@ func (s DuplicateResourceException) GoString() string {
 
 func newErrorDuplicateResourceException(v protocol.ResponseMetadata) error {
 	return &DuplicateResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4257,12 +4257,12 @@ func (s DuplicateResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the filter to apply when retrieving metrics.
@@ -5443,7 +5443,7 @@ func (s *HoursOfOperationSummary) SetName(v string) *HoursOfOperationSummary {
 // Request processing failed due to an error or failure with the service.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5461,7 +5461,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5489,18 +5489,18 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more of the specified parameters are not valid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5518,7 +5518,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5546,18 +5546,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request is not valid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5575,7 +5575,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5603,18 +5603,18 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The allowed limit for the resource has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5632,7 +5632,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5660,12 +5660,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListContactFlowsInput struct {
@@ -6531,7 +6531,7 @@ func (s *ListUsersOutput) SetUserSummaryList(v []*UserSummary) *ListUsersOutput 
 // The contact is not permitted.
 type OutboundContactNotPermittedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6549,7 +6549,7 @@ func (s OutboundContactNotPermittedException) GoString() string {
 
 func newErrorOutboundContactNotPermittedException(v protocol.ResponseMetadata) error {
 	return &OutboundContactNotPermittedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6577,12 +6577,12 @@ func (s OutboundContactNotPermittedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OutboundContactNotPermittedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OutboundContactNotPermittedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The customer's details.
@@ -6774,7 +6774,7 @@ func (s *QueueSummary) SetQueueType(v string) *QueueSummary {
 // The specified resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6792,7 +6792,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6820,12 +6820,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains summary information about a routing profile.
@@ -7389,7 +7389,7 @@ func (s *Threshold) SetThresholdValue(v float64) *Threshold {
 // The throttling limit has been exceeded.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7406,7 +7406,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7434,12 +7434,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -8212,7 +8212,7 @@ func (s *UserIdentityInfo) SetLastName(v string) *UserIdentityInfo {
 // No user with the specified credentials was found in the Amazon Connect instance.
 type UserNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8229,7 +8229,7 @@ func (s UserNotFoundException) GoString() string {
 
 func newErrorUserNotFoundException(v protocol.ResponseMetadata) error {
 	return &UserNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8257,12 +8257,12 @@ func (s UserNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about the phone configuration settings for a user.

--- a/service/connect/api.go
+++ b/service/connect/api.go
@@ -3408,8 +3408,8 @@ func (s *ContactFlowSummary) SetName(v string) *ContactFlowSummary {
 
 // The contact with the specified ID is not active or does not exist.
 type ContactNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -4121,8 +4121,8 @@ func (s *DescribeUserOutput) SetUser(v *User) *DescribeUserOutput {
 
 // Outbound calls to the destination number are not allowed.
 type DestinationNotAllowedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -4211,8 +4211,8 @@ func (s *Dimensions) SetQueue(v *QueueReference) *Dimensions {
 
 // A resource with the specified name already exists.
 type DuplicateResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5442,8 +5442,8 @@ func (s *HoursOfOperationSummary) SetName(v string) *HoursOfOperationSummary {
 
 // Request processing failed due to an error or failure with the service.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5499,8 +5499,8 @@ func (s InternalServiceException) RequestID() string {
 
 // One or more of the specified parameters are not valid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5556,8 +5556,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // The request is not valid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5613,8 +5613,8 @@ func (s InvalidRequestException) RequestID() string {
 
 // The allowed limit for the resource has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6530,8 +6530,8 @@ func (s *ListUsersOutput) SetUserSummaryList(v []*UserSummary) *ListUsersOutput 
 
 // The contact is not permitted.
 type OutboundContactNotPermittedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6773,8 +6773,8 @@ func (s *QueueSummary) SetQueueType(v string) *QueueSummary {
 
 // The specified resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -7388,8 +7388,8 @@ func (s *Threshold) SetThresholdValue(v float64) *Threshold {
 
 // The throttling limit has been exceeded.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8211,8 +8211,8 @@ func (s *UserIdentityInfo) SetLastName(v string) *UserIdentityInfo {
 
 // No user with the specified credentials was found in the Amazon Connect instance.
 type UserNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/connectparticipant/api.go
+++ b/service/connectparticipant/api.go
@@ -539,8 +539,8 @@ func (c *ConnectParticipant) SendMessageWithContext(ctx aws.Context, input *Send
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -939,8 +939,8 @@ func (s *GetTranscriptOutput) SetTranscript(v []*Item) *GetTranscriptOutput {
 // This exception occurs when there is an internal failure in the Amazon Connect
 // service.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1387,8 +1387,8 @@ func (s *StartPosition) SetMostRecent(v int64) *StartPosition {
 
 // The request was denied due to request throttling.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1443,8 +1443,8 @@ func (s ThrottlingException) RequestID() string {
 
 // The input fails to satisfy the constraints specified by Amazon Connect.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/connectparticipant/api.go
+++ b/service/connectparticipant/api.go
@@ -540,7 +540,7 @@ func (c *ConnectParticipant) SendMessageWithContext(ctx aws.Context, input *Send
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -557,7 +557,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -585,12 +585,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Connection credentials.
@@ -940,7 +940,7 @@ func (s *GetTranscriptOutput) SetTranscript(v []*Item) *GetTranscriptOutput {
 // service.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -957,7 +957,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -985,12 +985,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An item - message or event - that has been sent.
@@ -1388,7 +1388,7 @@ func (s *StartPosition) SetMostRecent(v int64) *StartPosition {
 // The request was denied due to request throttling.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1405,7 +1405,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1433,18 +1433,18 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input fails to satisfy the constraints specified by Amazon Connect.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1461,7 +1461,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1489,12 +1489,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The websocket for the participant's connection.

--- a/service/costandusagereportservice/api.go
+++ b/service/costandusagereportservice/api.go
@@ -540,8 +540,8 @@ func (s *DescribeReportDefinitionsOutput) SetReportDefinitions(v []*ReportDefini
 // A report with the specified name already exists in the account. Specify a
 // different report name.
 type DuplicateReportNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message to show the detail of the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -598,8 +598,8 @@ func (s DuplicateReportNameException) RequestID() string {
 // An error on the server occurred during the processing of your request. Try
 // again later.
 type InternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message to show the detail of the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -964,8 +964,8 @@ func (s *ReportDefinition) SetTimeUnit(v string) *ReportDefinition {
 // This account already has five reports defined. To define a new report, you
 // must delete an existing report.
 type ReportLimitReachedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message to show the detail of the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -1021,8 +1021,8 @@ func (s ReportLimitReachedException) RequestID() string {
 
 // The input fails to satisfy the constraints specified by an AWS service.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message to show the detail of the exception.
 	Message_ *string `locationName:"Message" type:"string"`

--- a/service/costandusagereportservice/api.go
+++ b/service/costandusagereportservice/api.go
@@ -541,7 +541,7 @@ func (s *DescribeReportDefinitionsOutput) SetReportDefinitions(v []*ReportDefini
 // different report name.
 type DuplicateReportNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message to show the detail of the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -559,7 +559,7 @@ func (s DuplicateReportNameException) GoString() string {
 
 func newErrorDuplicateReportNameException(v protocol.ResponseMetadata) error {
 	return &DuplicateReportNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -587,19 +587,19 @@ func (s DuplicateReportNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateReportNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateReportNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An error on the server occurred during the processing of your request. Try
 // again later.
 type InternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message to show the detail of the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -617,7 +617,7 @@ func (s InternalErrorException) GoString() string {
 
 func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 	return &InternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -645,12 +645,12 @@ func (s InternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ModifyReportDefinitionInput struct {
@@ -965,7 +965,7 @@ func (s *ReportDefinition) SetTimeUnit(v string) *ReportDefinition {
 // must delete an existing report.
 type ReportLimitReachedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message to show the detail of the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -983,7 +983,7 @@ func (s ReportLimitReachedException) GoString() string {
 
 func newErrorReportLimitReachedException(v protocol.ResponseMetadata) error {
 	return &ReportLimitReachedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1011,18 +1011,18 @@ func (s ReportLimitReachedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReportLimitReachedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReportLimitReachedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input fails to satisfy the constraints specified by an AWS service.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message to show the detail of the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -1040,7 +1040,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1068,12 +1068,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The region of the S3 bucket that AWS delivers the report into.

--- a/service/costexplorer/api.go
+++ b/service/costexplorer/api.go
@@ -1899,7 +1899,7 @@ func (c *CostExplorer) UpdateCostCategoryDefinitionWithContext(ctx aws.Context, 
 // The requested report expired. Update the date interval and try again.
 type BillExpirationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1916,7 +1916,7 @@ func (s BillExpirationException) GoString() string {
 
 func newErrorBillExpirationException(v protocol.ResponseMetadata) error {
 	return &BillExpirationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1944,12 +1944,12 @@ func (s BillExpirationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BillExpirationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BillExpirationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 //
@@ -2679,7 +2679,7 @@ func (s *CurrentInstance) SetTotalRunningHoursInLookbackPeriod(v string) *Curren
 // The requested data is unavailable.
 type DataUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2696,7 +2696,7 @@ func (s DataUnavailableException) GoString() string {
 
 func newErrorDataUnavailableException(v protocol.ResponseMetadata) error {
 	return &DataUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2724,12 +2724,12 @@ func (s DataUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DataUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DataUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The time period that you want the usage and costs for.
@@ -6089,7 +6089,7 @@ func (s *InstanceDetails) SetRedshiftInstanceDetails(v *RedshiftInstanceDetails)
 // The pagination token is invalid. Try again without a pagination token.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6106,7 +6106,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6134,18 +6134,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You made too many calls in a short period of time. Try again later.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6162,7 +6162,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6190,12 +6190,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListCostCategoryDefinitionsInput struct {
@@ -6503,7 +6503,7 @@ func (s *RedshiftInstanceDetails) SetSizeFlexEligible(v bool) *RedshiftInstanceD
 // or without a pagination token.
 type RequestChangedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6520,7 +6520,7 @@ func (s RequestChangedException) GoString() string {
 
 func newErrorRequestChangedException(v protocol.ResponseMetadata) error {
 	return &RequestChangedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6548,12 +6548,12 @@ func (s RequestChangedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestChangedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestChangedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The aggregated numbers for your reservation usage.
@@ -7177,7 +7177,7 @@ func (s *ResourceDetails) SetEC2ResourceDetails(v *EC2ResourceDetails) *Resource
 // The specified ARN in the request doesn't exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7194,7 +7194,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7222,12 +7222,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Resource utilization of current resource.
@@ -8318,7 +8318,7 @@ func (s *SavingsPlansUtilizationDetail) SetUtilization(v *SavingsPlansUtilizatio
 // the size of an individual resources.
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8335,7 +8335,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8363,12 +8363,12 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Hardware specifications for the service that you want recommendations for.
@@ -8538,7 +8538,7 @@ func (s *TerminateRecommendationDetail) SetEstimatedMonthlySavings(v string) *Te
 // filter selections that contain matching units, for example: hours.
 type UnresolvableUsageUnitException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8555,7 +8555,7 @@ func (s UnresolvableUsageUnitException) GoString() string {
 
 func newErrorUnresolvableUsageUnitException(v protocol.ResponseMetadata) error {
 	return &UnresolvableUsageUnitException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8583,12 +8583,12 @@ func (s UnresolvableUsageUnitException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnresolvableUsageUnitException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnresolvableUsageUnitException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateCostCategoryDefinitionInput struct {

--- a/service/costexplorer/api.go
+++ b/service/costexplorer/api.go
@@ -1898,8 +1898,8 @@ func (c *CostExplorer) UpdateCostCategoryDefinitionWithContext(ctx aws.Context, 
 
 // The requested report expired. Update the date interval and try again.
 type BillExpirationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2678,8 +2678,8 @@ func (s *CurrentInstance) SetTotalRunningHoursInLookbackPeriod(v string) *Curren
 
 // The requested data is unavailable.
 type DataUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6088,8 +6088,8 @@ func (s *InstanceDetails) SetRedshiftInstanceDetails(v *RedshiftInstanceDetails)
 
 // The pagination token is invalid. Try again without a pagination token.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6144,8 +6144,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // You made too many calls in a short period of time. Try again later.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6502,8 +6502,8 @@ func (s *RedshiftInstanceDetails) SetSizeFlexEligible(v bool) *RedshiftInstanceD
 // Your request parameters changed between pages. Try again with the old parameters
 // or without a pagination token.
 type RequestChangedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7176,8 +7176,8 @@ func (s *ResourceDetails) SetEC2ResourceDetails(v *EC2ResourceDetails) *Resource
 
 // The specified ARN in the request doesn't exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8317,8 +8317,8 @@ func (s *SavingsPlansUtilizationDetail) SetUtilization(v *SavingsPlansUtilizatio
 // You've reached the limit on the number of resources you can create, or exceeded
 // the size of an individual resources.
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8537,8 +8537,8 @@ func (s *TerminateRecommendationDetail) SetEstimatedMonthlySavings(v string) *Te
 // Cost Explorer was unable to identify the usage unit. Provide UsageType/UsageTypeGroup
 // filter selections that contain matching units, for example: hours.
 type UnresolvableUsageUnitException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/databasemigrationservice/api.go
+++ b/service/databasemigrationservice/api.go
@@ -4951,8 +4951,8 @@ func (c *DatabaseMigrationService) TestConnectionWithContext(ctx aws.Context, in
 // AWS DMS was denied access to the endpoint. Check that the role is correctly
 // configured.
 type AccessDeniedFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9485,8 +9485,8 @@ func (s *ImportCertificateOutput) SetCertificate(v *Certificate) *ImportCertific
 
 // There are not enough resources allocated to the database migration.
 type InsufficientResourceCapacityFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9541,8 +9541,8 @@ func (s InsufficientResourceCapacityFault) RequestID() string {
 
 // The certificate was not valid.
 type InvalidCertificateFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9598,8 +9598,8 @@ func (s InvalidCertificateFault) RequestID() string {
 // The resource is in a state that prevents it from being used for database
 // migration.
 type InvalidResourceStateFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9654,8 +9654,8 @@ func (s InvalidResourceStateFault) RequestID() string {
 
 // The subnet provided is invalid.
 type InvalidSubnet struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9711,8 +9711,8 @@ func (s InvalidSubnet) RequestID() string {
 // The ciphertext references a key that doesn't exist or that the DMS account
 // doesn't have access to.
 type KMSAccessDeniedFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9767,8 +9767,8 @@ func (s KMSAccessDeniedFault) RequestID() string {
 
 // The specified master key (CMK) isn't enabled.
 type KMSDisabledFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9823,8 +9823,8 @@ func (s KMSDisabledFault) RequestID() string {
 
 // The state of the specified AWS KMS resource isn't valid for this request.
 type KMSInvalidStateFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9879,8 +9879,8 @@ func (s KMSInvalidStateFault) RequestID() string {
 
 // AWS DMS cannot access the AWS KMS key.
 type KMSKeyNotAccessibleFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9935,8 +9935,8 @@ func (s KMSKeyNotAccessibleFault) RequestID() string {
 
 // The specified AWS KMS entity or resource can't be found.
 type KMSNotFoundFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9991,8 +9991,8 @@ func (s KMSNotFoundFault) RequestID() string {
 
 // This request triggered AWS KMS request throttling.
 type KMSThrottlingFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12501,8 +12501,8 @@ func (s *ReplicationSubnetGroup) SetVpcId(v string) *ReplicationSubnetGroup {
 // The replication subnet group does not cover enough Availability Zones (AZs).
 // Edit the replication subnet group and add more AZs.
 type ReplicationSubnetGroupDoesNotCoverEnoughAZs struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12949,8 +12949,8 @@ func (s *ReplicationTaskStats) SetTablesQueued(v int64) *ReplicationTaskStats {
 
 // The resource you are attempting to create already exists.
 type ResourceAlreadyExistsFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -13007,8 +13007,8 @@ func (s ResourceAlreadyExistsFault) RequestID() string {
 
 // The resource could not be found.
 type ResourceNotFoundFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13099,8 +13099,8 @@ func (s *ResourcePendingMaintenanceActions) SetResourceIdentifier(v string) *Res
 
 // The quota for this resource quota has been exceeded.
 type ResourceQuotaExceededFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13529,8 +13529,8 @@ func (s *S3Settings) SetTimestampColumnName(v string) *S3Settings {
 
 // The SNS topic is invalid.
 type SNSInvalidTopicFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13585,8 +13585,8 @@ func (s SNSInvalidTopicFault) RequestID() string {
 
 // You are not authorized for the SNS subscription.
 type SNSNoAuthorizationFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13891,8 +13891,8 @@ func (s *StopReplicationTaskOutput) SetReplicationTask(v *ReplicationTask) *Stop
 
 // The storage quota has been exceeded.
 type StorageQuotaExceededFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13991,8 +13991,8 @@ func (s *Subnet) SetSubnetStatus(v string) *Subnet {
 
 // The specified subnet is already in use.
 type SubnetAlreadyInUse struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14477,8 +14477,8 @@ func (s *TestConnectionOutput) SetConnection(v *Connection) *TestConnectionOutpu
 
 // An upgrade dependency is preventing the database migration.
 type UpgradeDependencyFailureFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/databasemigrationservice/api.go
+++ b/service/databasemigrationservice/api.go
@@ -4952,7 +4952,7 @@ func (c *DatabaseMigrationService) TestConnectionWithContext(ctx aws.Context, in
 // configured.
 type AccessDeniedFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4969,7 +4969,7 @@ func (s AccessDeniedFault) GoString() string {
 
 func newErrorAccessDeniedFault(v protocol.ResponseMetadata) error {
 	return &AccessDeniedFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4997,12 +4997,12 @@ func (s AccessDeniedFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a quota for an AWS account, for example, the number of replication
@@ -9486,7 +9486,7 @@ func (s *ImportCertificateOutput) SetCertificate(v *Certificate) *ImportCertific
 // There are not enough resources allocated to the database migration.
 type InsufficientResourceCapacityFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9503,7 +9503,7 @@ func (s InsufficientResourceCapacityFault) GoString() string {
 
 func newErrorInsufficientResourceCapacityFault(v protocol.ResponseMetadata) error {
 	return &InsufficientResourceCapacityFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9531,18 +9531,18 @@ func (s InsufficientResourceCapacityFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientResourceCapacityFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientResourceCapacityFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The certificate was not valid.
 type InvalidCertificateFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9559,7 +9559,7 @@ func (s InvalidCertificateFault) GoString() string {
 
 func newErrorInvalidCertificateFault(v protocol.ResponseMetadata) error {
 	return &InvalidCertificateFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9587,19 +9587,19 @@ func (s InvalidCertificateFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCertificateFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCertificateFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource is in a state that prevents it from being used for database
 // migration.
 type InvalidResourceStateFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9616,7 +9616,7 @@ func (s InvalidResourceStateFault) GoString() string {
 
 func newErrorInvalidResourceStateFault(v protocol.ResponseMetadata) error {
 	return &InvalidResourceStateFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9644,18 +9644,18 @@ func (s InvalidResourceStateFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceStateFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceStateFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The subnet provided is invalid.
 type InvalidSubnet struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9672,7 +9672,7 @@ func (s InvalidSubnet) GoString() string {
 
 func newErrorInvalidSubnet(v protocol.ResponseMetadata) error {
 	return &InvalidSubnet{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9700,19 +9700,19 @@ func (s InvalidSubnet) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSubnet) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSubnet) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The ciphertext references a key that doesn't exist or that the DMS account
 // doesn't have access to.
 type KMSAccessDeniedFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9729,7 +9729,7 @@ func (s KMSAccessDeniedFault) GoString() string {
 
 func newErrorKMSAccessDeniedFault(v protocol.ResponseMetadata) error {
 	return &KMSAccessDeniedFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9757,18 +9757,18 @@ func (s KMSAccessDeniedFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSAccessDeniedFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSAccessDeniedFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified master key (CMK) isn't enabled.
 type KMSDisabledFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9785,7 +9785,7 @@ func (s KMSDisabledFault) GoString() string {
 
 func newErrorKMSDisabledFault(v protocol.ResponseMetadata) error {
 	return &KMSDisabledFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9813,18 +9813,18 @@ func (s KMSDisabledFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSDisabledFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSDisabledFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The state of the specified AWS KMS resource isn't valid for this request.
 type KMSInvalidStateFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9841,7 +9841,7 @@ func (s KMSInvalidStateFault) GoString() string {
 
 func newErrorKMSInvalidStateFault(v protocol.ResponseMetadata) error {
 	return &KMSInvalidStateFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9869,18 +9869,18 @@ func (s KMSInvalidStateFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSInvalidStateFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSInvalidStateFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS DMS cannot access the AWS KMS key.
 type KMSKeyNotAccessibleFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9897,7 +9897,7 @@ func (s KMSKeyNotAccessibleFault) GoString() string {
 
 func newErrorKMSKeyNotAccessibleFault(v protocol.ResponseMetadata) error {
 	return &KMSKeyNotAccessibleFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9925,18 +9925,18 @@ func (s KMSKeyNotAccessibleFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSKeyNotAccessibleFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSKeyNotAccessibleFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified AWS KMS entity or resource can't be found.
 type KMSNotFoundFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9953,7 +9953,7 @@ func (s KMSNotFoundFault) GoString() string {
 
 func newErrorKMSNotFoundFault(v protocol.ResponseMetadata) error {
 	return &KMSNotFoundFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9981,18 +9981,18 @@ func (s KMSNotFoundFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSNotFoundFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSNotFoundFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This request triggered AWS KMS request throttling.
 type KMSThrottlingFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10009,7 +10009,7 @@ func (s KMSThrottlingFault) GoString() string {
 
 func newErrorKMSThrottlingFault(v protocol.ResponseMetadata) error {
 	return &KMSThrottlingFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10037,12 +10037,12 @@ func (s KMSThrottlingFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSThrottlingFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSThrottlingFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information that describes an Apache Kafka endpoint. This information
@@ -12502,7 +12502,7 @@ func (s *ReplicationSubnetGroup) SetVpcId(v string) *ReplicationSubnetGroup {
 // Edit the replication subnet group and add more AZs.
 type ReplicationSubnetGroupDoesNotCoverEnoughAZs struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12519,7 +12519,7 @@ func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) GoString() string {
 
 func newErrorReplicationSubnetGroupDoesNotCoverEnoughAZs(v protocol.ResponseMetadata) error {
 	return &ReplicationSubnetGroupDoesNotCoverEnoughAZs{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12547,12 +12547,12 @@ func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReplicationSubnetGroupDoesNotCoverEnoughAZs) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information that describes a replication task created by the CreateReplicationTask
@@ -12950,7 +12950,7 @@ func (s *ReplicationTaskStats) SetTablesQueued(v int64) *ReplicationTaskStats {
 // The resource you are attempting to create already exists.
 type ResourceAlreadyExistsFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -12969,7 +12969,7 @@ func (s ResourceAlreadyExistsFault) GoString() string {
 
 func newErrorResourceAlreadyExistsFault(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12997,18 +12997,18 @@ func (s ResourceAlreadyExistsFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource could not be found.
 type ResourceNotFoundFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13025,7 +13025,7 @@ func (s ResourceNotFoundFault) GoString() string {
 
 func newErrorResourceNotFoundFault(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13053,12 +13053,12 @@ func (s ResourceNotFoundFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Identifies an AWS DMS resource and any pending actions for it.
@@ -13100,7 +13100,7 @@ func (s *ResourcePendingMaintenanceActions) SetResourceIdentifier(v string) *Res
 // The quota for this resource quota has been exceeded.
 type ResourceQuotaExceededFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13117,7 +13117,7 @@ func (s ResourceQuotaExceededFault) GoString() string {
 
 func newErrorResourceQuotaExceededFault(v protocol.ResponseMetadata) error {
 	return &ResourceQuotaExceededFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13145,12 +13145,12 @@ func (s ResourceQuotaExceededFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceQuotaExceededFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceQuotaExceededFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Settings for exporting data to Amazon S3.
@@ -13530,7 +13530,7 @@ func (s *S3Settings) SetTimestampColumnName(v string) *S3Settings {
 // The SNS topic is invalid.
 type SNSInvalidTopicFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13547,7 +13547,7 @@ func (s SNSInvalidTopicFault) GoString() string {
 
 func newErrorSNSInvalidTopicFault(v protocol.ResponseMetadata) error {
 	return &SNSInvalidTopicFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13575,18 +13575,18 @@ func (s SNSInvalidTopicFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SNSInvalidTopicFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SNSInvalidTopicFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You are not authorized for the SNS subscription.
 type SNSNoAuthorizationFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13603,7 +13603,7 @@ func (s SNSNoAuthorizationFault) GoString() string {
 
 func newErrorSNSNoAuthorizationFault(v protocol.ResponseMetadata) error {
 	return &SNSNoAuthorizationFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13631,12 +13631,12 @@ func (s SNSNoAuthorizationFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SNSNoAuthorizationFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SNSNoAuthorizationFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartReplicationTaskAssessmentInput struct {
@@ -13892,7 +13892,7 @@ func (s *StopReplicationTaskOutput) SetReplicationTask(v *ReplicationTask) *Stop
 // The storage quota has been exceeded.
 type StorageQuotaExceededFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13909,7 +13909,7 @@ func (s StorageQuotaExceededFault) GoString() string {
 
 func newErrorStorageQuotaExceededFault(v protocol.ResponseMetadata) error {
 	return &StorageQuotaExceededFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13937,12 +13937,12 @@ func (s StorageQuotaExceededFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StorageQuotaExceededFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StorageQuotaExceededFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // In response to a request by the DescribeReplicationSubnetGroup operation,
@@ -13992,7 +13992,7 @@ func (s *Subnet) SetSubnetStatus(v string) *Subnet {
 // The specified subnet is already in use.
 type SubnetAlreadyInUse struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14009,7 +14009,7 @@ func (s SubnetAlreadyInUse) GoString() string {
 
 func newErrorSubnetAlreadyInUse(v protocol.ResponseMetadata) error {
 	return &SubnetAlreadyInUse{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14037,12 +14037,12 @@ func (s SubnetAlreadyInUse) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubnetAlreadyInUse) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubnetAlreadyInUse) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information about types of supported endpoints in response to a
@@ -14478,7 +14478,7 @@ func (s *TestConnectionOutput) SetConnection(v *Connection) *TestConnectionOutpu
 // An upgrade dependency is preventing the database migration.
 type UpgradeDependencyFailureFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14495,7 +14495,7 @@ func (s UpgradeDependencyFailureFault) GoString() string {
 
 func newErrorUpgradeDependencyFailureFault(v protocol.ResponseMetadata) error {
 	return &UpgradeDependencyFailureFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14523,12 +14523,12 @@ func (s UpgradeDependencyFailureFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UpgradeDependencyFailureFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UpgradeDependencyFailureFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes status of a security group associated with the virtual private

--- a/service/dataexchange/api.go
+++ b/service/dataexchange/api.go
@@ -2212,7 +2212,7 @@ func (c *DataExchange) UpdateRevisionWithContext(ctx aws.Context, input *UpdateR
 // Access to the resource is denied.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Access to the resource is denied.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2230,7 +2230,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2258,12 +2258,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The destination for the asset.
@@ -2592,7 +2592,7 @@ func (s CancelJobOutput) GoString() string {
 // state of the resource.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The request couldn't be completed because it conflicted with the current
 	// state of the resource.
@@ -2617,7 +2617,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2645,12 +2645,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A request to create a data set that contains one or more revisions.
@@ -4684,7 +4684,7 @@ func (s *ImportAssetsFromS3ResponseDetails) SetRevisionId(v string) *ImportAsset
 // An exception occurred with the service.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message identifying the service exception that occurred.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -4702,7 +4702,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4730,12 +4730,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Data Exchange Jobs are asynchronous import or export operations used
@@ -5461,7 +5461,7 @@ func (s *RequestDetails) SetImportAssetsFromS3(v *ImportAssetsFromS3RequestDetai
 // The resource couldn't be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The resource couldn't be found.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5485,7 +5485,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5513,12 +5513,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details for the response.
@@ -5708,7 +5708,7 @@ func (s *S3SnapshotAsset) SetSize(v float64) *S3SnapshotAsset {
 // The request has exceeded the quotas imposed by the service.
 type ServiceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	LimitName *string `type:"string" enum:"LimitName"`
 
@@ -5729,7 +5729,7 @@ func (s ServiceLimitExceededException) GoString() string {
 
 func newErrorServiceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5757,12 +5757,12 @@ func (s ServiceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartJobInput struct {
@@ -5886,7 +5886,7 @@ func (s TagResourceOutput) GoString() string {
 // The limit on the number of requests per second was exceeded.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The limit on the number of requests per second was exceeded.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5904,7 +5904,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5932,12 +5932,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -6524,7 +6524,7 @@ func (s *UpdateRevisionOutput) SetUpdatedAt(v time.Time) *UpdateRevisionOutput {
 // The request was invalid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message that informs you about what was invalid about the request.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6542,7 +6542,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6570,12 +6570,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The type of file your data is stored in. Currently, the supported asset type

--- a/service/dataexchange/api.go
+++ b/service/dataexchange/api.go
@@ -2211,8 +2211,8 @@ func (c *DataExchange) UpdateRevisionWithContext(ctx aws.Context, input *UpdateR
 
 // Access to the resource is denied.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Access to the resource is denied.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2591,8 +2591,8 @@ func (s CancelJobOutput) GoString() string {
 // The request couldn't be completed because it conflicted with the current
 // state of the resource.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The request couldn't be completed because it conflicted with the current
 	// state of the resource.
@@ -4683,8 +4683,8 @@ func (s *ImportAssetsFromS3ResponseDetails) SetRevisionId(v string) *ImportAsset
 
 // An exception occurred with the service.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message identifying the service exception that occurred.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5460,8 +5460,8 @@ func (s *RequestDetails) SetImportAssetsFromS3(v *ImportAssetsFromS3RequestDetai
 
 // The resource couldn't be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The resource couldn't be found.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5707,8 +5707,8 @@ func (s *S3SnapshotAsset) SetSize(v float64) *S3SnapshotAsset {
 
 // The request has exceeded the quotas imposed by the service.
 type ServiceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	LimitName *string `type:"string" enum:"LimitName"`
 
@@ -5885,8 +5885,8 @@ func (s TagResourceOutput) GoString() string {
 
 // The limit on the number of requests per second was exceeded.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The limit on the number of requests per second was exceeded.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6523,8 +6523,8 @@ func (s *UpdateRevisionOutput) SetUpdatedAt(v time.Time) *UpdateRevisionOutput {
 
 // The request was invalid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message that informs you about what was invalid about the request.
 	Message_ *string `locationName:"Message" type:"string"`

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -2899,8 +2899,8 @@ func (s *InstanceIdentity) SetSignature(v string) *InstanceIdentity {
 
 // An internal service error occurred.
 type InternalServiceError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2958,8 +2958,8 @@ func (s InternalServiceError) RequestID() string {
 // that the signature was generated with the correct credentials, and that you
 // haven't exceeded any of the service limits for your account.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3344,8 +3344,8 @@ func (s *ParameterValue) SetStringValue(v string) *ParameterValue {
 
 // The specified pipeline has been deleted.
 type PipelineDeletedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3507,8 +3507,8 @@ func (s *PipelineIdName) SetName(v string) *PipelineIdName {
 // The specified pipeline was not found. Verify that you used the correct user
 // and account identifiers.
 type PipelineNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4612,8 +4612,8 @@ func (s *Tag) SetValue(v string) *Tag {
 
 // The specified task was not found.
 type TaskNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -2900,7 +2900,7 @@ func (s *InstanceIdentity) SetSignature(v string) *InstanceIdentity {
 // An internal service error occurred.
 type InternalServiceError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2918,7 +2918,7 @@ func (s InternalServiceError) GoString() string {
 
 func newErrorInternalServiceError(v protocol.ResponseMetadata) error {
 	return &InternalServiceError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2946,12 +2946,12 @@ func (s InternalServiceError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was not valid. Verify that your request was properly formatted,
@@ -2959,7 +2959,7 @@ func (s InternalServiceError) RequestID() string {
 // haven't exceeded any of the service limits for your account.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2977,7 +2977,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3005,12 +3005,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the parameters for ListPipelines.
@@ -3345,7 +3345,7 @@ func (s *ParameterValue) SetStringValue(v string) *ParameterValue {
 // The specified pipeline has been deleted.
 type PipelineDeletedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3363,7 +3363,7 @@ func (s PipelineDeletedException) GoString() string {
 
 func newErrorPipelineDeletedException(v protocol.ResponseMetadata) error {
 	return &PipelineDeletedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3391,12 +3391,12 @@ func (s PipelineDeletedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PipelineDeletedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PipelineDeletedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains pipeline metadata.
@@ -3508,7 +3508,7 @@ func (s *PipelineIdName) SetName(v string) *PipelineIdName {
 // and account identifiers.
 type PipelineNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3526,7 +3526,7 @@ func (s PipelineNotFoundException) GoString() string {
 
 func newErrorPipelineNotFoundException(v protocol.ResponseMetadata) error {
 	return &PipelineNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3554,12 +3554,12 @@ func (s PipelineNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PipelineNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PipelineNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a pipeline object. This can be a logical, physical,
@@ -4613,7 +4613,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // The specified task was not found.
 type TaskNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Description of the error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4631,7 +4631,7 @@ func (s TaskNotFoundException) GoString() string {
 
 func newErrorTaskNotFoundException(v protocol.ResponseMetadata) error {
 	return &TaskNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4659,12 +4659,12 @@ func (s TaskNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TaskNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TaskNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a pipeline task that is assigned to a task runner.

--- a/service/datasync/api.go
+++ b/service/datasync/api.go
@@ -5272,8 +5272,8 @@ func (s *FilterRule) SetValue(v string) *FilterRule {
 
 // This exception is thrown when an error occurs in the AWS DataSync service.
 type InternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorCode *string `locationName:"errorCode" type:"string"`
 
@@ -5330,8 +5330,8 @@ func (s InternalException) RequestID() string {
 
 // This exception is thrown when the client submits a malformed request.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorCode *string `locationName:"errorCode" type:"string"`
 

--- a/service/datasync/api.go
+++ b/service/datasync/api.go
@@ -5273,7 +5273,7 @@ func (s *FilterRule) SetValue(v string) *FilterRule {
 // This exception is thrown when an error occurs in the AWS DataSync service.
 type InternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorCode *string `locationName:"errorCode" type:"string"`
 
@@ -5292,7 +5292,7 @@ func (s InternalException) GoString() string {
 
 func newErrorInternalException(v protocol.ResponseMetadata) error {
 	return &InternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5320,18 +5320,18 @@ func (s InternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the client submits a malformed request.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorCode *string `locationName:"errorCode" type:"string"`
 
@@ -5350,7 +5350,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5378,12 +5378,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // ListAgentsRequest

--- a/service/dax/api.go
+++ b/service/dax/api.go
@@ -2189,7 +2189,7 @@ func (s *Cluster) SetTotalNodes(v int64) *Cluster {
 // You already have a DAX cluster with the given identifier.
 type ClusterAlreadyExistsFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2206,7 +2206,7 @@ func (s ClusterAlreadyExistsFault) GoString() string {
 
 func newErrorClusterAlreadyExistsFault(v protocol.ResponseMetadata) error {
 	return &ClusterAlreadyExistsFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2234,18 +2234,18 @@ func (s ClusterAlreadyExistsFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClusterAlreadyExistsFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClusterAlreadyExistsFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested cluster ID does not refer to an existing DAX cluster.
 type ClusterNotFoundFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2262,7 +2262,7 @@ func (s ClusterNotFoundFault) GoString() string {
 
 func newErrorClusterNotFoundFault(v protocol.ResponseMetadata) error {
 	return &ClusterNotFoundFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2290,19 +2290,19 @@ func (s ClusterNotFoundFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClusterNotFoundFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClusterNotFoundFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have attempted to exceed the maximum number of DAX clusters for your
 // AWS account.
 type ClusterQuotaForCustomerExceededFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2319,7 +2319,7 @@ func (s ClusterQuotaForCustomerExceededFault) GoString() string {
 
 func newErrorClusterQuotaForCustomerExceededFault(v protocol.ResponseMetadata) error {
 	return &ClusterQuotaForCustomerExceededFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2347,12 +2347,12 @@ func (s ClusterQuotaForCustomerExceededFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClusterQuotaForCustomerExceededFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClusterQuotaForCustomerExceededFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateClusterInput struct {
@@ -3745,7 +3745,7 @@ func (s *IncreaseReplicationFactorOutput) SetCluster(v *Cluster) *IncreaseReplic
 // (or to resize an already-existing cluster).
 type InsufficientClusterCapacityFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3762,7 +3762,7 @@ func (s InsufficientClusterCapacityFault) GoString() string {
 
 func newErrorInsufficientClusterCapacityFault(v protocol.ResponseMetadata) error {
 	return &InsufficientClusterCapacityFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3790,18 +3790,18 @@ func (s InsufficientClusterCapacityFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientClusterCapacityFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientClusterCapacityFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon Resource Name (ARN) supplied in the request is not valid.
 type InvalidARNFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3818,7 +3818,7 @@ func (s InvalidARNFault) GoString() string {
 
 func newErrorInvalidARNFault(v protocol.ResponseMetadata) error {
 	return &InvalidARNFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3846,18 +3846,18 @@ func (s InvalidARNFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidARNFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidARNFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested DAX cluster is not in the available state.
 type InvalidClusterStateFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3874,7 +3874,7 @@ func (s InvalidClusterStateFault) GoString() string {
 
 func newErrorInvalidClusterStateFault(v protocol.ResponseMetadata) error {
 	return &InvalidClusterStateFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3902,18 +3902,18 @@ func (s InvalidClusterStateFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidClusterStateFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidClusterStateFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Two or more incompatible parameters were specified.
 type InvalidParameterCombinationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3930,7 +3930,7 @@ func (s InvalidParameterCombinationException) GoString() string {
 
 func newErrorInvalidParameterCombinationException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterCombinationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3958,18 +3958,18 @@ func (s InvalidParameterCombinationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterCombinationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterCombinationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more parameters in a parameter group are in an invalid state.
 type InvalidParameterGroupStateFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3986,7 +3986,7 @@ func (s InvalidParameterGroupStateFault) GoString() string {
 
 func newErrorInvalidParameterGroupStateFault(v protocol.ResponseMetadata) error {
 	return &InvalidParameterGroupStateFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4014,18 +4014,18 @@ func (s InvalidParameterGroupStateFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterGroupStateFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterGroupStateFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The value for a parameter is invalid.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4042,7 +4042,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4070,18 +4070,18 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid subnet identifier was specified.
 type InvalidSubnet struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4098,7 +4098,7 @@ func (s InvalidSubnet) GoString() string {
 
 func newErrorInvalidSubnet(v protocol.ResponseMetadata) error {
 	return &InvalidSubnet{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4126,18 +4126,18 @@ func (s InvalidSubnet) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSubnet) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSubnet) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The VPC network is in an invalid state.
 type InvalidVPCNetworkStateFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4154,7 +4154,7 @@ func (s InvalidVPCNetworkStateFault) GoString() string {
 
 func newErrorInvalidVPCNetworkStateFault(v protocol.ResponseMetadata) error {
 	return &InvalidVPCNetworkStateFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4182,12 +4182,12 @@ func (s InvalidVPCNetworkStateFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidVPCNetworkStateFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidVPCNetworkStateFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTagsInput struct {
@@ -4348,7 +4348,7 @@ func (s *Node) SetParameterGroupStatus(v string) *Node {
 // None of the nodes in the cluster have the given node ID.
 type NodeNotFoundFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4365,7 +4365,7 @@ func (s NodeNotFoundFault) GoString() string {
 
 func newErrorNodeNotFoundFault(v protocol.ResponseMetadata) error {
 	return &NodeNotFoundFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4393,18 +4393,18 @@ func (s NodeNotFoundFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NodeNotFoundFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NodeNotFoundFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have attempted to exceed the maximum number of nodes for a DAX cluster.
 type NodeQuotaForClusterExceededFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4421,7 +4421,7 @@ func (s NodeQuotaForClusterExceededFault) GoString() string {
 
 func newErrorNodeQuotaForClusterExceededFault(v protocol.ResponseMetadata) error {
 	return &NodeQuotaForClusterExceededFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4449,18 +4449,18 @@ func (s NodeQuotaForClusterExceededFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NodeQuotaForClusterExceededFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NodeQuotaForClusterExceededFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have attempted to exceed the maximum number of nodes for your AWS account.
 type NodeQuotaForCustomerExceededFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4477,7 +4477,7 @@ func (s NodeQuotaForCustomerExceededFault) GoString() string {
 
 func newErrorNodeQuotaForCustomerExceededFault(v protocol.ResponseMetadata) error {
 	return &NodeQuotaForCustomerExceededFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4505,12 +4505,12 @@ func (s NodeQuotaForCustomerExceededFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NodeQuotaForCustomerExceededFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NodeQuotaForCustomerExceededFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a parameter value that is applicable to a particular node type.
@@ -4726,7 +4726,7 @@ func (s *ParameterGroup) SetParameterGroupName(v string) *ParameterGroup {
 // The specified parameter group already exists.
 type ParameterGroupAlreadyExistsFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4743,7 +4743,7 @@ func (s ParameterGroupAlreadyExistsFault) GoString() string {
 
 func newErrorParameterGroupAlreadyExistsFault(v protocol.ResponseMetadata) error {
 	return &ParameterGroupAlreadyExistsFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4771,18 +4771,18 @@ func (s ParameterGroupAlreadyExistsFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterGroupAlreadyExistsFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterGroupAlreadyExistsFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified parameter group does not exist.
 type ParameterGroupNotFoundFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4799,7 +4799,7 @@ func (s ParameterGroupNotFoundFault) GoString() string {
 
 func newErrorParameterGroupNotFoundFault(v protocol.ResponseMetadata) error {
 	return &ParameterGroupNotFoundFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4827,18 +4827,18 @@ func (s ParameterGroupNotFoundFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterGroupNotFoundFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterGroupNotFoundFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have attempted to exceed the maximum number of parameter groups.
 type ParameterGroupQuotaExceededFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4855,7 +4855,7 @@ func (s ParameterGroupQuotaExceededFault) GoString() string {
 
 func newErrorParameterGroupQuotaExceededFault(v protocol.ResponseMetadata) error {
 	return &ParameterGroupQuotaExceededFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4883,12 +4883,12 @@ func (s ParameterGroupQuotaExceededFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterGroupQuotaExceededFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterGroupQuotaExceededFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The status of a parameter group.
@@ -5150,7 +5150,7 @@ func (s *SecurityGroupMembership) SetStatus(v string) *SecurityGroupMembership {
 // The specified service linked role (SLR) was not found.
 type ServiceLinkedRoleNotFoundFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5167,7 +5167,7 @@ func (s ServiceLinkedRoleNotFoundFault) GoString() string {
 
 func newErrorServiceLinkedRoleNotFoundFault(v protocol.ResponseMetadata) error {
 	return &ServiceLinkedRoleNotFoundFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5195,12 +5195,12 @@ func (s ServiceLinkedRoleNotFoundFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceLinkedRoleNotFoundFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceLinkedRoleNotFoundFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the subnet associated with a DAX cluster. This parameter refers
@@ -5296,7 +5296,7 @@ func (s *SubnetGroup) SetVpcId(v string) *SubnetGroup {
 // The specified subnet group already exists.
 type SubnetGroupAlreadyExistsFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5313,7 +5313,7 @@ func (s SubnetGroupAlreadyExistsFault) GoString() string {
 
 func newErrorSubnetGroupAlreadyExistsFault(v protocol.ResponseMetadata) error {
 	return &SubnetGroupAlreadyExistsFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5341,18 +5341,18 @@ func (s SubnetGroupAlreadyExistsFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubnetGroupAlreadyExistsFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubnetGroupAlreadyExistsFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified subnet group is currently in use.
 type SubnetGroupInUseFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5369,7 +5369,7 @@ func (s SubnetGroupInUseFault) GoString() string {
 
 func newErrorSubnetGroupInUseFault(v protocol.ResponseMetadata) error {
 	return &SubnetGroupInUseFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5397,18 +5397,18 @@ func (s SubnetGroupInUseFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubnetGroupInUseFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubnetGroupInUseFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested subnet group name does not refer to an existing subnet group.
 type SubnetGroupNotFoundFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5425,7 +5425,7 @@ func (s SubnetGroupNotFoundFault) GoString() string {
 
 func newErrorSubnetGroupNotFoundFault(v protocol.ResponseMetadata) error {
 	return &SubnetGroupNotFoundFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5453,19 +5453,19 @@ func (s SubnetGroupNotFoundFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubnetGroupNotFoundFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubnetGroupNotFoundFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request cannot be processed because it would exceed the allowed number
 // of subnets in a subnet group.
 type SubnetGroupQuotaExceededFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5482,7 +5482,7 @@ func (s SubnetGroupQuotaExceededFault) GoString() string {
 
 func newErrorSubnetGroupQuotaExceededFault(v protocol.ResponseMetadata) error {
 	return &SubnetGroupQuotaExceededFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5510,18 +5510,18 @@ func (s SubnetGroupQuotaExceededFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubnetGroupQuotaExceededFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubnetGroupQuotaExceededFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested subnet is being used by another subnet group.
 type SubnetInUse struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5538,7 +5538,7 @@ func (s SubnetInUse) GoString() string {
 
 func newErrorSubnetInUse(v protocol.ResponseMetadata) error {
 	return &SubnetInUse{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5566,19 +5566,19 @@ func (s SubnetInUse) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubnetInUse) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubnetInUse) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request cannot be processed because it would exceed the allowed number
 // of subnets in a subnet group.
 type SubnetQuotaExceededFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5595,7 +5595,7 @@ func (s SubnetQuotaExceededFault) GoString() string {
 
 func newErrorSubnetQuotaExceededFault(v protocol.ResponseMetadata) error {
 	return &SubnetQuotaExceededFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5623,12 +5623,12 @@ func (s SubnetQuotaExceededFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubnetQuotaExceededFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubnetQuotaExceededFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A description of a tag. Every tag is a key-value pair. You can add up to
@@ -5676,7 +5676,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // The tag does not exist.
 type TagNotFoundFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5693,7 +5693,7 @@ func (s TagNotFoundFault) GoString() string {
 
 func newErrorTagNotFoundFault(v protocol.ResponseMetadata) error {
 	return &TagNotFoundFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5721,18 +5721,18 @@ func (s TagNotFoundFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagNotFoundFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagNotFoundFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have exceeded the maximum number of tags for this DAX cluster.
 type TagQuotaPerResourceExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5749,7 +5749,7 @@ func (s TagQuotaPerResourceExceeded) GoString() string {
 
 func newErrorTagQuotaPerResourceExceeded(v protocol.ResponseMetadata) error {
 	return &TagQuotaPerResourceExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5777,12 +5777,12 @@ func (s TagQuotaPerResourceExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagQuotaPerResourceExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagQuotaPerResourceExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {

--- a/service/dax/api.go
+++ b/service/dax/api.go
@@ -2188,8 +2188,8 @@ func (s *Cluster) SetTotalNodes(v int64) *Cluster {
 
 // You already have a DAX cluster with the given identifier.
 type ClusterAlreadyExistsFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2244,8 +2244,8 @@ func (s ClusterAlreadyExistsFault) RequestID() string {
 
 // The requested cluster ID does not refer to an existing DAX cluster.
 type ClusterNotFoundFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2301,8 +2301,8 @@ func (s ClusterNotFoundFault) RequestID() string {
 // You have attempted to exceed the maximum number of DAX clusters for your
 // AWS account.
 type ClusterQuotaForCustomerExceededFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3744,8 +3744,8 @@ func (s *IncreaseReplicationFactorOutput) SetCluster(v *Cluster) *IncreaseReplic
 // There are not enough system resources to create the cluster you requested
 // (or to resize an already-existing cluster).
 type InsufficientClusterCapacityFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3800,8 +3800,8 @@ func (s InsufficientClusterCapacityFault) RequestID() string {
 
 // The Amazon Resource Name (ARN) supplied in the request is not valid.
 type InvalidARNFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3856,8 +3856,8 @@ func (s InvalidARNFault) RequestID() string {
 
 // The requested DAX cluster is not in the available state.
 type InvalidClusterStateFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3912,8 +3912,8 @@ func (s InvalidClusterStateFault) RequestID() string {
 
 // Two or more incompatible parameters were specified.
 type InvalidParameterCombinationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3968,8 +3968,8 @@ func (s InvalidParameterCombinationException) RequestID() string {
 
 // One or more parameters in a parameter group are in an invalid state.
 type InvalidParameterGroupStateFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4024,8 +4024,8 @@ func (s InvalidParameterGroupStateFault) RequestID() string {
 
 // The value for a parameter is invalid.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4080,8 +4080,8 @@ func (s InvalidParameterValueException) RequestID() string {
 
 // An invalid subnet identifier was specified.
 type InvalidSubnet struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4136,8 +4136,8 @@ func (s InvalidSubnet) RequestID() string {
 
 // The VPC network is in an invalid state.
 type InvalidVPCNetworkStateFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4347,8 +4347,8 @@ func (s *Node) SetParameterGroupStatus(v string) *Node {
 
 // None of the nodes in the cluster have the given node ID.
 type NodeNotFoundFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4403,8 +4403,8 @@ func (s NodeNotFoundFault) RequestID() string {
 
 // You have attempted to exceed the maximum number of nodes for a DAX cluster.
 type NodeQuotaForClusterExceededFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4459,8 +4459,8 @@ func (s NodeQuotaForClusterExceededFault) RequestID() string {
 
 // You have attempted to exceed the maximum number of nodes for your AWS account.
 type NodeQuotaForCustomerExceededFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4725,8 +4725,8 @@ func (s *ParameterGroup) SetParameterGroupName(v string) *ParameterGroup {
 
 // The specified parameter group already exists.
 type ParameterGroupAlreadyExistsFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4781,8 +4781,8 @@ func (s ParameterGroupAlreadyExistsFault) RequestID() string {
 
 // The specified parameter group does not exist.
 type ParameterGroupNotFoundFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4837,8 +4837,8 @@ func (s ParameterGroupNotFoundFault) RequestID() string {
 
 // You have attempted to exceed the maximum number of parameter groups.
 type ParameterGroupQuotaExceededFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5149,8 +5149,8 @@ func (s *SecurityGroupMembership) SetStatus(v string) *SecurityGroupMembership {
 
 // The specified service linked role (SLR) was not found.
 type ServiceLinkedRoleNotFoundFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5295,8 +5295,8 @@ func (s *SubnetGroup) SetVpcId(v string) *SubnetGroup {
 
 // The specified subnet group already exists.
 type SubnetGroupAlreadyExistsFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5351,8 +5351,8 @@ func (s SubnetGroupAlreadyExistsFault) RequestID() string {
 
 // The specified subnet group is currently in use.
 type SubnetGroupInUseFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5407,8 +5407,8 @@ func (s SubnetGroupInUseFault) RequestID() string {
 
 // The requested subnet group name does not refer to an existing subnet group.
 type SubnetGroupNotFoundFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5464,8 +5464,8 @@ func (s SubnetGroupNotFoundFault) RequestID() string {
 // The request cannot be processed because it would exceed the allowed number
 // of subnets in a subnet group.
 type SubnetGroupQuotaExceededFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5520,8 +5520,8 @@ func (s SubnetGroupQuotaExceededFault) RequestID() string {
 
 // The requested subnet is being used by another subnet group.
 type SubnetInUse struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5577,8 +5577,8 @@ func (s SubnetInUse) RequestID() string {
 // The request cannot be processed because it would exceed the allowed number
 // of subnets in a subnet group.
 type SubnetQuotaExceededFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5675,8 +5675,8 @@ func (s *Tag) SetValue(v string) *Tag {
 
 // The tag does not exist.
 type TagNotFoundFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5731,8 +5731,8 @@ func (s TagNotFoundFault) RequestID() string {
 
 // You have exceeded the maximum number of tags for this DAX cluster.
 type TagQuotaPerResourceExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/detective/api.go
+++ b/service/detective/api.go
@@ -1333,8 +1333,8 @@ func (s *Account) SetEmailAddress(v string) *Account {
 
 // The request attempted an invalid action.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1872,8 +1872,8 @@ func (s *Graph) SetCreatedTime(v time.Time) *Graph {
 
 // The request was valid but failed because of a problem with the service.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2361,8 +2361,8 @@ func (s RejectInvitationOutput) GoString() string {
 
 // The request refers to a nonexistent resource.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2419,8 +2419,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // to exceed the maximum allowed. A behavior graph cannot have more than 1000
 // member accounts.
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2511,8 +2511,8 @@ func (s *UnprocessedAccount) SetReason(v string) *UnprocessedAccount {
 
 // The request parameters are invalid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/detective/api.go
+++ b/service/detective/api.go
@@ -1334,7 +1334,7 @@ func (s *Account) SetEmailAddress(v string) *Account {
 // The request attempted an invalid action.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1351,7 +1351,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1379,12 +1379,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateGraphInput struct {
@@ -1873,7 +1873,7 @@ func (s *Graph) SetCreatedTime(v time.Time) *Graph {
 // The request was valid but failed because of a problem with the service.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1890,7 +1890,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1918,12 +1918,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListGraphsInput struct {
@@ -2362,7 +2362,7 @@ func (s RejectInvitationOutput) GoString() string {
 // The request refers to a nonexistent resource.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2379,7 +2379,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2407,12 +2407,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This request would cause the number of member accounts in the behavior graph
@@ -2420,7 +2420,7 @@ func (s ResourceNotFoundException) RequestID() string {
 // member accounts.
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2437,7 +2437,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2465,12 +2465,12 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Amazon Detective is currently in preview.
@@ -2512,7 +2512,7 @@ func (s *UnprocessedAccount) SetReason(v string) *UnprocessedAccount {
 // The request parameters are invalid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2529,7 +2529,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2557,12 +2557,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -8008,7 +8008,7 @@ func (s *AccountSettings) SetUnmeteredRemoteAccessDevices(v map[string]*int64) *
 // An invalid argument was specified.
 type ArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -8026,7 +8026,7 @@ func (s ArgumentException) GoString() string {
 
 func newErrorArgumentException(v protocol.ResponseMetadata) error {
 	return &ArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8054,12 +8054,12 @@ func (s ArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the output of a test. Examples of artifacts include logs and screenshots.
@@ -8229,7 +8229,7 @@ func (s *CPU) SetFrequency(v string) *CPU {
 // The requested object could not be deleted.
 type CannotDeleteException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8246,7 +8246,7 @@ func (s CannotDeleteException) GoString() string {
 
 func newErrorCannotDeleteException(v protocol.ResponseMetadata) error {
 	return &CannotDeleteException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8274,12 +8274,12 @@ func (s CannotDeleteException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CannotDeleteException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CannotDeleteException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents entity counters.
@@ -12178,7 +12178,7 @@ func (s *GetVPCEConfigurationOutput) SetVpceConfiguration(v *VPCEConfiguration) 
 // An entity with the same name already exists.
 type IdempotencyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -12196,7 +12196,7 @@ func (s IdempotencyException) GoString() string {
 
 func newErrorIdempotencyException(v protocol.ResponseMetadata) error {
 	return &IdempotencyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12224,12 +12224,12 @@ func (s IdempotencyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotencyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotencyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents information about incompatibility.
@@ -12443,7 +12443,7 @@ func (s *InstanceProfile) SetRebootAfterUse(v bool) *InstanceProfile {
 // (mailto:aws-devicefarm-support@amazon.com) if you see this error.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12460,7 +12460,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12488,19 +12488,19 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There was an error with the update request, or you do not have sufficient
 // permissions to update this VPC endpoint configuration.
 type InvalidOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12517,7 +12517,7 @@ func (s InvalidOperationException) GoString() string {
 
 func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 	return &InvalidOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12545,12 +12545,12 @@ func (s InvalidOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a device.
@@ -12782,7 +12782,7 @@ func (s *Job) SetVideoEndpoint(v string) *Job {
 // A limit was exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -12800,7 +12800,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12828,12 +12828,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a request to the list artifacts operation.
@@ -15350,7 +15350,7 @@ func (s *NetworkProfile) SetUplinkLossPercent(v int64) *NetworkProfile {
 // transaction.
 type NotEligibleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The HTTP response code of a Not Eligible exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15368,7 +15368,7 @@ func (s NotEligibleException) GoString() string {
 
 func newErrorNotEligibleException(v protocol.ResponseMetadata) error {
 	return &NotEligibleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15396,18 +15396,18 @@ func (s NotEligibleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotEligibleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotEligibleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified entity was not found.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15425,7 +15425,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15453,12 +15453,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the metadata of a device offering.
@@ -17458,7 +17458,7 @@ func (s *ScheduleRunTest) SetType(v string) *ScheduleRunTest {
 // There was a problem with the service account.
 type ServiceAccountException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -17476,7 +17476,7 @@ func (s ServiceAccountException) GoString() string {
 
 func newErrorServiceAccountException(v protocol.ResponseMetadata) error {
 	return &ServiceAccountException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17504,12 +17504,12 @@ func (s ServiceAccountException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceAccountException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceAccountException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StopJobInput struct {
@@ -17964,7 +17964,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // The operation was not successful. Try again.
 type TagOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -17983,7 +17983,7 @@ func (s TagOperationException) GoString() string {
 
 func newErrorTagOperationException(v protocol.ResponseMetadata) error {
 	return &TagOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18011,19 +18011,19 @@ func (s TagOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request doesn't comply with the AWS Identity and Access Management (IAM)
 // tag policy. Correct your request and then retry it.
 type TagPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -18042,7 +18042,7 @@ func (s TagPolicyException) GoString() string {
 
 func newErrorTagPolicyException(v protocol.ResponseMetadata) error {
 	return &TagPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18070,12 +18070,12 @@ func (s TagPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {
@@ -18582,7 +18582,7 @@ func (s *TestGridSessionArtifact) SetUrl(v string) *TestGridSessionArtifact {
 // of tags that can be applied to a repository is 50.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -18601,7 +18601,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18629,12 +18629,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents information about free trial device minutes for an AWS account.

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -8007,8 +8007,8 @@ func (s *AccountSettings) SetUnmeteredRemoteAccessDevices(v map[string]*int64) *
 
 // An invalid argument was specified.
 type ArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -8228,8 +8228,8 @@ func (s *CPU) SetFrequency(v string) *CPU {
 
 // The requested object could not be deleted.
 type CannotDeleteException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12177,8 +12177,8 @@ func (s *GetVPCEConfigurationOutput) SetVpceConfiguration(v *VPCEConfiguration) 
 
 // An entity with the same name already exists.
 type IdempotencyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -12442,8 +12442,8 @@ func (s *InstanceProfile) SetRebootAfterUse(v bool) *InstanceProfile {
 // An internal exception was raised in the service. Contact aws-devicefarm-support@amazon.com
 // (mailto:aws-devicefarm-support@amazon.com) if you see this error.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12499,8 +12499,8 @@ func (s InternalServiceException) RequestID() string {
 // There was an error with the update request, or you do not have sufficient
 // permissions to update this VPC endpoint configuration.
 type InvalidOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12781,8 +12781,8 @@ func (s *Job) SetVideoEndpoint(v string) *Job {
 
 // A limit was exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15349,8 +15349,8 @@ func (s *NetworkProfile) SetUplinkLossPercent(v int64) *NetworkProfile {
 // Exception gets thrown when a user is not eligible to perform the specified
 // transaction.
 type NotEligibleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The HTTP response code of a Not Eligible exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15406,8 +15406,8 @@ func (s NotEligibleException) RequestID() string {
 
 // The specified entity was not found.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -17457,8 +17457,8 @@ func (s *ScheduleRunTest) SetType(v string) *ScheduleRunTest {
 
 // There was a problem with the service account.
 type ServiceAccountException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Any additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -17963,8 +17963,8 @@ func (s *Tag) SetValue(v string) *Tag {
 
 // The operation was not successful. Try again.
 type TagOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -18022,8 +18022,8 @@ func (s TagOperationException) RequestID() string {
 // The request doesn't comply with the AWS Identity and Access Management (IAM)
 // tag policy. Correct your request and then retry it.
 type TagPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -18581,8 +18581,8 @@ func (s *TestGridSessionArtifact) SetUrl(v string) *TestGridSessionArtifact {
 // The list of tags on the repository is over the limit. The maximum number
 // of tags that can be applied to a repository is 50.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -5661,7 +5661,7 @@ func (s *BGPPeer) SetCustomerAddress(v string) *BGPPeer {
 // One or more parameters are not valid.
 type ClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5678,7 +5678,7 @@ func (s ClientException) GoString() string {
 
 func newErrorClientException(v protocol.ResponseMetadata) error {
 	return &ClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5706,12 +5706,12 @@ func (s ClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ConfirmConnectionInput struct {
@@ -8715,7 +8715,7 @@ func (s *DisassociateConnectionFromLagInput) SetLagId(v string) *DisassociateCon
 // A tag key was specified more than once.
 type DuplicateTagKeysException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8732,7 +8732,7 @@ func (s DuplicateTagKeysException) GoString() string {
 
 func newErrorDuplicateTagKeysException(v protocol.ResponseMetadata) error {
 	return &DuplicateTagKeysException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8760,12 +8760,12 @@ func (s DuplicateTagKeysException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateTagKeysException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateTagKeysException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a Direct Connect gateway, which enables you to connect
@@ -10535,7 +10535,7 @@ func (s *RouteFilterPrefix) SetCidr(v string) *RouteFilterPrefix {
 // A server-side error occurred.
 type ServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10552,7 +10552,7 @@ func (s ServerException) GoString() string {
 
 func newErrorServerException(v protocol.ResponseMetadata) error {
 	return &ServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10580,12 +10580,12 @@ func (s ServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a tag.
@@ -10721,7 +10721,7 @@ func (s TagResourceOutput) GoString() string {
 // You have reached the limit on the number of tags that can be assigned.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10738,7 +10738,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10766,12 +10766,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -5660,8 +5660,8 @@ func (s *BGPPeer) SetCustomerAddress(v string) *BGPPeer {
 
 // One or more parameters are not valid.
 type ClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8714,8 +8714,8 @@ func (s *DisassociateConnectionFromLagInput) SetLagId(v string) *DisassociateCon
 
 // A tag key was specified more than once.
 type DuplicateTagKeysException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10534,8 +10534,8 @@ func (s *RouteFilterPrefix) SetCidr(v string) *RouteFilterPrefix {
 
 // A server-side error occurred.
 type ServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10720,8 +10720,8 @@ func (s TagResourceOutput) GoString() string {
 
 // You have reached the limit on the number of tags that can be assigned.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -5569,8 +5569,8 @@ func (s *AcceptSharedDirectoryOutput) SetSharedDirectory(v *SharedDirectory) *Ac
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5872,8 +5872,8 @@ func (s *Attribute) SetValue(v string) *Attribute {
 
 // An authentication error occurred.
 type AuthenticationFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The textual message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6067,8 +6067,8 @@ func (s *Certificate) SetStateReason(v string) *Certificate {
 
 // The certificate has already been registered into the system.
 type CertificateAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6127,8 +6127,8 @@ func (s CertificateAlreadyExistsException) RequestID() string {
 
 // The certificate is not present in the system for describe or deregister activities.
 type CertificateDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6188,8 +6188,8 @@ func (s CertificateDoesNotExistException) RequestID() string {
 // The certificate is being used for the LDAP security connection and cannot
 // be removed without disabling LDAP security.
 type CertificateInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6300,8 +6300,8 @@ func (s *CertificateInfo) SetState(v string) *CertificateInfo {
 // The certificate could not be added because the certificate limit has been
 // reached.
 type CertificateLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6360,8 +6360,8 @@ func (s CertificateLimitExceededException) RequestID() string {
 
 // A client exception has occurred.
 type ClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -8813,8 +8813,8 @@ func (s *DescribeTrustsOutput) SetTrusts(v []*Trust) *DescribeTrustsOutput {
 
 // The specified directory has already been shared with this AWS account.
 type DirectoryAlreadySharedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9284,8 +9284,8 @@ func (s *DirectoryDescription) SetVpcSettings(v *DirectoryVpcSettingsDescription
 
 // The specified directory does not exist in the system.
 type DirectoryDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9346,8 +9346,8 @@ func (s DirectoryDoesNotExistException) RequestID() string {
 // use the GetDirectoryLimits operation to determine your directory limits in
 // the region.
 type DirectoryLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9503,8 +9503,8 @@ func (s *DirectoryLimits) SetConnectedDirectoriesLimitReached(v bool) *Directory
 
 // The specified directory has not been shared with this AWS account.
 type DirectoryNotSharedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9563,8 +9563,8 @@ func (s DirectoryNotSharedException) RequestID() string {
 
 // The specified directory is unavailable or could not be found.
 type DirectoryUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10043,8 +10043,8 @@ func (s *DomainController) SetVpcId(v string) *DomainController {
 // The maximum allowed number of domain controllers per directory was exceeded.
 // The default limit per directory is 20 domain controllers.
 type DomainControllerLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10330,8 +10330,8 @@ func (s EnableSsoOutput) GoString() string {
 
 // The specified entity already exists.
 type EntityAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10390,8 +10390,8 @@ func (s EntityAlreadyExistsException) RequestID() string {
 
 // The specified entity could not be found.
 type EntityDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10615,8 +10615,8 @@ func (s *GetSnapshotLimitsOutput) SetSnapshotLimits(v *SnapshotLimits) *GetSnaps
 
 // The account does not have sufficient permission to perform the operation.
 type InsufficientPermissionsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10675,8 +10675,8 @@ func (s InsufficientPermissionsException) RequestID() string {
 
 // The certificate PEM that was provided has incorrect encoding.
 type InvalidCertificateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10736,8 +10736,8 @@ func (s InvalidCertificateException) RequestID() string {
 // The LDAP activities could not be performed because they are limited by the
 // LDAPS status.
 type InvalidLDAPSStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10796,8 +10796,8 @@ func (s InvalidLDAPSStatusException) RequestID() string {
 
 // The NextToken value is not valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10856,8 +10856,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // One or more parameters are not valid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10917,8 +10917,8 @@ func (s InvalidParameterException) RequestID() string {
 // The new password provided by the user does not meet the password complexity
 // requirements defined in your directory.
 type InvalidPasswordException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10977,8 +10977,8 @@ func (s InvalidPasswordException) RequestID() string {
 
 // The specified shared target is not valid.
 type InvalidTargetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -11143,8 +11143,8 @@ func (s *IpRouteInfo) SetIpRouteStatusReason(v string) *IpRouteInfo {
 // The maximum allowed number of IP addresses was exceeded. The default limit
 // is 100 IP address blocks.
 type IpRouteLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -11734,8 +11734,8 @@ func (s *LogSubscription) SetSubscriptionCreatedDateTime(v time.Time) *LogSubscr
 // The LDAP activities could not be performed because at least one valid certificate
 // must be registered with the system.
 type NoAvailableCertificateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -11794,8 +11794,8 @@ func (s NoAvailableCertificateException) RequestID() string {
 
 // Exception encountered while trying to access your AWS organization.
 type OrganizationsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -12603,8 +12603,8 @@ func (s *SchemaExtensionInfo) SetStartDateTime(v time.Time) *SchemaExtensionInfo
 
 // An exception has occurred in AWS Directory Service.
 type ServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -12774,8 +12774,8 @@ func (s *ShareDirectoryOutput) SetSharedDirectoryId(v string) *ShareDirectoryOut
 // The maximum number of AWS accounts that you can share with this directory
 // has been reached.
 type ShareLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -13065,8 +13065,8 @@ func (s *Snapshot) SetType(v string) *Snapshot {
 // You can use the GetSnapshotLimits operation to determine the snapshot limits
 // for a directory.
 type SnapshotLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -13337,8 +13337,8 @@ func (s *Tag) SetValue(v string) *Tag {
 
 // The maximum allowed number of tags was exceeded.
 type TagLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -13653,8 +13653,8 @@ func (s *UnshareTarget) SetType(v string) *UnshareTarget {
 
 // The operation is not supported.
 type UnsupportedOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -14020,8 +14020,8 @@ func (s *UpdateTrustOutput) SetTrustId(v string) *UpdateTrustOutput {
 
 // The user provided a username that does not exist in your directory.
 type UserDoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -5570,7 +5570,7 @@ func (s *AcceptSharedDirectoryOutput) SetSharedDirectory(v *SharedDirectory) *Ac
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5591,7 +5591,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5619,12 +5619,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AddIpRoutesInput struct {
@@ -5873,7 +5873,7 @@ func (s *Attribute) SetValue(v string) *Attribute {
 // An authentication error occurred.
 type AuthenticationFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The textual message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -5894,7 +5894,7 @@ func (s AuthenticationFailedException) GoString() string {
 
 func newErrorAuthenticationFailedException(v protocol.ResponseMetadata) error {
 	return &AuthenticationFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5922,12 +5922,12 @@ func (s AuthenticationFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AuthenticationFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AuthenticationFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CancelSchemaExtensionInput struct {
@@ -6068,7 +6068,7 @@ func (s *Certificate) SetStateReason(v string) *Certificate {
 // The certificate has already been registered into the system.
 type CertificateAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6089,7 +6089,7 @@ func (s CertificateAlreadyExistsException) GoString() string {
 
 func newErrorCertificateAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &CertificateAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6117,18 +6117,18 @@ func (s CertificateAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CertificateAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CertificateAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The certificate is not present in the system for describe or deregister activities.
 type CertificateDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6149,7 +6149,7 @@ func (s CertificateDoesNotExistException) GoString() string {
 
 func newErrorCertificateDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &CertificateDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6177,19 +6177,19 @@ func (s CertificateDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CertificateDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CertificateDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The certificate is being used for the LDAP security connection and cannot
 // be removed without disabling LDAP security.
 type CertificateInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6210,7 +6210,7 @@ func (s CertificateInUseException) GoString() string {
 
 func newErrorCertificateInUseException(v protocol.ResponseMetadata) error {
 	return &CertificateInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6238,12 +6238,12 @@ func (s CertificateInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CertificateInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CertificateInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains general information about a certificate.
@@ -6301,7 +6301,7 @@ func (s *CertificateInfo) SetState(v string) *CertificateInfo {
 // reached.
 type CertificateLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6322,7 +6322,7 @@ func (s CertificateLimitExceededException) GoString() string {
 
 func newErrorCertificateLimitExceededException(v protocol.ResponseMetadata) error {
 	return &CertificateLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6350,18 +6350,18 @@ func (s CertificateLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CertificateLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CertificateLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A client exception has occurred.
 type ClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -6382,7 +6382,7 @@ func (s ClientException) GoString() string {
 
 func newErrorClientException(v protocol.ResponseMetadata) error {
 	return &ClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6410,12 +6410,12 @@ func (s ClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a computer account in a directory.
@@ -8814,7 +8814,7 @@ func (s *DescribeTrustsOutput) SetTrusts(v []*Trust) *DescribeTrustsOutput {
 // The specified directory has already been shared with this AWS account.
 type DirectoryAlreadySharedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -8835,7 +8835,7 @@ func (s DirectoryAlreadySharedException) GoString() string {
 
 func newErrorDirectoryAlreadySharedException(v protocol.ResponseMetadata) error {
 	return &DirectoryAlreadySharedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8863,12 +8863,12 @@ func (s DirectoryAlreadySharedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryAlreadySharedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryAlreadySharedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information for the ConnectDirectory operation when an AD Connector
@@ -9285,7 +9285,7 @@ func (s *DirectoryDescription) SetVpcSettings(v *DirectoryVpcSettingsDescription
 // The specified directory does not exist in the system.
 type DirectoryDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9306,7 +9306,7 @@ func (s DirectoryDoesNotExistException) GoString() string {
 
 func newErrorDirectoryDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &DirectoryDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9334,12 +9334,12 @@ func (s DirectoryDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of directories in the region has been reached. You can
@@ -9347,7 +9347,7 @@ func (s DirectoryDoesNotExistException) RequestID() string {
 // the region.
 type DirectoryLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9368,7 +9368,7 @@ func (s DirectoryLimitExceededException) GoString() string {
 
 func newErrorDirectoryLimitExceededException(v protocol.ResponseMetadata) error {
 	return &DirectoryLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9396,12 +9396,12 @@ func (s DirectoryLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains directory limit information for a Region.
@@ -9504,7 +9504,7 @@ func (s *DirectoryLimits) SetConnectedDirectoriesLimitReached(v bool) *Directory
 // The specified directory has not been shared with this AWS account.
 type DirectoryNotSharedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9525,7 +9525,7 @@ func (s DirectoryNotSharedException) GoString() string {
 
 func newErrorDirectoryNotSharedException(v protocol.ResponseMetadata) error {
 	return &DirectoryNotSharedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9553,18 +9553,18 @@ func (s DirectoryNotSharedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryNotSharedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryNotSharedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified directory is unavailable or could not be found.
 type DirectoryUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -9585,7 +9585,7 @@ func (s DirectoryUnavailableException) GoString() string {
 
 func newErrorDirectoryUnavailableException(v protocol.ResponseMetadata) error {
 	return &DirectoryUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9613,12 +9613,12 @@ func (s DirectoryUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains VPC information for the CreateDirectory or CreateMicrosoftAD operation.
@@ -10044,7 +10044,7 @@ func (s *DomainController) SetVpcId(v string) *DomainController {
 // The default limit per directory is 20 domain controllers.
 type DomainControllerLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10065,7 +10065,7 @@ func (s DomainControllerLimitExceededException) GoString() string {
 
 func newErrorDomainControllerLimitExceededException(v protocol.ResponseMetadata) error {
 	return &DomainControllerLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10093,12 +10093,12 @@ func (s DomainControllerLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DomainControllerLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DomainControllerLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type EnableLDAPSInput struct {
@@ -10331,7 +10331,7 @@ func (s EnableSsoOutput) GoString() string {
 // The specified entity already exists.
 type EntityAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10352,7 +10352,7 @@ func (s EntityAlreadyExistsException) GoString() string {
 
 func newErrorEntityAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &EntityAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10380,18 +10380,18 @@ func (s EntityAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EntityAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EntityAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified entity could not be found.
 type EntityDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10412,7 +10412,7 @@ func (s EntityDoesNotExistException) GoString() string {
 
 func newErrorEntityDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &EntityDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10440,12 +10440,12 @@ func (s EntityDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EntityDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EntityDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about SNS topic and AWS Directory Service directory associations.
@@ -10616,7 +10616,7 @@ func (s *GetSnapshotLimitsOutput) SetSnapshotLimits(v *SnapshotLimits) *GetSnaps
 // The account does not have sufficient permission to perform the operation.
 type InsufficientPermissionsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10637,7 +10637,7 @@ func (s InsufficientPermissionsException) GoString() string {
 
 func newErrorInsufficientPermissionsException(v protocol.ResponseMetadata) error {
 	return &InsufficientPermissionsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10665,18 +10665,18 @@ func (s InsufficientPermissionsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientPermissionsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientPermissionsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The certificate PEM that was provided has incorrect encoding.
 type InvalidCertificateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10697,7 +10697,7 @@ func (s InvalidCertificateException) GoString() string {
 
 func newErrorInvalidCertificateException(v protocol.ResponseMetadata) error {
 	return &InvalidCertificateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10725,19 +10725,19 @@ func (s InvalidCertificateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCertificateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCertificateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The LDAP activities could not be performed because they are limited by the
 // LDAPS status.
 type InvalidLDAPSStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10758,7 +10758,7 @@ func (s InvalidLDAPSStatusException) GoString() string {
 
 func newErrorInvalidLDAPSStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidLDAPSStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10786,18 +10786,18 @@ func (s InvalidLDAPSStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLDAPSStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLDAPSStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The NextToken value is not valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10818,7 +10818,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10846,18 +10846,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more parameters are not valid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10878,7 +10878,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10906,19 +10906,19 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The new password provided by the user does not meet the password complexity
 // requirements defined in your directory.
 type InvalidPasswordException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10939,7 +10939,7 @@ func (s InvalidPasswordException) GoString() string {
 
 func newErrorInvalidPasswordException(v protocol.ResponseMetadata) error {
 	return &InvalidPasswordException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10967,18 +10967,18 @@ func (s InvalidPasswordException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPasswordException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPasswordException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified shared target is not valid.
 type InvalidTargetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -10999,7 +10999,7 @@ func (s InvalidTargetException) GoString() string {
 
 func newErrorInvalidTargetException(v protocol.ResponseMetadata) error {
 	return &InvalidTargetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11027,12 +11027,12 @@ func (s InvalidTargetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTargetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTargetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // IP address block. This is often the address block of the DNS server used
@@ -11144,7 +11144,7 @@ func (s *IpRouteInfo) SetIpRouteStatusReason(v string) *IpRouteInfo {
 // is 100 IP address blocks.
 type IpRouteLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -11165,7 +11165,7 @@ func (s IpRouteLimitExceededException) GoString() string {
 
 func newErrorIpRouteLimitExceededException(v protocol.ResponseMetadata) error {
 	return &IpRouteLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11193,12 +11193,12 @@ func (s IpRouteLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IpRouteLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IpRouteLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains general information about the LDAPS settings.
@@ -11735,7 +11735,7 @@ func (s *LogSubscription) SetSubscriptionCreatedDateTime(v time.Time) *LogSubscr
 // must be registered with the system.
 type NoAvailableCertificateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -11756,7 +11756,7 @@ func (s NoAvailableCertificateException) GoString() string {
 
 func newErrorNoAvailableCertificateException(v protocol.ResponseMetadata) error {
 	return &NoAvailableCertificateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11784,18 +11784,18 @@ func (s NoAvailableCertificateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoAvailableCertificateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoAvailableCertificateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception encountered while trying to access your AWS organization.
 type OrganizationsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -11816,7 +11816,7 @@ func (s OrganizationsException) GoString() string {
 
 func newErrorOrganizationsException(v protocol.ResponseMetadata) error {
 	return &OrganizationsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11844,12 +11844,12 @@ func (s OrganizationsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the directory owner account details that have been shared to the
@@ -12604,7 +12604,7 @@ func (s *SchemaExtensionInfo) SetStartDateTime(v time.Time) *SchemaExtensionInfo
 // An exception has occurred in AWS Directory Service.
 type ServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -12625,7 +12625,7 @@ func (s ServiceException) GoString() string {
 
 func newErrorServiceException(v protocol.ResponseMetadata) error {
 	return &ServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12653,12 +12653,12 @@ func (s ServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ShareDirectoryInput struct {
@@ -12775,7 +12775,7 @@ func (s *ShareDirectoryOutput) SetSharedDirectoryId(v string) *ShareDirectoryOut
 // has been reached.
 type ShareLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -12796,7 +12796,7 @@ func (s ShareLimitExceededException) GoString() string {
 
 func newErrorShareLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ShareLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12824,12 +12824,12 @@ func (s ShareLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ShareLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ShareLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Identifier that contains details about the directory consumer account.
@@ -13066,7 +13066,7 @@ func (s *Snapshot) SetType(v string) *Snapshot {
 // for a directory.
 type SnapshotLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -13087,7 +13087,7 @@ func (s SnapshotLimitExceededException) GoString() string {
 
 func newErrorSnapshotLimitExceededException(v protocol.ResponseMetadata) error {
 	return &SnapshotLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13115,12 +13115,12 @@ func (s SnapshotLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SnapshotLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SnapshotLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains manual snapshot limit information for a directory.
@@ -13338,7 +13338,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // The maximum allowed number of tags was exceeded.
 type TagLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -13359,7 +13359,7 @@ func (s TagLimitExceededException) GoString() string {
 
 func newErrorTagLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TagLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13387,12 +13387,12 @@ func (s TagLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a trust relationship between an AWS Managed Microsoft AD directory
@@ -13654,7 +13654,7 @@ func (s *UnshareTarget) SetType(v string) *UnshareTarget {
 // The operation is not supported.
 type UnsupportedOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -13675,7 +13675,7 @@ func (s UnsupportedOperationException) GoString() string {
 
 func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 	return &UnsupportedOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13703,12 +13703,12 @@ func (s UnsupportedOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Updates a conditional forwarder.
@@ -14021,7 +14021,7 @@ func (s *UpdateTrustOutput) SetTrustId(v string) *UpdateTrustOutput {
 // The user provided a username that does not exist in your directory.
 type UserDoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The descriptive message for the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -14042,7 +14042,7 @@ func (s UserDoesNotExistException) GoString() string {
 
 func newErrorUserDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &UserDoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14070,12 +14070,12 @@ func (s UserDoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserDoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserDoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Initiates the verification of an existing trust relationship between an AWS

--- a/service/dlm/api.go
+++ b/service/dlm/api.go
@@ -1337,8 +1337,8 @@ func (s *GetLifecyclePolicyOutput) SetPolicy(v *LifecyclePolicy) *GetLifecyclePo
 
 // The service failed in an unexpected way.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -1395,8 +1395,8 @@ func (s InternalServerException) RequestID() string {
 
 // Bad request. The request is missing required parameters or has invalid parameters.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -1616,8 +1616,8 @@ func (s *LifecyclePolicySummary) SetTags(v map[string]*string) *LifecyclePolicyS
 
 // The request failed because a limit was exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -1868,8 +1868,8 @@ func (s *PolicyDetails) SetTargetTags(v []*Tag) *PolicyDetails {
 
 // A requested resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 

--- a/service/dlm/api.go
+++ b/service/dlm/api.go
@@ -1338,7 +1338,7 @@ func (s *GetLifecyclePolicyOutput) SetPolicy(v *LifecyclePolicy) *GetLifecyclePo
 // The service failed in an unexpected way.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -1357,7 +1357,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1385,18 +1385,18 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Bad request. The request is missing required parameters or has invalid parameters.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -1421,7 +1421,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1449,12 +1449,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Detailed information about a lifecycle policy.
@@ -1617,7 +1617,7 @@ func (s *LifecyclePolicySummary) SetTags(v map[string]*string) *LifecyclePolicyS
 // The request failed because a limit was exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -1639,7 +1639,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1667,12 +1667,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTagsForResourceInput struct {
@@ -1869,7 +1869,7 @@ func (s *PolicyDetails) SetTargetTags(v []*Tag) *PolicyDetails {
 // A requested resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -1894,7 +1894,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1922,12 +1922,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the retention rule for a lifecycle policy. You can retain snapshots

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -6808,8 +6808,8 @@ func (s *BackupDetails) SetBackupType(v string) *BackupDetails {
 // There is another ongoing conflicting backup control plane operation on the
 // table. The backup is either being created, deleted or restored to a table.
 type BackupInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6864,8 +6864,8 @@ func (s BackupInUseException) RequestID() string {
 
 // Backup not found for the given BackupARN.
 type BackupNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7818,8 +7818,8 @@ func (s *ConditionCheck) SetTableName(v string) *ConditionCheck {
 
 // A condition specified in the operation could not be evaluated.
 type ConditionalCheckFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The conditional request failed.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7994,8 +7994,8 @@ func (s *ContinuousBackupsDescription) SetPointInTimeRecoveryDescription(v *Poin
 
 // Backups have not yet been enabled for this table.
 type ContinuousBackupsUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11273,8 +11273,8 @@ func (s *GlobalTable) SetReplicationGroup(v []*Replica) *GlobalTable {
 
 // The specified global table already exists.
 type GlobalTableAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11469,8 +11469,8 @@ func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) SetProvisionedWriteCapac
 
 // The specified global table does not exist.
 type GlobalTableNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11526,8 +11526,8 @@ func (s GlobalTableNotFoundException) RequestID() string {
 // DynamoDB rejected the request because you retried a request with a different
 // payload but with an idempotent token that was already used.
 type IdempotentParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11582,8 +11582,8 @@ func (s IdempotentParameterMismatchException) RequestID() string {
 
 // The operation tried to access a nonexistent index.
 type IndexNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11638,8 +11638,8 @@ func (s IndexNotFoundException) RequestID() string {
 
 // An error occurred on the server side.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The server encountered an internal error trying to fulfill the request.
 	Message_ *string `locationName:"message" type:"string"`
@@ -11696,8 +11696,8 @@ func (s InternalServerError) RequestID() string {
 // An invalid restore time was specified. RestoreDateTime must be between EarliestRestorableDateTime
 // and LatestRestorableDateTime.
 type InvalidRestoreTimeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11798,8 +11798,8 @@ func (s *ItemCollectionMetrics) SetSizeEstimateRangeGB(v []*float64) *ItemCollec
 // An item collection is too large. This exception is only returned for tables
 // that have one or more local secondary indexes.
 type ItemCollectionSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The total size of an item collection has exceeded the maximum limit of 10
 	// gigabytes.
@@ -12104,8 +12104,8 @@ func (s *KeysAndAttributes) SetProjectionExpression(v string) *KeysAndAttributes
 //
 // There is a soft account limit of 256 tables.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Too many operations for a given subscriber.
 	Message_ *string `locationName:"message" type:"string"`
@@ -13006,8 +13006,8 @@ func (s *PointInTimeRecoverySpecification) SetPointInTimeRecoveryEnabled(v bool)
 
 // Point in time recovery has not yet been enabled for this source table.
 type PointInTimeRecoveryUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13269,8 +13269,8 @@ func (s *ProvisionedThroughputDescription) SetWriteCapacityUnits(v int64) *Provi
 // Exponential Backoff (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.RetryAndBackoff)
 // in the Amazon DynamoDB Developer Guide.
 type ProvisionedThroughputExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// You exceeded your maximum allowed provisioned throughput.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14360,8 +14360,8 @@ func (s *Replica) SetRegionName(v string) *Replica {
 
 // The specified replica is already part of the global table.
 type ReplicaAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15010,8 +15010,8 @@ func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) SetProvisionedReadCapacityUn
 
 // The specified replica is no longer part of the global table.
 type ReplicaNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15400,8 +15400,8 @@ func (s *ReplicationGroupUpdate) SetUpdate(v *UpdateReplicationGroupMemberAction
 // contact AWS Support at AWS Support (https://aws.amazon.com/support) to request
 // a limit increase.
 type RequestLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15458,8 +15458,8 @@ func (s RequestLimitExceeded) RequestID() string {
 // attempted to recreate an existing table, or tried to delete a table currently
 // in the CREATING state.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The resource which is being attempted to be changed is in use.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15516,8 +15516,8 @@ func (s ResourceInUseException) RequestID() string {
 // The operation tried to access a nonexistent table or index. The resource
 // might not be specified correctly, or its status might not be ACTIVE.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The resource which is being requested does not exist.
 	Message_ *string `locationName:"message" type:"string"`
@@ -16792,8 +16792,8 @@ func (s *StreamSpecification) SetStreamViewType(v string) *StreamSpecification {
 
 // A target table with the specified name already exists.
 type TableAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17246,8 +17246,8 @@ func (s *TableDescription) SetTableStatus(v string) *TableDescription {
 
 // A target table with the specified name is either being created or deleted.
 type TableInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17303,8 +17303,8 @@ func (s TableInUseException) RequestID() string {
 // A source table with the name TableName does not currently exist within the
 // subscriber's account.
 type TableNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18070,8 +18070,8 @@ func (s *TransactWriteItemsOutput) SetItemCollectionMetrics(v map[string][]*Item
 //    The provided expression refers to an attribute that does not exist in
 //    the item.
 type TransactionCanceledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A list of cancellation reasons.
 	CancellationReasons []*CancellationReason `min:"1" type:"list"`
@@ -18129,8 +18129,8 @@ func (s TransactionCanceledException) RequestID() string {
 
 // Operation was rejected because there is an ongoing transaction for the item.
 type TransactionConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18185,8 +18185,8 @@ func (s TransactionConflictException) RequestID() string {
 
 // The transaction with the given request token is already in progress.
 type TransactionInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -6809,7 +6809,7 @@ func (s *BackupDetails) SetBackupType(v string) *BackupDetails {
 // table. The backup is either being created, deleted or restored to a table.
 type BackupInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6826,7 +6826,7 @@ func (s BackupInUseException) GoString() string {
 
 func newErrorBackupInUseException(v protocol.ResponseMetadata) error {
 	return &BackupInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6854,18 +6854,18 @@ func (s BackupInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BackupInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BackupInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Backup not found for the given BackupARN.
 type BackupNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6882,7 +6882,7 @@ func (s BackupNotFoundException) GoString() string {
 
 func newErrorBackupNotFoundException(v protocol.ResponseMetadata) error {
 	return &BackupNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6910,12 +6910,12 @@ func (s BackupNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BackupNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BackupNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details for the backup.
@@ -7819,7 +7819,7 @@ func (s *ConditionCheck) SetTableName(v string) *ConditionCheck {
 // A condition specified in the operation could not be evaluated.
 type ConditionalCheckFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The conditional request failed.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7837,7 +7837,7 @@ func (s ConditionalCheckFailedException) GoString() string {
 
 func newErrorConditionalCheckFailedException(v protocol.ResponseMetadata) error {
 	return &ConditionalCheckFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7865,12 +7865,12 @@ func (s ConditionalCheckFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConditionalCheckFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConditionalCheckFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The capacity units consumed by an operation. The data returned includes the
@@ -7995,7 +7995,7 @@ func (s *ContinuousBackupsDescription) SetPointInTimeRecoveryDescription(v *Poin
 // Backups have not yet been enabled for this table.
 type ContinuousBackupsUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8012,7 +8012,7 @@ func (s ContinuousBackupsUnavailableException) GoString() string {
 
 func newErrorContinuousBackupsUnavailableException(v protocol.ResponseMetadata) error {
 	return &ContinuousBackupsUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8040,12 +8040,12 @@ func (s ContinuousBackupsUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ContinuousBackupsUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ContinuousBackupsUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a Contributor Insights summary entry..
@@ -11274,7 +11274,7 @@ func (s *GlobalTable) SetReplicationGroup(v []*Replica) *GlobalTable {
 // The specified global table already exists.
 type GlobalTableAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11291,7 +11291,7 @@ func (s GlobalTableAlreadyExistsException) GoString() string {
 
 func newErrorGlobalTableAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &GlobalTableAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11319,12 +11319,12 @@ func (s GlobalTableAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GlobalTableAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GlobalTableAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about the global table.
@@ -11470,7 +11470,7 @@ func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) SetProvisionedWriteCapac
 // The specified global table does not exist.
 type GlobalTableNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11487,7 +11487,7 @@ func (s GlobalTableNotFoundException) GoString() string {
 
 func newErrorGlobalTableNotFoundException(v protocol.ResponseMetadata) error {
 	return &GlobalTableNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11515,19 +11515,19 @@ func (s GlobalTableNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GlobalTableNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GlobalTableNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // DynamoDB rejected the request because you retried a request with a different
 // payload but with an idempotent token that was already used.
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11544,7 +11544,7 @@ func (s IdempotentParameterMismatchException) GoString() string {
 
 func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11572,18 +11572,18 @@ func (s IdempotentParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation tried to access a nonexistent index.
 type IndexNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11600,7 +11600,7 @@ func (s IndexNotFoundException) GoString() string {
 
 func newErrorIndexNotFoundException(v protocol.ResponseMetadata) error {
 	return &IndexNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11628,18 +11628,18 @@ func (s IndexNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IndexNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IndexNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An error occurred on the server side.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The server encountered an internal error trying to fulfill the request.
 	Message_ *string `locationName:"message" type:"string"`
@@ -11657,7 +11657,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11685,19 +11685,19 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid restore time was specified. RestoreDateTime must be between EarliestRestorableDateTime
 // and LatestRestorableDateTime.
 type InvalidRestoreTimeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11714,7 +11714,7 @@ func (s InvalidRestoreTimeException) GoString() string {
 
 func newErrorInvalidRestoreTimeException(v protocol.ResponseMetadata) error {
 	return &InvalidRestoreTimeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11742,12 +11742,12 @@ func (s InvalidRestoreTimeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRestoreTimeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRestoreTimeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about item collections, if any, that were affected by the operation.
@@ -11799,7 +11799,7 @@ func (s *ItemCollectionMetrics) SetSizeEstimateRangeGB(v []*float64) *ItemCollec
 // that have one or more local secondary indexes.
 type ItemCollectionSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The total size of an item collection has exceeded the maximum limit of 10
 	// gigabytes.
@@ -11818,7 +11818,7 @@ func (s ItemCollectionSizeLimitExceededException) GoString() string {
 
 func newErrorItemCollectionSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ItemCollectionSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11846,12 +11846,12 @@ func (s ItemCollectionSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ItemCollectionSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ItemCollectionSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details for the requested item.
@@ -12105,7 +12105,7 @@ func (s *KeysAndAttributes) SetProjectionExpression(v string) *KeysAndAttributes
 // There is a soft account limit of 256 tables.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Too many operations for a given subscriber.
 	Message_ *string `locationName:"message" type:"string"`
@@ -12123,7 +12123,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12151,12 +12151,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListBackupsInput struct {
@@ -13007,7 +13007,7 @@ func (s *PointInTimeRecoverySpecification) SetPointInTimeRecoveryEnabled(v bool)
 // Point in time recovery has not yet been enabled for this source table.
 type PointInTimeRecoveryUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13024,7 +13024,7 @@ func (s PointInTimeRecoveryUnavailableException) GoString() string {
 
 func newErrorPointInTimeRecoveryUnavailableException(v protocol.ResponseMetadata) error {
 	return &PointInTimeRecoveryUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13052,12 +13052,12 @@ func (s PointInTimeRecoveryUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PointInTimeRecoveryUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PointInTimeRecoveryUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents attributes that are copied (projected) from the table into an
@@ -13270,7 +13270,7 @@ func (s *ProvisionedThroughputDescription) SetWriteCapacityUnits(v int64) *Provi
 // in the Amazon DynamoDB Developer Guide.
 type ProvisionedThroughputExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// You exceeded your maximum allowed provisioned throughput.
 	Message_ *string `locationName:"message" type:"string"`
@@ -13288,7 +13288,7 @@ func (s ProvisionedThroughputExceededException) GoString() string {
 
 func newErrorProvisionedThroughputExceededException(v protocol.ResponseMetadata) error {
 	return &ProvisionedThroughputExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13316,12 +13316,12 @@ func (s ProvisionedThroughputExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProvisionedThroughputExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProvisionedThroughputExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Replica-specific provisioned throughput settings. If not specified, uses
@@ -14361,7 +14361,7 @@ func (s *Replica) SetRegionName(v string) *Replica {
 // The specified replica is already part of the global table.
 type ReplicaAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14378,7 +14378,7 @@ func (s ReplicaAlreadyExistsException) GoString() string {
 
 func newErrorReplicaAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ReplicaAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14406,12 +14406,12 @@ func (s ReplicaAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReplicaAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReplicaAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the auto scaling settings of the replica.
@@ -15011,7 +15011,7 @@ func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) SetProvisionedReadCapacityUn
 // The specified replica is no longer part of the global table.
 type ReplicaNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15028,7 +15028,7 @@ func (s ReplicaNotFoundException) GoString() string {
 
 func newErrorReplicaNotFoundException(v protocol.ResponseMetadata) error {
 	return &ReplicaNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15056,12 +15056,12 @@ func (s ReplicaNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReplicaNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReplicaNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the properties of a replica.
@@ -15401,7 +15401,7 @@ func (s *ReplicationGroupUpdate) SetUpdate(v *UpdateReplicationGroupMemberAction
 // a limit increase.
 type RequestLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15418,7 +15418,7 @@ func (s RequestLimitExceeded) GoString() string {
 
 func newErrorRequestLimitExceeded(v protocol.ResponseMetadata) error {
 	return &RequestLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15446,12 +15446,12 @@ func (s RequestLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation conflicts with the resource's availability. For example, you
@@ -15459,7 +15459,7 @@ func (s RequestLimitExceeded) RequestID() string {
 // in the CREATING state.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The resource which is being attempted to be changed is in use.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15477,7 +15477,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15505,19 +15505,19 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation tried to access a nonexistent table or index. The resource
 // might not be specified correctly, or its status might not be ACTIVE.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The resource which is being requested does not exist.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15535,7 +15535,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15563,12 +15563,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details for the restore.
@@ -16793,7 +16793,7 @@ func (s *StreamSpecification) SetStreamViewType(v string) *StreamSpecification {
 // A target table with the specified name already exists.
 type TableAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16810,7 +16810,7 @@ func (s TableAlreadyExistsException) GoString() string {
 
 func newErrorTableAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &TableAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16838,12 +16838,12 @@ func (s TableAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TableAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TableAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the auto scaling configuration for a global table.
@@ -17247,7 +17247,7 @@ func (s *TableDescription) SetTableStatus(v string) *TableDescription {
 // A target table with the specified name is either being created or deleted.
 type TableInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17264,7 +17264,7 @@ func (s TableInUseException) GoString() string {
 
 func newErrorTableInUseException(v protocol.ResponseMetadata) error {
 	return &TableInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17292,19 +17292,19 @@ func (s TableInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TableInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TableInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A source table with the name TableName does not currently exist within the
 // subscriber's account.
 type TableNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17321,7 +17321,7 @@ func (s TableNotFoundException) GoString() string {
 
 func newErrorTableNotFoundException(v protocol.ResponseMetadata) error {
 	return &TableNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17349,12 +17349,12 @@ func (s TableNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TableNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TableNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a tag. A tag is a key-value pair. You can add up to 50 tags to
@@ -18071,7 +18071,7 @@ func (s *TransactWriteItemsOutput) SetItemCollectionMetrics(v map[string][]*Item
 //    the item.
 type TransactionCanceledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A list of cancellation reasons.
 	CancellationReasons []*CancellationReason `min:"1" type:"list"`
@@ -18091,7 +18091,7 @@ func (s TransactionCanceledException) GoString() string {
 
 func newErrorTransactionCanceledException(v protocol.ResponseMetadata) error {
 	return &TransactionCanceledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18119,18 +18119,18 @@ func (s TransactionCanceledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TransactionCanceledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TransactionCanceledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Operation was rejected because there is an ongoing transaction for the item.
 type TransactionConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18147,7 +18147,7 @@ func (s TransactionConflictException) GoString() string {
 
 func newErrorTransactionConflictException(v protocol.ResponseMetadata) error {
 	return &TransactionConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18175,18 +18175,18 @@ func (s TransactionConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TransactionConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TransactionConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The transaction with the given request token is already in progress.
 type TransactionInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18203,7 +18203,7 @@ func (s TransactionInProgressException) GoString() string {
 
 func newErrorTransactionInProgressException(v protocol.ResponseMetadata) error {
 	return &TransactionInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18231,12 +18231,12 @@ func (s TransactionInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TransactionInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TransactionInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/dynamodbstreams/api.go
+++ b/service/dynamodbstreams/api.go
@@ -508,8 +508,8 @@ func (s *DescribeStreamOutput) SetStreamDescription(v *StreamDescription) *Descr
 // records. A shard iterator expires 15 minutes after it is retrieved using
 // the GetShardIterator action.
 type ExpiredIteratorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The provided iterator exceeds the maximum age allowed.
 	Message_ *string `locationName:"message" type:"string"`
@@ -817,8 +817,8 @@ func (s *Identity) SetType(v string) *Identity {
 
 // An error occurred on the server side.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The server encountered an internal error trying to fulfill the request.
 	Message_ *string `locationName:"message" type:"string"`
@@ -879,8 +879,8 @@ func (s InternalServerError) RequestID() string {
 // Exponential Backoff (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#APIRetries)
 // in the Amazon DynamoDB Developer Guide.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Too many operations for a given subscriber.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1139,8 +1139,8 @@ func (s *Record) SetUserIdentity(v *Identity) *Record {
 
 // The operation tried to access a nonexistent stream.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The resource which is being requested does not exist.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1561,8 +1561,8 @@ func (s *StreamRecord) SetStreamViewType(v string) *StreamRecord {
 //    request, a stream record in the shard exceeds the 24 hour period and is
 //    trimmed. This causes the iterator to access a record that no longer exists.
 type TrimmedDataAccessException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// "The data you are trying to access has been trimmed.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/dynamodbstreams/api.go
+++ b/service/dynamodbstreams/api.go
@@ -509,7 +509,7 @@ func (s *DescribeStreamOutput) SetStreamDescription(v *StreamDescription) *Descr
 // the GetShardIterator action.
 type ExpiredIteratorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The provided iterator exceeds the maximum age allowed.
 	Message_ *string `locationName:"message" type:"string"`
@@ -527,7 +527,7 @@ func (s ExpiredIteratorException) GoString() string {
 
 func newErrorExpiredIteratorException(v protocol.ResponseMetadata) error {
 	return &ExpiredIteratorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -555,12 +555,12 @@ func (s ExpiredIteratorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExpiredIteratorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExpiredIteratorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of a GetRecords operation.
@@ -818,7 +818,7 @@ func (s *Identity) SetType(v string) *Identity {
 // An error occurred on the server side.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The server encountered an internal error trying to fulfill the request.
 	Message_ *string `locationName:"message" type:"string"`
@@ -836,7 +836,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -864,12 +864,12 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Your request rate is too high. The AWS SDKs for DynamoDB automatically retry
@@ -880,7 +880,7 @@ func (s InternalServerError) RequestID() string {
 // in the Amazon DynamoDB Developer Guide.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Too many operations for a given subscriber.
 	Message_ *string `locationName:"message" type:"string"`
@@ -898,7 +898,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -926,12 +926,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input of a ListStreams operation.
@@ -1140,7 +1140,7 @@ func (s *Record) SetUserIdentity(v *Identity) *Record {
 // The operation tried to access a nonexistent stream.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The resource which is being requested does not exist.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1158,7 +1158,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1186,12 +1186,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The beginning and ending sequence numbers for the stream records contained
@@ -1562,7 +1562,7 @@ func (s *StreamRecord) SetStreamViewType(v string) *StreamRecord {
 //    trimmed. This causes the iterator to access a record that no longer exists.
 type TrimmedDataAccessException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// "The data you are trying to access has been trimmed.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1580,7 +1580,7 @@ func (s TrimmedDataAccessException) GoString() string {
 
 func newErrorTrimmedDataAccessException(v protocol.ResponseMetadata) error {
 	return &TrimmedDataAccessException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1608,12 +1608,12 @@ func (s TrimmedDataAccessException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TrimmedDataAccessException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TrimmedDataAccessException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/ebs/api.go
+++ b/service/ebs/api.go
@@ -869,7 +869,7 @@ func (s *ListSnapshotBlocksOutput) SetVolumeSize(v int64) *ListSnapshotBlocksOut
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -886,7 +886,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -914,18 +914,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input fails to satisfy the constraints of the EBS direct APIs.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -945,7 +945,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -973,12 +973,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/ebs/api.go
+++ b/service/ebs/api.go
@@ -868,8 +868,8 @@ func (s *ListSnapshotBlocksOutput) SetVolumeSize(v int64) *ListSnapshotBlocksOut
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -924,8 +924,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The input fails to satisfy the constraints of the EBS direct APIs.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 

--- a/service/ec2instanceconnect/api.go
+++ b/service/ec2instanceconnect/api.go
@@ -112,8 +112,8 @@ func (c *EC2InstanceConnect) SendSSHPublicKeyWithContext(ctx aws.Context, input 
 // Indicates that either your AWS credentials are invalid or you do not have
 // access to the EC2 instance.
 type AuthException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -169,8 +169,8 @@ func (s AuthException) RequestID() string {
 // Indicates that the instance requested was not found in the given zone. Check
 // that you have provided a valid instance ID and the correct zone.
 type EC2InstanceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -226,8 +226,8 @@ func (s EC2InstanceNotFoundException) RequestID() string {
 // Indicates that you provided bad input. Ensure you have a valid instance ID,
 // the correct zone, and a valid SSH public key.
 type InvalidArgsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -410,8 +410,8 @@ func (s *SendSSHPublicKeyOutput) SetSuccess(v bool) *SendSSHPublicKeyOutput {
 // Indicates that the service encountered an error. Follow the message's instructions
 // and try again.
 type ServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -468,8 +468,8 @@ func (s ServiceException) RequestID() string {
 // Wait for a while and try again. If higher call volume is warranted contact
 // AWS Support.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/ec2instanceconnect/api.go
+++ b/service/ec2instanceconnect/api.go
@@ -113,7 +113,7 @@ func (c *EC2InstanceConnect) SendSSHPublicKeyWithContext(ctx aws.Context, input 
 // access to the EC2 instance.
 type AuthException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -130,7 +130,7 @@ func (s AuthException) GoString() string {
 
 func newErrorAuthException(v protocol.ResponseMetadata) error {
 	return &AuthException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -158,19 +158,19 @@ func (s AuthException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AuthException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AuthException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the instance requested was not found in the given zone. Check
 // that you have provided a valid instance ID and the correct zone.
 type EC2InstanceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -187,7 +187,7 @@ func (s EC2InstanceNotFoundException) GoString() string {
 
 func newErrorEC2InstanceNotFoundException(v protocol.ResponseMetadata) error {
 	return &EC2InstanceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -215,19 +215,19 @@ func (s EC2InstanceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EC2InstanceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EC2InstanceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that you provided bad input. Ensure you have a valid instance ID,
 // the correct zone, and a valid SSH public key.
 type InvalidArgsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -244,7 +244,7 @@ func (s InvalidArgsException) GoString() string {
 
 func newErrorInvalidArgsException(v protocol.ResponseMetadata) error {
 	return &InvalidArgsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -272,12 +272,12 @@ func (s InvalidArgsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SendSSHPublicKeyInput struct {
@@ -411,7 +411,7 @@ func (s *SendSSHPublicKeyOutput) SetSuccess(v bool) *SendSSHPublicKeyOutput {
 // and try again.
 type ServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -428,7 +428,7 @@ func (s ServiceException) GoString() string {
 
 func newErrorServiceException(v protocol.ResponseMetadata) error {
 	return &ServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -456,12 +456,12 @@ func (s ServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates you have been making requests too frequently and have been throttled.
@@ -469,7 +469,7 @@ func (s ServiceException) RequestID() string {
 // AWS Support.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -486,7 +486,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -514,10 +514,10 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }

--- a/service/ecr/api.go
+++ b/service/ecr/api.go
@@ -4458,7 +4458,7 @@ func (s *DescribeRepositoriesOutput) SetRepositories(v []*Repository) *DescribeR
 // The specified layer upload does not contain any layer parts.
 type EmptyUploadException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4476,7 +4476,7 @@ func (s EmptyUploadException) GoString() string {
 
 func newErrorEmptyUploadException(v protocol.ResponseMetadata) error {
 	return &EmptyUploadException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4504,12 +4504,12 @@ func (s EmptyUploadException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EmptyUploadException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EmptyUploadException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetAuthorizationTokenInput struct {
@@ -5115,7 +5115,7 @@ func (s *Image) SetRepositoryName(v string) *Image {
 // the manifest or image tag after the last push.
 type ImageAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5133,7 +5133,7 @@ func (s ImageAlreadyExistsException) GoString() string {
 
 func newErrorImageAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ImageAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5161,12 +5161,12 @@ func (s ImageAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ImageAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ImageAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that describes an image returned by a DescribeImages operation.
@@ -5353,7 +5353,7 @@ func (s *ImageIdentifier) SetImageTag(v string) *ImageIdentifier {
 // The image requested does not exist in the specified repository.
 type ImageNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5370,7 +5370,7 @@ func (s ImageNotFoundException) GoString() string {
 
 func newErrorImageNotFoundException(v protocol.ResponseMetadata) error {
 	return &ImageNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5398,12 +5398,12 @@ func (s ImageNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ImageNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ImageNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about an image scan finding.
@@ -5624,7 +5624,7 @@ func (s *ImageScanningConfiguration) SetScanOnPush(v bool) *ImageScanningConfigu
 // is configured for tag immutability.
 type ImageTagAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5641,7 +5641,7 @@ func (s ImageTagAlreadyExistsException) GoString() string {
 
 func newErrorImageTagAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ImageTagAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5669,12 +5669,12 @@ func (s ImageTagAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ImageTagAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ImageTagAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InitiateLayerUploadInput struct {
@@ -5766,7 +5766,7 @@ func (s *InitiateLayerUploadOutput) SetUploadId(v string) *InitiateLayerUploadOu
 // image layer does not match the digest specified.
 type InvalidLayerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5784,7 +5784,7 @@ func (s InvalidLayerException) GoString() string {
 
 func newErrorInvalidLayerException(v protocol.ResponseMetadata) error {
 	return &InvalidLayerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5812,19 +5812,19 @@ func (s InvalidLayerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLayerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLayerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The layer part size is not valid, or the first byte specified is not consecutive
 // to the last byte of a previous layer part upload.
 type InvalidLayerPartException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The last valid byte received from the layer part upload that is associated
 	// with the exception.
@@ -5855,7 +5855,7 @@ func (s InvalidLayerPartException) GoString() string {
 
 func newErrorInvalidLayerPartException(v protocol.ResponseMetadata) error {
 	return &InvalidLayerPartException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5883,19 +5883,19 @@ func (s InvalidLayerPartException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLayerPartException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLayerPartException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified parameter is invalid. Review the available parameters for the
 // API request.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5913,7 +5913,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5941,12 +5941,12 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid parameter has been specified. Tag keys can have a maximum character
@@ -5954,7 +5954,7 @@ func (s InvalidParameterException) RequestID() string {
 // characters.
 type InvalidTagParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5971,7 +5971,7 @@ func (s InvalidTagParameterException) GoString() string {
 
 func newErrorInvalidTagParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidTagParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5999,12 +5999,12 @@ func (s InvalidTagParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing an Amazon ECR image layer.
@@ -6062,7 +6062,7 @@ func (s *Layer) SetMediaType(v string) *Layer {
 // The image layer already exists in the associated repository.
 type LayerAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6080,7 +6080,7 @@ func (s LayerAlreadyExistsException) GoString() string {
 
 func newErrorLayerAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &LayerAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6108,12 +6108,12 @@ func (s LayerAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LayerAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LayerAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing an Amazon ECR image layer failure.
@@ -6162,7 +6162,7 @@ func (s *LayerFailure) SetLayerDigest(v string) *LayerFailure {
 // image. Unassociated image layers may be cleaned up at any time.
 type LayerInaccessibleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6180,7 +6180,7 @@ func (s LayerInaccessibleException) GoString() string {
 
 func newErrorLayerInaccessibleException(v protocol.ResponseMetadata) error {
 	return &LayerInaccessibleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6208,18 +6208,18 @@ func (s LayerInaccessibleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LayerInaccessibleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LayerInaccessibleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Layer parts must be at least 5 MiB in size.
 type LayerPartTooSmallException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6237,7 +6237,7 @@ func (s LayerPartTooSmallException) GoString() string {
 
 func newErrorLayerPartTooSmallException(v protocol.ResponseMetadata) error {
 	return &LayerPartTooSmallException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6265,19 +6265,19 @@ func (s LayerPartTooSmallException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LayerPartTooSmallException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LayerPartTooSmallException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified layers could not be found, or the specified layer is not valid
 // for this repository.
 type LayersNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6295,7 +6295,7 @@ func (s LayersNotFoundException) GoString() string {
 
 func newErrorLayersNotFoundException(v protocol.ResponseMetadata) error {
 	return &LayersNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6323,18 +6323,18 @@ func (s LayersNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LayersNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LayersNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The lifecycle policy could not be found, and no policy is set to the repository.
 type LifecyclePolicyNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6351,7 +6351,7 @@ func (s LifecyclePolicyNotFoundException) GoString() string {
 
 func newErrorLifecyclePolicyNotFoundException(v protocol.ResponseMetadata) error {
 	return &LifecyclePolicyNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6379,12 +6379,12 @@ func (s LifecyclePolicyNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LifecyclePolicyNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LifecyclePolicyNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The filter for the lifecycle policy preview.
@@ -6415,7 +6415,7 @@ func (s *LifecyclePolicyPreviewFilter) SetTagStatus(v string) *LifecyclePolicyPr
 // again later.
 type LifecyclePolicyPreviewInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6432,7 +6432,7 @@ func (s LifecyclePolicyPreviewInProgressException) GoString() string {
 
 func newErrorLifecyclePolicyPreviewInProgressException(v protocol.ResponseMetadata) error {
 	return &LifecyclePolicyPreviewInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6460,18 +6460,18 @@ func (s LifecyclePolicyPreviewInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LifecyclePolicyPreviewInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LifecyclePolicyPreviewInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There is no dry run for this repository.
 type LifecyclePolicyPreviewNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6488,7 +6488,7 @@ func (s LifecyclePolicyPreviewNotFoundException) GoString() string {
 
 func newErrorLifecyclePolicyPreviewNotFoundException(v protocol.ResponseMetadata) error {
 	return &LifecyclePolicyPreviewNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6516,12 +6516,12 @@ func (s LifecyclePolicyPreviewNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LifecyclePolicyPreviewNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LifecyclePolicyPreviewNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The result of the lifecycle policy preview.
@@ -6639,7 +6639,7 @@ func (s *LifecyclePolicyRuleAction) SetType(v string) *LifecyclePolicyRuleAction
 // in the Amazon Elastic Container Registry User Guide.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6657,7 +6657,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6685,12 +6685,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing a filter on a ListImages operation.
@@ -7427,7 +7427,7 @@ func (s *Repository) SetRepositoryUri(v string) *Repository {
 // The specified repository already exists in the specified registry.
 type RepositoryAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7445,7 +7445,7 @@ func (s RepositoryAlreadyExistsException) GoString() string {
 
 func newErrorRepositoryAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &RepositoryAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7473,19 +7473,19 @@ func (s RepositoryAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified repository contains images. To delete a repository that contains
 // images, you must force the deletion with the force parameter.
 type RepositoryNotEmptyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7503,7 +7503,7 @@ func (s RepositoryNotEmptyException) GoString() string {
 
 func newErrorRepositoryNotEmptyException(v protocol.ResponseMetadata) error {
 	return &RepositoryNotEmptyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7531,19 +7531,19 @@ func (s RepositoryNotEmptyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryNotEmptyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryNotEmptyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified repository could not be found. Check the spelling of the specified
 // repository and ensure that you are performing operations on the correct registry.
 type RepositoryNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7561,7 +7561,7 @@ func (s RepositoryNotFoundException) GoString() string {
 
 func newErrorRepositoryNotFoundException(v protocol.ResponseMetadata) error {
 	return &RepositoryNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7589,19 +7589,19 @@ func (s RepositoryNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified repository and registry combination does not have an associated
 // repository policy.
 type RepositoryPolicyNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7619,7 +7619,7 @@ func (s RepositoryPolicyNotFoundException) GoString() string {
 
 func newErrorRepositoryPolicyNotFoundException(v protocol.ResponseMetadata) error {
 	return &RepositoryPolicyNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7647,19 +7647,19 @@ func (s RepositoryPolicyNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RepositoryPolicyNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RepositoryPolicyNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified image scan could not be found. Ensure that image scanning is
 // enabled on the repository and try again.
 type ScanNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7676,7 +7676,7 @@ func (s ScanNotFoundException) GoString() string {
 
 func newErrorScanNotFoundException(v protocol.ResponseMetadata) error {
 	return &ScanNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7704,18 +7704,18 @@ func (s ScanNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ScanNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ScanNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // These errors are usually caused by a server-side issue.
 type ServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7733,7 +7733,7 @@ func (s ServerException) GoString() string {
 
 func newErrorServerException(v protocol.ResponseMetadata) error {
 	return &ServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7761,12 +7761,12 @@ func (s ServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SetRepositoryPolicyInput struct {
@@ -8234,7 +8234,7 @@ func (s TagResourceOutput) GoString() string {
 // of tags that can be applied to a repository is 50.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8251,7 +8251,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8279,12 +8279,12 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -8518,7 +8518,7 @@ func (s *UploadLayerPartOutput) SetUploadId(v string) *UploadLayerPartOutput {
 // this repository.
 type UploadNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -8536,7 +8536,7 @@ func (s UploadNotFoundException) GoString() string {
 
 func newErrorUploadNotFoundException(v protocol.ResponseMetadata) error {
 	return &UploadNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8564,12 +8564,12 @@ func (s UploadNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UploadNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UploadNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/ecr/api.go
+++ b/service/ecr/api.go
@@ -4457,8 +4457,8 @@ func (s *DescribeRepositoriesOutput) SetRepositories(v []*Repository) *DescribeR
 
 // The specified layer upload does not contain any layer parts.
 type EmptyUploadException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5114,8 +5114,8 @@ func (s *Image) SetRepositoryName(v string) *Image {
 // The specified image has already been pushed, and there were no changes to
 // the manifest or image tag after the last push.
 type ImageAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5352,8 +5352,8 @@ func (s *ImageIdentifier) SetImageTag(v string) *ImageIdentifier {
 
 // The image requested does not exist in the specified repository.
 type ImageNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5623,8 +5623,8 @@ func (s *ImageScanningConfiguration) SetScanOnPush(v bool) *ImageScanningConfigu
 // The specified image is tagged with a tag that already exists. The repository
 // is configured for tag immutability.
 type ImageTagAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5765,8 +5765,8 @@ func (s *InitiateLayerUploadOutput) SetUploadId(v string) *InitiateLayerUploadOu
 // The layer digest calculation performed by Amazon ECR upon receipt of the
 // image layer does not match the digest specified.
 type InvalidLayerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5823,8 +5823,8 @@ func (s InvalidLayerException) RequestID() string {
 // The layer part size is not valid, or the first byte specified is not consecutive
 // to the last byte of a previous layer part upload.
 type InvalidLayerPartException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The last valid byte received from the layer part upload that is associated
 	// with the exception.
@@ -5894,8 +5894,8 @@ func (s InvalidLayerPartException) RequestID() string {
 // The specified parameter is invalid. Review the available parameters for the
 // API request.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5953,8 +5953,8 @@ func (s InvalidParameterException) RequestID() string {
 // length of 128 characters, and tag values can have a maximum length of 256
 // characters.
 type InvalidTagParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6061,8 +6061,8 @@ func (s *Layer) SetMediaType(v string) *Layer {
 
 // The image layer already exists in the associated repository.
 type LayerAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6161,8 +6161,8 @@ func (s *LayerFailure) SetLayerDigest(v string) *LayerFailure {
 // The specified layer is not available because it is not associated with an
 // image. Unassociated image layers may be cleaned up at any time.
 type LayerInaccessibleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6218,8 +6218,8 @@ func (s LayerInaccessibleException) RequestID() string {
 
 // Layer parts must be at least 5 MiB in size.
 type LayerPartTooSmallException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6276,8 +6276,8 @@ func (s LayerPartTooSmallException) RequestID() string {
 // The specified layers could not be found, or the specified layer is not valid
 // for this repository.
 type LayersNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6333,8 +6333,8 @@ func (s LayersNotFoundException) RequestID() string {
 
 // The lifecycle policy could not be found, and no policy is set to the repository.
 type LifecyclePolicyNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6414,8 +6414,8 @@ func (s *LifecyclePolicyPreviewFilter) SetTagStatus(v string) *LifecyclePolicyPr
 // The previous lifecycle policy preview request has not completed. Please try
 // again later.
 type LifecyclePolicyPreviewInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6470,8 +6470,8 @@ func (s LifecyclePolicyPreviewInProgressException) RequestID() string {
 
 // There is no dry run for this repository.
 type LifecyclePolicyPreviewNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6638,8 +6638,8 @@ func (s *LifecyclePolicyRuleAction) SetType(v string) *LifecyclePolicyRuleAction
 // (https://docs.aws.amazon.com/AmazonECR/latest/userguide/service_limits.html)
 // in the Amazon Elastic Container Registry User Guide.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7426,8 +7426,8 @@ func (s *Repository) SetRepositoryUri(v string) *Repository {
 
 // The specified repository already exists in the specified registry.
 type RepositoryAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7484,8 +7484,8 @@ func (s RepositoryAlreadyExistsException) RequestID() string {
 // The specified repository contains images. To delete a repository that contains
 // images, you must force the deletion with the force parameter.
 type RepositoryNotEmptyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7542,8 +7542,8 @@ func (s RepositoryNotEmptyException) RequestID() string {
 // The specified repository could not be found. Check the spelling of the specified
 // repository and ensure that you are performing operations on the correct registry.
 type RepositoryNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7600,8 +7600,8 @@ func (s RepositoryNotFoundException) RequestID() string {
 // The specified repository and registry combination does not have an associated
 // repository policy.
 type RepositoryPolicyNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7658,8 +7658,8 @@ func (s RepositoryPolicyNotFoundException) RequestID() string {
 // The specified image scan could not be found. Ensure that image scanning is
 // enabled on the repository and try again.
 type ScanNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7714,8 +7714,8 @@ func (s ScanNotFoundException) RequestID() string {
 
 // These errors are usually caused by a server-side issue.
 type ServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -8233,8 +8233,8 @@ func (s TagResourceOutput) GoString() string {
 // The list of tags on the repository is over the limit. The maximum number
 // of tags that can be applied to a repository is 50.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8517,8 +8517,8 @@ func (s *UploadLayerPartOutput) SetUploadId(v string) *UploadLayerPartOutput {
 // The upload could not be found, or the specified upload id is not valid for
 // this repository.
 type UploadNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -5517,7 +5517,7 @@ func (c *ECS) UpdateTaskSetWithContext(ctx aws.Context, input *UpdateTaskSetInpu
 // You do not have authorization to perform the requested action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5534,7 +5534,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5562,12 +5562,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing a container instance or task attachment.
@@ -5757,7 +5757,7 @@ func (s *Attribute) SetValue(v string) *Attribute {
 // a resource with DeleteAttributes.
 type AttributeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5774,7 +5774,7 @@ func (s AttributeLimitExceededException) GoString() string {
 
 func newErrorAttributeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &AttributeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5802,12 +5802,12 @@ func (s AttributeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AttributeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AttributeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The details of the Auto Scaling group for the capacity provider.
@@ -5956,7 +5956,7 @@ func (s *AwsVpcConfiguration) SetSubnets(v []*string) *AwsVpcConfiguration {
 // (http://aws.amazon.com/contact-us/).
 type BlockedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5973,7 +5973,7 @@ func (s BlockedException) GoString() string {
 
 func newErrorBlockedException(v protocol.ResponseMetadata) error {
 	return &BlockedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6001,12 +6001,12 @@ func (s BlockedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BlockedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BlockedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The details of a capacity provider.
@@ -6167,7 +6167,7 @@ func (s *CapacityProviderStrategyItem) SetWeight(v int64) *CapacityProviderStrat
 // action or resource, or specifying an identifier that is not valid.
 type ClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6184,7 +6184,7 @@ func (s ClientException) GoString() string {
 
 func newErrorClientException(v protocol.ResponseMetadata) error {
 	return &ClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6212,12 +6212,12 @@ func (s ClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A regional grouping of one or more container instances on which you can run
@@ -6463,7 +6463,7 @@ func (s *Cluster) SetTags(v []*Tag) *Cluster {
 // more information, see DeregisterContainerInstance.
 type ClusterContainsContainerInstancesException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6480,7 +6480,7 @@ func (s ClusterContainsContainerInstancesException) GoString() string {
 
 func newErrorClusterContainsContainerInstancesException(v protocol.ResponseMetadata) error {
 	return &ClusterContainsContainerInstancesException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6508,12 +6508,12 @@ func (s ClusterContainsContainerInstancesException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClusterContainsContainerInstancesException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClusterContainsContainerInstancesException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You cannot delete a cluster that contains services. First, update the service
@@ -6521,7 +6521,7 @@ func (s ClusterContainsContainerInstancesException) RequestID() string {
 // information, see UpdateService and DeleteService.
 type ClusterContainsServicesException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6538,7 +6538,7 @@ func (s ClusterContainsServicesException) GoString() string {
 
 func newErrorClusterContainsServicesException(v protocol.ResponseMetadata) error {
 	return &ClusterContainsServicesException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6566,18 +6566,18 @@ func (s ClusterContainsServicesException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClusterContainsServicesException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClusterContainsServicesException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You cannot delete a cluster that has active tasks.
 type ClusterContainsTasksException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6594,7 +6594,7 @@ func (s ClusterContainsTasksException) GoString() string {
 
 func newErrorClusterContainsTasksException(v protocol.ResponseMetadata) error {
 	return &ClusterContainsTasksException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6622,19 +6622,19 @@ func (s ClusterContainsTasksException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClusterContainsTasksException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClusterContainsTasksException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified cluster could not be found. You can view your available clusters
 // with ListClusters. Amazon ECS clusters are Region-specific.
 type ClusterNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6651,7 +6651,7 @@ func (s ClusterNotFoundException) GoString() string {
 
 func newErrorClusterNotFoundException(v protocol.ResponseMetadata) error {
 	return &ClusterNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6679,12 +6679,12 @@ func (s ClusterNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClusterNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClusterNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The settings to use when creating a cluster. This parameter is used to enable
@@ -11528,7 +11528,7 @@ func (s *InferenceAcceleratorOverride) SetDeviceType(v string) *InferenceAcceler
 // API request.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11545,7 +11545,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11573,12 +11573,12 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Linux capabilities for the container that are added to or dropped from
@@ -11687,7 +11687,7 @@ func (s *KeyValuePair) SetValue(v string) *KeyValuePair {
 // The limit for the resource has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11704,7 +11704,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11732,12 +11732,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Linux-specific options that are applied to the container, such as Linux KernelCapabilities.
@@ -13207,7 +13207,7 @@ func (s *ManagedScaling) SetTargetCapacity(v int64) *ManagedScaling {
 // instance is an older or custom version that does not use our version information.
 type MissingVersionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13224,7 +13224,7 @@ func (s MissingVersionException) GoString() string {
 
 func newErrorMissingVersionException(v protocol.ResponseMetadata) error {
 	return &MissingVersionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13252,12 +13252,12 @@ func (s MissingVersionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MissingVersionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MissingVersionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details on a volume mount point that is used in a container definition.
@@ -13448,7 +13448,7 @@ func (s *NetworkInterface) SetPrivateIpv4Address(v string) *NetworkInterface {
 // that there is no update path to the current version.
 type NoUpdateAvailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13465,7 +13465,7 @@ func (s NoUpdateAvailableException) GoString() string {
 
 func newErrorNoUpdateAvailableException(v protocol.ResponseMetadata) error {
 	return &NoUpdateAvailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13493,12 +13493,12 @@ func (s NoUpdateAvailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoUpdateAvailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoUpdateAvailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing a constraint on task placement. For more information,
@@ -13651,7 +13651,7 @@ func (s *PlatformDevice) SetType(v string) *PlatformDevice {
 // capabilities.
 type PlatformTaskDefinitionIncompatibilityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13668,7 +13668,7 @@ func (s PlatformTaskDefinitionIncompatibilityException) GoString() string {
 
 func newErrorPlatformTaskDefinitionIncompatibilityException(v protocol.ResponseMetadata) error {
 	return &PlatformTaskDefinitionIncompatibilityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13696,18 +13696,18 @@ func (s PlatformTaskDefinitionIncompatibilityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PlatformTaskDefinitionIncompatibilityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PlatformTaskDefinitionIncompatibilityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified platform version does not exist.
 type PlatformUnknownException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13724,7 +13724,7 @@ func (s PlatformUnknownException) GoString() string {
 
 func newErrorPlatformUnknownException(v protocol.ResponseMetadata) error {
 	return &PlatformUnknownException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13752,12 +13752,12 @@ func (s PlatformUnknownException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PlatformUnknownException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PlatformUnknownException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Port mappings allow containers to access ports on the host container instance
@@ -15081,7 +15081,7 @@ func (s *Resource) SetType(v string) *Resource {
 // The specified resource is in-use and cannot be removed.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15098,7 +15098,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15126,18 +15126,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15154,7 +15154,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15182,12 +15182,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The type and amount of a resource to assign to a container. The supported
@@ -15692,7 +15692,7 @@ func (s *Secret) SetValueFrom(v string) *Secret {
 // These errors are usually caused by a server issue.
 type ServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15709,7 +15709,7 @@ func (s ServerException) GoString() string {
 
 func newErrorServerException(v protocol.ResponseMetadata) error {
 	return &ServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15737,12 +15737,12 @@ func (s ServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details on a service within a cluster
@@ -16139,7 +16139,7 @@ func (s *ServiceEvent) SetMessage(v string) *ServiceEvent {
 // If you have previously deleted a service, you can re-create it with CreateService.
 type ServiceNotActiveException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16156,7 +16156,7 @@ func (s ServiceNotActiveException) GoString() string {
 
 func newErrorServiceNotActiveException(v protocol.ResponseMetadata) error {
 	return &ServiceNotActiveException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16184,19 +16184,19 @@ func (s ServiceNotActiveException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceNotActiveException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceNotActiveException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified service could not be found. You can view your available services
 // with ListServices. Amazon ECS services are cluster-specific and Region-specific.
 type ServiceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16213,7 +16213,7 @@ func (s ServiceNotFoundException) GoString() string {
 
 func newErrorServiceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ServiceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16241,12 +16241,12 @@ func (s ServiceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details of the service registry.
@@ -17239,7 +17239,7 @@ func (s TagResourceOutput) GoString() string {
 // cluster-specific and Region-specific.
 type TargetNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17256,7 +17256,7 @@ func (s TargetNotFoundException) GoString() string {
 
 func newErrorTargetNotFoundException(v protocol.ResponseMetadata) error {
 	return &TargetNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17284,12 +17284,12 @@ func (s TargetNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TargetNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TargetNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details on a task in a cluster.
@@ -18506,7 +18506,7 @@ func (s *TaskSet) SetUpdatedAt(v time.Time) *TaskSet {
 // and Region.
 type TaskSetNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18523,7 +18523,7 @@ func (s TaskSetNotFoundException) GoString() string {
 
 func newErrorTaskSetNotFoundException(v protocol.ResponseMetadata) error {
 	return &TaskSetNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18551,12 +18551,12 @@ func (s TaskSetNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TaskSetNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TaskSetNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The container path, mount options, and size of the tmpfs mount.
@@ -18698,7 +18698,7 @@ func (s *Ulimit) SetSoftLimit(v int64) *Ulimit {
 // The specified task is not supported in this Region.
 type UnsupportedFeatureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18715,7 +18715,7 @@ func (s UnsupportedFeatureException) GoString() string {
 
 func newErrorUnsupportedFeatureException(v protocol.ResponseMetadata) error {
 	return &UnsupportedFeatureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18743,12 +18743,12 @@ func (s UnsupportedFeatureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedFeatureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedFeatureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -19080,7 +19080,7 @@ func (s *UpdateContainerInstancesStateOutput) SetFailures(v []*Failure) *UpdateC
 // it resumes where it stopped previously.
 type UpdateInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19097,7 +19097,7 @@ func (s UpdateInProgressException) GoString() string {
 
 func newErrorUpdateInProgressException(v protocol.ResponseMetadata) error {
 	return &UpdateInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19125,12 +19125,12 @@ func (s UpdateInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UpdateInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UpdateInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateServiceInput struct {

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -5516,8 +5516,8 @@ func (c *ECS) UpdateTaskSetWithContext(ctx aws.Context, input *UpdateTaskSetInpu
 
 // You do not have authorization to perform the requested action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5756,8 +5756,8 @@ func (s *Attribute) SetValue(v string) *Attribute {
 // of a resource with ListAttributes. You can remove existing attributes on
 // a resource with DeleteAttributes.
 type AttributeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5955,8 +5955,8 @@ func (s *AwsVpcConfiguration) SetSubnets(v []*string) *AwsVpcConfiguration {
 // Your AWS account has been blocked. For more information, contact AWS Support
 // (http://aws.amazon.com/contact-us/).
 type BlockedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6166,8 +6166,8 @@ func (s *CapacityProviderStrategyItem) SetWeight(v int64) *CapacityProviderStrat
 // or resource on behalf of a user that doesn't have permissions to use the
 // action or resource, or specifying an identifier that is not valid.
 type ClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6462,8 +6462,8 @@ func (s *Cluster) SetTags(v []*Tag) *Cluster {
 // deregister the container instances before you can delete the cluster. For
 // more information, see DeregisterContainerInstance.
 type ClusterContainsContainerInstancesException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6520,8 +6520,8 @@ func (s ClusterContainsContainerInstancesException) RequestID() string {
 // to reduce its desired task count to 0 and then delete the service. For more
 // information, see UpdateService and DeleteService.
 type ClusterContainsServicesException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6576,8 +6576,8 @@ func (s ClusterContainsServicesException) RequestID() string {
 
 // You cannot delete a cluster that has active tasks.
 type ClusterContainsTasksException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6633,8 +6633,8 @@ func (s ClusterContainsTasksException) RequestID() string {
 // The specified cluster could not be found. You can view your available clusters
 // with ListClusters. Amazon ECS clusters are Region-specific.
 type ClusterNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11527,8 +11527,8 @@ func (s *InferenceAcceleratorOverride) SetDeviceType(v string) *InferenceAcceler
 // The specified parameter is invalid. Review the available parameters for the
 // API request.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11686,8 +11686,8 @@ func (s *KeyValuePair) SetValue(v string) *KeyValuePair {
 
 // The limit for the resource has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13206,8 +13206,8 @@ func (s *ManagedScaling) SetTargetCapacity(v int64) *ManagedScaling {
 // with an update. This could be because the agent running on the container
 // instance is an older or custom version that does not use our version information.
 type MissingVersionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13447,8 +13447,8 @@ func (s *NetworkInterface) SetPrivateIpv4Address(v string) *NetworkInterface {
 // be because the agent is already running the latest version, or it is so old
 // that there is no update path to the current version.
 type NoUpdateAvailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13650,8 +13650,8 @@ func (s *PlatformDevice) SetType(v string) *PlatformDevice {
 // The specified platform version does not satisfy the task definition's required
 // capabilities.
 type PlatformTaskDefinitionIncompatibilityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13706,8 +13706,8 @@ func (s PlatformTaskDefinitionIncompatibilityException) RequestID() string {
 
 // The specified platform version does not exist.
 type PlatformUnknownException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15080,8 +15080,8 @@ func (s *Resource) SetType(v string) *Resource {
 
 // The specified resource is in-use and cannot be removed.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15136,8 +15136,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15691,8 +15691,8 @@ func (s *Secret) SetValueFrom(v string) *Secret {
 
 // These errors are usually caused by a server issue.
 type ServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16138,8 +16138,8 @@ func (s *ServiceEvent) SetMessage(v string) *ServiceEvent {
 // The specified service is not active. You can't update a service that is inactive.
 // If you have previously deleted a service, you can re-create it with CreateService.
 type ServiceNotActiveException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16195,8 +16195,8 @@ func (s ServiceNotActiveException) RequestID() string {
 // The specified service could not be found. You can view your available services
 // with ListServices. Amazon ECS services are cluster-specific and Region-specific.
 type ServiceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17238,8 +17238,8 @@ func (s TagResourceOutput) GoString() string {
 // instances with ListContainerInstances. Amazon ECS container instances are
 // cluster-specific and Region-specific.
 type TargetNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18505,8 +18505,8 @@ func (s *TaskSet) SetUpdatedAt(v time.Time) *TaskSet {
 // sets with DescribeTaskSets. Task sets are specific to each cluster, service
 // and Region.
 type TaskSetNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18697,8 +18697,8 @@ func (s *Ulimit) SetSoftLimit(v int64) *Ulimit {
 
 // The specified task is not supported in this Region.
 type UnsupportedFeatureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19079,8 +19079,8 @@ func (s *UpdateContainerInstancesStateOutput) SetFailures(v []*Failure) *UpdateC
 // process can get stuck in that state. However, when the agent reconnects,
 // it resumes where it stopped previously.
 type UpdateInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -2750,7 +2750,7 @@ func (c *EFS) UpdateFileSystemWithContext(ctx aws.Context, input *UpdateFileSyst
 // the creation token you provided in the request.
 type AccessPointAlreadyExists struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// AccessPointId is a required field
 	AccessPointId *string `type:"string" required:"true"`
@@ -2773,7 +2773,7 @@ func (s AccessPointAlreadyExists) GoString() string {
 
 func newErrorAccessPointAlreadyExists(v protocol.ResponseMetadata) error {
 	return &AccessPointAlreadyExists{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2801,12 +2801,12 @@ func (s AccessPointAlreadyExists) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessPointAlreadyExists) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessPointAlreadyExists) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides a description of an EFS file system access point.
@@ -2921,7 +2921,7 @@ func (s *AccessPointDescription) SetTags(v []*Tag) *AccessPointDescription {
 // points allowed per file system.
 type AccessPointLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -2941,7 +2941,7 @@ func (s AccessPointLimitExceeded) GoString() string {
 
 func newErrorAccessPointLimitExceeded(v protocol.ResponseMetadata) error {
 	return &AccessPointLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2969,19 +2969,19 @@ func (s AccessPointLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessPointLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessPointLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the specified AccessPointId value doesn't exist in the requester's
 // AWS account.
 type AccessPointNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -3001,7 +3001,7 @@ func (s AccessPointNotFound) GoString() string {
 
 func newErrorAccessPointNotFound(v protocol.ResponseMetadata) error {
 	return &AccessPointNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3029,19 +3029,19 @@ func (s AccessPointNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessPointNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessPointNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the request is malformed or contains an error such as an invalid
 // parameter value or a missing required parameter.
 type BadRequest struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -3061,7 +3061,7 @@ func (s BadRequest) GoString() string {
 
 func newErrorBadRequest(v protocol.ResponseMetadata) error {
 	return &BadRequest{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3089,12 +3089,12 @@ func (s BadRequest) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequest) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequest) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateAccessPointInput struct {
@@ -3981,7 +3981,7 @@ func (s DeleteTagsOutput) GoString() string {
 // try the call again.
 type DependencyTimeout struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -4001,7 +4001,7 @@ func (s DependencyTimeout) GoString() string {
 
 func newErrorDependencyTimeout(v protocol.ResponseMetadata) error {
 	return &DependencyTimeout{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4029,12 +4029,12 @@ func (s DependencyTimeout) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DependencyTimeout) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DependencyTimeout) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DescribeAccessPointsInput struct {
@@ -4703,7 +4703,7 @@ func (s *DescribeTagsOutput) SetTags(v []*Tag) *DescribeTagsOutput {
 // the creation token you provided.
 type FileSystemAlreadyExists struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -4726,7 +4726,7 @@ func (s FileSystemAlreadyExists) GoString() string {
 
 func newErrorFileSystemAlreadyExists(v protocol.ResponseMetadata) error {
 	return &FileSystemAlreadyExists{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4754,12 +4754,12 @@ func (s FileSystemAlreadyExists) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileSystemAlreadyExists) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileSystemAlreadyExists) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A description of the file system.
@@ -4947,7 +4947,7 @@ func (s *FileSystemDescription) SetThroughputMode(v string) *FileSystemDescripti
 // Returned if a file system has mount targets.
 type FileSystemInUse struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -4967,7 +4967,7 @@ func (s FileSystemInUse) GoString() string {
 
 func newErrorFileSystemInUse(v protocol.ResponseMetadata) error {
 	return &FileSystemInUse{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4995,19 +4995,19 @@ func (s FileSystemInUse) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileSystemInUse) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileSystemInUse) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the AWS account has already created the maximum number of file
 // systems allowed per account.
 type FileSystemLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5027,7 +5027,7 @@ func (s FileSystemLimitExceeded) GoString() string {
 
 func newErrorFileSystemLimitExceeded(v protocol.ResponseMetadata) error {
 	return &FileSystemLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5055,19 +5055,19 @@ func (s FileSystemLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileSystemLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileSystemLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the specified FileSystemId value doesn't exist in the requester's
 // AWS account.
 type FileSystemNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5087,7 +5087,7 @@ func (s FileSystemNotFound) GoString() string {
 
 func newErrorFileSystemNotFound(v protocol.ResponseMetadata) error {
 	return &FileSystemNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5115,12 +5115,12 @@ func (s FileSystemNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileSystemNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileSystemNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The latest known metered size (in bytes) of data stored in the file system,
@@ -5189,7 +5189,7 @@ func (s *FileSystemSize) SetValueInStandard(v int64) *FileSystemSize {
 // Returned if the file system's lifecycle state is not "available".
 type IncorrectFileSystemLifeCycleState struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5209,7 +5209,7 @@ func (s IncorrectFileSystemLifeCycleState) GoString() string {
 
 func newErrorIncorrectFileSystemLifeCycleState(v protocol.ResponseMetadata) error {
 	return &IncorrectFileSystemLifeCycleState{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5237,18 +5237,18 @@ func (s IncorrectFileSystemLifeCycleState) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncorrectFileSystemLifeCycleState) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncorrectFileSystemLifeCycleState) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the mount target is not in the correct state for the operation.
 type IncorrectMountTargetState struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5268,7 +5268,7 @@ func (s IncorrectMountTargetState) GoString() string {
 
 func newErrorIncorrectMountTargetState(v protocol.ResponseMetadata) error {
 	return &IncorrectMountTargetState{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5296,12 +5296,12 @@ func (s IncorrectMountTargetState) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncorrectMountTargetState) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncorrectMountTargetState) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if there's not enough capacity to provision additional throughput.
@@ -5311,7 +5311,7 @@ func (s IncorrectMountTargetState) RequestID() string {
 // system from bursting to provisioned throughput mode.
 type InsufficientThroughputCapacity struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5331,7 +5331,7 @@ func (s InsufficientThroughputCapacity) GoString() string {
 
 func newErrorInsufficientThroughputCapacity(v protocol.ResponseMetadata) error {
 	return &InsufficientThroughputCapacity{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5359,18 +5359,18 @@ func (s InsufficientThroughputCapacity) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientThroughputCapacity) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientThroughputCapacity) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if an error occurred on the server side.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5390,7 +5390,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5418,12 +5418,12 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the FileSystemPolicy is is malformed or contains an error such
@@ -5431,7 +5431,7 @@ func (s InternalServerError) RequestID() string {
 // the case of a policy lockout safety check error.
 type InvalidPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorCode *string `min:"1" type:"string"`
 
@@ -5450,7 +5450,7 @@ func (s InvalidPolicyException) GoString() string {
 
 func newErrorInvalidPolicyException(v protocol.ResponseMetadata) error {
 	return &InvalidPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5478,19 +5478,19 @@ func (s InvalidPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the request specified an IpAddress that is already in use in
 // the subnet.
 type IpAddressInUse struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5510,7 +5510,7 @@ func (s IpAddressInUse) GoString() string {
 
 func newErrorIpAddressInUse(v protocol.ResponseMetadata) error {
 	return &IpAddressInUse{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5538,12 +5538,12 @@ func (s IpAddressInUse) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IpAddressInUse) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IpAddressInUse) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a policy used by EFS lifecycle management to transition files to
@@ -5739,7 +5739,7 @@ func (s ModifyMountTargetSecurityGroupsOutput) GoString() string {
 // based on the file system's existing mount targets.
 type MountTargetConflict struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5759,7 +5759,7 @@ func (s MountTargetConflict) GoString() string {
 
 func newErrorMountTargetConflict(v protocol.ResponseMetadata) error {
 	return &MountTargetConflict{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5787,12 +5787,12 @@ func (s MountTargetConflict) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MountTargetConflict) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MountTargetConflict) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides a description of a mount target.
@@ -5909,7 +5909,7 @@ func (s *MountTargetDescription) SetSubnetId(v string) *MountTargetDescription {
 // account.
 type MountTargetNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5929,7 +5929,7 @@ func (s MountTargetNotFound) GoString() string {
 
 func newErrorMountTargetNotFound(v protocol.ResponseMetadata) error {
 	return &MountTargetNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5957,12 +5957,12 @@ func (s MountTargetNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MountTargetNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MountTargetNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The calling account has reached the limit for elastic network interfaces
@@ -5973,7 +5973,7 @@ func (s MountTargetNotFound) RequestID() string {
 // the table).
 type NetworkInterfaceLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5993,7 +5993,7 @@ func (s NetworkInterfaceLimitExceeded) GoString() string {
 
 func newErrorNetworkInterfaceLimitExceeded(v protocol.ResponseMetadata) error {
 	return &NetworkInterfaceLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6021,19 +6021,19 @@ func (s NetworkInterfaceLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NetworkInterfaceLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NetworkInterfaceLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if IpAddress was not specified in the request and there are no free
 // IP addresses in the subnet.
 type NoFreeAddressesInSubnet struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6053,7 +6053,7 @@ func (s NoFreeAddressesInSubnet) GoString() string {
 
 func newErrorNoFreeAddressesInSubnet(v protocol.ResponseMetadata) error {
 	return &NoFreeAddressesInSubnet{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6081,19 +6081,19 @@ func (s NoFreeAddressesInSubnet) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoFreeAddressesInSubnet) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoFreeAddressesInSubnet) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the default file system policy is in effect for the EFS file
 // system specified.
 type PolicyNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorCode *string `min:"1" type:"string"`
 
@@ -6112,7 +6112,7 @@ func (s PolicyNotFound) GoString() string {
 
 func newErrorPolicyNotFound(v protocol.ResponseMetadata) error {
 	return &PolicyNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6140,12 +6140,12 @@ func (s PolicyNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The full POSIX identity, including the user ID, group ID, and any secondary
@@ -6472,7 +6472,7 @@ func (s *RootDirectory) SetPath(v string) *RootDirectory {
 // than five.
 type SecurityGroupLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6492,7 +6492,7 @@ func (s SecurityGroupLimitExceeded) GoString() string {
 
 func newErrorSecurityGroupLimitExceeded(v protocol.ResponseMetadata) error {
 	return &SecurityGroupLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6520,19 +6520,19 @@ func (s SecurityGroupLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SecurityGroupLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SecurityGroupLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if one of the specified security groups doesn't exist in the subnet's
 // VPC.
 type SecurityGroupNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6552,7 +6552,7 @@ func (s SecurityGroupNotFound) GoString() string {
 
 func newErrorSecurityGroupNotFound(v protocol.ResponseMetadata) error {
 	return &SecurityGroupNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6580,18 +6580,18 @@ func (s SecurityGroupNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SecurityGroupNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SecurityGroupNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if there is no subnet with ID SubnetId provided in the request.
 type SubnetNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6611,7 +6611,7 @@ func (s SubnetNotFound) GoString() string {
 
 func newErrorSubnetNotFound(v protocol.ResponseMetadata) error {
 	return &SubnetNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6639,12 +6639,12 @@ func (s SubnetNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubnetNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubnetNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A tag is a key-value pair. Allowed characters are letters, white space, and
@@ -6786,7 +6786,7 @@ func (s TagResourceOutput) GoString() string {
 // be changed because the throughput limit of 1024 MiB/s has been reached.
 type ThroughputLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6806,7 +6806,7 @@ func (s ThroughputLimitExceeded) GoString() string {
 
 func newErrorThroughputLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ThroughputLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6834,19 +6834,19 @@ func (s ThroughputLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThroughputLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThroughputLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if you don’t wait at least 24 hours before changing the throughput
 // mode, or decreasing the Provisioned Throughput value.
 type TooManyRequests struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6866,7 +6866,7 @@ func (s TooManyRequests) GoString() string {
 
 func newErrorTooManyRequests(v protocol.ResponseMetadata) error {
 	return &TooManyRequests{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6894,17 +6894,17 @@ func (s TooManyRequests) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequests) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequests) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UnsupportedAvailabilityZone struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6924,7 +6924,7 @@ func (s UnsupportedAvailabilityZone) GoString() string {
 
 func newErrorUnsupportedAvailabilityZone(v protocol.ResponseMetadata) error {
 	return &UnsupportedAvailabilityZone{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6952,12 +6952,12 @@ func (s UnsupportedAvailabilityZone) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedAvailabilityZone) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedAvailabilityZone) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -2749,8 +2749,8 @@ func (c *EFS) UpdateFileSystemWithContext(ctx aws.Context, input *UpdateFileSyst
 // Returned if the access point you are trying to create already exists, with
 // the creation token you provided in the request.
 type AccessPointAlreadyExists struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// AccessPointId is a required field
 	AccessPointId *string `type:"string" required:"true"`
@@ -2920,8 +2920,8 @@ func (s *AccessPointDescription) SetTags(v []*Tag) *AccessPointDescription {
 // Returned if the AWS account has already created the maximum number of access
 // points allowed per file system.
 type AccessPointLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -2980,8 +2980,8 @@ func (s AccessPointLimitExceeded) RequestID() string {
 // Returned if the specified AccessPointId value doesn't exist in the requester's
 // AWS account.
 type AccessPointNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -3040,8 +3040,8 @@ func (s AccessPointNotFound) RequestID() string {
 // Returned if the request is malformed or contains an error such as an invalid
 // parameter value or a missing required parameter.
 type BadRequest struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -3980,8 +3980,8 @@ func (s DeleteTagsOutput) GoString() string {
 // The service timed out trying to fulfill the request, and the client should
 // try the call again.
 type DependencyTimeout struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -4702,8 +4702,8 @@ func (s *DescribeTagsOutput) SetTags(v []*Tag) *DescribeTagsOutput {
 // Returned if the file system you are trying to create already exists, with
 // the creation token you provided.
 type FileSystemAlreadyExists struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -4946,8 +4946,8 @@ func (s *FileSystemDescription) SetThroughputMode(v string) *FileSystemDescripti
 
 // Returned if a file system has mount targets.
 type FileSystemInUse struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5006,8 +5006,8 @@ func (s FileSystemInUse) RequestID() string {
 // Returned if the AWS account has already created the maximum number of file
 // systems allowed per account.
 type FileSystemLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5066,8 +5066,8 @@ func (s FileSystemLimitExceeded) RequestID() string {
 // Returned if the specified FileSystemId value doesn't exist in the requester's
 // AWS account.
 type FileSystemNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5188,8 +5188,8 @@ func (s *FileSystemSize) SetValueInStandard(v int64) *FileSystemSize {
 
 // Returned if the file system's lifecycle state is not "available".
 type IncorrectFileSystemLifeCycleState struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5247,8 +5247,8 @@ func (s IncorrectFileSystemLifeCycleState) RequestID() string {
 
 // Returned if the mount target is not in the correct state for the operation.
 type IncorrectMountTargetState struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5310,8 +5310,8 @@ func (s IncorrectMountTargetState) RequestID() string {
 // of an existing file system, or when you attempt to change an existing file
 // system from bursting to provisioned throughput mode.
 type InsufficientThroughputCapacity struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5369,8 +5369,8 @@ func (s InsufficientThroughputCapacity) RequestID() string {
 
 // Returned if an error occurred on the server side.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5430,8 +5430,8 @@ func (s InternalServerError) RequestID() string {
 // as an invalid parameter value or a missing required parameter. Returned in
 // the case of a policy lockout safety check error.
 type InvalidPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorCode *string `min:"1" type:"string"`
 
@@ -5489,8 +5489,8 @@ func (s InvalidPolicyException) RequestID() string {
 // Returned if the request specified an IpAddress that is already in use in
 // the subnet.
 type IpAddressInUse struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5738,8 +5738,8 @@ func (s ModifyMountTargetSecurityGroupsOutput) GoString() string {
 // Returned if the mount target would violate one of the specified restrictions
 // based on the file system's existing mount targets.
 type MountTargetConflict struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5908,8 +5908,8 @@ func (s *MountTargetDescription) SetSubnetId(v string) *MountTargetDescription {
 // Returned if there is no mount target with the specified ID found in the caller's
 // account.
 type MountTargetNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -5972,8 +5972,8 @@ func (s MountTargetNotFound) RequestID() string {
 // in the Amazon VPC User Guide (see the Network interfaces per VPC entry in
 // the table).
 type NetworkInterfaceLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6032,8 +6032,8 @@ func (s NetworkInterfaceLimitExceeded) RequestID() string {
 // Returned if IpAddress was not specified in the request and there are no free
 // IP addresses in the subnet.
 type NoFreeAddressesInSubnet struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6092,8 +6092,8 @@ func (s NoFreeAddressesInSubnet) RequestID() string {
 // Returned if the default file system policy is in effect for the EFS file
 // system specified.
 type PolicyNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorCode *string `min:"1" type:"string"`
 
@@ -6471,8 +6471,8 @@ func (s *RootDirectory) SetPath(v string) *RootDirectory {
 // Returned if the size of SecurityGroups specified in the request is greater
 // than five.
 type SecurityGroupLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6531,8 +6531,8 @@ func (s SecurityGroupLimitExceeded) RequestID() string {
 // Returned if one of the specified security groups doesn't exist in the subnet's
 // VPC.
 type SecurityGroupNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6590,8 +6590,8 @@ func (s SecurityGroupNotFound) RequestID() string {
 
 // Returned if there is no subnet with ID SubnetId provided in the request.
 type SubnetNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6785,8 +6785,8 @@ func (s TagResourceOutput) GoString() string {
 // Returned if the throughput mode or amount of provisioned throughput can't
 // be changed because the throughput limit of 1024 MiB/s has been reached.
 type ThroughputLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6845,8 +6845,8 @@ func (s ThroughputLimitExceeded) RequestID() string {
 // Returned if you don’t wait at least 24 hours before changing the throughput
 // mode, or decreasing the Provisioned Throughput value.
 type TooManyRequests struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`
@@ -6903,8 +6903,8 @@ func (s TooManyRequests) RequestID() string {
 }
 
 type UnsupportedAvailabilityZone struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// ErrorCode is a required field
 	ErrorCode *string `min:"1" type:"string" required:"true"`

--- a/service/eks/api.go
+++ b/service/eks/api.go
@@ -2450,7 +2450,7 @@ func (s *AutoScalingGroup) SetName(v string) *AutoScalingGroup {
 // meaning will depend on the API, and will be documented in the error message.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2467,7 +2467,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2495,12 +2495,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing the certificate-authority-data for your cluster.
@@ -2534,7 +2534,7 @@ func (s *Certificate) SetData(v string) *Certificate {
 // use the action or resource or specifying an identifier that is not valid.
 type ClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -2557,7 +2557,7 @@ func (s ClientException) GoString() string {
 
 func newErrorClientException(v protocol.ResponseMetadata) error {
 	return &ClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2585,12 +2585,12 @@ func (s ClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing an Amazon EKS cluster.
@@ -4096,7 +4096,7 @@ func (s *Identity) SetOidc(v *OIDC) *Identity {
 // API request.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -4122,7 +4122,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4150,19 +4150,19 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request is invalid given the state of the cluster. Check the state of
 // the cluster and the associated operations.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -4185,7 +4185,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4213,12 +4213,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing an issue with an Amazon EKS resource.
@@ -5198,7 +5198,7 @@ func (s *NodegroupScalingConfig) SetMinSize(v int64) *NodegroupScalingConfig {
 // should not retry such requests.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5215,7 +5215,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5243,12 +5243,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object representing the OpenID Connect (https://openid.net/connect/) identity
@@ -5351,7 +5351,7 @@ func (s *RemoteAccessConfig) SetSourceSecurityGroups(v []*string) *RemoteAccessC
 // The specified resource is in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5374,7 +5374,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5402,18 +5402,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have encountered a service limit on the specified resource.
 type ResourceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5436,7 +5436,7 @@ func (s ResourceLimitExceededException) GoString() string {
 
 func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5464,12 +5464,12 @@ func (s ResourceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource could not be found. You can view your available clusters
@@ -5477,7 +5477,7 @@ func (s ResourceLimitExceededException) RequestID() string {
 // Amazon EKS clusters and node groups are Region-specific.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5503,7 +5503,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5531,18 +5531,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // These errors are usually caused by a server-side issue.
 type ServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5565,7 +5565,7 @@ func (s ServerException) GoString() string {
 
 func newErrorServerException(v protocol.ResponseMetadata) error {
 	return &ServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5593,18 +5593,18 @@ func (s ServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service is unavailable. Back off and retry the operation.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5621,7 +5621,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5649,12 +5649,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {
@@ -5736,7 +5736,7 @@ func (s TagResourceOutput) GoString() string {
 // your cluster.
 type UnsupportedAvailabilityZoneException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5763,7 +5763,7 @@ func (s UnsupportedAvailabilityZoneException) GoString() string {
 
 func newErrorUnsupportedAvailabilityZoneException(v protocol.ResponseMetadata) error {
 	return &UnsupportedAvailabilityZoneException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5791,12 +5791,12 @@ func (s UnsupportedAvailabilityZoneException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedAvailabilityZoneException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedAvailabilityZoneException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/eks/api.go
+++ b/service/eks/api.go
@@ -2449,8 +2449,8 @@ func (s *AutoScalingGroup) SetName(v string) *AutoScalingGroup {
 // This exception is thrown if the request contains a semantic error. The precise
 // meaning will depend on the API, and will be documented in the error message.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2533,8 +2533,8 @@ func (s *Certificate) SetData(v string) *Certificate {
 // an action or resource on behalf of a user that doesn't have permissions to
 // use the action or resource or specifying an identifier that is not valid.
 type ClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -4095,8 +4095,8 @@ func (s *Identity) SetOidc(v *OIDC) *Identity {
 // The specified parameter is invalid. Review the available parameters for the
 // API request.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -4161,8 +4161,8 @@ func (s InvalidParameterException) RequestID() string {
 // The request is invalid given the state of the cluster. Check the state of
 // the cluster and the associated operations.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5197,8 +5197,8 @@ func (s *NodegroupScalingConfig) SetMinSize(v int64) *NodegroupScalingConfig {
 // A service resource associated with the request could not be found. Clients
 // should not retry such requests.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5350,8 +5350,8 @@ func (s *RemoteAccessConfig) SetSourceSecurityGroups(v []*string) *RemoteAccessC
 
 // The specified resource is in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5412,8 +5412,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // You have encountered a service limit on the specified resource.
 type ResourceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5476,8 +5476,8 @@ func (s ResourceLimitExceededException) RequestID() string {
 // with ListClusters. You can view your available managed node groups with ListNodegroups.
 // Amazon EKS clusters and node groups are Region-specific.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5541,8 +5541,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // These errors are usually caused by a server-side issue.
 type ServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`
@@ -5603,8 +5603,8 @@ func (s ServerException) RequestID() string {
 
 // The service is unavailable. Back off and retry the operation.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5735,8 +5735,8 @@ func (s TagResourceOutput) GoString() string {
 // Availability Zones for your account, from which you can choose subnets for
 // your cluster.
 type UnsupportedAvailabilityZoneException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Amazon EKS cluster associated with the exception.
 	ClusterName *string `locationName:"clusterName" type:"string"`

--- a/service/elasticinference/api.go
+++ b/service/elasticinference/api.go
@@ -272,7 +272,7 @@ func (c *ElasticInference) UntagResourceWithContext(ctx aws.Context, input *Unta
 // Raised when a malformed input has been provided to the API.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -289,7 +289,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -317,18 +317,18 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Raised when an unexpected error occurred during request processing.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -345,7 +345,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -373,12 +373,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTagsForResourceInput struct {
@@ -448,7 +448,7 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 // Raised when the requested resource cannot be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -465,7 +465,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -493,12 +493,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {

--- a/service/elasticinference/api.go
+++ b/service/elasticinference/api.go
@@ -271,8 +271,8 @@ func (c *ElasticInference) UntagResourceWithContext(ctx aws.Context, input *Unta
 
 // Raised when a malformed input has been provided to the API.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -327,8 +327,8 @@ func (s BadRequestException) RequestID() string {
 
 // Raised when an unexpected error occurred during request processing.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -447,8 +447,8 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 
 // Raised when the requested resource cannot be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -2757,7 +2757,7 @@ func (s *AdvancedSecurityOptionsStatus) SetStatus(v *OptionStatus) *AdvancedSecu
 // An error occurred while processing the request.
 type BaseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description of the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2775,7 +2775,7 @@ func (s BaseException) GoString() string {
 
 func newErrorBaseException(v protocol.ResponseMetadata) error {
 	return &BaseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2803,12 +2803,12 @@ func (s BaseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BaseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BaseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Container for the parameters to the CancelElasticsearchServiceSoftwareUpdate
@@ -3808,7 +3808,7 @@ func (s *DescribeReservedElasticsearchInstancesOutput) SetReservedElasticsearchI
 // Gives http status code of 409.
 type DisabledOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3825,7 +3825,7 @@ func (s DisabledOperationException) GoString() string {
 
 func newErrorDisabledOperationException(v protocol.ResponseMetadata) error {
 	return &DisabledOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3853,12 +3853,12 @@ func (s DisabledOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DisabledOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DisabledOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Options to configure endpoint for the Elasticsearch domain.
@@ -5040,7 +5040,7 @@ func (s *InstanceLimits) SetInstanceCountLimits(v *InstanceCountLimits) *Instanc
 // of 500.
 type InternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5057,7 +5057,7 @@ func (s InternalException) GoString() string {
 
 func newErrorInternalException(v protocol.ResponseMetadata) error {
 	return &InternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5085,19 +5085,19 @@ func (s InternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An exception for trying to create or access sub-resource that is either invalid
 // or not supported. Gives http status code of 409.
 type InvalidTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5114,7 +5114,7 @@ func (s InvalidTypeException) GoString() string {
 
 func newErrorInvalidTypeException(v protocol.ResponseMetadata) error {
 	return &InvalidTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5142,19 +5142,19 @@ func (s InvalidTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An exception for trying to create more than allowed resources or sub-resources.
 // Gives http status code of 409.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5171,7 +5171,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5199,12 +5199,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Limits for given InstanceType and for each of it's role. Limits contains
@@ -6249,7 +6249,7 @@ func (s *ReservedElasticsearchInstanceOffering) SetUsagePrice(v float64) *Reserv
 // code of 400.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6266,7 +6266,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6294,19 +6294,19 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An exception for accessing or deleting a resource that does not exist. Gives
 // http status code of 400.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6323,7 +6323,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6351,12 +6351,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The current options of an Elasticsearch domain service software options.
@@ -7274,7 +7274,7 @@ func (s *VPCOptions) SetSubnetIds(v []*string) *VPCOptions {
 // 400.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7291,7 +7291,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7319,12 +7319,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the zone awareness configuration for the domain cluster, such as

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -2756,8 +2756,8 @@ func (s *AdvancedSecurityOptionsStatus) SetStatus(v *OptionStatus) *AdvancedSecu
 
 // An error occurred while processing the request.
 type BaseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description of the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3807,8 +3807,8 @@ func (s *DescribeReservedElasticsearchInstancesOutput) SetReservedElasticsearchI
 // An error occured because the client wanted to access a not supported operation.
 // Gives http status code of 409.
 type DisabledOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5039,8 +5039,8 @@ func (s *InstanceLimits) SetInstanceCountLimits(v *InstanceCountLimits) *Instanc
 // or failure (the failure is internal to the service) . Gives http status code
 // of 500.
 type InternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5096,8 +5096,8 @@ func (s InternalException) RequestID() string {
 // An exception for trying to create or access sub-resource that is either invalid
 // or not supported. Gives http status code of 409.
 type InvalidTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5153,8 +5153,8 @@ func (s InvalidTypeException) RequestID() string {
 // An exception for trying to create more than allowed resources or sub-resources.
 // Gives http status code of 409.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6248,8 +6248,8 @@ func (s *ReservedElasticsearchInstanceOffering) SetUsagePrice(v float64) *Reserv
 // An exception for creating a resource that already exists. Gives http status
 // code of 400.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6305,8 +6305,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 // An exception for accessing or deleting a resource that does not exist. Gives
 // http status code of 400.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7273,8 +7273,8 @@ func (s *VPCOptions) SetSubnetIds(v []*string) *VPCOptions {
 // An exception for missing / invalid input fields. Gives http status code of
 // 400.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -1866,7 +1866,7 @@ func (c *ElasticTranscoder) UpdatePipelineStatusWithContext(ctx aws.Context, inp
 // General authentication failure. The request was not signed correctly.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1883,7 +1883,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1911,12 +1911,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The file to be used as album art. There can be multiple artworks associated
@@ -4096,7 +4096,7 @@ func (s *HlsContentProtection) SetMethod(v string) *HlsContentProtection {
 
 type IncompatibleVersionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4113,7 +4113,7 @@ func (s IncompatibleVersionException) GoString() string {
 
 func newErrorIncompatibleVersionException(v protocol.ResponseMetadata) error {
 	return &IncompatibleVersionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4141,12 +4141,12 @@ func (s IncompatibleVersionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncompatibleVersionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncompatibleVersionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The captions to be created, if any.
@@ -4225,7 +4225,7 @@ func (s *InputCaptions) SetMergePolicy(v string) *InputCaptions {
 // the request.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4242,7 +4242,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4270,12 +4270,12 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A section of the response body that provides information about the job that
@@ -5132,7 +5132,7 @@ func (s *JobWatermark) SetPresetWatermarkId(v string) *JobWatermark {
 // exceeds the maximum allowed.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5149,7 +5149,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5177,12 +5177,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The ListJobsByPipelineRequest structure.
@@ -6764,7 +6764,7 @@ func (s *ReadPresetOutput) SetPreset(v *Preset) *ReadPresetOutput {
 // attempting to delete a pipeline that is currently in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6781,7 +6781,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6809,12 +6809,12 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested resource does not exist or is not available. For example, the
@@ -6822,7 +6822,7 @@ func (s ResourceInUseException) RequestID() string {
 // created.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6839,7 +6839,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6867,12 +6867,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The TestRoleRequest structure.
@@ -7709,7 +7709,7 @@ func (s *UpdatePipelineStatusOutput) SetPipeline(v *Pipeline) *UpdatePipelineSta
 // One or more required parameter values were not provided in the request.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7726,7 +7726,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7754,12 +7754,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The VideoParameters structure.

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -1865,8 +1865,8 @@ func (c *ElasticTranscoder) UpdatePipelineStatusWithContext(ctx aws.Context, inp
 
 // General authentication failure. The request was not signed correctly.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4095,8 +4095,8 @@ func (s *HlsContentProtection) SetMethod(v string) *HlsContentProtection {
 }
 
 type IncompatibleVersionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4224,8 +4224,8 @@ func (s *InputCaptions) SetMergePolicy(v string) *InputCaptions {
 // Elastic Transcoder encountered an unexpected exception while trying to fulfill
 // the request.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5131,8 +5131,8 @@ func (s *JobWatermark) SetPresetWatermarkId(v string) *JobWatermark {
 // Too many operations for a given AWS account. For example, the number of pipelines
 // exceeds the maximum allowed.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6763,8 +6763,8 @@ func (s *ReadPresetOutput) SetPreset(v *Preset) *ReadPresetOutput {
 // The resource you are attempting to change is in use. For example, you are
 // attempting to delete a pipeline that is currently in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6821,8 +6821,8 @@ func (s ResourceInUseException) RequestID() string {
 // pipeline to which you're trying to add a job doesn't exist or is still being
 // created.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7708,8 +7708,8 @@ func (s *UpdatePipelineStatusOutput) SetPipeline(v *Pipeline) *UpdatePipelineSta
 
 // One or more required parameter values were not provided in the request.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -7393,7 +7393,7 @@ func (s *InstanceTypeSpecification) SetWeightedCapacity(v int64) *InstanceTypeSp
 // request was not completed.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7410,7 +7410,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7438,18 +7438,18 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception occurs when there is an internal failure in the EMR service.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message associated with the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -7467,7 +7467,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7495,18 +7495,18 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception occurs when there is something wrong with user input.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error code associated with the exception.
 	ErrorCode *string `min:"1" type:"string"`
@@ -7527,7 +7527,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7555,12 +7555,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A description of a cluster (job flow).

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -7392,8 +7392,8 @@ func (s *InstanceTypeSpecification) SetWeightedCapacity(v int64) *InstanceTypeSp
 // Indicates that an error occurred while processing the request and that the
 // request was not completed.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7448,8 +7448,8 @@ func (s InternalServerError) RequestID() string {
 
 // This exception occurs when there is an internal failure in the EMR service.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message associated with the exception.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -7505,8 +7505,8 @@ func (s InternalServerException) RequestID() string {
 
 // This exception occurs when there is something wrong with user input.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error code associated with the exception.
 	ErrorCode *string `min:"1" type:"string"`

--- a/service/eventbridge/api.go
+++ b/service/eventbridge/api.go
@@ -3243,7 +3243,7 @@ func (s *BatchRetryStrategy) SetAttempts(v int64) *BatchRetryStrategy {
 // There is concurrent modification on a rule or target.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3260,7 +3260,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3288,12 +3288,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A JSON string which you can use to limit the event bus permissions you are
@@ -4709,7 +4709,7 @@ func (s *InputTransformer) SetInputTemplate(v string) *InputTransformer {
 // This exception occurs due to unexpected causes.
 type InternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4726,7 +4726,7 @@ func (s InternalException) GoString() string {
 
 func newErrorInternalException(v protocol.ResponseMetadata) error {
 	return &InternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4754,18 +4754,18 @@ func (s InternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The event pattern is not valid.
 type InvalidEventPatternException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4782,7 +4782,7 @@ func (s InvalidEventPatternException) GoString() string {
 
 func newErrorInvalidEventPatternException(v protocol.ResponseMetadata) error {
 	return &InvalidEventPatternException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4810,18 +4810,18 @@ func (s InvalidEventPatternException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEventPatternException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEventPatternException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified state is not a valid state for an event source.
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4838,7 +4838,7 @@ func (s InvalidStateException) GoString() string {
 
 func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 	return &InvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4866,12 +4866,12 @@ func (s InvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This object enables you to specify a JSON path to extract from the event
@@ -4921,7 +4921,7 @@ func (s *KinesisParameters) SetPartitionKeyPath(v string) *KinesisParameters {
 // You tried to create more rules or add more targets to a rule than is allowed.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4938,7 +4938,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4966,12 +4966,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListEventBusesInput struct {
@@ -5769,7 +5769,7 @@ func (s *ListTargetsByRuleOutput) SetTargets(v []*Target) *ListTargetsByRuleOutp
 // or UntagResource.
 type ManagedRuleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5786,7 +5786,7 @@ func (s ManagedRuleException) GoString() string {
 
 func newErrorManagedRuleException(v protocol.ResponseMetadata) error {
 	return &ManagedRuleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5814,12 +5814,12 @@ func (s ManagedRuleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ManagedRuleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ManagedRuleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This structure specifies the network configuration for an ECS task.
@@ -5957,7 +5957,7 @@ func (s *PartnerEventSourceAccount) SetState(v string) *PartnerEventSourceAccoun
 // The event bus policy is too long. For more information, see the limits.
 type PolicyLengthExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5974,7 +5974,7 @@ func (s PolicyLengthExceededException) GoString() string {
 
 func newErrorPolicyLengthExceededException(v protocol.ResponseMetadata) error {
 	return &PolicyLengthExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6002,12 +6002,12 @@ func (s PolicyLengthExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyLengthExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyLengthExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutEventsInput struct {
@@ -7097,7 +7097,7 @@ func (s *RemoveTargetsResultEntry) SetTargetId(v string) *RemoveTargetsResultEnt
 // The resource you are trying to create already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7114,7 +7114,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7142,18 +7142,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An entity that you specified does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7170,7 +7170,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7198,12 +7198,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a rule in Amazon EventBridge.

--- a/service/eventbridge/api.go
+++ b/service/eventbridge/api.go
@@ -3242,8 +3242,8 @@ func (s *BatchRetryStrategy) SetAttempts(v int64) *BatchRetryStrategy {
 
 // There is concurrent modification on a rule or target.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4708,8 +4708,8 @@ func (s *InputTransformer) SetInputTemplate(v string) *InputTransformer {
 
 // This exception occurs due to unexpected causes.
 type InternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4764,8 +4764,8 @@ func (s InternalException) RequestID() string {
 
 // The event pattern is not valid.
 type InvalidEventPatternException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4820,8 +4820,8 @@ func (s InvalidEventPatternException) RequestID() string {
 
 // The specified state is not a valid state for an event source.
 type InvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4920,8 +4920,8 @@ func (s *KinesisParameters) SetPartitionKeyPath(v string) *KinesisParameters {
 
 // You tried to create more rules or add more targets to a rule than is allowed.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5768,8 +5768,8 @@ func (s *ListTargetsByRuleOutput) SetTargets(v []*Target) *ListTargetsByRuleOutp
 // rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
 // or UntagResource.
 type ManagedRuleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5956,8 +5956,8 @@ func (s *PartnerEventSourceAccount) SetState(v string) *PartnerEventSourceAccoun
 
 // The event bus policy is too long. For more information, see the limits.
 type PolicyLengthExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7096,8 +7096,8 @@ func (s *RemoveTargetsResultEntry) SetTargetId(v string) *RemoveTargetsResultEnt
 
 // The resource you are trying to create already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7152,8 +7152,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // An entity that you specified does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -1471,7 +1471,7 @@ func (s *CloudWatchLoggingOptions) SetLogStreamName(v string) *CloudWatchLogging
 // it to update the destination.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1489,7 +1489,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1517,12 +1517,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a COPY command for Amazon Redshift.
@@ -3694,7 +3694,7 @@ func (s *InputFormatConfiguration) SetDeserializer(v *Deserializer) *InputFormat
 // The specified input parameter has a value that is not valid.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3712,7 +3712,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3740,12 +3740,12 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Kinesis Data Firehose throws this exception when an attempt to put records
@@ -3754,7 +3754,7 @@ func (s InvalidArgumentException) RequestID() string {
 // InvalidStateException, DisabledException, or NotFoundException.
 type InvalidKMSResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -3773,7 +3773,7 @@ func (s InvalidKMSResourceException) GoString() string {
 
 func newErrorInvalidKMSResourceException(v protocol.ResponseMetadata) error {
 	return &InvalidKMSResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3801,12 +3801,12 @@ func (s InvalidKMSResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidKMSResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidKMSResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes an encryption key for a destination in Amazon S3.
@@ -3965,7 +3965,7 @@ func (s *KinesisStreamSourceDescription) SetRoleARN(v string) *KinesisStreamSour
 // You have already reached the limit for a requested resource.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3983,7 +3983,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4011,12 +4011,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDeliveryStreamsInput struct {
@@ -5541,7 +5541,7 @@ func (s *RedshiftRetryOptions) SetDurationInSeconds(v int64) *RedshiftRetryOptio
 // The resource is already in use and not available for this operation.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5559,7 +5559,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5587,18 +5587,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5616,7 +5616,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5644,12 +5644,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the configuration of a destination in Amazon S3.
@@ -6162,7 +6162,7 @@ func (s *Serializer) SetParquetSerDe(v *ParquetSerDe) *Serializer {
 // see Amazon Kinesis Data Firehose Limits (https://docs.aws.amazon.com/firehose/latest/dev/limits.html).
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6180,7 +6180,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6208,12 +6208,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details about a Kinesis data stream used as the source for a Kinesis Data

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -1470,8 +1470,8 @@ func (s *CloudWatchLoggingOptions) SetLogStreamName(v string) *CloudWatchLogging
 // Another modification has already happened. Fetch VersionId again and use
 // it to update the destination.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3693,8 +3693,8 @@ func (s *InputFormatConfiguration) SetDeserializer(v *Deserializer) *InputFormat
 
 // The specified input parameter has a value that is not valid.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3753,8 +3753,8 @@ func (s InvalidArgumentException) RequestID() string {
 // KMS service throws one of the following exception types: AccessDeniedException,
 // InvalidStateException, DisabledException, or NotFoundException.
 type InvalidKMSResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -3964,8 +3964,8 @@ func (s *KinesisStreamSourceDescription) SetRoleARN(v string) *KinesisStreamSour
 
 // You have already reached the limit for a requested resource.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5540,8 +5540,8 @@ func (s *RedshiftRetryOptions) SetDurationInSeconds(v int64) *RedshiftRetryOptio
 
 // The resource is already in use and not available for this operation.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5597,8 +5597,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6161,8 +6161,8 @@ func (s *Serializer) SetParquetSerDe(v *ParquetSerDe) *Serializer {
 // been exceeded. For more information about limits and how to request an increase,
 // see Amazon Kinesis Data Firehose Limits (https://docs.aws.amazon.com/firehose/latest/dev/limits.html).
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/fms/api.go
+++ b/service/fms/api.go
@@ -2488,8 +2488,8 @@ func (s *GetProtectionStatusOutput) SetServiceType(v string) *GetProtectionStatu
 // The operation failed because of a system problem, even though the request
 // was valid. Retry your request.
 type InternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2544,8 +2544,8 @@ func (s InternalErrorException) RequestID() string {
 
 // The parameters of the request were invalid.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2602,8 +2602,8 @@ func (s InvalidInputException) RequestID() string {
 // have submitted an AssociateAdminAccount request, but the account ID that
 // you submitted was already set as the AWS Firewall Manager administrator.
 type InvalidOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2658,8 +2658,8 @@ func (s InvalidOperationException) RequestID() string {
 
 // The value of the Type parameter is invalid.
 type InvalidTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2717,8 +2717,8 @@ func (s InvalidTypeException) RequestID() string {
 // see Firewall Manager Limits (https://docs.aws.amazon.com/waf/latest/developerguide/fms-limits.html)
 // in the AWS WAF Developer Guide.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3749,8 +3749,8 @@ func (s *PutPolicyOutput) SetPolicyArn(v string) *PutPolicyOutput {
 
 // The specified resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/fms/api.go
+++ b/service/fms/api.go
@@ -2489,7 +2489,7 @@ func (s *GetProtectionStatusOutput) SetServiceType(v string) *GetProtectionStatu
 // was valid. Retry your request.
 type InternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2506,7 +2506,7 @@ func (s InternalErrorException) GoString() string {
 
 func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 	return &InternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2534,18 +2534,18 @@ func (s InternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The parameters of the request were invalid.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2562,7 +2562,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2590,12 +2590,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because there was nothing to do. For example, you might
@@ -2603,7 +2603,7 @@ func (s InvalidInputException) RequestID() string {
 // you submitted was already set as the AWS Firewall Manager administrator.
 type InvalidOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2620,7 +2620,7 @@ func (s InvalidOperationException) GoString() string {
 
 func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 	return &InvalidOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2648,18 +2648,18 @@ func (s InvalidOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The value of the Type parameter is invalid.
 type InvalidTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2676,7 +2676,7 @@ func (s InvalidTypeException) GoString() string {
 
 func newErrorInvalidTypeException(v protocol.ResponseMetadata) error {
 	return &InvalidTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2704,12 +2704,12 @@ func (s InvalidTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation exceeds a resource limit, for example, the maximum number of
@@ -2718,7 +2718,7 @@ func (s InvalidTypeException) RequestID() string {
 // in the AWS WAF Developer Guide.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2735,7 +2735,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2763,12 +2763,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListComplianceStatusInput struct {
@@ -3750,7 +3750,7 @@ func (s *PutPolicyOutput) SetPolicyArn(v string) *PutPolicyOutput {
 // The specified resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3767,7 +3767,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3795,12 +3795,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource tags that AWS Firewall Manager uses to determine if a particular

--- a/service/forecastqueryservice/api.go
+++ b/service/forecastqueryservice/api.go
@@ -185,8 +185,8 @@ func (s *Forecast) SetPredictions(v map[string][]*DataPoint) *Forecast {
 
 // The value is invalid or is too long.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -241,8 +241,8 @@ func (s InvalidInputException) RequestID() string {
 
 // The token is not valid. Tokens expire after 24 hours.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -297,8 +297,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // The limit on the number of requests per second has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -472,8 +472,8 @@ func (s *QueryForecastOutput) SetForecast(v *Forecast) *QueryForecastOutput {
 
 // The specified resource is in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -529,8 +529,8 @@ func (s ResourceInUseException) RequestID() string {
 // We can't find that resource. Check the information that you've provided and
 // try again.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/forecastqueryservice/api.go
+++ b/service/forecastqueryservice/api.go
@@ -186,7 +186,7 @@ func (s *Forecast) SetPredictions(v map[string][]*DataPoint) *Forecast {
 // The value is invalid or is too long.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -203,7 +203,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -231,18 +231,18 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The token is not valid. Tokens expire after 24 hours.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -259,7 +259,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -287,18 +287,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The limit on the number of requests per second has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -315,7 +315,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -343,12 +343,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type QueryForecastInput struct {
@@ -473,7 +473,7 @@ func (s *QueryForecastOutput) SetForecast(v *Forecast) *QueryForecastOutput {
 // The specified resource is in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -490,7 +490,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -518,19 +518,19 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // We can't find that resource. Check the information that you've provided and
 // try again.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -547,7 +547,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -575,10 +575,10 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }

--- a/service/forecastservice/api.go
+++ b/service/forecastservice/api.go
@@ -6470,7 +6470,7 @@ func (s *IntegerParameterRange) SetScalingType(v string) *IntegerParameterRange 
 // that exceeds the valid range.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6487,7 +6487,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6515,18 +6515,18 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The token is not valid. Tokens expire after 24 hours.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6543,7 +6543,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6571,18 +6571,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The limit on the number of resources per account has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6599,7 +6599,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6627,12 +6627,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDatasetGroupsInput struct {
@@ -7576,7 +7576,7 @@ func (s *PredictorSummary) SetStatus(v string) *PredictorSummary {
 // There is already a resource with this name. Try again with a different name.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7593,7 +7593,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7621,18 +7621,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource is in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7649,7 +7649,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7677,19 +7677,19 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // We can't find a resource with that Amazon Resource Name (ARN). Check the
 // ARN and try again.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7706,7 +7706,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7734,12 +7734,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The path to the file(s) in an Amazon Simple Storage Service (Amazon S3) bucket,

--- a/service/forecastservice/api.go
+++ b/service/forecastservice/api.go
@@ -6469,8 +6469,8 @@ func (s *IntegerParameterRange) SetScalingType(v string) *IntegerParameterRange 
 // We can't process the request because it includes an invalid value or a value
 // that exceeds the valid range.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6525,8 +6525,8 @@ func (s InvalidInputException) RequestID() string {
 
 // The token is not valid. Tokens expire after 24 hours.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6581,8 +6581,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // The limit on the number of resources per account has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7575,8 +7575,8 @@ func (s *PredictorSummary) SetStatus(v string) *PredictorSummary {
 
 // There is already a resource with this name. Try again with a different name.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7631,8 +7631,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The specified resource is in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7688,8 +7688,8 @@ func (s ResourceInUseException) RequestID() string {
 // We can't find a resource with that Amazon Resource Name (ARN). Check the
 // ARN and try again.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/frauddetector/api.go
+++ b/service/frauddetector/api.go
@@ -5309,8 +5309,8 @@ func (s *GetVariablesOutput) SetVariables(v []*Variable) *GetVariablesOutput {
 
 // An exception indicating an internal server error.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6435,8 +6435,8 @@ func (s PutOutcomeOutput) GoString() string {
 
 // An exception indicating the specified resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6716,8 +6716,8 @@ func (s *RuleDetail) SetRuleVersion(v string) *RuleDetail {
 
 // An exception indicating a throttling error.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7543,8 +7543,8 @@ func (s UpdateVariableOutput) GoString() string {
 
 // An exception indicating a specified value is not allowed.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/frauddetector/api.go
+++ b/service/frauddetector/api.go
@@ -5310,7 +5310,7 @@ func (s *GetVariablesOutput) SetVariables(v []*Variable) *GetVariablesOutput {
 // An exception indicating an internal server error.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5327,7 +5327,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5355,12 +5355,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The label schema.
@@ -6436,7 +6436,7 @@ func (s PutOutcomeOutput) GoString() string {
 // An exception indicating the specified resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6453,7 +6453,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6481,12 +6481,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The role used to invoke external model endpoints.
@@ -6717,7 +6717,7 @@ func (s *RuleDetail) SetRuleVersion(v string) *RuleDetail {
 // An exception indicating a throttling error.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6734,7 +6734,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6762,12 +6762,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The training data source.
@@ -7544,7 +7544,7 @@ func (s UpdateVariableOutput) GoString() string {
 // An exception indicating a specified value is not allowed.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7561,7 +7561,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7589,12 +7589,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The variable.

--- a/service/fsx/api.go
+++ b/service/fsx/api.go
@@ -1773,7 +1773,7 @@ func (s *ActiveDirectoryBackupAttributes) SetDomainName(v string) *ActiveDirecto
 // An Active Directory error.
 type ActiveDirectoryError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The directory ID of the directory that an error pertains to.
 	//
@@ -1799,7 +1799,7 @@ func (s ActiveDirectoryError) GoString() string {
 
 func newErrorActiveDirectoryError(v protocol.ResponseMetadata) error {
 	return &ActiveDirectoryError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1827,12 +1827,12 @@ func (s ActiveDirectoryError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ActiveDirectoryError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ActiveDirectoryError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A backup of an Amazon FSx for Windows File Server file system. You can create
@@ -1992,7 +1992,7 @@ func (s *BackupFailureDetails) SetMessage(v string) *BackupFailureDetails {
 // additional backups of this file system.
 type BackupInProgress struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -2010,7 +2010,7 @@ func (s BackupInProgress) GoString() string {
 
 func newErrorBackupInProgress(v protocol.ResponseMetadata) error {
 	return &BackupInProgress{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2038,18 +2038,18 @@ func (s BackupInProgress) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BackupInProgress) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BackupInProgress) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // No Amazon FSx backups were found based upon the supplied parameters.
 type BackupNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -2067,7 +2067,7 @@ func (s BackupNotFound) GoString() string {
 
 func newErrorBackupNotFound(v protocol.ResponseMetadata) error {
 	return &BackupNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2095,18 +2095,18 @@ func (s BackupNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BackupNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BackupNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You can't delete a backup while it's being used to restore a file system.
 type BackupRestoring struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The ID of a file system being restored from the backup.
 	FileSystemId *string `min:"11" type:"string"`
@@ -2127,7 +2127,7 @@ func (s BackupRestoring) GoString() string {
 
 func newErrorBackupRestoring(v protocol.ResponseMetadata) error {
 	return &BackupRestoring{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2155,18 +2155,18 @@ func (s BackupRestoring) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BackupRestoring) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BackupRestoring) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A generic error indicating a failure with a client request.
 type BadRequest struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -2184,7 +2184,7 @@ func (s BadRequest) GoString() string {
 
 func newErrorBadRequest(v protocol.ResponseMetadata) error {
 	return &BadRequest{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2212,12 +2212,12 @@ func (s BadRequest) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequest) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequest) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Cancels a data repository task.
@@ -3539,7 +3539,7 @@ func (s *DataRepositoryTask) SetType(v string) *DataRepositoryTask {
 // ended.
 type DataRepositoryTaskEnded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -3557,7 +3557,7 @@ func (s DataRepositoryTaskEnded) GoString() string {
 
 func newErrorDataRepositoryTaskEnded(v protocol.ResponseMetadata) error {
 	return &DataRepositoryTaskEnded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3585,19 +3585,19 @@ func (s DataRepositoryTaskEnded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DataRepositoryTaskEnded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DataRepositoryTaskEnded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An existing data repository task is currently executing on the file system.
 // Wait until the existing task has completed, then create the new task.
 type DataRepositoryTaskExecuting struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -3615,7 +3615,7 @@ func (s DataRepositoryTaskExecuting) GoString() string {
 
 func newErrorDataRepositoryTaskExecuting(v protocol.ResponseMetadata) error {
 	return &DataRepositoryTaskExecuting{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3643,12 +3643,12 @@ func (s DataRepositoryTaskExecuting) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DataRepositoryTaskExecuting) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DataRepositoryTaskExecuting) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information about why a data repository task failed. Only populated
@@ -3724,7 +3724,7 @@ func (s *DataRepositoryTaskFilter) SetValues(v []*string) *DataRepositoryTaskFil
 // The data repository task or tasks you specified could not be found.
 type DataRepositoryTaskNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -3742,7 +3742,7 @@ func (s DataRepositoryTaskNotFound) GoString() string {
 
 func newErrorDataRepositoryTaskNotFound(v protocol.ResponseMetadata) error {
 	return &DataRepositoryTaskNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3770,12 +3770,12 @@ func (s DataRepositoryTaskNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DataRepositoryTaskNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DataRepositoryTaskNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides the task status showing a running total of the total number of files
@@ -4667,7 +4667,7 @@ func (s *FileSystemFailureDetails) SetMessage(v string) *FileSystemFailureDetail
 // No Amazon FSx file systems were found based upon supplied parameters.
 type FileSystemNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4685,7 +4685,7 @@ func (s FileSystemNotFound) GoString() string {
 
 func newErrorFileSystemNotFound(v protocol.ResponseMetadata) error {
 	return &FileSystemNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4713,12 +4713,12 @@ func (s FileSystemNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FileSystemNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FileSystemNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A filter used to restrict the results of describe calls. You can use multiple
@@ -4761,7 +4761,7 @@ func (s *Filter) SetValues(v []*string) *Filter {
 // always uniquely identify a single request.
 type IncompatibleParameterError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4784,7 +4784,7 @@ func (s IncompatibleParameterError) GoString() string {
 
 func newErrorIncompatibleParameterError(v protocol.ResponseMetadata) error {
 	return &IncompatibleParameterError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4812,18 +4812,18 @@ func (s IncompatibleParameterError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncompatibleParameterError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncompatibleParameterError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A generic error indicating a server-side failure.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4841,7 +4841,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4869,18 +4869,18 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The path provided for data repository export isn't valid.
 type InvalidExportPath struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4898,7 +4898,7 @@ func (s InvalidExportPath) GoString() string {
 
 func newErrorInvalidExportPath(v protocol.ResponseMetadata) error {
 	return &InvalidExportPath{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4926,18 +4926,18 @@ func (s InvalidExportPath) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidExportPath) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidExportPath) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The path provided for data repository import isn't valid.
 type InvalidImportPath struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4955,7 +4955,7 @@ func (s InvalidImportPath) GoString() string {
 
 func newErrorInvalidImportPath(v protocol.ResponseMetadata) error {
 	return &InvalidImportPath{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4983,12 +4983,12 @@ func (s InvalidImportPath) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidImportPath) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidImportPath) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more network settings specified in the request are invalid. InvalidVpcId
@@ -4999,7 +4999,7 @@ func (s InvalidImportPath) RequestID() string {
 // specified.
 type InvalidNetworkSettings struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The ID of your Amazon EC2 security group. This ID is used to control network
 	// access to the endpoint that Amazon FSx creates on your behalf in each subnet.
@@ -5029,7 +5029,7 @@ func (s InvalidNetworkSettings) GoString() string {
 
 func newErrorInvalidNetworkSettings(v protocol.ResponseMetadata) error {
 	return &InvalidNetworkSettings{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5057,19 +5057,19 @@ func (s InvalidNetworkSettings) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNetworkSettings) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNetworkSettings) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid value for PerUnitStorageThroughput was provided. Please create
 // your file system again, using a valid value.
 type InvalidPerUnitStorageThroughput struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5087,7 +5087,7 @@ func (s InvalidPerUnitStorageThroughput) GoString() string {
 
 func newErrorInvalidPerUnitStorageThroughput(v protocol.ResponseMetadata) error {
 	return &InvalidPerUnitStorageThroughput{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5115,12 +5115,12 @@ func (s InvalidPerUnitStorageThroughput) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPerUnitStorageThroughput) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPerUnitStorageThroughput) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request object for ListTagsForResource operation.
@@ -5300,7 +5300,7 @@ func (s *LustreFileSystemConfiguration) SetWeeklyMaintenanceStartTime(v string) 
 // A file system configuration is required for this operation.
 type MissingFileSystemConfiguration struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5318,7 +5318,7 @@ func (s MissingFileSystemConfiguration) GoString() string {
 
 func newErrorMissingFileSystemConfiguration(v protocol.ResponseMetadata) error {
 	return &MissingFileSystemConfiguration{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5346,19 +5346,19 @@ func (s MissingFileSystemConfiguration) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MissingFileSystemConfiguration) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MissingFileSystemConfiguration) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource specified for the tagging operation is not a resource type owned
 // by Amazon FSx. Use the API of the relevant service to perform the operation.
 type NotServiceResourceError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5381,7 +5381,7 @@ func (s NotServiceResourceError) GoString() string {
 
 func newErrorNotServiceResourceError(v protocol.ResponseMetadata) error {
 	return &NotServiceResourceError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5409,18 +5409,18 @@ func (s NotServiceResourceError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotServiceResourceError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotServiceResourceError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource specified does not support tagging.
 type ResourceDoesNotSupportTagging struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5443,7 +5443,7 @@ func (s ResourceDoesNotSupportTagging) GoString() string {
 
 func newErrorResourceDoesNotSupportTagging(v protocol.ResponseMetadata) error {
 	return &ResourceDoesNotSupportTagging{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5471,18 +5471,18 @@ func (s ResourceDoesNotSupportTagging) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceDoesNotSupportTagging) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceDoesNotSupportTagging) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource specified by the Amazon Resource Name (ARN) can't be found.
 type ResourceNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5505,7 +5505,7 @@ func (s ResourceNotFound) GoString() string {
 
 func newErrorResourceNotFound(v protocol.ResponseMetadata) error {
 	return &ResourceNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5533,12 +5533,12 @@ func (s ResourceNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The configuration of the self-managed Microsoft Active Directory (AD) directory
@@ -5827,7 +5827,7 @@ func (s *SelfManagedActiveDirectoryConfigurationUpdates) SetUserName(v string) *
 // increase some service limits by contacting AWS Support.
 type ServiceLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Enumeration of the service limit that was exceeded.
 	//
@@ -5850,7 +5850,7 @@ func (s ServiceLimitExceeded) GoString() string {
 
 func newErrorServiceLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ServiceLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5878,12 +5878,12 @@ func (s ServiceLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies a key-value pair for a resource tag.
@@ -6025,7 +6025,7 @@ func (s TagResourceOutput) GoString() string {
 // The requested operation is not supported for this resource or API.
 type UnsupportedOperation struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -6043,7 +6043,7 @@ func (s UnsupportedOperation) GoString() string {
 
 func newErrorUnsupportedOperation(v protocol.ResponseMetadata) error {
 	return &UnsupportedOperation{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6071,12 +6071,12 @@ func (s UnsupportedOperation) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedOperation) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedOperation) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request object for UntagResource action.

--- a/service/fsx/api.go
+++ b/service/fsx/api.go
@@ -1772,8 +1772,8 @@ func (s *ActiveDirectoryBackupAttributes) SetDomainName(v string) *ActiveDirecto
 
 // An Active Directory error.
 type ActiveDirectoryError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The directory ID of the directory that an error pertains to.
 	//
@@ -1991,8 +1991,8 @@ func (s *BackupFailureDetails) SetMessage(v string) *BackupFailureDetails {
 // Another backup is already under way. Wait for completion before initiating
 // additional backups of this file system.
 type BackupInProgress struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -2048,8 +2048,8 @@ func (s BackupInProgress) RequestID() string {
 
 // No Amazon FSx backups were found based upon the supplied parameters.
 type BackupNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -2105,8 +2105,8 @@ func (s BackupNotFound) RequestID() string {
 
 // You can't delete a backup while it's being used to restore a file system.
 type BackupRestoring struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The ID of a file system being restored from the backup.
 	FileSystemId *string `min:"11" type:"string"`
@@ -2165,8 +2165,8 @@ func (s BackupRestoring) RequestID() string {
 
 // A generic error indicating a failure with a client request.
 type BadRequest struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -3538,8 +3538,8 @@ func (s *DataRepositoryTask) SetType(v string) *DataRepositoryTask {
 // The data repository task could not be canceled because the task has already
 // ended.
 type DataRepositoryTaskEnded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -3596,8 +3596,8 @@ func (s DataRepositoryTaskEnded) RequestID() string {
 // An existing data repository task is currently executing on the file system.
 // Wait until the existing task has completed, then create the new task.
 type DataRepositoryTaskExecuting struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -3723,8 +3723,8 @@ func (s *DataRepositoryTaskFilter) SetValues(v []*string) *DataRepositoryTaskFil
 
 // The data repository task or tasks you specified could not be found.
 type DataRepositoryTaskNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4666,8 +4666,8 @@ func (s *FileSystemFailureDetails) SetMessage(v string) *FileSystemFailureDetail
 
 // No Amazon FSx file systems were found based upon supplied parameters.
 type FileSystemNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4760,8 +4760,8 @@ func (s *Filter) SetValues(v []*string) *Filter {
 // request token but different parameters settings. A client request token should
 // always uniquely identify a single request.
 type IncompatibleParameterError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4822,8 +4822,8 @@ func (s IncompatibleParameterError) RequestID() string {
 
 // A generic error indicating a server-side failure.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4879,8 +4879,8 @@ func (s InternalServerError) RequestID() string {
 
 // The path provided for data repository export isn't valid.
 type InvalidExportPath struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4936,8 +4936,8 @@ func (s InvalidExportPath) RequestID() string {
 
 // The path provided for data repository import isn't valid.
 type InvalidImportPath struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -4998,8 +4998,8 @@ func (s InvalidImportPath) RequestID() string {
 // of IDs for security groups that are either invalid or not part of the VPC
 // specified.
 type InvalidNetworkSettings struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The ID of your Amazon EC2 security group. This ID is used to control network
 	// access to the endpoint that Amazon FSx creates on your behalf in each subnet.
@@ -5068,8 +5068,8 @@ func (s InvalidNetworkSettings) RequestID() string {
 // An invalid value for PerUnitStorageThroughput was provided. Please create
 // your file system again, using a valid value.
 type InvalidPerUnitStorageThroughput struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5299,8 +5299,8 @@ func (s *LustreFileSystemConfiguration) SetWeeklyMaintenanceStartTime(v string) 
 
 // A file system configuration is required for this operation.
 type MissingFileSystemConfiguration struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5357,8 +5357,8 @@ func (s MissingFileSystemConfiguration) RequestID() string {
 // The resource specified for the tagging operation is not a resource type owned
 // by Amazon FSx. Use the API of the relevant service to perform the operation.
 type NotServiceResourceError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5419,8 +5419,8 @@ func (s NotServiceResourceError) RequestID() string {
 
 // The resource specified does not support tagging.
 type ResourceDoesNotSupportTagging struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5481,8 +5481,8 @@ func (s ResourceDoesNotSupportTagging) RequestID() string {
 
 // The resource specified by the Amazon Resource Name (ARN) can't be found.
 type ResourceNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
@@ -5826,8 +5826,8 @@ func (s *SelfManagedActiveDirectoryConfigurationUpdates) SetUserName(v string) *
 // An error indicating that a particular service limit was exceeded. You can
 // increase some service limits by contacting AWS Support.
 type ServiceLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Enumeration of the service limit that was exceeded.
 	//
@@ -6024,8 +6024,8 @@ func (s TagResourceOutput) GoString() string {
 
 // The requested operation is not supported for this resource or API.
 type UnsupportedOperation struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A detailed error message.
 	Message_ *string `locationName:"Message" min:"1" type:"string"`

--- a/service/gamelift/api.go
+++ b/service/gamelift/api.go
@@ -9799,8 +9799,8 @@ func (s *CertificateConfiguration) SetCertificateType(v string) *CertificateConf
 // a service resource associated with the request. Resolve the conflict before
 // retrying this request.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -15051,8 +15051,8 @@ func (s *FleetCapacity) SetInstanceType(v string) *FleetCapacity {
 // The specified fleet has no available instances to fulfill a CreateGameSession
 // request. Clients can retry such requests immediately or after a waiting period.
 type FleetCapacityExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -15595,8 +15595,8 @@ func (s *GameSessionDetail) SetProtectionPolicy(v string) *GameSessionDetail {
 // The game instance is currently full and cannot allow the requested player(s)
 // to join. Clients can retry such requests immediately or after a waiting period.
 type GameSessionFullException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16192,8 +16192,8 @@ func (s *GetInstanceAccessOutput) SetInstanceAccess(v *InstanceAccess) *GetInsta
 // A game session with this custom ID string already exists in this fleet. Resolve
 // this conflict before retrying this request.
 type IdempotentParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16458,8 +16458,8 @@ func (s *InstanceCredentials) SetUserName(v string) *InstanceCredentials {
 // the request. Clients can retry such requests immediately or after a waiting
 // period.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16516,8 +16516,8 @@ func (s InternalServiceException) RequestID() string {
 // a resource associated with the request and/or the fleet. Resolve the conflict
 // before retrying.
 type InvalidFleetStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16574,8 +16574,8 @@ func (s InvalidFleetStatusException) RequestID() string {
 // a resource associated with the request and/or the game instance. Resolve
 // the conflict before retrying.
 type InvalidGameSessionStatusException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16631,8 +16631,8 @@ func (s InvalidGameSessionStatusException) RequestID() string {
 // One or more parameter values in the request are invalid. Correct the invalid
 // parameter values before retrying.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16784,8 +16784,8 @@ func (s *IpPermission) SetToPort(v int64) *IpPermission {
 // The requested operation would cause the resource to exceed the allowed service
 // limit. Resolve the issue before retrying.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -17817,8 +17817,8 @@ func (s *MatchmakingTicket) SetTicketId(v string) *MatchmakingTicket {
 // A service resource associated with the request could not be found. Clients
 // should not retry such requests.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -20373,8 +20373,8 @@ func (s TagResourceOutput) GoString() string {
 // tag format or the maximum tag limit may have been exceeded. Resolve the issue
 // before retrying.
 type TaggingFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -20492,8 +20492,8 @@ func (s *TargetConfiguration) SetTargetValue(v float64) *TargetConfiguration {
 // Such requests should only be retried if the routing strategy for the specified
 // alias is modified.
 type TerminalRoutingStrategyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -20548,8 +20548,8 @@ func (s TerminalRoutingStrategyException) RequestID() string {
 
 // The client failed authentication. Clients should not retry such requests.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -20604,8 +20604,8 @@ func (s UnauthorizedException) RequestID() string {
 
 // The requested operation is not supported in the Region specified.
 type UnsupportedRegionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/gamelift/api.go
+++ b/service/gamelift/api.go
@@ -9800,7 +9800,7 @@ func (s *CertificateConfiguration) SetCertificateType(v string) *CertificateConf
 // retrying this request.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -9817,7 +9817,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9845,12 +9845,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input for a request action.
@@ -15052,7 +15052,7 @@ func (s *FleetCapacity) SetInstanceType(v string) *FleetCapacity {
 // request. Clients can retry such requests immediately or after a waiting period.
 type FleetCapacityExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -15069,7 +15069,7 @@ func (s FleetCapacityExceededException) GoString() string {
 
 func newErrorFleetCapacityExceededException(v protocol.ResponseMetadata) error {
 	return &FleetCapacityExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15097,12 +15097,12 @@ func (s FleetCapacityExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FleetCapacityExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FleetCapacityExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Current status of fleet utilization, including the number of game and player
@@ -15596,7 +15596,7 @@ func (s *GameSessionDetail) SetProtectionPolicy(v string) *GameSessionDetail {
 // to join. Clients can retry such requests immediately or after a waiting period.
 type GameSessionFullException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -15613,7 +15613,7 @@ func (s GameSessionFullException) GoString() string {
 
 func newErrorGameSessionFullException(v protocol.ResponseMetadata) error {
 	return &GameSessionFullException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15641,12 +15641,12 @@ func (s GameSessionFullException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GameSessionFullException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GameSessionFullException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Object that describes a StartGameSessionPlacement request. This object includes
@@ -16193,7 +16193,7 @@ func (s *GetInstanceAccessOutput) SetInstanceAccess(v *InstanceAccess) *GetInsta
 // this conflict before retrying this request.
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16210,7 +16210,7 @@ func (s IdempotentParameterMismatchException) GoString() string {
 
 func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16238,12 +16238,12 @@ func (s IdempotentParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Properties that describe an instance of a virtual computing resource that
@@ -16459,7 +16459,7 @@ func (s *InstanceCredentials) SetUserName(v string) *InstanceCredentials {
 // period.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16476,7 +16476,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16504,12 +16504,12 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested operation would cause a conflict with the current state of
@@ -16517,7 +16517,7 @@ func (s InternalServiceException) RequestID() string {
 // before retrying.
 type InvalidFleetStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16534,7 +16534,7 @@ func (s InvalidFleetStatusException) GoString() string {
 
 func newErrorInvalidFleetStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidFleetStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16562,12 +16562,12 @@ func (s InvalidFleetStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFleetStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFleetStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested operation would cause a conflict with the current state of
@@ -16575,7 +16575,7 @@ func (s InvalidFleetStatusException) RequestID() string {
 // the conflict before retrying.
 type InvalidGameSessionStatusException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16592,7 +16592,7 @@ func (s InvalidGameSessionStatusException) GoString() string {
 
 func newErrorInvalidGameSessionStatusException(v protocol.ResponseMetadata) error {
 	return &InvalidGameSessionStatusException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16620,19 +16620,19 @@ func (s InvalidGameSessionStatusException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidGameSessionStatusException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidGameSessionStatusException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more parameter values in the request are invalid. Correct the invalid
 // parameter values before retrying.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16649,7 +16649,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16677,12 +16677,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A range of IP addresses and port settings that allow inbound traffic to connect
@@ -16785,7 +16785,7 @@ func (s *IpPermission) SetToPort(v int64) *IpPermission {
 // limit. Resolve the issue before retrying.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -16802,7 +16802,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16830,12 +16830,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input for a request action.
@@ -17818,7 +17818,7 @@ func (s *MatchmakingTicket) SetTicketId(v string) *MatchmakingTicket {
 // should not retry such requests.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -17835,7 +17835,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17863,12 +17863,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a player session that was created as part of a StartGameSessionPlacement
@@ -20374,7 +20374,7 @@ func (s TagResourceOutput) GoString() string {
 // before retrying.
 type TaggingFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -20391,7 +20391,7 @@ func (s TaggingFailedException) GoString() string {
 
 func newErrorTaggingFailedException(v protocol.ResponseMetadata) error {
 	return &TaggingFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20419,12 +20419,12 @@ func (s TaggingFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TaggingFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TaggingFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Settings for a target-based scaling policy (see ScalingPolicy. A target-based
@@ -20493,7 +20493,7 @@ func (s *TargetConfiguration) SetTargetValue(v float64) *TargetConfiguration {
 // alias is modified.
 type TerminalRoutingStrategyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -20510,7 +20510,7 @@ func (s TerminalRoutingStrategyException) GoString() string {
 
 func newErrorTerminalRoutingStrategyException(v protocol.ResponseMetadata) error {
 	return &TerminalRoutingStrategyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20538,18 +20538,18 @@ func (s TerminalRoutingStrategyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TerminalRoutingStrategyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TerminalRoutingStrategyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The client failed authentication. Clients should not retry such requests.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -20566,7 +20566,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20594,18 +20594,18 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested operation is not supported in the Region specified.
 type UnsupportedRegionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -20622,7 +20622,7 @@ func (s UnsupportedRegionException) GoString() string {
 
 func newErrorUnsupportedRegionException(v protocol.ResponseMetadata) error {
 	return &UnsupportedRegionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20650,12 +20650,12 @@ func (s UnsupportedRegionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedRegionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedRegionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -6180,7 +6180,7 @@ func (s *InputSerialization) SetCsv(v *CSVInput) *InputSerialization {
 // retrievals.
 type InsufficientCapacityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -6201,7 +6201,7 @@ func (s InsufficientCapacityException) GoString() string {
 
 func newErrorInsufficientCapacityException(v protocol.ResponseMetadata) error {
 	return &InsufficientCapacityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6229,18 +6229,18 @@ func (s InsufficientCapacityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InsufficientCapacityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InsufficientCapacityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if a parameter of the request is incorrectly specified.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 400 Bad Request
 	Code_ *string `locationName:"code" type:"string"`
@@ -6264,7 +6264,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6292,12 +6292,12 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the options for a range inventory retrieval job.
@@ -6816,7 +6816,7 @@ func (s *JobParameters) SetType(v string) *JobParameters {
 // Returned if the request results in a vault or account limit being exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 400 Bad Request
 	Code_ *string `locationName:"code" type:"string"`
@@ -6840,7 +6840,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6868,12 +6868,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides options for retrieving a job list for an Amazon S3 Glacier vault.
@@ -7589,7 +7589,7 @@ func (s *ListVaultsOutput) SetVaultList(v []*DescribeVaultOutput) *ListVaultsOut
 // Returned if a required header or parameter is missing from the request.
 type MissingParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 400 Bad Request
 	Code_ *string `locationName:"code" type:"string"`
@@ -7613,7 +7613,7 @@ func (s MissingParameterValueException) GoString() string {
 
 func newErrorMissingParameterValueException(v protocol.ResponseMetadata) error {
 	return &MissingParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7641,12 +7641,12 @@ func (s MissingParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MissingParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MissingParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about the location where the select job results are
@@ -7751,7 +7751,7 @@ func (s *PartListElement) SetSHA256TreeHash(v string) *PartListElement {
 // rate limit. For more information about data retrieval policies,
 type PolicyEnforcedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// PolicyEnforcedException
 	Code_ *string `locationName:"code" type:"string"`
@@ -7775,7 +7775,7 @@ func (s PolicyEnforcedException) GoString() string {
 
 func newErrorPolicyEnforcedException(v protocol.ResponseMetadata) error {
 	return &PolicyEnforcedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7803,12 +7803,12 @@ func (s PolicyEnforcedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyEnforcedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyEnforcedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The definition for a provisioned capacity unit.
@@ -8013,7 +8013,7 @@ func (s RemoveTagsFromVaultOutput) GoString() string {
 // receiving the upload.
 type RequestTimeoutException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 408 Request Timeout
 	Code_ *string `locationName:"code" type:"string"`
@@ -8038,7 +8038,7 @@ func (s RequestTimeoutException) GoString() string {
 
 func newErrorRequestTimeoutException(v protocol.ResponseMetadata) error {
 	return &RequestTimeoutException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8066,19 +8066,19 @@ func (s RequestTimeoutException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestTimeoutException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestTimeoutException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the specified resource (such as a vault, upload ID, or job ID)
 // doesn't exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 404 Not Found
 	Code_ *string `locationName:"code" type:"string"`
@@ -8103,7 +8103,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8131,12 +8131,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about the location in Amazon S3 where the select job
@@ -8302,7 +8302,7 @@ func (s *SelectParameters) SetOutputSerialization(v *OutputSerialization) *Selec
 // Returned if the service cannot complete the request.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 500 Internal Server Error
 	Code_ *string `locationName:"code" type:"string"`
@@ -8326,7 +8326,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8354,12 +8354,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // SetDataRetrievalPolicy input.

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -6179,8 +6179,8 @@ func (s *InputSerialization) SetCsv(v *CSVInput) *InputSerialization {
 // This error only applies to expedited retrievals and not to standard or bulk
 // retrievals.
 type InsufficientCapacityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -6239,8 +6239,8 @@ func (s InsufficientCapacityException) RequestID() string {
 
 // Returned if a parameter of the request is incorrectly specified.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 400 Bad Request
 	Code_ *string `locationName:"code" type:"string"`
@@ -6815,8 +6815,8 @@ func (s *JobParameters) SetType(v string) *JobParameters {
 
 // Returned if the request results in a vault or account limit being exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 400 Bad Request
 	Code_ *string `locationName:"code" type:"string"`
@@ -7588,8 +7588,8 @@ func (s *ListVaultsOutput) SetVaultList(v []*DescribeVaultOutput) *ListVaultsOut
 
 // Returned if a required header or parameter is missing from the request.
 type MissingParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 400 Bad Request
 	Code_ *string `locationName:"code" type:"string"`
@@ -7750,8 +7750,8 @@ func (s *PartListElement) SetSHA256TreeHash(v string) *PartListElement {
 // Returned if a retrieval job would exceed the current data policy's retrieval
 // rate limit. For more information about data retrieval policies,
 type PolicyEnforcedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// PolicyEnforcedException
 	Code_ *string `locationName:"code" type:"string"`
@@ -8012,8 +8012,8 @@ func (s RemoveTagsFromVaultOutput) GoString() string {
 // Returned if, when uploading an archive, Amazon S3 Glacier times out while
 // receiving the upload.
 type RequestTimeoutException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 408 Request Timeout
 	Code_ *string `locationName:"code" type:"string"`
@@ -8077,8 +8077,8 @@ func (s RequestTimeoutException) RequestID() string {
 // Returned if the specified resource (such as a vault, upload ID, or job ID)
 // doesn't exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 404 Not Found
 	Code_ *string `locationName:"code" type:"string"`
@@ -8301,8 +8301,8 @@ func (s *SelectParameters) SetOutputSerialization(v *OutputSerialization) *Selec
 
 // Returned if the service cannot complete the request.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 500 Internal Server Error
 	Code_ *string `locationName:"code" type:"string"`

--- a/service/globalaccelerator/api.go
+++ b/service/globalaccelerator/api.go
@@ -2505,8 +2505,8 @@ func (s *AcceleratorAttributes) SetFlowLogsS3Prefix(v string) *AcceleratorAttrib
 
 // The accelerator that you specified could not be disabled.
 type AcceleratorNotDisabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2561,8 +2561,8 @@ func (s AcceleratorNotDisabledException) RequestID() string {
 
 // The accelerator that you specified doesn't exist.
 type AcceleratorNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2617,8 +2617,8 @@ func (s AcceleratorNotFoundException) RequestID() string {
 
 // You don't have access permission.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2737,8 +2737,8 @@ func (s *AdvertiseByoipCidrOutput) SetByoipCidr(v *ByoipCidr) *AdvertiseByoipCid
 // You must remove all dependent resources from a listener before you can delete
 // it.
 type AssociatedEndpointGroupFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2795,8 +2795,8 @@ func (s AssociatedEndpointGroupFoundException) RequestID() string {
 // must remove all dependent resources from an accelerator before you can delete
 // it.
 type AssociatedListenerFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2930,8 +2930,8 @@ func (s *ByoipCidr) SetState(v string) *ByoipCidr {
 
 // The CIDR that you specified was not found or is incorrect.
 type ByoipCidrNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4237,8 +4237,8 @@ func (s *EndpointGroup) SetTrafficDialPercentage(v float64) *EndpointGroup {
 
 // The endpoint group that you specified already exists.
 type EndpointGroupAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4293,8 +4293,8 @@ func (s EndpointGroupAlreadyExistsException) RequestID() string {
 
 // The endpoint group that you specified doesn't exist.
 type EndpointGroupNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4350,8 +4350,8 @@ func (s EndpointGroupNotFoundException) RequestID() string {
 // The CIDR that you specified is not valid for this action. For example, the
 // state of the CIDR might be incorrect for this action.
 type IncorrectCidrStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4406,8 +4406,8 @@ func (s IncorrectCidrStateException) RequestID() string {
 
 // There was an internal error for AWS Global Accelerator.
 type InternalServiceErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4462,8 +4462,8 @@ func (s InternalServiceErrorException) RequestID() string {
 
 // An argument that you specified is invalid.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4518,8 +4518,8 @@ func (s InvalidArgumentException) RequestID() string {
 
 // There isn't another item to return.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4575,8 +4575,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // The port numbers that you specified are not valid numbers or are not unique
 // for this accelerator.
 type InvalidPortRangeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4666,8 +4666,8 @@ func (s *IpSet) SetIpFamily(v string) *IpSet {
 // Processing your request would cause you to exceed an AWS Global Accelerator
 // limit.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5204,8 +5204,8 @@ func (s *Listener) SetProtocol(v string) *Listener {
 
 // The listener that you specified doesn't exist.
 type ListenerNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/globalaccelerator/api.go
+++ b/service/globalaccelerator/api.go
@@ -2506,7 +2506,7 @@ func (s *AcceleratorAttributes) SetFlowLogsS3Prefix(v string) *AcceleratorAttrib
 // The accelerator that you specified could not be disabled.
 type AcceleratorNotDisabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2523,7 +2523,7 @@ func (s AcceleratorNotDisabledException) GoString() string {
 
 func newErrorAcceleratorNotDisabledException(v protocol.ResponseMetadata) error {
 	return &AcceleratorNotDisabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2551,18 +2551,18 @@ func (s AcceleratorNotDisabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AcceleratorNotDisabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AcceleratorNotDisabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The accelerator that you specified doesn't exist.
 type AcceleratorNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2579,7 +2579,7 @@ func (s AcceleratorNotFoundException) GoString() string {
 
 func newErrorAcceleratorNotFoundException(v protocol.ResponseMetadata) error {
 	return &AcceleratorNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2607,18 +2607,18 @@ func (s AcceleratorNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AcceleratorNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AcceleratorNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You don't have access permission.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2635,7 +2635,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2663,12 +2663,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AdvertiseByoipCidrInput struct {
@@ -2738,7 +2738,7 @@ func (s *AdvertiseByoipCidrOutput) SetByoipCidr(v *ByoipCidr) *AdvertiseByoipCid
 // it.
 type AssociatedEndpointGroupFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2755,7 +2755,7 @@ func (s AssociatedEndpointGroupFoundException) GoString() string {
 
 func newErrorAssociatedEndpointGroupFoundException(v protocol.ResponseMetadata) error {
 	return &AssociatedEndpointGroupFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2783,12 +2783,12 @@ func (s AssociatedEndpointGroupFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AssociatedEndpointGroupFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AssociatedEndpointGroupFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The accelerator that you specified has a listener associated with it. You
@@ -2796,7 +2796,7 @@ func (s AssociatedEndpointGroupFoundException) RequestID() string {
 // it.
 type AssociatedListenerFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2813,7 +2813,7 @@ func (s AssociatedListenerFoundException) GoString() string {
 
 func newErrorAssociatedListenerFoundException(v protocol.ResponseMetadata) error {
 	return &AssociatedListenerFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2841,12 +2841,12 @@ func (s AssociatedListenerFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AssociatedListenerFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AssociatedListenerFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about an IP address range that is provisioned for use with your
@@ -2931,7 +2931,7 @@ func (s *ByoipCidr) SetState(v string) *ByoipCidr {
 // The CIDR that you specified was not found or is incorrect.
 type ByoipCidrNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2948,7 +2948,7 @@ func (s ByoipCidrNotFoundException) GoString() string {
 
 func newErrorByoipCidrNotFoundException(v protocol.ResponseMetadata) error {
 	return &ByoipCidrNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2976,12 +2976,12 @@ func (s ByoipCidrNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ByoipCidrNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ByoipCidrNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides authorization for Amazon to bring a specific IP address range to
@@ -4238,7 +4238,7 @@ func (s *EndpointGroup) SetTrafficDialPercentage(v float64) *EndpointGroup {
 // The endpoint group that you specified already exists.
 type EndpointGroupAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4255,7 +4255,7 @@ func (s EndpointGroupAlreadyExistsException) GoString() string {
 
 func newErrorEndpointGroupAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &EndpointGroupAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4283,18 +4283,18 @@ func (s EndpointGroupAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EndpointGroupAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EndpointGroupAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The endpoint group that you specified doesn't exist.
 type EndpointGroupNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4311,7 +4311,7 @@ func (s EndpointGroupNotFoundException) GoString() string {
 
 func newErrorEndpointGroupNotFoundException(v protocol.ResponseMetadata) error {
 	return &EndpointGroupNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4339,19 +4339,19 @@ func (s EndpointGroupNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EndpointGroupNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EndpointGroupNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The CIDR that you specified is not valid for this action. For example, the
 // state of the CIDR might be incorrect for this action.
 type IncorrectCidrStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4368,7 +4368,7 @@ func (s IncorrectCidrStateException) GoString() string {
 
 func newErrorIncorrectCidrStateException(v protocol.ResponseMetadata) error {
 	return &IncorrectCidrStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4396,18 +4396,18 @@ func (s IncorrectCidrStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncorrectCidrStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncorrectCidrStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There was an internal error for AWS Global Accelerator.
 type InternalServiceErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4424,7 +4424,7 @@ func (s InternalServiceErrorException) GoString() string {
 
 func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServiceErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4452,18 +4452,18 @@ func (s InternalServiceErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An argument that you specified is invalid.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4480,7 +4480,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4508,18 +4508,18 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There isn't another item to return.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4536,7 +4536,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4564,19 +4564,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The port numbers that you specified are not valid numbers or are not unique
 // for this accelerator.
 type InvalidPortRangeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4593,7 +4593,7 @@ func (s InvalidPortRangeException) GoString() string {
 
 func newErrorInvalidPortRangeException(v protocol.ResponseMetadata) error {
 	return &InvalidPortRangeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4621,12 +4621,12 @@ func (s InvalidPortRangeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPortRangeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPortRangeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A complex type for the set of IP addresses for an accelerator.
@@ -4667,7 +4667,7 @@ func (s *IpSet) SetIpFamily(v string) *IpSet {
 // limit.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4684,7 +4684,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4712,12 +4712,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAcceleratorsInput struct {
@@ -5205,7 +5205,7 @@ func (s *Listener) SetProtocol(v string) *Listener {
 // The listener that you specified doesn't exist.
 type ListenerNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5222,7 +5222,7 @@ func (s ListenerNotFoundException) GoString() string {
 
 func newErrorListenerNotFoundException(v protocol.ResponseMetadata) error {
 	return &ListenerNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5250,12 +5250,12 @@ func (s ListenerNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ListenerNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ListenerNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A complex type for a range of ports for a listener.

--- a/service/glue/api.go
+++ b/service/glue/api.go
@@ -12663,8 +12663,8 @@ func (c *Glue) UpdateWorkflowWithContext(ctx aws.Context, input *UpdateWorkflowI
 
 // Access to a resource was denied.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -12831,8 +12831,8 @@ func (s *Action) SetTimeout(v int64) *Action {
 
 // A resource to be created or added already exists.
 type AlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -14714,8 +14714,8 @@ func (s *Column) SetType(v string) *Column {
 
 // Two processes are trying to modify a resource simultaneously.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -14771,8 +14771,8 @@ func (s ConcurrentModificationException) RequestID() string {
 
 // Too many jobs are being run concurrently.
 type ConcurrentRunsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -14906,8 +14906,8 @@ func (s *Condition) SetState(v string) *Condition {
 
 // A specified condition was not satisfied.
 type ConditionCheckFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -15730,8 +15730,8 @@ func (s *CrawlerNodeDetails) SetCrawls(v []*Crawl) *CrawlerNodeDetails {
 
 // The specified crawler is not running.
 type CrawlerNotRunningException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -15787,8 +15787,8 @@ func (s CrawlerNotRunningException) RequestID() string {
 
 // The operation cannot be performed because the crawler is already running.
 type CrawlerRunningException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -15844,8 +15844,8 @@ func (s CrawlerRunningException) RequestID() string {
 
 // The specified crawler is stopping.
 type CrawlerStoppingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -20351,8 +20351,8 @@ func (s *EncryptionConfiguration) SetS3Encryption(v []*S3Encryption) *Encryption
 
 // An encryption operation failed.
 type EncryptionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -20408,8 +20408,8 @@ func (s EncryptionException) RequestID() string {
 
 // A specified entity does not exist
 type EntityNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -25030,8 +25030,8 @@ func (s *GrokClassifier) SetVersion(v int64) *GrokClassifier {
 
 // The same unique identifier was associated with two different records.
 type IdempotentParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -25172,8 +25172,8 @@ func (s *ImportLabelsTaskRunProperties) SetReplace(v bool) *ImportLabelsTaskRunP
 
 // An internal service error occurred.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -25229,8 +25229,8 @@ func (s InternalServiceException) RequestID() string {
 
 // The input provided was not valid.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -27348,8 +27348,8 @@ func (s *MLTransform) SetWorkerType(v string) *MLTransform {
 
 // The machine learning transform is not ready to run.
 type MLTransformNotReadyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -27474,8 +27474,8 @@ func (s *MappingEntry) SetTargetType(v string) *MappingEntry {
 
 // There is no applicable schedule.
 type NoScheduleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -27639,8 +27639,8 @@ func (s *NotificationProperty) SetNotifyDelayAfter(v int64) *NotificationPropert
 
 // The operation timed out.
 type OperationTimeoutException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28547,8 +28547,8 @@ func (s *ResetJobBookmarkOutput) SetJobBookmarkEntry(v *JobBookmarkEntry) *Reset
 
 // A resource numerical limit was exceeded.
 type ResourceNumberLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28753,8 +28753,8 @@ func (s *Schedule) SetState(v string) *Schedule {
 
 // The specified scheduler is not running.
 type SchedulerNotRunningException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28810,8 +28810,8 @@ func (s SchedulerNotRunningException) RequestID() string {
 
 // The specified scheduler is already running.
 type SchedulerRunningException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28867,8 +28867,8 @@ func (s SchedulerRunningException) RequestID() string {
 
 // The specified scheduler is transitioning.
 type SchedulerTransitioningException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -33711,8 +33711,8 @@ func (s *UserDefinedFunctionInput) SetResourceUris(v []*ResourceUri) *UserDefine
 
 // A value could not be validated.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -33768,8 +33768,8 @@ func (s ValidationException) RequestID() string {
 
 // There was a version conflict.
 type VersionMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`

--- a/service/glue/api.go
+++ b/service/glue/api.go
@@ -12664,7 +12664,7 @@ func (c *Glue) UpdateWorkflowWithContext(ctx aws.Context, input *UpdateWorkflowI
 // Access to a resource was denied.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -12682,7 +12682,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12710,12 +12710,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Defines an action to be initiated by a trigger.
@@ -12832,7 +12832,7 @@ func (s *Action) SetTimeout(v int64) *Action {
 // A resource to be created or added already exists.
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -12850,7 +12850,7 @@ func (s AlreadyExistsException) GoString() string {
 
 func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &AlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12878,12 +12878,12 @@ func (s AlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type BatchCreatePartitionInput struct {
@@ -14715,7 +14715,7 @@ func (s *Column) SetType(v string) *Column {
 // Two processes are trying to modify a resource simultaneously.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -14733,7 +14733,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14761,18 +14761,18 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Too many jobs are being run concurrently.
 type ConcurrentRunsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -14790,7 +14790,7 @@ func (s ConcurrentRunsExceededException) GoString() string {
 
 func newErrorConcurrentRunsExceededException(v protocol.ResponseMetadata) error {
 	return &ConcurrentRunsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14818,12 +14818,12 @@ func (s ConcurrentRunsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentRunsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentRunsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Defines a condition under which a trigger fires.
@@ -14907,7 +14907,7 @@ func (s *Condition) SetState(v string) *Condition {
 // A specified condition was not satisfied.
 type ConditionCheckFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -14925,7 +14925,7 @@ func (s ConditionCheckFailureException) GoString() string {
 
 func newErrorConditionCheckFailureException(v protocol.ResponseMetadata) error {
 	return &ConditionCheckFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14953,12 +14953,12 @@ func (s ConditionCheckFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConditionCheckFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConditionCheckFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The confusion matrix shows you what your transform is predicting accurately
@@ -15731,7 +15731,7 @@ func (s *CrawlerNodeDetails) SetCrawls(v []*Crawl) *CrawlerNodeDetails {
 // The specified crawler is not running.
 type CrawlerNotRunningException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -15749,7 +15749,7 @@ func (s CrawlerNotRunningException) GoString() string {
 
 func newErrorCrawlerNotRunningException(v protocol.ResponseMetadata) error {
 	return &CrawlerNotRunningException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15777,18 +15777,18 @@ func (s CrawlerNotRunningException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CrawlerNotRunningException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CrawlerNotRunningException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation cannot be performed because the crawler is already running.
 type CrawlerRunningException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -15806,7 +15806,7 @@ func (s CrawlerRunningException) GoString() string {
 
 func newErrorCrawlerRunningException(v protocol.ResponseMetadata) error {
 	return &CrawlerRunningException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15834,18 +15834,18 @@ func (s CrawlerRunningException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CrawlerRunningException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CrawlerRunningException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified crawler is stopping.
 type CrawlerStoppingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -15863,7 +15863,7 @@ func (s CrawlerStoppingException) GoString() string {
 
 func newErrorCrawlerStoppingException(v protocol.ResponseMetadata) error {
 	return &CrawlerStoppingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15891,12 +15891,12 @@ func (s CrawlerStoppingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CrawlerStoppingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CrawlerStoppingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies data stores to crawl.
@@ -20352,7 +20352,7 @@ func (s *EncryptionConfiguration) SetS3Encryption(v []*S3Encryption) *Encryption
 // An encryption operation failed.
 type EncryptionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -20370,7 +20370,7 @@ func (s EncryptionException) GoString() string {
 
 func newErrorEncryptionException(v protocol.ResponseMetadata) error {
 	return &EncryptionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20398,18 +20398,18 @@ func (s EncryptionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EncryptionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EncryptionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A specified entity does not exist
 type EntityNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -20427,7 +20427,7 @@ func (s EntityNotFoundException) GoString() string {
 
 func newErrorEntityNotFoundException(v protocol.ResponseMetadata) error {
 	return &EntityNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20455,12 +20455,12 @@ func (s EntityNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EntityNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EntityNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about an error.
@@ -25031,7 +25031,7 @@ func (s *GrokClassifier) SetVersion(v int64) *GrokClassifier {
 // The same unique identifier was associated with two different records.
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -25049,7 +25049,7 @@ func (s IdempotentParameterMismatchException) GoString() string {
 
 func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25077,12 +25077,12 @@ func (s IdempotentParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ImportCatalogToGlueInput struct {
@@ -25173,7 +25173,7 @@ func (s *ImportLabelsTaskRunProperties) SetReplace(v bool) *ImportLabelsTaskRunP
 // An internal service error occurred.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -25191,7 +25191,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25219,18 +25219,18 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input provided was not valid.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -25248,7 +25248,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25276,12 +25276,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies a JDBC data store to crawl.
@@ -27349,7 +27349,7 @@ func (s *MLTransform) SetWorkerType(v string) *MLTransform {
 // The machine learning transform is not ready to run.
 type MLTransformNotReadyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -27367,7 +27367,7 @@ func (s MLTransformNotReadyException) GoString() string {
 
 func newErrorMLTransformNotReadyException(v protocol.ResponseMetadata) error {
 	return &MLTransformNotReadyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27395,12 +27395,12 @@ func (s MLTransformNotReadyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MLTransformNotReadyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MLTransformNotReadyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Defines a mapping.
@@ -27475,7 +27475,7 @@ func (s *MappingEntry) SetTargetType(v string) *MappingEntry {
 // There is no applicable schedule.
 type NoScheduleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -27493,7 +27493,7 @@ func (s NoScheduleException) GoString() string {
 
 func newErrorNoScheduleException(v protocol.ResponseMetadata) error {
 	return &NoScheduleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27521,12 +27521,12 @@ func (s NoScheduleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoScheduleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoScheduleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A node represents an AWS Glue component like Trigger, Job etc. which is part
@@ -27640,7 +27640,7 @@ func (s *NotificationProperty) SetNotifyDelayAfter(v int64) *NotificationPropert
 // The operation timed out.
 type OperationTimeoutException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -27658,7 +27658,7 @@ func (s OperationTimeoutException) GoString() string {
 
 func newErrorOperationTimeoutException(v protocol.ResponseMetadata) error {
 	return &OperationTimeoutException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27686,12 +27686,12 @@ func (s OperationTimeoutException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationTimeoutException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationTimeoutException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the sort order of a sorted column.
@@ -28548,7 +28548,7 @@ func (s *ResetJobBookmarkOutput) SetJobBookmarkEntry(v *JobBookmarkEntry) *Reset
 // A resource numerical limit was exceeded.
 type ResourceNumberLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28566,7 +28566,7 @@ func (s ResourceNumberLimitExceededException) GoString() string {
 
 func newErrorResourceNumberLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceNumberLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28594,12 +28594,12 @@ func (s ResourceNumberLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNumberLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNumberLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The URIs for function resources.
@@ -28754,7 +28754,7 @@ func (s *Schedule) SetState(v string) *Schedule {
 // The specified scheduler is not running.
 type SchedulerNotRunningException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28772,7 +28772,7 @@ func (s SchedulerNotRunningException) GoString() string {
 
 func newErrorSchedulerNotRunningException(v protocol.ResponseMetadata) error {
 	return &SchedulerNotRunningException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28800,18 +28800,18 @@ func (s SchedulerNotRunningException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SchedulerNotRunningException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SchedulerNotRunningException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified scheduler is already running.
 type SchedulerRunningException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28829,7 +28829,7 @@ func (s SchedulerRunningException) GoString() string {
 
 func newErrorSchedulerRunningException(v protocol.ResponseMetadata) error {
 	return &SchedulerRunningException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28857,18 +28857,18 @@ func (s SchedulerRunningException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SchedulerRunningException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SchedulerRunningException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified scheduler is transitioning.
 type SchedulerTransitioningException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28886,7 +28886,7 @@ func (s SchedulerTransitioningException) GoString() string {
 
 func newErrorSchedulerTransitioningException(v protocol.ResponseMetadata) error {
 	return &SchedulerTransitioningException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28914,12 +28914,12 @@ func (s SchedulerTransitioningException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SchedulerTransitioningException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SchedulerTransitioningException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A policy that specifies update and deletion behaviors for the crawler.
@@ -33712,7 +33712,7 @@ func (s *UserDefinedFunctionInput) SetResourceUris(v []*ResourceUri) *UserDefine
 // A value could not be validated.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -33730,7 +33730,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -33758,18 +33758,18 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There was a version conflict.
 type VersionMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -33787,7 +33787,7 @@ func (s VersionMismatchException) GoString() string {
 
 func newErrorVersionMismatchException(v protocol.ResponseMetadata) error {
 	return &VersionMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -33815,12 +33815,12 @@ func (s VersionMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s VersionMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s VersionMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A workflow represents a flow in which AWS Glue components should be executed

--- a/service/greengrass/api.go
+++ b/service/greengrass/api.go
@@ -7328,8 +7328,8 @@ func (s *AssociateServiceRoleToAccountOutput) SetAssociatedAt(v string) *Associa
 
 // General error information.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A list of error details.
 	ErrorDetails []*ErrorDetail `type:"list"`
@@ -14206,8 +14206,8 @@ func (s *GroupVersion) SetSubscriptionDefinitionVersionArn(v string) *GroupVersi
 
 // General error information.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A list of error details.
 	ErrorDetails []*ErrorDetail `type:"list"`

--- a/service/greengrass/api.go
+++ b/service/greengrass/api.go
@@ -7329,7 +7329,7 @@ func (s *AssociateServiceRoleToAccountOutput) SetAssociatedAt(v string) *Associa
 // General error information.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A list of error details.
 	ErrorDetails []*ErrorDetail `type:"list"`
@@ -7349,7 +7349,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7377,12 +7377,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a bulk deployment. You cannot start a new bulk deployment
@@ -14207,7 +14207,7 @@ func (s *GroupVersion) SetSubscriptionDefinitionVersionArn(v string) *GroupVersi
 // General error information.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A list of error details.
 	ErrorDetails []*ErrorDetail `type:"list"`
@@ -14227,7 +14227,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14255,12 +14255,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListBulkDeploymentDetailedReportsInput struct {

--- a/service/groundstation/api.go
+++ b/service/groundstation/api.go
@@ -3905,8 +3905,8 @@ func (s *DemodulationConfig) SetUnvalidatedJSON(v string) *DemodulationConfig {
 
 // Dependency encountered an error.
 type DependencyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -4965,8 +4965,8 @@ func (s *GetSatelliteOutput) SetSatelliteId(v string) *GetSatelliteOutput {
 
 // One or more parameters are not valid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -5748,8 +5748,8 @@ func (s *ReserveContactOutput) SetContactId(v string) *ReserveContactOutput {
 
 // Account limits for this resource have been exceeded.
 type ResourceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -5806,8 +5806,8 @@ func (s ResourceLimitExceededException) RequestID() string {
 
 // Resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/groundstation/api.go
+++ b/service/groundstation/api.go
@@ -3906,7 +3906,7 @@ func (s *DemodulationConfig) SetUnvalidatedJSON(v string) *DemodulationConfig {
 // Dependency encountered an error.
 type DependencyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -3925,7 +3925,7 @@ func (s DependencyException) GoString() string {
 
 func newErrorDependencyException(v protocol.ResponseMetadata) error {
 	return &DependencyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3953,12 +3953,12 @@ func (s DependencyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DependencyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DependencyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DescribeContactInput struct {
@@ -4966,7 +4966,7 @@ func (s *GetSatelliteOutput) SetSatelliteId(v string) *GetSatelliteOutput {
 // One or more parameters are not valid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -4985,7 +4985,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5013,12 +5013,12 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListConfigsInput struct {
@@ -5749,7 +5749,7 @@ func (s *ReserveContactOutput) SetContactId(v string) *ReserveContactOutput {
 // Account limits for this resource have been exceeded.
 type ResourceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -5768,7 +5768,7 @@ func (s ResourceLimitExceededException) GoString() string {
 
 func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5796,18 +5796,18 @@ func (s ResourceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5824,7 +5824,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5852,12 +5852,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Item in a list of satellites.

--- a/service/guardduty/api.go
+++ b/service/guardduty/api.go
@@ -5020,7 +5020,7 @@ func (s *AwsApiCallAction) SetServiceName(v string) *AwsApiCallAction {
 // Bad request exception object.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5041,7 +5041,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5069,12 +5069,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about the city associated with the IP address.
@@ -8397,7 +8397,7 @@ func (s *InstanceDetails) SetTags(v []*Tag) *InstanceDetails {
 // Internal server error exception object.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -8418,7 +8418,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8446,12 +8446,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about the invitation to become a member account.

--- a/service/guardduty/api.go
+++ b/service/guardduty/api.go
@@ -5019,8 +5019,8 @@ func (s *AwsApiCallAction) SetServiceName(v string) *AwsApiCallAction {
 
 // Bad request exception object.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -8396,8 +8396,8 @@ func (s *InstanceDetails) SetTags(v []*Tag) *InstanceDetails {
 
 // Internal server error exception object.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/health/api.go
+++ b/service/health/api.go
@@ -1630,7 +1630,7 @@ func (s *AffectedEntity) SetTags(v map[string]*string) *AffectedEntity {
 // the DescribeHealthServiceStatusForOrganization operation.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1647,7 +1647,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1675,12 +1675,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A range of dates and times that is used by the EventFilter and EntityFilter
@@ -3619,7 +3619,7 @@ func (s *EventTypeFilter) SetServices(v []*string) *EventTypeFilter {
 // The specified pagination token (nextToken) is not valid.
 type InvalidPaginationToken struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3636,7 +3636,7 @@ func (s InvalidPaginationToken) GoString() string {
 
 func newErrorInvalidPaginationToken(v protocol.ResponseMetadata) error {
 	return &InvalidPaginationToken{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3664,12 +3664,12 @@ func (s InvalidPaginationToken) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPaginationToken) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPaginationToken) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Error information returned when a DescribeAffectedEntitiesForOrganization
@@ -4101,7 +4101,7 @@ func (s *OrganizationEventFilter) SetStartTime(v *DateTimeRange) *OrganizationEv
 // The specified locale is not supported.
 type UnsupportedLocale struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4118,7 +4118,7 @@ func (s UnsupportedLocale) GoString() string {
 
 func newErrorUnsupportedLocale(v protocol.ResponseMetadata) error {
 	return &UnsupportedLocale{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4146,12 +4146,12 @@ func (s UnsupportedLocale) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedLocale) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedLocale) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/health/api.go
+++ b/service/health/api.go
@@ -1629,8 +1629,8 @@ func (s *AffectedEntity) SetTags(v map[string]*string) *AffectedEntity {
 // the action to complete before trying again. To get the current status, use
 // the DescribeHealthServiceStatusForOrganization operation.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3618,8 +3618,8 @@ func (s *EventTypeFilter) SetServices(v []*string) *EventTypeFilter {
 
 // The specified pagination token (nextToken) is not valid.
 type InvalidPaginationToken struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4100,8 +4100,8 @@ func (s *OrganizationEventFilter) SetStartTime(v *DateTimeRange) *OrganizationEv
 
 // The specified locale is not supported.
 type UnsupportedLocale struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/imagebuilder/api.go
+++ b/service/imagebuilder/api.go
@@ -4884,7 +4884,7 @@ func (s *AmiDistributionConfiguration) SetName(v string) *AmiDistributionConfigu
 // You have exceeded the permitted request rate for the specific operation.
 type CallRateLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4901,7 +4901,7 @@ func (s CallRateLimitExceededException) GoString() string {
 
 func newErrorCallRateLimitExceededException(v protocol.ResponseMetadata) error {
 	return &CallRateLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4929,12 +4929,12 @@ func (s CallRateLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CallRateLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CallRateLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CancelImageCreationInput struct {
@@ -5033,7 +5033,7 @@ func (s *CancelImageCreationOutput) SetRequestId(v string) *CancelImageCreationO
 // action or resource, or specifying an invalid resource identifier.
 type ClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5050,7 +5050,7 @@ func (s ClientException) GoString() string {
 
 func newErrorClientException(v protocol.ResponseMetadata) error {
 	return &ClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5078,12 +5078,12 @@ func (s ClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A detailed view of a component.
@@ -7329,7 +7329,7 @@ func (s *Filter) SetValues(v []*string) *Filter {
 // You are not authorized to perform the requested operation.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7346,7 +7346,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7374,12 +7374,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetComponentInput struct {
@@ -8023,7 +8023,7 @@ func (s *GetInfrastructureConfigurationOutput) SetRequestId(v string) *GetInfras
 // that differ from a previous request that used the same client token.
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8040,7 +8040,7 @@ func (s IdempotentParameterMismatchException) GoString() string {
 
 func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8068,12 +8068,12 @@ func (s IdempotentParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An image build version.
@@ -9316,7 +9316,7 @@ func (s *InstanceBlockDeviceMapping) SetVirtualName(v string) *InstanceBlockDevi
 // You have provided an invalid pagination token in your request.
 type InvalidPaginationTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9333,7 +9333,7 @@ func (s InvalidPaginationTokenException) GoString() string {
 
 func newErrorInvalidPaginationTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidPaginationTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9361,19 +9361,19 @@ func (s InvalidPaginationTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPaginationTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPaginationTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have specified two or more mutually exclusive parameters. Review the
 // error message for details.
 type InvalidParameterCombinationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9390,7 +9390,7 @@ func (s InvalidParameterCombinationException) GoString() string {
 
 func newErrorInvalidParameterCombinationException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterCombinationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9418,19 +9418,19 @@ func (s InvalidParameterCombinationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterCombinationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterCombinationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified parameter is invalid. Review the available parameters for the
 // API request.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9447,7 +9447,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9475,18 +9475,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The value that you provided for the specified parameter is invalid.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9503,7 +9503,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9531,18 +9531,18 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have made a request for an action that is not supported by the service.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9559,7 +9559,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9587,18 +9587,18 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Your version number is out of bounds or does not follow the required syntax.
 type InvalidVersionNumberException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9615,7 +9615,7 @@ func (s InvalidVersionNumberException) GoString() string {
 
 func newErrorInvalidVersionNumberException(v protocol.ResponseMetadata) error {
 	return &InvalidVersionNumberException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9643,12 +9643,12 @@ func (s InvalidVersionNumberException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidVersionNumberException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidVersionNumberException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the configuration for a launch permission. The launch permission
@@ -11169,7 +11169,7 @@ func (s *PutImageRecipePolicyOutput) SetRequestId(v string) *PutImageRecipePolic
 // The resource that you are trying to create already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11186,7 +11186,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11214,19 +11214,19 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have attempted to mutate or delete a resource with a dependency that
 // prohibits this action. See the error message for more details.
 type ResourceDependencyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11243,7 +11243,7 @@ func (s ResourceDependencyException) GoString() string {
 
 func newErrorResourceDependencyException(v protocol.ResponseMetadata) error {
 	return &ResourceDependencyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11271,19 +11271,19 @@ func (s ResourceDependencyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceDependencyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceDependencyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource that you are trying to operate on is currently in use. Review
 // the message details and retry later.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11300,7 +11300,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11328,18 +11328,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // At least one of the resources referenced by your request does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11356,7 +11356,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11384,12 +11384,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Amazon S3 logging configuration.
@@ -11495,7 +11495,7 @@ func (s *Schedule) SetScheduleExpression(v string) *Schedule {
 // This exception is thrown when the service encounters an unrecoverable exception.
 type ServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11512,7 +11512,7 @@ func (s ServiceException) GoString() string {
 
 func newErrorServiceException(v protocol.ResponseMetadata) error {
 	return &ServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11540,18 +11540,18 @@ func (s ServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service is unable to process your request at this time.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11568,7 +11568,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11596,12 +11596,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartImagePipelineExecutionInput struct {

--- a/service/imagebuilder/api.go
+++ b/service/imagebuilder/api.go
@@ -4883,8 +4883,8 @@ func (s *AmiDistributionConfiguration) SetName(v string) *AmiDistributionConfigu
 
 // You have exceeded the permitted request rate for the specific operation.
 type CallRateLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5032,8 +5032,8 @@ func (s *CancelImageCreationOutput) SetRequestId(v string) *CancelImageCreationO
 // or resource on behalf of a user that doesn't have permissions to use the
 // action or resource, or specifying an invalid resource identifier.
 type ClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7328,8 +7328,8 @@ func (s *Filter) SetValues(v []*string) *Filter {
 
 // You are not authorized to perform the requested operation.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8022,8 +8022,8 @@ func (s *GetInfrastructureConfigurationOutput) SetRequestId(v string) *GetInfras
 // You have specified a client token for an operation using parameter values
 // that differ from a previous request that used the same client token.
 type IdempotentParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9315,8 +9315,8 @@ func (s *InstanceBlockDeviceMapping) SetVirtualName(v string) *InstanceBlockDevi
 
 // You have provided an invalid pagination token in your request.
 type InvalidPaginationTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9372,8 +9372,8 @@ func (s InvalidPaginationTokenException) RequestID() string {
 // You have specified two or more mutually exclusive parameters. Review the
 // error message for details.
 type InvalidParameterCombinationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9429,8 +9429,8 @@ func (s InvalidParameterCombinationException) RequestID() string {
 // The specified parameter is invalid. Review the available parameters for the
 // API request.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9485,8 +9485,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // The value that you provided for the specified parameter is invalid.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9541,8 +9541,8 @@ func (s InvalidParameterValueException) RequestID() string {
 
 // You have made a request for an action that is not supported by the service.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9597,8 +9597,8 @@ func (s InvalidRequestException) RequestID() string {
 
 // Your version number is out of bounds or does not follow the required syntax.
 type InvalidVersionNumberException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11168,8 +11168,8 @@ func (s *PutImageRecipePolicyOutput) SetRequestId(v string) *PutImageRecipePolic
 
 // The resource that you are trying to create already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11225,8 +11225,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 // You have attempted to mutate or delete a resource with a dependency that
 // prohibits this action. See the error message for more details.
 type ResourceDependencyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11282,8 +11282,8 @@ func (s ResourceDependencyException) RequestID() string {
 // The resource that you are trying to operate on is currently in use. Review
 // the message details and retry later.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11338,8 +11338,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // At least one of the resources referenced by your request does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11494,8 +11494,8 @@ func (s *Schedule) SetScheduleExpression(v string) *Schedule {
 
 // This exception is thrown when the service encounters an unrecoverable exception.
 type ServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11550,8 +11550,8 @@ func (s ServiceException) RequestID() string {
 
 // The service is unable to process your request at this time.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/inspector/api.go
+++ b/service/inspector/api.go
@@ -4028,7 +4028,7 @@ func (c *Inspector) UpdateAssessmentTargetWithContext(ctx aws.Context, input *Up
 // You do not have required permissions to access the requested resource.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// You can immediately retry your request.
 	//
@@ -4056,7 +4056,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4084,12 +4084,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AddAttributesToFindingsInput struct {
@@ -4374,7 +4374,7 @@ func (s *AgentPreview) SetOperatingSystem(v string) *AgentPreview {
 // in another assessment run.
 type AgentsAlreadyRunningAssessmentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Agents is a required field
 	Agents []*AgentAlreadyRunningAssessment `locationName:"agents" min:"1" type:"list" required:"true"`
@@ -4403,7 +4403,7 @@ func (s AgentsAlreadyRunningAssessmentException) GoString() string {
 
 func newErrorAgentsAlreadyRunningAssessmentException(v protocol.ResponseMetadata) error {
 	return &AgentsAlreadyRunningAssessmentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4431,12 +4431,12 @@ func (s AgentsAlreadyRunningAssessmentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AgentsAlreadyRunningAssessmentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AgentsAlreadyRunningAssessmentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A snapshot of an Amazon Inspector assessment run that contains the findings
@@ -4828,7 +4828,7 @@ func (s *AssessmentRunFilter) SetStates(v []*string) *AssessmentRunFilter {
 // progress.
 type AssessmentRunInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The ARNs of the assessment runs that are currently in progress.
 	//
@@ -4862,7 +4862,7 @@ func (s AssessmentRunInProgressException) GoString() string {
 
 func newErrorAssessmentRunInProgressException(v protocol.ResponseMetadata) error {
 	return &AssessmentRunInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4890,12 +4890,12 @@ func (s AssessmentRunInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AssessmentRunInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AssessmentRunInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Used as one of the elements of the AssessmentRun data type.
@@ -7530,7 +7530,7 @@ func (s *GetTelemetryMetadataOutput) SetTelemetryMetadata(v []*TelemetryMetadata
 // Internal server error.
 type InternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// You can immediately retry your request.
 	//
@@ -7553,7 +7553,7 @@ func (s InternalException) GoString() string {
 
 func newErrorInternalException(v protocol.ResponseMetadata) error {
 	return &InternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7581,19 +7581,19 @@ func (s InternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Amazon Inspector cannot assume the cross-account role that it needs to list
 // your EC2 instances during the assessment run.
 type InvalidCrossAccountRoleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// You can immediately retry your request.
 	//
@@ -7621,7 +7621,7 @@ func (s InvalidCrossAccountRoleException) GoString() string {
 
 func newErrorInvalidCrossAccountRoleException(v protocol.ResponseMetadata) error {
 	return &InvalidCrossAccountRoleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7649,19 +7649,19 @@ func (s InvalidCrossAccountRoleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCrossAccountRoleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCrossAccountRoleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because an invalid or out-of-range value was supplied
 // for an input parameter.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// You can immediately retry your request.
 	//
@@ -7689,7 +7689,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7717,19 +7717,19 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because it attempted to create resources beyond
 // the current AWS account limits. The error code describes the limit exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// You can immediately retry your request.
 	//
@@ -7757,7 +7757,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7785,12 +7785,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAssessmentRunAgentsInput struct {
@@ -8835,7 +8835,7 @@ func (s *NetworkInterface) SetVpcId(v string) *NetworkInterface {
 // The error code describes the entity.
 type NoSuchEntityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// You can immediately retry your request.
 	//
@@ -8863,7 +8863,7 @@ func (s NoSuchEntityException) GoString() string {
 
 func newErrorNoSuchEntityException(v protocol.ResponseMetadata) error {
 	return &NoSuchEntityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8891,12 +8891,12 @@ func (s NoSuchEntityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchEntityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchEntityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PreviewAgentsInput struct {
@@ -9006,7 +9006,7 @@ func (s *PreviewAgentsOutput) SetNextToken(v string) *PreviewAgentsOutput {
 // an exclusions preview.
 type PreviewGenerationInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9023,7 +9023,7 @@ func (s PreviewGenerationInProgressException) GoString() string {
 
 func newErrorPreviewGenerationInProgressException(v protocol.ResponseMetadata) error {
 	return &PreviewGenerationInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9051,12 +9051,12 @@ func (s PreviewGenerationInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PreviewGenerationInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PreviewGenerationInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a private IP address associated with a network
@@ -9521,7 +9521,7 @@ func (s *ServiceAttributes) SetSchemaVersion(v int64) *ServiceAttributes {
 // The serice is temporary unavailable.
 type ServiceTemporarilyUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// You can wait and then retry your request.
 	//
@@ -9544,7 +9544,7 @@ func (s ServiceTemporarilyUnavailableException) GoString() string {
 
 func newErrorServiceTemporarilyUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceTemporarilyUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9572,12 +9572,12 @@ func (s ServiceTemporarilyUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceTemporarilyUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceTemporarilyUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SetTagsForResourceInput struct {
@@ -10172,7 +10172,7 @@ func (s UnsubscribeFromEventOutput) GoString() string {
 // Inspector became available.
 type UnsupportedFeatureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// CanRetry is a required field
 	CanRetry *bool `locationName:"canRetry" type:"boolean" required:"true"`
@@ -10192,7 +10192,7 @@ func (s UnsupportedFeatureException) GoString() string {
 
 func newErrorUnsupportedFeatureException(v protocol.ResponseMetadata) error {
 	return &UnsupportedFeatureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10220,12 +10220,12 @@ func (s UnsupportedFeatureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedFeatureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedFeatureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateAssessmentTargetInput struct {

--- a/service/inspector/api.go
+++ b/service/inspector/api.go
@@ -4027,8 +4027,8 @@ func (c *Inspector) UpdateAssessmentTargetWithContext(ctx aws.Context, input *Up
 
 // You do not have required permissions to access the requested resource.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// You can immediately retry your request.
 	//
@@ -4373,8 +4373,8 @@ func (s *AgentPreview) SetOperatingSystem(v string) *AgentPreview {
 // You started an assessment run, but one of the instances is already participating
 // in another assessment run.
 type AgentsAlreadyRunningAssessmentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Agents is a required field
 	Agents []*AgentAlreadyRunningAssessment `locationName:"agents" min:"1" type:"list" required:"true"`
@@ -4827,8 +4827,8 @@ func (s *AssessmentRunFilter) SetStates(v []*string) *AssessmentRunFilter {
 // You cannot perform a specified action if an assessment run is currently in
 // progress.
 type AssessmentRunInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The ARNs of the assessment runs that are currently in progress.
 	//
@@ -7529,8 +7529,8 @@ func (s *GetTelemetryMetadataOutput) SetTelemetryMetadata(v []*TelemetryMetadata
 
 // Internal server error.
 type InternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// You can immediately retry your request.
 	//
@@ -7592,8 +7592,8 @@ func (s InternalException) RequestID() string {
 // Amazon Inspector cannot assume the cross-account role that it needs to list
 // your EC2 instances during the assessment run.
 type InvalidCrossAccountRoleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// You can immediately retry your request.
 	//
@@ -7660,8 +7660,8 @@ func (s InvalidCrossAccountRoleException) RequestID() string {
 // The request was rejected because an invalid or out-of-range value was supplied
 // for an input parameter.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// You can immediately retry your request.
 	//
@@ -7728,8 +7728,8 @@ func (s InvalidInputException) RequestID() string {
 // The request was rejected because it attempted to create resources beyond
 // the current AWS account limits. The error code describes the limit exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// You can immediately retry your request.
 	//
@@ -8834,8 +8834,8 @@ func (s *NetworkInterface) SetVpcId(v string) *NetworkInterface {
 // The request was rejected because it referenced an entity that does not exist.
 // The error code describes the entity.
 type NoSuchEntityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// You can immediately retry your request.
 	//
@@ -9005,8 +9005,8 @@ func (s *PreviewAgentsOutput) SetNextToken(v string) *PreviewAgentsOutput {
 // The request is rejected. The specified assessment template is currently generating
 // an exclusions preview.
 type PreviewGenerationInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9520,8 +9520,8 @@ func (s *ServiceAttributes) SetSchemaVersion(v int64) *ServiceAttributes {
 
 // The serice is temporary unavailable.
 type ServiceTemporarilyUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// You can wait and then retry your request.
 	//
@@ -10171,8 +10171,8 @@ func (s UnsubscribeFromEventOutput) GoString() string {
 // runs that took place or will take place after generating reports in Amazon
 // Inspector became available.
 type UnsupportedFeatureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// CanRetry is a required field
 	CanRetry *bool `locationName:"canRetry" type:"boolean" required:"true"`

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -21409,7 +21409,7 @@ func (s *Certificate) SetStatus(v string) *Certificate {
 // than one CA certificate that has the same subject field and public key.
 type CertificateConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -21427,7 +21427,7 @@ func (s CertificateConflictException) GoString() string {
 
 func newErrorCertificateConflictException(v protocol.ResponseMetadata) error {
 	return &CertificateConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21455,12 +21455,12 @@ func (s CertificateConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CertificateConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CertificateConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a certificate.
@@ -21598,7 +21598,7 @@ func (s *CertificateDescription) SetValidity(v *CertificateValidity) *Certificat
 // The certificate operation is not allowed.
 type CertificateStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -21616,7 +21616,7 @@ func (s CertificateStateException) GoString() string {
 
 func newErrorCertificateStateException(v protocol.ResponseMetadata) error {
 	return &CertificateStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21644,18 +21644,18 @@ func (s CertificateStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CertificateStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CertificateStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The certificate is invalid.
 type CertificateValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -21673,7 +21673,7 @@ func (s CertificateValidationException) GoString() string {
 
 func newErrorCertificateValidationException(v protocol.ResponseMetadata) error {
 	return &CertificateValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21701,12 +21701,12 @@ func (s CertificateValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CertificateValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CertificateValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // When the certificate is valid.
@@ -22209,7 +22209,7 @@ func (s ConfirmTopicRuleDestinationOutput) GoString() string {
 // pending updates cause a conflict.
 type ConflictingResourceUpdateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -22227,7 +22227,7 @@ func (s ConflictingResourceUpdateException) GoString() string {
 
 func newErrorConflictingResourceUpdateException(v protocol.ResponseMetadata) error {
 	return &ConflictingResourceUpdateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22255,12 +22255,12 @@ func (s ConflictingResourceUpdateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictingResourceUpdateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictingResourceUpdateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateAuthorizerInput struct {
@@ -25480,7 +25480,7 @@ func (s DeleteCertificateOutput) GoString() string {
 // You can't delete the resource because it is attached to one or more resources.
 type DeleteConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -25498,7 +25498,7 @@ func (s DeleteConflictException) GoString() string {
 
 func newErrorDeleteConflictException(v protocol.ResponseMetadata) error {
 	return &DeleteConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -25526,12 +25526,12 @@ func (s DeleteConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeleteConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeleteConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteDomainConfigurationInput struct {
@@ -32131,7 +32131,7 @@ func (s *ImplicitDeny) SetPolicies(v []*Policy) *ImplicitDeny {
 // The index is not ready.
 type IndexNotReadyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32149,7 +32149,7 @@ func (s IndexNotReadyException) GoString() string {
 
 func newErrorIndexNotReadyException(v protocol.ResponseMetadata) error {
 	return &IndexNotReadyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -32177,18 +32177,18 @@ func (s IndexNotReadyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IndexNotReadyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IndexNotReadyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An unexpected error has occurred.
 type InternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32206,7 +32206,7 @@ func (s InternalException) GoString() string {
 
 func newErrorInternalException(v protocol.ResponseMetadata) error {
 	return &InternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -32234,18 +32234,18 @@ func (s InternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An unexpected error has occurred.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32263,7 +32263,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -32291,18 +32291,18 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The aggregation is invalid.
 type InvalidAggregationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -32319,7 +32319,7 @@ func (s InvalidAggregationException) GoString() string {
 
 func newErrorInvalidAggregationException(v protocol.ResponseMetadata) error {
 	return &InvalidAggregationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -32347,18 +32347,18 @@ func (s InvalidAggregationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAggregationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAggregationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The query is invalid.
 type InvalidQueryException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32376,7 +32376,7 @@ func (s InvalidQueryException) GoString() string {
 
 func newErrorInvalidQueryException(v protocol.ResponseMetadata) error {
 	return &InvalidQueryException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -32404,18 +32404,18 @@ func (s InvalidQueryException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidQueryException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidQueryException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request is not valid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32433,7 +32433,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -32461,18 +32461,18 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The response is invalid.
 type InvalidResponseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32490,7 +32490,7 @@ func (s InvalidResponseException) GoString() string {
 
 func newErrorInvalidResponseException(v protocol.ResponseMetadata) error {
 	return &InvalidResponseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -32518,12 +32518,12 @@ func (s InvalidResponseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResponseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResponseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An attempt was made to change to an invalid state, for example by deleting
@@ -32531,7 +32531,7 @@ func (s InvalidResponseException) RequestID() string {
 // parameter.
 type InvalidStateTransitionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32549,7 +32549,7 @@ func (s InvalidStateTransitionException) GoString() string {
 
 func newErrorInvalidStateTransitionException(v protocol.ResponseMetadata) error {
 	return &InvalidStateTransitionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -32577,12 +32577,12 @@ func (s InvalidStateTransitionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateTransitionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateTransitionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Sends message data to an AWS IoT Analytics channel.
@@ -33601,7 +33601,7 @@ func (s *LambdaAction) SetFunctionArn(v string) *LambdaAction {
 // A limit has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -33619,7 +33619,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -33647,12 +33647,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListActiveViolationsInput struct {
@@ -38359,7 +38359,7 @@ func (s *LoggingOptionsPayload) SetRoleArn(v string) *LoggingOptionsPayload {
 // The policy documentation is not valid.
 type MalformedPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -38377,7 +38377,7 @@ func (s MalformedPolicyException) GoString() string {
 
 func newErrorMalformedPolicyException(v protocol.ResponseMetadata) error {
 	return &MalformedPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -38405,12 +38405,12 @@ func (s MalformedPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MalformedPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MalformedPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The value to be compared with the metric.
@@ -38779,7 +38779,7 @@ func (s *NonCompliantResource) SetResourceType(v string) *NonCompliantResource {
 // The resource is not configured.
 type NotConfiguredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -38797,7 +38797,7 @@ func (s NotConfiguredException) GoString() string {
 
 func newErrorNotConfiguredException(v protocol.ResponseMetadata) error {
 	return &NotConfiguredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -38825,12 +38825,12 @@ func (s NotConfiguredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotConfiguredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotConfiguredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a file to be associated with an OTA update.
@@ -40057,7 +40057,7 @@ func (s *RegisterThingOutput) SetResourceArns(v map[string]*string) *RegisterThi
 // The registration code is invalid.
 type RegistrationCodeValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -40075,7 +40075,7 @@ func (s RegistrationCodeValidationException) GoString() string {
 
 func newErrorRegistrationCodeValidationException(v protocol.ResponseMetadata) error {
 	return &RegistrationCodeValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -40103,12 +40103,12 @@ func (s RegistrationCodeValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RegistrationCodeValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RegistrationCodeValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The registration configuration.
@@ -40606,7 +40606,7 @@ func (s *RepublishAction) SetTopic(v string) *RepublishAction {
 // The resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -40630,7 +40630,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -40658,12 +40658,12 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information that identifies the noncompliant resource.
@@ -40786,7 +40786,7 @@ func (s *ResourceIdentifier) SetRoleAliasArn(v string) *ResourceIdentifier {
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -40804,7 +40804,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -40832,18 +40832,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource registration failed.
 type ResourceRegistrationFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -40861,7 +40861,7 @@ func (s ResourceRegistrationFailureException) GoString() string {
 
 func newErrorResourceRegistrationFailureException(v protocol.ResponseMetadata) error {
 	return &ResourceRegistrationFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -40889,12 +40889,12 @@ func (s ResourceRegistrationFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceRegistrationFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceRegistrationFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Role alias description.
@@ -41545,7 +41545,7 @@ func (s *ServerCertificateSummary) SetServerCertificateStatusDetail(v string) *S
 // The service is temporarily unavailable.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -41563,7 +41563,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -41591,12 +41591,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SetDefaultAuthorizerInput struct {
@@ -42108,7 +42108,7 @@ func (s *SnsAction) SetTargetArn(v string) *SnsAction {
 // The Rule-SQL expression can't be parsed correctly.
 type SqlParseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -42126,7 +42126,7 @@ func (s SqlParseException) GoString() string {
 
 func newErrorSqlParseException(v protocol.ResponseMetadata) error {
 	return &SqlParseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42154,12 +42154,12 @@ func (s SqlParseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SqlParseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SqlParseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes an action to publish data to an Amazon SQS queue.
@@ -43151,7 +43151,7 @@ func (s TagResourceOutput) GoString() string {
 // as an existing task but with a different clientRequestToken.
 type TaskAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -43168,7 +43168,7 @@ func (s TaskAlreadyExistsException) GoString() string {
 
 func newErrorTaskAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &TaskAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -43196,12 +43196,12 @@ func (s TaskAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TaskAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TaskAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Statistics for the checks performed during the audit.
@@ -44211,7 +44211,7 @@ func (s *ThingTypeProperties) SetThingTypeDescription(v string) *ThingTypeProper
 // The rate exceeds the limit.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -44229,7 +44229,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -44257,12 +44257,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the amount of time each device has to finish its execution of the
@@ -44784,7 +44784,7 @@ func (s *TopicRulePayload) SetSql(v string) *TopicRulePayload {
 // complete.
 type TransferAlreadyCompletedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -44802,7 +44802,7 @@ func (s TransferAlreadyCompletedException) GoString() string {
 
 func newErrorTransferAlreadyCompletedException(v protocol.ResponseMetadata) error {
 	return &TransferAlreadyCompletedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -44830,12 +44830,12 @@ func (s TransferAlreadyCompletedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TransferAlreadyCompletedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TransferAlreadyCompletedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input for the TransferCertificate operation.
@@ -44935,7 +44935,7 @@ func (s *TransferCertificateOutput) SetTransferredCertificateArn(v string) *Tran
 // attached.
 type TransferConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -44953,7 +44953,7 @@ func (s TransferConflictException) GoString() string {
 
 func newErrorTransferConflictException(v protocol.ResponseMetadata) error {
 	return &TransferConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -44981,12 +44981,12 @@ func (s TransferConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TransferConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TransferConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Data used to transfer a certificate to an AWS account.
@@ -45052,7 +45052,7 @@ func (s *TransferData) SetTransferMessage(v string) *TransferData {
 // You are not authorized to perform this operation.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -45070,7 +45070,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -45098,12 +45098,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -47428,7 +47428,7 @@ func (s *ValidationError) SetErrorMessage(v string) *ValidationError {
 // parameter does not match the latest version in the system.
 type VersionConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -47446,7 +47446,7 @@ func (s VersionConflictException) GoString() string {
 
 func newErrorVersionConflictException(v protocol.ResponseMetadata) error {
 	return &VersionConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -47474,18 +47474,18 @@ func (s VersionConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s VersionConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s VersionConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of policy versions exceeds the limit.
 type VersionsLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -47503,7 +47503,7 @@ func (s VersionsLimitExceededException) GoString() string {
 
 func newErrorVersionsLimitExceededException(v protocol.ResponseMetadata) error {
 	return &VersionsLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -47531,12 +47531,12 @@ func (s VersionsLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s VersionsLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s VersionsLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a Device Defender security profile behavior violation.

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -21408,8 +21408,8 @@ func (s *Certificate) SetStatus(v string) *Certificate {
 // are attempting to register. This is happens when you have registered more
 // than one CA certificate that has the same subject field and public key.
 type CertificateConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -21597,8 +21597,8 @@ func (s *CertificateDescription) SetValidity(v *CertificateValidity) *Certificat
 
 // The certificate operation is not allowed.
 type CertificateStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -21654,8 +21654,8 @@ func (s CertificateStateException) RequestID() string {
 
 // The certificate is invalid.
 type CertificateValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -22208,8 +22208,8 @@ func (s ConfirmTopicRuleDestinationOutput) GoString() string {
 // A conflicting resource update exception. This exception is thrown when two
 // pending updates cause a conflict.
 type ConflictingResourceUpdateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -25479,8 +25479,8 @@ func (s DeleteCertificateOutput) GoString() string {
 
 // You can't delete the resource because it is attached to one or more resources.
 type DeleteConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32130,8 +32130,8 @@ func (s *ImplicitDeny) SetPolicies(v []*Policy) *ImplicitDeny {
 
 // The index is not ready.
 type IndexNotReadyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32187,8 +32187,8 @@ func (s IndexNotReadyException) RequestID() string {
 
 // An unexpected error has occurred.
 type InternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32244,8 +32244,8 @@ func (s InternalException) RequestID() string {
 
 // An unexpected error has occurred.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32301,8 +32301,8 @@ func (s InternalFailureException) RequestID() string {
 
 // The aggregation is invalid.
 type InvalidAggregationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -32357,8 +32357,8 @@ func (s InvalidAggregationException) RequestID() string {
 
 // The query is invalid.
 type InvalidQueryException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32414,8 +32414,8 @@ func (s InvalidQueryException) RequestID() string {
 
 // The request is not valid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32471,8 +32471,8 @@ func (s InvalidRequestException) RequestID() string {
 
 // The response is invalid.
 type InvalidResponseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -32530,8 +32530,8 @@ func (s InvalidResponseException) RequestID() string {
 // a job or a job execution which is "IN_PROGRESS" without setting the force
 // parameter.
 type InvalidStateTransitionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -33600,8 +33600,8 @@ func (s *LambdaAction) SetFunctionArn(v string) *LambdaAction {
 
 // A limit has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -38358,8 +38358,8 @@ func (s *LoggingOptionsPayload) SetRoleArn(v string) *LoggingOptionsPayload {
 
 // The policy documentation is not valid.
 type MalformedPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -38778,8 +38778,8 @@ func (s *NonCompliantResource) SetResourceType(v string) *NonCompliantResource {
 
 // The resource is not configured.
 type NotConfiguredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -40056,8 +40056,8 @@ func (s *RegisterThingOutput) SetResourceArns(v map[string]*string) *RegisterThi
 
 // The registration code is invalid.
 type RegistrationCodeValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -40605,8 +40605,8 @@ func (s *RepublishAction) SetTopic(v string) *RepublishAction {
 
 // The resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -40785,8 +40785,8 @@ func (s *ResourceIdentifier) SetRoleAliasArn(v string) *ResourceIdentifier {
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -40842,8 +40842,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The resource registration failed.
 type ResourceRegistrationFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -41544,8 +41544,8 @@ func (s *ServerCertificateSummary) SetServerCertificateStatusDetail(v string) *S
 
 // The service is temporarily unavailable.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -42107,8 +42107,8 @@ func (s *SnsAction) SetTargetArn(v string) *SnsAction {
 
 // The Rule-SQL expression can't be parsed correctly.
 type SqlParseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -43150,8 +43150,8 @@ func (s TagResourceOutput) GoString() string {
 // This exception occurs if you attempt to start a task with the same task-id
 // as an existing task but with a different clientRequestToken.
 type TaskAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -44210,8 +44210,8 @@ func (s *ThingTypeProperties) SetThingTypeDescription(v string) *ThingTypeProper
 
 // The rate exceeds the limit.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -44783,8 +44783,8 @@ func (s *TopicRulePayload) SetSql(v string) *TopicRulePayload {
 // You can't revert the certificate transfer because the transfer is already
 // complete.
 type TransferAlreadyCompletedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -44934,8 +44934,8 @@ func (s *TransferCertificateOutput) SetTransferredCertificateArn(v string) *Tran
 // You can't transfer the certificate because authorization policies are still
 // attached.
 type TransferConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -45051,8 +45051,8 @@ func (s *TransferData) SetTransferMessage(v string) *TransferData {
 
 // You are not authorized to perform this operation.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -47427,8 +47427,8 @@ func (s *ValidationError) SetErrorMessage(v string) *ValidationError {
 // An exception thrown when the version of an entity specified with the expectedVersion
 // parameter does not match the latest version in the system.
 type VersionConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -47484,8 +47484,8 @@ func (s VersionConflictException) RequestID() string {
 
 // The number of policy versions exceeds the limit.
 type VersionsLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/iot1clickdevicesservice/api.go
+++ b/service/iot1clickdevicesservice/api.go
@@ -1511,8 +1511,8 @@ func (s *FinalizeDeviceClaimOutput) SetState(v string) *FinalizeDeviceClaimOutpu
 }
 
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 403
 	Code_ *string `locationName:"code" type:"string"`
@@ -1693,8 +1693,8 @@ func (s *InitiateDeviceClaimOutput) SetState(v string) *InitiateDeviceClaimOutpu
 }
 
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 500
 	Code_ *string `locationName:"code" type:"string"`
@@ -1752,8 +1752,8 @@ func (s InternalFailureException) RequestID() string {
 }
 
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 400
 	Code_ *string `locationName:"code" type:"string"`
@@ -2147,8 +2147,8 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 }
 
 type PreconditionFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 412
 	Code_ *string `locationName:"code" type:"string"`
@@ -2206,8 +2206,8 @@ func (s PreconditionFailedException) RequestID() string {
 }
 
 type RangeNotSatisfiableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 416
 	Code_ *string `locationName:"code" type:"string"`
@@ -2265,8 +2265,8 @@ func (s RangeNotSatisfiableException) RequestID() string {
 }
 
 type ResourceConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 409
 	Code_ *string `locationName:"code" type:"string"`
@@ -2324,8 +2324,8 @@ func (s ResourceConflictException) RequestID() string {
 }
 
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 404
 	Code_ *string `locationName:"code" type:"string"`

--- a/service/iot1clickdevicesservice/api.go
+++ b/service/iot1clickdevicesservice/api.go
@@ -1512,7 +1512,7 @@ func (s *FinalizeDeviceClaimOutput) SetState(v string) *FinalizeDeviceClaimOutpu
 
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 403
 	Code_ *string `locationName:"code" type:"string"`
@@ -1533,7 +1533,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1561,12 +1561,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetDeviceMethodsInput struct {
@@ -1694,7 +1694,7 @@ func (s *InitiateDeviceClaimOutput) SetState(v string) *InitiateDeviceClaimOutpu
 
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 500
 	Code_ *string `locationName:"code" type:"string"`
@@ -1715,7 +1715,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1743,17 +1743,17 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 400
 	Code_ *string `locationName:"code" type:"string"`
@@ -1774,7 +1774,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1802,12 +1802,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvokeDeviceMethodInput struct {
@@ -2148,7 +2148,7 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 
 type PreconditionFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 412
 	Code_ *string `locationName:"code" type:"string"`
@@ -2169,7 +2169,7 @@ func (s PreconditionFailedException) GoString() string {
 
 func newErrorPreconditionFailedException(v protocol.ResponseMetadata) error {
 	return &PreconditionFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2197,17 +2197,17 @@ func (s PreconditionFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PreconditionFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PreconditionFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RangeNotSatisfiableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 416
 	Code_ *string `locationName:"code" type:"string"`
@@ -2228,7 +2228,7 @@ func (s RangeNotSatisfiableException) GoString() string {
 
 func newErrorRangeNotSatisfiableException(v protocol.ResponseMetadata) error {
 	return &RangeNotSatisfiableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2256,17 +2256,17 @@ func (s RangeNotSatisfiableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RangeNotSatisfiableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RangeNotSatisfiableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResourceConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 409
 	Code_ *string `locationName:"code" type:"string"`
@@ -2287,7 +2287,7 @@ func (s ResourceConflictException) GoString() string {
 
 func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 	return &ResourceConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2315,17 +2315,17 @@ func (s ResourceConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 404
 	Code_ *string `locationName:"code" type:"string"`
@@ -2346,7 +2346,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2374,12 +2374,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {

--- a/service/iot1clickprojects/api.go
+++ b/service/iot1clickprojects/api.go
@@ -2243,7 +2243,7 @@ func (s *GetDevicesInPlacementOutput) SetDevices(v map[string]*string) *GetDevic
 
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -2262,7 +2262,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2290,17 +2290,17 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -2319,7 +2319,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2347,12 +2347,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListPlacementsInput struct {
@@ -2928,7 +2928,7 @@ func (s *ProjectSummary) SetUpdatedDate(v time.Time) *ProjectSummary {
 
 type ResourceConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -2947,7 +2947,7 @@ func (s ResourceConflictException) GoString() string {
 
 func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 	return &ResourceConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2975,17 +2975,17 @@ func (s ResourceConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -3004,7 +3004,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3032,12 +3032,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {
@@ -3116,7 +3116,7 @@ func (s TagResourceOutput) GoString() string {
 
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -3135,7 +3135,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3163,12 +3163,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/iot1clickprojects/api.go
+++ b/service/iot1clickprojects/api.go
@@ -2242,8 +2242,8 @@ func (s *GetDevicesInPlacementOutput) SetDevices(v map[string]*string) *GetDevic
 }
 
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -2299,8 +2299,8 @@ func (s InternalFailureException) RequestID() string {
 }
 
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -2927,8 +2927,8 @@ func (s *ProjectSummary) SetUpdatedDate(v time.Time) *ProjectSummary {
 }
 
 type ResourceConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -2984,8 +2984,8 @@ func (s ResourceConflictException) RequestID() string {
 }
 
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -3115,8 +3115,8 @@ func (s TagResourceOutput) GoString() string {
 }
 
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 

--- a/service/iotanalytics/api.go
+++ b/service/iotanalytics/api.go
@@ -7191,8 +7191,8 @@ func (s *GlueConfiguration) SetTableName(v string) *GlueConfiguration {
 
 // There was an internal failure.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7247,8 +7247,8 @@ func (s InternalFailureException) RequestID() string {
 
 // The request was not valid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7454,8 +7454,8 @@ func (s *LambdaActivity) SetNext(v string) *LambdaActivity {
 
 // The command caused an internal limit to be exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8770,8 +8770,8 @@ func (s *ReprocessingSummary) SetStatus(v string) *ReprocessingSummary {
 
 // A resource with the same name already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -8890,8 +8890,8 @@ func (s *ResourceConfiguration) SetVolumeSizeInGB(v int64) *ResourceConfiguratio
 
 // A resource with the specified name could not be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9447,8 +9447,8 @@ func (s ServiceManagedDatastoreS3StorageSummary) GoString() string {
 
 // The service is temporarily unavailable.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9784,8 +9784,8 @@ func (s TagResourceOutput) GoString() string {
 
 // The request was denied due to request throttling.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/iotanalytics/api.go
+++ b/service/iotanalytics/api.go
@@ -7192,7 +7192,7 @@ func (s *GlueConfiguration) SetTableName(v string) *GlueConfiguration {
 // There was an internal failure.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7209,7 +7209,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7237,18 +7237,18 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was not valid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7265,7 +7265,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7293,12 +7293,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Configuration information for delivery of data set contents to AWS IoT Events.
@@ -7455,7 +7455,7 @@ func (s *LambdaActivity) SetNext(v string) *LambdaActivity {
 // The command caused an internal limit to be exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7472,7 +7472,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7500,12 +7500,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListChannelsInput struct {
@@ -8771,7 +8771,7 @@ func (s *ReprocessingSummary) SetStatus(v string) *ReprocessingSummary {
 // A resource with the same name already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -8794,7 +8794,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8822,12 +8822,12 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The configuration of the resource used to execute the "containerAction".
@@ -8891,7 +8891,7 @@ func (s *ResourceConfiguration) SetVolumeSizeInGB(v int64) *ResourceConfiguratio
 // A resource with the specified name could not be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8908,7 +8908,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8936,12 +8936,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // How long, in days, message data is kept.
@@ -9448,7 +9448,7 @@ func (s ServiceManagedDatastoreS3StorageSummary) GoString() string {
 // The service is temporarily unavailable.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9465,7 +9465,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9493,12 +9493,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The SQL query to modify the message.
@@ -9785,7 +9785,7 @@ func (s TagResourceOutput) GoString() string {
 // The request was denied due to request throttling.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9802,7 +9802,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9830,12 +9830,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the data set whose content generation triggers the new

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -406,8 +406,8 @@ func (c *IoTDataPlane) UpdateThingShadowWithContext(ctx aws.Context, input *Upda
 
 // The specified version does not match the version of the document.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -597,8 +597,8 @@ func (s *GetThingShadowOutput) SetPayload(v []byte) *GetThingShadowOutput {
 
 // An unexpected error has occurred.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -654,8 +654,8 @@ func (s InternalFailureException) RequestID() string {
 
 // The request is not valid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -711,8 +711,8 @@ func (s InvalidRequestException) RequestID() string {
 
 // The specified combination of HTTP verb and URI is not supported.
 type MethodNotAllowedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -842,8 +842,8 @@ func (s PublishOutput) GoString() string {
 
 // The payload exceeds the maximum size allowed.
 type RequestEntityTooLargeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -899,8 +899,8 @@ func (s RequestEntityTooLargeException) RequestID() string {
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -956,8 +956,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The service is temporarily unavailable.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1013,8 +1013,8 @@ func (s ServiceUnavailableException) RequestID() string {
 
 // The rate exceeds the limit.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1070,8 +1070,8 @@ func (s ThrottlingException) RequestID() string {
 
 // You are not authorized to perform this operation.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1127,8 +1127,8 @@ func (s UnauthorizedException) RequestID() string {
 
 // The document encoding is not supported.
 type UnsupportedDocumentEncodingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -407,7 +407,7 @@ func (c *IoTDataPlane) UpdateThingShadowWithContext(ctx aws.Context, input *Upda
 // The specified version does not match the version of the document.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -425,7 +425,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -453,12 +453,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input for the DeleteThingShadow operation.
@@ -598,7 +598,7 @@ func (s *GetThingShadowOutput) SetPayload(v []byte) *GetThingShadowOutput {
 // An unexpected error has occurred.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -616,7 +616,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -644,18 +644,18 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request is not valid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -673,7 +673,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -701,18 +701,18 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified combination of HTTP verb and URI is not supported.
 type MethodNotAllowedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -730,7 +730,7 @@ func (s MethodNotAllowedException) GoString() string {
 
 func newErrorMethodNotAllowedException(v protocol.ResponseMetadata) error {
 	return &MethodNotAllowedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -758,12 +758,12 @@ func (s MethodNotAllowedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MethodNotAllowedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MethodNotAllowedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input for the Publish operation.
@@ -843,7 +843,7 @@ func (s PublishOutput) GoString() string {
 // The payload exceeds the maximum size allowed.
 type RequestEntityTooLargeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -861,7 +861,7 @@ func (s RequestEntityTooLargeException) GoString() string {
 
 func newErrorRequestEntityTooLargeException(v protocol.ResponseMetadata) error {
 	return &RequestEntityTooLargeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -889,18 +889,18 @@ func (s RequestEntityTooLargeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestEntityTooLargeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestEntityTooLargeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -918,7 +918,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -946,18 +946,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service is temporarily unavailable.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -975,7 +975,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1003,18 +1003,18 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The rate exceeds the limit.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1032,7 +1032,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1060,18 +1060,18 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You are not authorized to perform this operation.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1089,7 +1089,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1117,18 +1117,18 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The document encoding is not supported.
 type UnsupportedDocumentEncodingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1146,7 +1146,7 @@ func (s UnsupportedDocumentEncodingException) GoString() string {
 
 func newErrorUnsupportedDocumentEncodingException(v protocol.ResponseMetadata) error {
 	return &UnsupportedDocumentEncodingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1174,12 +1174,12 @@ func (s UnsupportedDocumentEncodingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedDocumentEncodingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedDocumentEncodingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input for the UpdateThingShadow operation.

--- a/service/iotevents/api.go
+++ b/service/iotevents/api.go
@@ -3126,7 +3126,7 @@ func (s *InputSummary) SetStatus(v string) *InputSummary {
 // An internal failure occurred.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3144,7 +3144,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3172,18 +3172,18 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was invalid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3201,7 +3201,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3229,12 +3229,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information required to publish the MQTT message through the AWS IoT message
@@ -3328,7 +3328,7 @@ func (s *LambdaAction) SetFunctionArn(v string) *LambdaAction {
 // A limit was exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3346,7 +3346,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3374,12 +3374,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDetectorModelVersionsInput struct {
@@ -4048,7 +4048,7 @@ func (s *ResetTimerAction) SetTimerName(v string) *ResetTimerAction {
 // The resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4072,7 +4072,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4100,18 +4100,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource is in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4129,7 +4129,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4157,18 +4157,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4186,7 +4186,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4214,12 +4214,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information required to publish the Amazon SNS message.
@@ -4267,7 +4267,7 @@ func (s *SNSTopicPublishAction) SetTargetArn(v string) *SNSTopicPublishAction {
 // The service is currently unavailable.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4285,7 +4285,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4313,12 +4313,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information needed to set the timer.
@@ -4728,7 +4728,7 @@ func (s TagResourceOutput) GoString() string {
 // The request could not be completed due to throttling.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4746,7 +4746,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4774,12 +4774,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the actions performed and the next state entered when a condition
@@ -4876,7 +4876,7 @@ func (s *TransitionEvent) SetNextState(v string) *TransitionEvent {
 // The requested operation is not supported.
 type UnsupportedOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4894,7 +4894,7 @@ func (s UnsupportedOperationException) GoString() string {
 
 func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 	return &UnsupportedOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4922,12 +4922,12 @@ func (s UnsupportedOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/iotevents/api.go
+++ b/service/iotevents/api.go
@@ -3125,8 +3125,8 @@ func (s *InputSummary) SetStatus(v string) *InputSummary {
 
 // An internal failure occurred.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3182,8 +3182,8 @@ func (s InternalFailureException) RequestID() string {
 
 // The request was invalid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3327,8 +3327,8 @@ func (s *LambdaAction) SetFunctionArn(v string) *LambdaAction {
 
 // A limit was exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4047,8 +4047,8 @@ func (s *ResetTimerAction) SetTimerName(v string) *ResetTimerAction {
 
 // The resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4110,8 +4110,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The resource is in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4167,8 +4167,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4266,8 +4266,8 @@ func (s *SNSTopicPublishAction) SetTargetArn(v string) *SNSTopicPublishAction {
 
 // The service is currently unavailable.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4727,8 +4727,8 @@ func (s TagResourceOutput) GoString() string {
 
 // The request could not be completed due to throttling.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4875,8 +4875,8 @@ func (s *TransitionEvent) SetNextState(v string) *TransitionEvent {
 
 // The requested operation is not supported.
 type UnsupportedOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/ioteventsdata/api.go
+++ b/service/ioteventsdata/api.go
@@ -997,7 +997,7 @@ func (s *DetectorSummary) SetState(v *DetectorStateSummary) *DetectorSummary {
 // An internal failure occured.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1015,7 +1015,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1043,18 +1043,18 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was invalid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1072,7 +1072,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1100,12 +1100,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDetectorsInput struct {
@@ -1296,7 +1296,7 @@ func (s *Message) SetPayload(v []byte) *Message {
 // The resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1314,7 +1314,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1342,18 +1342,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service is currently unavailable.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1371,7 +1371,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1399,18 +1399,18 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request could not be completed due to throttling.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1428,7 +1428,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1456,12 +1456,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The current state of a timer.

--- a/service/ioteventsdata/api.go
+++ b/service/ioteventsdata/api.go
@@ -996,8 +996,8 @@ func (s *DetectorSummary) SetState(v *DetectorStateSummary) *DetectorSummary {
 
 // An internal failure occured.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1053,8 +1053,8 @@ func (s InternalFailureException) RequestID() string {
 
 // The request was invalid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1295,8 +1295,8 @@ func (s *Message) SetPayload(v []byte) *Message {
 
 // The resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1352,8 +1352,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The service is currently unavailable.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1409,8 +1409,8 @@ func (s ServiceUnavailableException) RequestID() string {
 
 // The request could not be completed due to throttling.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/iotjobsdataplane/api.go
+++ b/service/iotjobsdataplane/api.go
@@ -395,8 +395,8 @@ func (c *IoTJobsDataPlane) UpdateJobExecutionWithContext(ctx aws.Context, input 
 
 // The certificate is invalid.
 type CertificateValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -628,8 +628,8 @@ func (s *GetPendingJobExecutionsOutput) SetQueuedJobs(v []*JobExecutionSummary) 
 // when an UpdateJobExecution request contains invalid status details. The message
 // contains details about the error.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -688,8 +688,8 @@ func (s InvalidRequestException) RequestID() string {
 // change a request in state SUCCESS to state IN_PROGRESS). In this case, the
 // body of the error message also contains the executionState field.
 type InvalidStateTransitionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -978,8 +978,8 @@ func (s *JobExecutionSummary) SetVersionNumber(v int64) *JobExecutionSummary {
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1035,8 +1035,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The service is temporarily unavailable.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1182,8 +1182,8 @@ func (s *StartNextPendingJobExecutionOutput) SetExecution(v *JobExecution) *Star
 
 // The job is in a terminal state.
 type TerminalStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1238,8 +1238,8 @@ func (s TerminalStateException) RequestID() string {
 
 // The rate exceeds the limit.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/iotjobsdataplane/api.go
+++ b/service/iotjobsdataplane/api.go
@@ -396,7 +396,7 @@ func (c *IoTJobsDataPlane) UpdateJobExecutionWithContext(ctx aws.Context, input 
 // The certificate is invalid.
 type CertificateValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Additional information about the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -414,7 +414,7 @@ func (s CertificateValidationException) GoString() string {
 
 func newErrorCertificateValidationException(v protocol.ResponseMetadata) error {
 	return &CertificateValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -442,12 +442,12 @@ func (s CertificateValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CertificateValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CertificateValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DescribeJobExecutionInput struct {
@@ -629,7 +629,7 @@ func (s *GetPendingJobExecutionsOutput) SetQueuedJobs(v []*JobExecutionSummary) 
 // contains details about the error.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -647,7 +647,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -675,12 +675,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An update attempted to change the job execution to a state that is invalid
@@ -689,7 +689,7 @@ func (s InvalidRequestException) RequestID() string {
 // body of the error message also contains the executionState field.
 type InvalidStateTransitionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -706,7 +706,7 @@ func (s InvalidStateTransitionException) GoString() string {
 
 func newErrorInvalidStateTransitionException(v protocol.ResponseMetadata) error {
 	return &InvalidStateTransitionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -734,12 +734,12 @@ func (s InvalidStateTransitionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateTransitionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateTransitionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains data about a job execution.
@@ -979,7 +979,7 @@ func (s *JobExecutionSummary) SetVersionNumber(v int64) *JobExecutionSummary {
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -997,7 +997,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1025,18 +1025,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service is temporarily unavailable.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message for the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1054,7 +1054,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1082,12 +1082,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartNextPendingJobExecutionInput struct {
@@ -1183,7 +1183,7 @@ func (s *StartNextPendingJobExecutionOutput) SetExecution(v *JobExecution) *Star
 // The job is in a terminal state.
 type TerminalStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1200,7 +1200,7 @@ func (s TerminalStateException) GoString() string {
 
 func newErrorTerminalStateException(v protocol.ResponseMetadata) error {
 	return &TerminalStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1228,18 +1228,18 @@ func (s TerminalStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TerminalStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TerminalStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The rate exceeds the limit.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The message associated with the exception.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1262,7 +1262,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1290,12 +1290,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateJobExecutionInput struct {

--- a/service/iotsecuretunneling/api.go
+++ b/service/iotsecuretunneling/api.go
@@ -846,8 +846,8 @@ func (s *DestinationConfig) SetThingName(v string) *DestinationConfig {
 
 // Thrown when a tunnel limit is exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1190,8 +1190,8 @@ func (s *OpenTunnelOutput) SetTunnelId(v string) *OpenTunnelOutput {
 
 // Thrown when an operation is attempted on a resource that does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/iotsecuretunneling/api.go
+++ b/service/iotsecuretunneling/api.go
@@ -847,7 +847,7 @@ func (s *DestinationConfig) SetThingName(v string) *DestinationConfig {
 // Thrown when a tunnel limit is exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -864,7 +864,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -892,12 +892,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTagsForResourceInput struct {
@@ -1191,7 +1191,7 @@ func (s *OpenTunnelOutput) SetTunnelId(v string) *OpenTunnelOutput {
 // Thrown when an operation is attempted on a resource that does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1208,7 +1208,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1236,12 +1236,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An arbitary key/value pair used to add searchable metadata to secure tunnel

--- a/service/iotthingsgraph/api.go
+++ b/service/iotthingsgraph/api.go
@@ -5702,8 +5702,8 @@ func (s *GetUploadStatusOutput) SetUploadStatus(v string) *GetUploadStatusOutput
 }
 
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5757,8 +5757,8 @@ func (s InternalFailureException) RequestID() string {
 }
 
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5812,8 +5812,8 @@ func (s InvalidRequestException) RequestID() string {
 }
 
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6101,8 +6101,8 @@ func (s *MetricsConfiguration) SetMetricRuleRoleArn(v string) *MetricsConfigurat
 }
 
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6156,8 +6156,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 }
 
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6211,8 +6211,8 @@ func (s ResourceInUseException) RequestID() string {
 }
 
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7437,8 +7437,8 @@ func (s *Thing) SetThingName(v string) *Thing {
 }
 
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/iotthingsgraph/api.go
+++ b/service/iotthingsgraph/api.go
@@ -5703,7 +5703,7 @@ func (s *GetUploadStatusOutput) SetUploadStatus(v string) *GetUploadStatusOutput
 
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5720,7 +5720,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5748,17 +5748,17 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5775,7 +5775,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5803,17 +5803,17 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5830,7 +5830,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5858,12 +5858,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListFlowExecutionMessagesInput struct {
@@ -6102,7 +6102,7 @@ func (s *MetricsConfiguration) SetMetricRuleRoleArn(v string) *MetricsConfigurat
 
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6119,7 +6119,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6147,17 +6147,17 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6174,7 +6174,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6202,17 +6202,17 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6229,7 +6229,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6257,12 +6257,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SearchEntitiesInput struct {
@@ -7438,7 +7438,7 @@ func (s *Thing) SetThingName(v string) *Thing {
 
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7455,7 +7455,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7483,12 +7483,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UndeploySystemInstanceInput struct {

--- a/service/kafka/api.go
+++ b/service/kafka/api.go
@@ -2276,7 +2276,7 @@ func (c *Kafka) UpdateMonitoringWithContext(ctx aws.Context, input *UpdateMonito
 // Returns information about an error.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -2295,7 +2295,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2323,12 +2323,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the EBS volume upgrade information. The broker identifier must
@@ -3194,7 +3194,7 @@ func (s *ConfigurationRevision) SetRevision(v int64) *ConfigurationRevision {
 // Returns information about an error.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -3213,7 +3213,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3241,12 +3241,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Creates a cluster.
@@ -4287,7 +4287,7 @@ func (s *Firehose) SetEnabled(v bool) *Firehose {
 // Returns information about an error.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -4306,7 +4306,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4334,12 +4334,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetBootstrapBrokersInput struct {
@@ -4419,7 +4419,7 @@ func (s *GetBootstrapBrokersOutput) SetBootstrapBrokerStringTls(v string) *GetBo
 // Returns information about an error.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -4438,7 +4438,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4466,12 +4466,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates whether you want to enable or disable the JMX Exporter.
@@ -5409,7 +5409,7 @@ func (s *NodeInfo) SetZookeeperNodeInfo(v *ZookeeperNodeInfo) *NodeInfo {
 // Returns information about an error.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -5428,7 +5428,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5456,12 +5456,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // JMX and Node monitoring for the MSK cluster.
@@ -5680,7 +5680,7 @@ func (s *S3) SetPrefix(v string) *S3 {
 // Returns information about an error.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -5699,7 +5699,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5727,12 +5727,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about storage volumes attached to MSK broker nodes.
@@ -5869,7 +5869,7 @@ func (s *Tls) SetCertificateAuthorityArnList(v []*string) *Tls {
 // Returns information about an error.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -5888,7 +5888,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5916,18 +5916,18 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about an error.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -5946,7 +5946,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5974,12 +5974,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/kafka/api.go
+++ b/service/kafka/api.go
@@ -2275,8 +2275,8 @@ func (c *Kafka) UpdateMonitoringWithContext(ctx aws.Context, input *UpdateMonito
 
 // Returns information about an error.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -3193,8 +3193,8 @@ func (s *ConfigurationRevision) SetRevision(v int64) *ConfigurationRevision {
 
 // Returns information about an error.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -4286,8 +4286,8 @@ func (s *Firehose) SetEnabled(v bool) *Firehose {
 
 // Returns information about an error.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -4418,8 +4418,8 @@ func (s *GetBootstrapBrokersOutput) SetBootstrapBrokerStringTls(v string) *GetBo
 
 // Returns information about an error.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -5408,8 +5408,8 @@ func (s *NodeInfo) SetZookeeperNodeInfo(v *ZookeeperNodeInfo) *NodeInfo {
 
 // Returns information about an error.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -5679,8 +5679,8 @@ func (s *S3) SetPrefix(v string) *S3 {
 
 // Returns information about an error.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -5868,8 +5868,8 @@ func (s *Tls) SetCertificateAuthorityArnList(v []*string) *Tls {
 
 // Returns information about an error.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 
@@ -5926,8 +5926,8 @@ func (s TooManyRequestsException) RequestID() string {
 
 // Returns information about an error.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	InvalidParameter *string `locationName:"invalidParameter" type:"string"`
 

--- a/service/kendra/api.go
+++ b/service/kendra/api.go
@@ -2039,7 +2039,7 @@ func (s *AccessControlListConfiguration) SetKeyPath(v string) *AccessControlList
 
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2056,7 +2056,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2084,12 +2084,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information about the column that should be used for filtering the
@@ -2843,7 +2843,7 @@ func (s *ColumnConfiguration) SetFieldMappings(v []*DataSourceToIndexFieldMappin
 
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2860,7 +2860,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2888,12 +2888,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides the information necessary to connect to a database.
@@ -5253,7 +5253,7 @@ func (s *IndexStatistics) SetTextDocumentStatistics(v *TextDocumentStatistics) *
 
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -5270,7 +5270,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5298,12 +5298,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDataSourceSyncJobsInput struct {
@@ -6264,7 +6264,7 @@ func (s *RelevanceFeedback) SetResultId(v string) *RelevanceFeedback {
 
 type ResourceAlreadyExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6281,7 +6281,7 @@ func (s ResourceAlreadyExistException) GoString() string {
 
 func newErrorResourceAlreadyExistException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6309,17 +6309,17 @@ func (s ResourceAlreadyExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6336,7 +6336,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6364,17 +6364,17 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6391,7 +6391,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6419,17 +6419,17 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResourceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6446,7 +6446,7 @@ func (s ResourceUnavailableException) GoString() string {
 
 func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ResourceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6474,12 +6474,12 @@ func (s ResourceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides configuration information for a data source to index documents in
@@ -6727,7 +6727,7 @@ func (s *ServerSideEncryptionConfiguration) SetKmsKeyId(v string) *ServerSideEnc
 
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6744,7 +6744,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6772,12 +6772,12 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides configuration information for connecting to a Microsoft SharePoint
@@ -7248,7 +7248,7 @@ func (s *TextWithHighlights) SetText(v string) *TextWithHighlights {
 
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -7265,7 +7265,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7293,12 +7293,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides a range of time.
@@ -7581,7 +7581,7 @@ func (s UpdateIndexOutput) GoString() string {
 
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -7598,7 +7598,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7626,12 +7626,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/kendra/api.go
+++ b/service/kendra/api.go
@@ -2038,8 +2038,8 @@ func (s *AccessControlListConfiguration) SetKeyPath(v string) *AccessControlList
 }
 
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2842,8 +2842,8 @@ func (s *ColumnConfiguration) SetFieldMappings(v []*DataSourceToIndexFieldMappin
 }
 
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -5252,8 +5252,8 @@ func (s *IndexStatistics) SetTextDocumentStatistics(v *TextDocumentStatistics) *
 }
 
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6263,8 +6263,8 @@ func (s *RelevanceFeedback) SetResultId(v string) *RelevanceFeedback {
 }
 
 type ResourceAlreadyExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6318,8 +6318,8 @@ func (s ResourceAlreadyExistException) RequestID() string {
 }
 
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6373,8 +6373,8 @@ func (s ResourceInUseException) RequestID() string {
 }
 
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6428,8 +6428,8 @@ func (s ResourceNotFoundException) RequestID() string {
 }
 
 type ResourceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -6726,8 +6726,8 @@ func (s *ServerSideEncryptionConfiguration) SetKmsKeyId(v string) *ServerSideEnc
 }
 
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -7247,8 +7247,8 @@ func (s *TextWithHighlights) SetText(v string) *TextWithHighlights {
 }
 
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -7580,8 +7580,8 @@ func (s UpdateIndexOutput) GoString() string {
 }
 
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -4603,8 +4603,8 @@ func (s *EnhancedMonitoringOutput) SetStreamName(v string) *EnhancedMonitoringOu
 
 // The provided iterator exceeds the maximum age allowed.
 type ExpiredIteratorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4660,8 +4660,8 @@ func (s ExpiredIteratorException) RequestID() string {
 
 // The pagination token passed to the operation is expired.
 type ExpiredNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5075,8 +5075,8 @@ func (s IncreaseStreamRetentionPeriodOutput) GoString() string {
 }
 
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5159,8 +5159,8 @@ func (s InternalFailureException) RequestID() string {
 // A specified parameter exceeds its restrictions, is not supported, or can't
 // be used. For more information, see the returned message.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5217,8 +5217,8 @@ func (s InvalidArgumentException) RequestID() string {
 // The ciphertext references a key that doesn't exist or that you don't have
 // access to.
 type KMSAccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5302,8 +5302,8 @@ func (s KMSAccessDeniedException) RequestID() string {
 // The request was rejected because the specified customer master key (CMK)
 // isn't enabled.
 type KMSDisabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5389,8 +5389,8 @@ func (s KMSDisabledException) RequestID() string {
 // of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide.
 type KMSInvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5474,8 +5474,8 @@ func (s KMSInvalidStateException) RequestID() string {
 // The request was rejected because the specified entity or resource can't be
 // found.
 type KMSNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5558,8 +5558,8 @@ func (s KMSNotFoundException) RequestID() string {
 
 // The AWS access key ID needs a subscription for the service.
 type KMSOptInRequired struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5644,8 +5644,8 @@ func (s KMSOptInRequired) RequestID() string {
 // throttling, see Limits (http://docs.aws.amazon.com/kms/latest/developerguide/limits.html#requests-per-second)
 // in the AWS Key Management Service Developer Guide.
 type KMSThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5729,8 +5729,8 @@ func (s KMSThrottlingException) RequestID() string {
 // The requested resource exceeds the maximum number allowed, or the number
 // of concurrent stream requests exceeds the maximum number allowed.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6387,8 +6387,8 @@ func (s MergeShardsOutput) GoString() string {
 // Exponential Backoff in AWS (http://docs.aws.amazon.com/general/latest/gr/api-retries.html)
 // in the AWS General Reference.
 type ProvisionedThroughputExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7107,8 +7107,8 @@ func (s RemoveTagsFromStreamOutput) GoString() string {
 // The resource is not available for this operation. For successful operation,
 // the resource must be in the ACTIVE state.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7192,8 +7192,8 @@ func (s ResourceInUseException) RequestID() string {
 // The requested resource could not be found. The stream might not be specified
 // correctly.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -4604,7 +4604,7 @@ func (s *EnhancedMonitoringOutput) SetStreamName(v string) *EnhancedMonitoringOu
 // The provided iterator exceeds the maximum age allowed.
 type ExpiredIteratorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4622,7 +4622,7 @@ func (s ExpiredIteratorException) GoString() string {
 
 func newErrorExpiredIteratorException(v protocol.ResponseMetadata) error {
 	return &ExpiredIteratorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4650,18 +4650,18 @@ func (s ExpiredIteratorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExpiredIteratorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExpiredIteratorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pagination token passed to the operation is expired.
 type ExpiredNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4678,7 +4678,7 @@ func (s ExpiredNextTokenException) GoString() string {
 
 func newErrorExpiredNextTokenException(v protocol.ResponseMetadata) error {
 	return &ExpiredNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4706,12 +4706,12 @@ func (s ExpiredNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExpiredNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExpiredNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input for GetRecords.
@@ -5076,7 +5076,7 @@ func (s IncreaseStreamRetentionPeriodOutput) GoString() string {
 
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5120,7 +5120,7 @@ func (s *InternalFailureException) MarshalEvent(pm protocol.PayloadMarshaler) (m
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5148,19 +5148,19 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A specified parameter exceeds its restrictions, is not supported, or can't
 // be used. For more information, see the returned message.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5178,7 +5178,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5206,19 +5206,19 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The ciphertext references a key that doesn't exist or that you don't have
 // access to.
 type KMSAccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5263,7 +5263,7 @@ func (s *KMSAccessDeniedException) MarshalEvent(pm protocol.PayloadMarshaler) (m
 
 func newErrorKMSAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &KMSAccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5291,19 +5291,19 @@ func (s KMSAccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSAccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSAccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the specified customer master key (CMK)
 // isn't enabled.
 type KMSDisabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5348,7 +5348,7 @@ func (s *KMSDisabledException) MarshalEvent(pm protocol.PayloadMarshaler) (msg e
 
 func newErrorKMSDisabledException(v protocol.ResponseMetadata) error {
 	return &KMSDisabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5376,12 +5376,12 @@ func (s KMSDisabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSDisabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSDisabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the state of the specified resource isn't
@@ -5390,7 +5390,7 @@ func (s KMSDisabledException) RequestID() string {
 // in the AWS Key Management Service Developer Guide.
 type KMSInvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5435,7 +5435,7 @@ func (s *KMSInvalidStateException) MarshalEvent(pm protocol.PayloadMarshaler) (m
 
 func newErrorKMSInvalidStateException(v protocol.ResponseMetadata) error {
 	return &KMSInvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5463,19 +5463,19 @@ func (s KMSInvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSInvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSInvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the specified entity or resource can't be
 // found.
 type KMSNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5520,7 +5520,7 @@ func (s *KMSNotFoundException) MarshalEvent(pm protocol.PayloadMarshaler) (msg e
 
 func newErrorKMSNotFoundException(v protocol.ResponseMetadata) error {
 	return &KMSNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5548,18 +5548,18 @@ func (s KMSNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The AWS access key ID needs a subscription for the service.
 type KMSOptInRequired struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5604,7 +5604,7 @@ func (s *KMSOptInRequired) MarshalEvent(pm protocol.PayloadMarshaler) (msg event
 
 func newErrorKMSOptInRequired(v protocol.ResponseMetadata) error {
 	return &KMSOptInRequired{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5632,12 +5632,12 @@ func (s KMSOptInRequired) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSOptInRequired) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSOptInRequired) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was denied due to request throttling. For more information about
@@ -5645,7 +5645,7 @@ func (s KMSOptInRequired) RequestID() string {
 // in the AWS Key Management Service Developer Guide.
 type KMSThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5690,7 +5690,7 @@ func (s *KMSThrottlingException) MarshalEvent(pm protocol.PayloadMarshaler) (msg
 
 func newErrorKMSThrottlingException(v protocol.ResponseMetadata) error {
 	return &KMSThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5718,19 +5718,19 @@ func (s KMSThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested resource exceeds the maximum number allowed, or the number
 // of concurrent stream requests exceeds the maximum number allowed.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5748,7 +5748,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5776,12 +5776,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListShardsInput struct {
@@ -6388,7 +6388,7 @@ func (s MergeShardsOutput) GoString() string {
 // in the AWS General Reference.
 type ProvisionedThroughputExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6406,7 +6406,7 @@ func (s ProvisionedThroughputExceededException) GoString() string {
 
 func newErrorProvisionedThroughputExceededException(v protocol.ResponseMetadata) error {
 	return &ProvisionedThroughputExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6434,12 +6434,12 @@ func (s ProvisionedThroughputExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProvisionedThroughputExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProvisionedThroughputExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the input for PutRecord.
@@ -7108,7 +7108,7 @@ func (s RemoveTagsFromStreamOutput) GoString() string {
 // the resource must be in the ACTIVE state.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7153,7 +7153,7 @@ func (s *ResourceInUseException) MarshalEvent(pm protocol.PayloadMarshaler) (msg
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7181,19 +7181,19 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested resource could not be found. The stream might not be specified
 // correctly.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message that provides information about the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7238,7 +7238,7 @@ func (s *ResourceNotFoundException) MarshalEvent(pm protocol.PayloadMarshaler) (
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7266,12 +7266,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The range of possible sequence numbers for the shard.

--- a/service/kinesis/eventstream_test.go
+++ b/service/kinesis/eventstream_test.go
@@ -228,7 +228,7 @@ func TestSubscribeToShard_ReadException(t *testing.T) {
 	expectEvents := []SubscribeToShardEventStreamEvent{
 		&SubscribeToShardOutput{},
 		&InternalFailureException{
-			respMetadata: protocol.ResponseMetadata{
+			RespMetadata: protocol.ResponseMetadata{
 				StatusCode: 200,
 			},
 			Message_: aws.String("string value goes here"),
@@ -292,7 +292,7 @@ func TestSubscribeToShard_ReadException(t *testing.T) {
 	}
 
 	expectErr := &InternalFailureException{
-		respMetadata: protocol.ResponseMetadata{
+		RespMetadata: protocol.ResponseMetadata{
 			StatusCode: 200,
 		},
 		Message_: aws.String("string value goes here"),

--- a/service/kinesisanalytics/api.go
+++ b/service/kinesisanalytics/api.go
@@ -3197,8 +3197,8 @@ func (s *CloudWatchLoggingOptionUpdate) SetRoleARNUpdate(v string) *CloudWatchLo
 // User-provided application code (query) is invalid. This can be a simple syntax
 // error.
 type CodeValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Test
 	Message_ *string `locationName:"message" type:"string"`
@@ -3256,8 +3256,8 @@ func (s CodeValidationException) RequestID() string {
 // For example, two individuals attempting to edit the same application at the
 // same time.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5125,8 +5125,8 @@ func (s *InputUpdate) SetNamePrefixUpdate(v string) *InputUpdate {
 
 // User-provided application configuration is not valid.
 type InvalidApplicationConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// test
 	Message_ *string `locationName:"message" type:"string"`
@@ -5182,8 +5182,8 @@ func (s InvalidApplicationConfigurationException) RequestID() string {
 
 // Specified input parameter value is invalid.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6047,8 +6047,8 @@ func (s *LambdaOutputUpdate) SetRoleARNUpdate(v string) *LambdaOutputUpdate {
 
 // Exceeded the number of applications allowed.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6976,8 +6976,8 @@ func (s *ReferenceDataSourceUpdate) SetTableNameUpdate(v string) *ReferenceDataS
 
 // Application is not available for this operation.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7032,8 +7032,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // Specified application can't be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7091,8 +7091,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // see GetRecords (https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html)
 // in the Amazon Kinesis Streams API Reference.
 type ResourceProvisionedThroughputExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7425,8 +7425,8 @@ func (s *S3ReferenceDataSourceUpdate) SetReferenceRoleARNUpdate(v string) *S3Ref
 
 // The service is unavailable. Back off and retry the operation.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7839,8 +7839,8 @@ func (s TagResourceOutput) GoString() string {
 // Note that the maximum number of application tags includes system tags. The
 // maximum number of user-defined application tags is 50.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7896,8 +7896,8 @@ func (s TooManyTagsException) RequestID() string {
 // Data format is not valid. Amazon Kinesis Analytics is not able to detect
 // schema for the given streaming source.
 type UnableToDetectSchemaException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -7957,8 +7957,8 @@ func (s UnableToDetectSchemaException) RequestID() string {
 // The request was rejected because a specified parameter is not supported or
 // a specified resource is not valid for this operation.
 type UnsupportedOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/kinesisanalytics/api.go
+++ b/service/kinesisanalytics/api.go
@@ -3198,7 +3198,7 @@ func (s *CloudWatchLoggingOptionUpdate) SetRoleARNUpdate(v string) *CloudWatchLo
 // error.
 type CodeValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Test
 	Message_ *string `locationName:"message" type:"string"`
@@ -3216,7 +3216,7 @@ func (s CodeValidationException) GoString() string {
 
 func newErrorCodeValidationException(v protocol.ResponseMetadata) error {
 	return &CodeValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3244,12 +3244,12 @@ func (s CodeValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CodeValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CodeValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception thrown as a result of concurrent modification to an application.
@@ -3257,7 +3257,7 @@ func (s CodeValidationException) RequestID() string {
 // same time.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3274,7 +3274,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3302,12 +3302,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // TBD
@@ -5126,7 +5126,7 @@ func (s *InputUpdate) SetNamePrefixUpdate(v string) *InputUpdate {
 // User-provided application configuration is not valid.
 type InvalidApplicationConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// test
 	Message_ *string `locationName:"message" type:"string"`
@@ -5144,7 +5144,7 @@ func (s InvalidApplicationConfigurationException) GoString() string {
 
 func newErrorInvalidApplicationConfigurationException(v protocol.ResponseMetadata) error {
 	return &InvalidApplicationConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5172,18 +5172,18 @@ func (s InvalidApplicationConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApplicationConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApplicationConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specified input parameter value is invalid.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5200,7 +5200,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5228,12 +5228,12 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides additional mapping information when JSON is the record format on
@@ -6048,7 +6048,7 @@ func (s *LambdaOutputUpdate) SetRoleARNUpdate(v string) *LambdaOutputUpdate {
 // Exceeded the number of applications allowed.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6065,7 +6065,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6093,12 +6093,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListApplicationsInput struct {
@@ -6977,7 +6977,7 @@ func (s *ReferenceDataSourceUpdate) SetTableNameUpdate(v string) *ReferenceDataS
 // Application is not available for this operation.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6994,7 +6994,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7022,18 +7022,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specified application can't be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7050,7 +7050,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7078,12 +7078,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Discovery failed to get a record from the streaming source because of the
@@ -7092,7 +7092,7 @@ func (s ResourceNotFoundException) RequestID() string {
 // in the Amazon Kinesis Streams API Reference.
 type ResourceProvisionedThroughputExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7109,7 +7109,7 @@ func (s ResourceProvisionedThroughputExceededException) GoString() string {
 
 func newErrorResourceProvisionedThroughputExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceProvisionedThroughputExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7137,12 +7137,12 @@ func (s ResourceProvisionedThroughputExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceProvisionedThroughputExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceProvisionedThroughputExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides a description of an Amazon S3 data source, including the Amazon
@@ -7426,7 +7426,7 @@ func (s *S3ReferenceDataSourceUpdate) SetReferenceRoleARNUpdate(v string) *S3Ref
 // The service is unavailable. Back off and retry the operation.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7443,7 +7443,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7471,12 +7471,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the format of the data in the streaming source, and how each data
@@ -7840,7 +7840,7 @@ func (s TagResourceOutput) GoString() string {
 // maximum number of user-defined application tags is 50.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7857,7 +7857,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7885,19 +7885,19 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Data format is not valid. Amazon Kinesis Analytics is not able to detect
 // schema for the given streaming source.
 type UnableToDetectSchemaException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -7918,7 +7918,7 @@ func (s UnableToDetectSchemaException) GoString() string {
 
 func newErrorUnableToDetectSchemaException(v protocol.ResponseMetadata) error {
 	return &UnableToDetectSchemaException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7946,19 +7946,19 @@ func (s UnableToDetectSchemaException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnableToDetectSchemaException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnableToDetectSchemaException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because a specified parameter is not supported or
 // a specified resource is not valid for this operation.
 type UnsupportedOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7975,7 +7975,7 @@ func (s UnsupportedOperationException) GoString() string {
 
 func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 	return &UnsupportedOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8003,12 +8003,12 @@ func (s UnsupportedOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/kinesisanalyticsv2/api.go
+++ b/service/kinesisanalyticsv2/api.go
@@ -4751,8 +4751,8 @@ func (s *CodeContentUpdate) SetZipFileContentUpdate(v []byte) *CodeContentUpdate
 // The user-provided application code (query) is not valid. This can be a simple
 // syntax error.
 type CodeValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4809,8 +4809,8 @@ func (s CodeValidationException) RequestID() string {
 // This error can be the result of attempting to modify an application without
 // using the current application ID.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7339,8 +7339,8 @@ func (s *InputUpdate) SetNamePrefixUpdate(v string) *InputUpdate {
 
 // The user-provided application configuration is not valid.
 type InvalidApplicationConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7395,8 +7395,8 @@ func (s InvalidApplicationConfigurationException) RequestID() string {
 
 // The specified input parameter value is not valid.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7451,8 +7451,8 @@ func (s InvalidArgumentException) RequestID() string {
 
 // The request JSON is not valid for the operation.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8206,8 +8206,8 @@ func (s *LambdaOutputUpdate) SetResourceARNUpdate(v string) *LambdaOutputUpdate 
 
 // The number of allowed resources has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9692,8 +9692,8 @@ func (s *ReferenceDataSourceUpdate) SetTableNameUpdate(v string) *ReferenceDataS
 
 // The application is not available for this operation.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9748,8 +9748,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // Specified application can't be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9807,8 +9807,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // see GetRecords (http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html)
 // in the Amazon Kinesis Streams API Reference.
 type ResourceProvisionedThroughputExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10405,8 +10405,8 @@ func (s *S3ReferenceDataSourceUpdate) SetFileKeyUpdate(v string) *S3ReferenceDat
 
 // The service cannot complete the request.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11146,8 +11146,8 @@ func (s TagResourceOutput) GoString() string {
 // Note that the maximum number of application tags includes system tags. The
 // maximum number of user-defined application tags is 50.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11203,8 +11203,8 @@ func (s TooManyTagsException) RequestID() string {
 // The data format is not valid. Amazon Kinesis Data Analytics cannot detect
 // the schema for the given streaming source.
 type UnableToDetectSchemaException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -11267,8 +11267,8 @@ func (s UnableToDetectSchemaException) RequestID() string {
 // The request was rejected because a specified parameter is not supported or
 // a specified resource is not valid for this operation.
 type UnsupportedOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/kinesisanalyticsv2/api.go
+++ b/service/kinesisanalyticsv2/api.go
@@ -4752,7 +4752,7 @@ func (s *CodeContentUpdate) SetZipFileContentUpdate(v []byte) *CodeContentUpdate
 // syntax error.
 type CodeValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4769,7 +4769,7 @@ func (s CodeValidationException) GoString() string {
 
 func newErrorCodeValidationException(v protocol.ResponseMetadata) error {
 	return &CodeValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4797,12 +4797,12 @@ func (s CodeValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CodeValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CodeValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception thrown as a result of concurrent modifications to an application.
@@ -4810,7 +4810,7 @@ func (s CodeValidationException) RequestID() string {
 // using the current application ID.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4827,7 +4827,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4855,12 +4855,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateApplicationInput struct {
@@ -7340,7 +7340,7 @@ func (s *InputUpdate) SetNamePrefixUpdate(v string) *InputUpdate {
 // The user-provided application configuration is not valid.
 type InvalidApplicationConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7357,7 +7357,7 @@ func (s InvalidApplicationConfigurationException) GoString() string {
 
 func newErrorInvalidApplicationConfigurationException(v protocol.ResponseMetadata) error {
 	return &InvalidApplicationConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7385,18 +7385,18 @@ func (s InvalidApplicationConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidApplicationConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidApplicationConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified input parameter value is not valid.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7413,7 +7413,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7441,18 +7441,18 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request JSON is not valid for the operation.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7469,7 +7469,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7497,12 +7497,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // For an SQL-based Amazon Kinesis Data Analytics application, provides additional
@@ -8207,7 +8207,7 @@ func (s *LambdaOutputUpdate) SetResourceARNUpdate(v string) *LambdaOutputUpdate 
 // The number of allowed resources has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8224,7 +8224,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8252,12 +8252,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListApplicationSnapshotsInput struct {
@@ -9693,7 +9693,7 @@ func (s *ReferenceDataSourceUpdate) SetTableNameUpdate(v string) *ReferenceDataS
 // The application is not available for this operation.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9710,7 +9710,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9738,18 +9738,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specified application can't be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9766,7 +9766,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9794,12 +9794,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Discovery failed to get a record from the streaming source because of the
@@ -9808,7 +9808,7 @@ func (s ResourceNotFoundException) RequestID() string {
 // in the Amazon Kinesis Streams API Reference.
 type ResourceProvisionedThroughputExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9825,7 +9825,7 @@ func (s ResourceProvisionedThroughputExceededException) GoString() string {
 
 func newErrorResourceProvisionedThroughputExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceProvisionedThroughputExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9853,12 +9853,12 @@ func (s ResourceProvisionedThroughputExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceProvisionedThroughputExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceProvisionedThroughputExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the starting parameters for an Amazon Kinesis Data Analytics application.
@@ -10406,7 +10406,7 @@ func (s *S3ReferenceDataSourceUpdate) SetFileKeyUpdate(v string) *S3ReferenceDat
 // The service cannot complete the request.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10423,7 +10423,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10451,12 +10451,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides details about a snapshot of application state.
@@ -11147,7 +11147,7 @@ func (s TagResourceOutput) GoString() string {
 // maximum number of user-defined application tags is 50.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11164,7 +11164,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11192,19 +11192,19 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The data format is not valid. Amazon Kinesis Data Analytics cannot detect
 // the schema for the given streaming source.
 type UnableToDetectSchemaException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -11228,7 +11228,7 @@ func (s UnableToDetectSchemaException) GoString() string {
 
 func newErrorUnableToDetectSchemaException(v protocol.ResponseMetadata) error {
 	return &UnableToDetectSchemaException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11256,19 +11256,19 @@ func (s UnableToDetectSchemaException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnableToDetectSchemaException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnableToDetectSchemaException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because a specified parameter is not supported or
 // a specified resource is not valid for this operation.
 type UnsupportedOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11285,7 +11285,7 @@ func (s UnsupportedOperationException) GoString() string {
 
 func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 	return &UnsupportedOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11313,12 +11313,12 @@ func (s UnsupportedOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/kinesisvideo/api.go
+++ b/service/kinesisvideo/api.go
@@ -2006,8 +2006,8 @@ func (c *KinesisVideo) UpdateStreamWithContext(ctx aws.Context, input *UpdateStr
 
 // You do not have required permissions to perform this operation.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2063,8 +2063,8 @@ func (s AccessDeniedException) RequestID() string {
 // You have reached the maximum limit of active signaling channels for this
 // AWS account in this region.
 type AccountChannelLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2119,8 +2119,8 @@ func (s AccountChannelLimitExceededException) RequestID() string {
 
 // The number of streams created for the account is too high.
 type AccountStreamLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2304,8 +2304,8 @@ func (s *ChannelNameCondition) SetComparisonValue(v string) *ChannelNameConditio
 // Kinesis Video Streams has throttled the request because you have exceeded
 // the limit of allowed client calls. Try making the call later.
 type ClientLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2902,8 +2902,8 @@ func (s *DescribeStreamOutput) SetStreamInfo(v *StreamInfo) *DescribeStreamOutpu
 
 // Not implemented.
 type DeviceStreamLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3125,8 +3125,8 @@ func (s *GetSignalingChannelEndpointOutput) SetResourceEndpointList(v []*Resourc
 
 // The value for this input parameter is invalid.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3181,8 +3181,8 @@ func (s InvalidArgumentException) RequestID() string {
 
 // Not implemented.
 type InvalidDeviceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3237,8 +3237,8 @@ func (s InvalidDeviceException) RequestID() string {
 
 // The format of the StreamARN is invalid.
 type InvalidResourceFormatException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3662,8 +3662,8 @@ func (s *ListTagsForStreamOutput) SetTags(v map[string]*string) *ListTagsForStre
 
 // The caller is not authorized to perform this operation.
 type NotAuthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3754,8 +3754,8 @@ func (s *ResourceEndpointListItem) SetResourceEndpoint(v string) *ResourceEndpoi
 
 // The stream is currently not available for this operation.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3810,8 +3810,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // Amazon Kinesis Video Streams can't find the stream that you specified.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4327,8 +4327,8 @@ func (s TagStreamOutput) GoString() string {
 // You have exceeded the limit of tags that you can associate with the resource.
 // Kinesis video streams support up to 50 tags.
 type TagsPerResourceExceededLimitException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4851,8 +4851,8 @@ func (s UpdateStreamOutput) GoString() string {
 // latest version, use the DescribeStream (https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_DescribeStream.html)
 // API.
 type VersionMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/kinesisvideo/api.go
+++ b/service/kinesisvideo/api.go
@@ -2007,7 +2007,7 @@ func (c *KinesisVideo) UpdateStreamWithContext(ctx aws.Context, input *UpdateStr
 // You do not have required permissions to perform this operation.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2024,7 +2024,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2052,19 +2052,19 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have reached the maximum limit of active signaling channels for this
 // AWS account in this region.
 type AccountChannelLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2081,7 +2081,7 @@ func (s AccountChannelLimitExceededException) GoString() string {
 
 func newErrorAccountChannelLimitExceededException(v protocol.ResponseMetadata) error {
 	return &AccountChannelLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2109,18 +2109,18 @@ func (s AccountChannelLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccountChannelLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccountChannelLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of streams created for the account is too high.
 type AccountStreamLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2137,7 +2137,7 @@ func (s AccountStreamLimitExceededException) GoString() string {
 
 func newErrorAccountStreamLimitExceededException(v protocol.ResponseMetadata) error {
 	return &AccountStreamLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2165,12 +2165,12 @@ func (s AccountStreamLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccountStreamLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccountStreamLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A structure that encapsulates a signaling channel's metadata and properties.
@@ -2305,7 +2305,7 @@ func (s *ChannelNameCondition) SetComparisonValue(v string) *ChannelNameConditio
 // the limit of allowed client calls. Try making the call later.
 type ClientLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2322,7 +2322,7 @@ func (s ClientLimitExceededException) GoString() string {
 
 func newErrorClientLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ClientLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2350,12 +2350,12 @@ func (s ClientLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateSignalingChannelInput struct {
@@ -2903,7 +2903,7 @@ func (s *DescribeStreamOutput) SetStreamInfo(v *StreamInfo) *DescribeStreamOutpu
 // Not implemented.
 type DeviceStreamLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2920,7 +2920,7 @@ func (s DeviceStreamLimitExceededException) GoString() string {
 
 func newErrorDeviceStreamLimitExceededException(v protocol.ResponseMetadata) error {
 	return &DeviceStreamLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2948,12 +2948,12 @@ func (s DeviceStreamLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeviceStreamLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeviceStreamLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetDataEndpointInput struct {
@@ -3126,7 +3126,7 @@ func (s *GetSignalingChannelEndpointOutput) SetResourceEndpointList(v []*Resourc
 // The value for this input parameter is invalid.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3143,7 +3143,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3171,18 +3171,18 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Not implemented.
 type InvalidDeviceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3199,7 +3199,7 @@ func (s InvalidDeviceException) GoString() string {
 
 func newErrorInvalidDeviceException(v protocol.ResponseMetadata) error {
 	return &InvalidDeviceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3227,18 +3227,18 @@ func (s InvalidDeviceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeviceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeviceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The format of the StreamARN is invalid.
 type InvalidResourceFormatException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3255,7 +3255,7 @@ func (s InvalidResourceFormatException) GoString() string {
 
 func newErrorInvalidResourceFormatException(v protocol.ResponseMetadata) error {
 	return &InvalidResourceFormatException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3283,12 +3283,12 @@ func (s InvalidResourceFormatException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceFormatException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceFormatException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListSignalingChannelsInput struct {
@@ -3663,7 +3663,7 @@ func (s *ListTagsForStreamOutput) SetTags(v map[string]*string) *ListTagsForStre
 // The caller is not authorized to perform this operation.
 type NotAuthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3680,7 +3680,7 @@ func (s NotAuthorizedException) GoString() string {
 
 func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 	return &NotAuthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3708,12 +3708,12 @@ func (s NotAuthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotAuthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotAuthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that describes the endpoint of the signaling channel returned by
@@ -3755,7 +3755,7 @@ func (s *ResourceEndpointListItem) SetResourceEndpoint(v string) *ResourceEndpoi
 // The stream is currently not available for this operation.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3772,7 +3772,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3800,18 +3800,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Amazon Kinesis Video Streams can't find the stream that you specified.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3828,7 +3828,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3856,12 +3856,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that contains the endpoint configuration for the SINGLE_MASTER
@@ -4328,7 +4328,7 @@ func (s TagStreamOutput) GoString() string {
 // Kinesis video streams support up to 50 tags.
 type TagsPerResourceExceededLimitException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4345,7 +4345,7 @@ func (s TagsPerResourceExceededLimitException) GoString() string {
 
 func newErrorTagsPerResourceExceededLimitException(v protocol.ResponseMetadata) error {
 	return &TagsPerResourceExceededLimitException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4373,12 +4373,12 @@ func (s TagsPerResourceExceededLimitException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagsPerResourceExceededLimitException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagsPerResourceExceededLimitException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -4852,7 +4852,7 @@ func (s UpdateStreamOutput) GoString() string {
 // API.
 type VersionMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4869,7 +4869,7 @@ func (s VersionMismatchException) GoString() string {
 
 func newErrorVersionMismatchException(v protocol.ResponseMetadata) error {
 	return &VersionMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4897,12 +4897,12 @@ func (s VersionMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s VersionMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s VersionMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/kinesisvideoarchivedmedia/api.go
+++ b/service/kinesisvideoarchivedmedia/api.go
@@ -830,8 +830,8 @@ func (c *KinesisVideoArchivedMedia) ListFragmentsPagesWithContext(ctx aws.Contex
 // Kinesis Video Streams has throttled the request because you have exceeded
 // the limit of allowed client calls. Try making the call later.
 type ClientLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1874,8 +1874,8 @@ func (s *HLSTimestampRange) SetStartTimestamp(v time.Time) *HLSTimestampRange {
 // A specified parameter exceeds its restrictions, is not supported, or can't
 // be used.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1931,8 +1931,8 @@ func (s InvalidArgumentException) RequestID() string {
 // The codec private data in at least one of the tracks of the video stream
 // is not valid for this operation.
 type InvalidCodecPrivateDataException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2105,8 +2105,8 @@ func (s *ListFragmentsOutput) SetNextToken(v string) *ListFragmentsOutput {
 
 // No codec private data was found in at least one of tracks of the video stream.
 type MissingCodecPrivateDataException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2162,8 +2162,8 @@ func (s MissingCodecPrivateDataException) RequestID() string {
 // A streaming session was requested for a stream that does not retain data
 // (that is, has a DataRetentionInHours of 0).
 type NoDataRetentionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2219,8 +2219,8 @@ func (s NoDataRetentionException) RequestID() string {
 // Status Code: 403, The caller is not authorized to perform an operation on
 // the given stream, or the token has expired.
 type NotAuthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2282,8 +2282,8 @@ func (s NotAuthorizedException) RequestID() string {
 // a session with a PlaybackMode of LIVE is requested for a stream that has
 // no fragments within the last 30 seconds.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2394,8 +2394,8 @@ func (s *TimestampRange) SetStartTimestamp(v time.Time) *TimestampRange {
 // fragment for a playback session. The codec ID for track 1 should be V_MPEG/ISO/AVC
 // and, optionally, the codec ID for track 2 should be A_AAC.
 type UnsupportedStreamMediaTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/kinesisvideoarchivedmedia/api.go
+++ b/service/kinesisvideoarchivedmedia/api.go
@@ -831,7 +831,7 @@ func (c *KinesisVideoArchivedMedia) ListFragmentsPagesWithContext(ctx aws.Contex
 // the limit of allowed client calls. Try making the call later.
 type ClientLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -848,7 +848,7 @@ func (s ClientLimitExceededException) GoString() string {
 
 func newErrorClientLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ClientLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -876,12 +876,12 @@ func (s ClientLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the range of timestamps for the requested media, and the source
@@ -1875,7 +1875,7 @@ func (s *HLSTimestampRange) SetStartTimestamp(v time.Time) *HLSTimestampRange {
 // be used.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1892,7 +1892,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1920,19 +1920,19 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The codec private data in at least one of the tracks of the video stream
 // is not valid for this operation.
 type InvalidCodecPrivateDataException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1949,7 +1949,7 @@ func (s InvalidCodecPrivateDataException) GoString() string {
 
 func newErrorInvalidCodecPrivateDataException(v protocol.ResponseMetadata) error {
 	return &InvalidCodecPrivateDataException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1977,12 +1977,12 @@ func (s InvalidCodecPrivateDataException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCodecPrivateDataException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCodecPrivateDataException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListFragmentsInput struct {
@@ -2106,7 +2106,7 @@ func (s *ListFragmentsOutput) SetNextToken(v string) *ListFragmentsOutput {
 // No codec private data was found in at least one of tracks of the video stream.
 type MissingCodecPrivateDataException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2123,7 +2123,7 @@ func (s MissingCodecPrivateDataException) GoString() string {
 
 func newErrorMissingCodecPrivateDataException(v protocol.ResponseMetadata) error {
 	return &MissingCodecPrivateDataException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2151,19 +2151,19 @@ func (s MissingCodecPrivateDataException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MissingCodecPrivateDataException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MissingCodecPrivateDataException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A streaming session was requested for a stream that does not retain data
 // (that is, has a DataRetentionInHours of 0).
 type NoDataRetentionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2180,7 +2180,7 @@ func (s NoDataRetentionException) GoString() string {
 
 func newErrorNoDataRetentionException(v protocol.ResponseMetadata) error {
 	return &NoDataRetentionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2208,19 +2208,19 @@ func (s NoDataRetentionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoDataRetentionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoDataRetentionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Status Code: 403, The caller is not authorized to perform an operation on
 // the given stream, or the token has expired.
 type NotAuthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2237,7 +2237,7 @@ func (s NotAuthorizedException) GoString() string {
 
 func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 	return &NotAuthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2265,12 +2265,12 @@ func (s NotAuthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotAuthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotAuthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // GetMedia throws this error when Kinesis Video Streams can't find the stream
@@ -2283,7 +2283,7 @@ func (s NotAuthorizedException) RequestID() string {
 // no fragments within the last 30 seconds.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2300,7 +2300,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2328,12 +2328,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The range of timestamps for which to return fragments.
@@ -2395,7 +2395,7 @@ func (s *TimestampRange) SetStartTimestamp(v time.Time) *TimestampRange {
 // and, optionally, the codec ID for track 2 should be A_AAC.
 type UnsupportedStreamMediaTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2412,7 +2412,7 @@ func (s UnsupportedStreamMediaTypeException) GoString() string {
 
 func newErrorUnsupportedStreamMediaTypeException(v protocol.ResponseMetadata) error {
 	return &UnsupportedStreamMediaTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2440,12 +2440,12 @@ func (s UnsupportedStreamMediaTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedStreamMediaTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedStreamMediaTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/kinesisvideomedia/api.go
+++ b/service/kinesisvideomedia/api.go
@@ -155,8 +155,8 @@ func (c *KinesisVideoMedia) GetMediaWithContext(ctx aws.Context, input *GetMedia
 // Kinesis Video Streams has throttled the request because you have exceeded
 // the limit of allowed client calls. Try making the call later.
 type ClientLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -212,8 +212,8 @@ func (s ClientLimitExceededException) RequestID() string {
 // Kinesis Video Streams has throttled the request because you have exceeded
 // the limit of allowed client connections.
 type ConnectionLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -415,8 +415,8 @@ func (s *GetMediaOutput) SetPayload(v io.ReadCloser) *GetMediaOutput {
 
 // The value for this input parameter is invalid.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -474,8 +474,8 @@ func (s InvalidArgumentException) RequestID() string {
 // set to "READ" and use the endpoint Kinesis Video returns in the next GetMedia
 // call.
 type InvalidEndpointException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -531,8 +531,8 @@ func (s InvalidEndpointException) RequestID() string {
 // Status Code: 403, The caller is not authorized to perform an operation on
 // the given stream, or the token has expired.
 type NotAuthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -587,8 +587,8 @@ func (s NotAuthorizedException) RequestID() string {
 
 // Status Code: 404, The stream with the given name does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/kinesisvideomedia/api.go
+++ b/service/kinesisvideomedia/api.go
@@ -156,7 +156,7 @@ func (c *KinesisVideoMedia) GetMediaWithContext(ctx aws.Context, input *GetMedia
 // the limit of allowed client calls. Try making the call later.
 type ClientLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -173,7 +173,7 @@ func (s ClientLimitExceededException) GoString() string {
 
 func newErrorClientLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ClientLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -201,19 +201,19 @@ func (s ClientLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Kinesis Video Streams has throttled the request because you have exceeded
 // the limit of allowed client connections.
 type ConnectionLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -230,7 +230,7 @@ func (s ConnectionLimitExceededException) GoString() string {
 
 func newErrorConnectionLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ConnectionLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -258,12 +258,12 @@ func (s ConnectionLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConnectionLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConnectionLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetMediaInput struct {
@@ -416,7 +416,7 @@ func (s *GetMediaOutput) SetPayload(v io.ReadCloser) *GetMediaOutput {
 // The value for this input parameter is invalid.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -433,7 +433,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -461,12 +461,12 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Status Code: 400, Caller used wrong endpoint to write data to a stream. On
@@ -475,7 +475,7 @@ func (s InvalidArgumentException) RequestID() string {
 // call.
 type InvalidEndpointException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -492,7 +492,7 @@ func (s InvalidEndpointException) GoString() string {
 
 func newErrorInvalidEndpointException(v protocol.ResponseMetadata) error {
 	return &InvalidEndpointException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -520,19 +520,19 @@ func (s InvalidEndpointException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEndpointException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEndpointException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Status Code: 403, The caller is not authorized to perform an operation on
 // the given stream, or the token has expired.
 type NotAuthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -549,7 +549,7 @@ func (s NotAuthorizedException) GoString() string {
 
 func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 	return &NotAuthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -577,18 +577,18 @@ func (s NotAuthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotAuthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotAuthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Status Code: 404, The stream with the given name does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -605,7 +605,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -633,12 +633,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Identifies the chunk on the Kinesis video stream where you want the GetMedia

--- a/service/kinesisvideosignalingchannels/api.go
+++ b/service/kinesisvideosignalingchannels/api.go
@@ -220,8 +220,8 @@ func (c *KinesisVideoSignalingChannels) SendAlexaOfferToMasterWithContext(ctx aw
 // Your request was throttled because you have exceeded the limit of allowed
 // client calls. Try making the call later.
 type ClientLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -429,8 +429,8 @@ func (s *IceServer) SetUsername(v string) *IceServer {
 
 // The value for this input parameter is invalid.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -485,8 +485,8 @@ func (s InvalidArgumentException) RequestID() string {
 
 // The specified client is invalid.
 type InvalidClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -541,8 +541,8 @@ func (s InvalidClientException) RequestID() string {
 
 // The caller is not authorized to perform this operation.
 type NotAuthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -597,8 +597,8 @@ func (s NotAuthorizedException) RequestID() string {
 
 // The specified resource is not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -753,8 +753,8 @@ func (s *SendAlexaOfferToMasterOutput) SetAnswer(v string) *SendAlexaOfferToMast
 // is valid for 45 minutes. Client should reconnect to the channel to continue
 // sending/receiving messages.
 type SessionExpiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/kinesisvideosignalingchannels/api.go
+++ b/service/kinesisvideosignalingchannels/api.go
@@ -221,7 +221,7 @@ func (c *KinesisVideoSignalingChannels) SendAlexaOfferToMasterWithContext(ctx aw
 // client calls. Try making the call later.
 type ClientLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -238,7 +238,7 @@ func (s ClientLimitExceededException) GoString() string {
 
 func newErrorClientLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ClientLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -266,12 +266,12 @@ func (s ClientLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClientLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClientLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetIceServerConfigInput struct {
@@ -430,7 +430,7 @@ func (s *IceServer) SetUsername(v string) *IceServer {
 // The value for this input parameter is invalid.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -447,7 +447,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -475,18 +475,18 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified client is invalid.
 type InvalidClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -503,7 +503,7 @@ func (s InvalidClientException) GoString() string {
 
 func newErrorInvalidClientException(v protocol.ResponseMetadata) error {
 	return &InvalidClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -531,18 +531,18 @@ func (s InvalidClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The caller is not authorized to perform this operation.
 type NotAuthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -559,7 +559,7 @@ func (s NotAuthorizedException) GoString() string {
 
 func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 	return &NotAuthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -587,18 +587,18 @@ func (s NotAuthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotAuthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotAuthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource is not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -615,7 +615,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -643,12 +643,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SendAlexaOfferToMasterInput struct {
@@ -754,7 +754,7 @@ func (s *SendAlexaOfferToMasterOutput) SetAnswer(v string) *SendAlexaOfferToMast
 // sending/receiving messages.
 type SessionExpiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -771,7 +771,7 @@ func (s SessionExpiredException) GoString() string {
 
 func newErrorSessionExpiredException(v protocol.ResponseMetadata) error {
 	return &SessionExpiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -799,12 +799,12 @@ func (s SessionExpiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SessionExpiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SessionExpiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -6534,7 +6534,7 @@ func (s *AliasListEntry) SetTargetKeyId(v string) *AliasListEntry {
 // exists.
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6551,7 +6551,7 @@ func (s AlreadyExistsException) GoString() string {
 
 func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &AlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6579,12 +6579,12 @@ func (s AlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CancelKeyDeletionInput struct {
@@ -6672,7 +6672,7 @@ func (s *CancelKeyDeletionOutput) SetKeyId(v string) *CancelKeyDeletionOutput {
 // operation.
 type CloudHsmClusterInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6689,7 +6689,7 @@ func (s CloudHsmClusterInUseException) GoString() string {
 
 func newErrorCloudHsmClusterInUseException(v protocol.ResponseMetadata) error {
 	return &CloudHsmClusterInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6717,12 +6717,12 @@ func (s CloudHsmClusterInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmClusterInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmClusterInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the associated AWS CloudHSM cluster did
@@ -6757,7 +6757,7 @@ func (s CloudHsmClusterInUseException) RequestID() string {
 // in the AWS CloudHSM User Guide .
 type CloudHsmClusterInvalidConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6774,7 +6774,7 @@ func (s CloudHsmClusterInvalidConfigurationException) GoString() string {
 
 func newErrorCloudHsmClusterInvalidConfigurationException(v protocol.ResponseMetadata) error {
 	return &CloudHsmClusterInvalidConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6802,12 +6802,12 @@ func (s CloudHsmClusterInvalidConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmClusterInvalidConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmClusterInvalidConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the AWS CloudHSM cluster that is associated
@@ -6817,7 +6817,7 @@ func (s CloudHsmClusterInvalidConfigurationException) RequestID() string {
 // in the AWS CloudHSM User Guide.
 type CloudHsmClusterNotActiveException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6834,7 +6834,7 @@ func (s CloudHsmClusterNotActiveException) GoString() string {
 
 func newErrorCloudHsmClusterNotActiveException(v protocol.ResponseMetadata) error {
 	return &CloudHsmClusterNotActiveException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6862,12 +6862,12 @@ func (s CloudHsmClusterNotActiveException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmClusterNotActiveException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmClusterNotActiveException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
@@ -6875,7 +6875,7 @@ func (s CloudHsmClusterNotActiveException) RequestID() string {
 // ID.
 type CloudHsmClusterNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6892,7 +6892,7 @@ func (s CloudHsmClusterNotFoundException) GoString() string {
 
 func newErrorCloudHsmClusterNotFoundException(v protocol.ResponseMetadata) error {
 	return &CloudHsmClusterNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6920,12 +6920,12 @@ func (s CloudHsmClusterNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmClusterNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmClusterNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the specified AWS CloudHSM cluster has a
@@ -6942,7 +6942,7 @@ func (s CloudHsmClusterNotFoundException) RequestID() string {
 // operation.
 type CloudHsmClusterNotRelatedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6959,7 +6959,7 @@ func (s CloudHsmClusterNotRelatedException) GoString() string {
 
 func newErrorCloudHsmClusterNotRelatedException(v protocol.ResponseMetadata) error {
 	return &CloudHsmClusterNotRelatedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6987,12 +6987,12 @@ func (s CloudHsmClusterNotRelatedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CloudHsmClusterNotRelatedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CloudHsmClusterNotRelatedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ConnectCustomKeyStoreInput struct {
@@ -7715,7 +7715,7 @@ func (s *CreateKeyOutput) SetKeyMetadata(v *KeyMetadata) *CreateKeyOutput {
 // deleted, you can delete the custom key store.
 type CustomKeyStoreHasCMKsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7732,7 +7732,7 @@ func (s CustomKeyStoreHasCMKsException) GoString() string {
 
 func newErrorCustomKeyStoreHasCMKsException(v protocol.ResponseMetadata) error {
 	return &CustomKeyStoreHasCMKsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7760,12 +7760,12 @@ func (s CustomKeyStoreHasCMKsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CustomKeyStoreHasCMKsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CustomKeyStoreHasCMKsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because of the ConnectionState of the custom key
@@ -7787,7 +7787,7 @@ func (s CustomKeyStoreHasCMKsException) RequestID() string {
 //    for all other ConnectionState values.
 type CustomKeyStoreInvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7804,7 +7804,7 @@ func (s CustomKeyStoreInvalidStateException) GoString() string {
 
 func newErrorCustomKeyStoreInvalidStateException(v protocol.ResponseMetadata) error {
 	return &CustomKeyStoreInvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7832,12 +7832,12 @@ func (s CustomKeyStoreInvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CustomKeyStoreInvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CustomKeyStoreInvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the specified custom key store name is already
@@ -7845,7 +7845,7 @@ func (s CustomKeyStoreInvalidStateException) RequestID() string {
 // key store name that is unique in the account.
 type CustomKeyStoreNameInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7862,7 +7862,7 @@ func (s CustomKeyStoreNameInUseException) GoString() string {
 
 func newErrorCustomKeyStoreNameInUseException(v protocol.ResponseMetadata) error {
 	return &CustomKeyStoreNameInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7890,19 +7890,19 @@ func (s CustomKeyStoreNameInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CustomKeyStoreNameInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CustomKeyStoreNameInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because AWS KMS cannot find a custom key store with
 // the specified key store name or ID.
 type CustomKeyStoreNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7919,7 +7919,7 @@ func (s CustomKeyStoreNotFoundException) GoString() string {
 
 func newErrorCustomKeyStoreNotFoundException(v protocol.ResponseMetadata) error {
 	return &CustomKeyStoreNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7947,12 +7947,12 @@ func (s CustomKeyStoreNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CustomKeyStoreNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CustomKeyStoreNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about each custom key store in the custom key store
@@ -8461,7 +8461,7 @@ func (s DeleteImportedKeyMaterialOutput) GoString() string {
 // be retried.
 type DependencyTimeoutException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8478,7 +8478,7 @@ func (s DependencyTimeoutException) GoString() string {
 
 func newErrorDependencyTimeoutException(v protocol.ResponseMetadata) error {
 	return &DependencyTimeoutException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8506,12 +8506,12 @@ func (s DependencyTimeoutException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DependencyTimeoutException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DependencyTimeoutException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DescribeCustomKeyStoresInput struct {
@@ -8880,7 +8880,7 @@ func (s DisableKeyRotationOutput) GoString() string {
 // The request was rejected because the specified CMK is not enabled.
 type DisabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8897,7 +8897,7 @@ func (s DisabledException) GoString() string {
 
 func newErrorDisabledException(v protocol.ResponseMetadata) error {
 	return &DisabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8925,12 +8925,12 @@ func (s DisabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DisabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DisabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DisconnectCustomKeyStoreInput struct {
@@ -9294,7 +9294,7 @@ func (s *EncryptOutput) SetKeyId(v string) *EncryptOutput {
 // new public key to encrypt the key material, and then try the request again.
 type ExpiredImportTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9311,7 +9311,7 @@ func (s ExpiredImportTokenException) GoString() string {
 
 func newErrorExpiredImportTokenException(v protocol.ResponseMetadata) error {
 	return &ExpiredImportTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9339,12 +9339,12 @@ func (s ExpiredImportTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExpiredImportTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExpiredImportTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GenerateDataKeyInput struct {
@@ -10874,7 +10874,7 @@ func (s ImportKeyMaterialOutput) GoString() string {
 // must identify the same CMK that was used to encrypt the ciphertext.
 type IncorrectKeyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10891,7 +10891,7 @@ func (s IncorrectKeyException) GoString() string {
 
 func newErrorIncorrectKeyException(v protocol.ResponseMetadata) error {
 	return &IncorrectKeyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10919,12 +10919,12 @@ func (s IncorrectKeyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncorrectKeyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncorrectKeyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the key material in the request is, expired,
@@ -10932,7 +10932,7 @@ func (s IncorrectKeyException) RequestID() string {
 // this customer master key (CMK).
 type IncorrectKeyMaterialException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10949,7 +10949,7 @@ func (s IncorrectKeyMaterialException) GoString() string {
 
 func newErrorIncorrectKeyMaterialException(v protocol.ResponseMetadata) error {
 	return &IncorrectKeyMaterialException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10977,12 +10977,12 @@ func (s IncorrectKeyMaterialException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncorrectKeyMaterialException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncorrectKeyMaterialException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the trust anchor certificate in the request
@@ -10993,7 +10993,7 @@ func (s IncorrectKeyMaterialException) RequestID() string {
 // file.
 type IncorrectTrustAnchorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11010,7 +11010,7 @@ func (s IncorrectTrustAnchorException) GoString() string {
 
 func newErrorIncorrectTrustAnchorException(v protocol.ResponseMetadata) error {
 	return &IncorrectTrustAnchorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11038,19 +11038,19 @@ func (s IncorrectTrustAnchorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncorrectTrustAnchorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncorrectTrustAnchorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because an internal exception occurred. The request
 // can be retried.
 type InternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11067,7 +11067,7 @@ func (s InternalException) GoString() string {
 
 func newErrorInternalException(v protocol.ResponseMetadata) error {
 	return &InternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11095,18 +11095,18 @@ func (s InternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the specified alias name is not valid.
 type InvalidAliasNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11123,7 +11123,7 @@ func (s InvalidAliasNameException) GoString() string {
 
 func newErrorInvalidAliasNameException(v protocol.ResponseMetadata) error {
 	return &InvalidAliasNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11151,19 +11151,19 @@ func (s InvalidAliasNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAliasNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAliasNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because a specified ARN, or an ARN in a key policy,
 // is not valid.
 type InvalidArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11180,7 +11180,7 @@ func (s InvalidArnException) GoString() string {
 
 func newErrorInvalidArnException(v protocol.ResponseMetadata) error {
 	return &InvalidArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11208,12 +11208,12 @@ func (s InvalidArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // From the Decrypt or ReEncrypt operation, the request was rejected because
@@ -11225,7 +11225,7 @@ func (s InvalidArnException) RequestID() string {
 // KMS could not decrypt the encrypted (wrapped) key material.
 type InvalidCiphertextException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11242,7 +11242,7 @@ func (s InvalidCiphertextException) GoString() string {
 
 func newErrorInvalidCiphertextException(v protocol.ResponseMetadata) error {
 	return &InvalidCiphertextException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11270,18 +11270,18 @@ func (s InvalidCiphertextException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCiphertextException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCiphertextException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the specified GrantId is not valid.
 type InvalidGrantIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11298,7 +11298,7 @@ func (s InvalidGrantIdException) GoString() string {
 
 func newErrorInvalidGrantIdException(v protocol.ResponseMetadata) error {
 	return &InvalidGrantIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11326,18 +11326,18 @@ func (s InvalidGrantIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidGrantIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidGrantIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the specified grant token is not valid.
 type InvalidGrantTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11354,7 +11354,7 @@ func (s InvalidGrantTokenException) GoString() string {
 
 func newErrorInvalidGrantTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidGrantTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11382,19 +11382,19 @@ func (s InvalidGrantTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidGrantTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidGrantTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the provided import token is invalid or
 // is associated with a different customer master key (CMK).
 type InvalidImportTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11411,7 +11411,7 @@ func (s InvalidImportTokenException) GoString() string {
 
 func newErrorInvalidImportTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidImportTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11439,12 +11439,12 @@ func (s InvalidImportTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidImportTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidImportTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected for one of the following reasons:
@@ -11462,7 +11462,7 @@ func (s InvalidImportTokenException) RequestID() string {
 // use the DescribeKey operation.
 type InvalidKeyUsageException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11479,7 +11479,7 @@ func (s InvalidKeyUsageException) GoString() string {
 
 func newErrorInvalidKeyUsageException(v protocol.ResponseMetadata) error {
 	return &InvalidKeyUsageException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11507,19 +11507,19 @@ func (s InvalidKeyUsageException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidKeyUsageException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidKeyUsageException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the marker that specifies where pagination
 // should next begin is not valid.
 type InvalidMarkerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11536,7 +11536,7 @@ func (s InvalidMarkerException) GoString() string {
 
 func newErrorInvalidMarkerException(v protocol.ResponseMetadata) error {
 	return &InvalidMarkerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11564,12 +11564,12 @@ func (s InvalidMarkerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidMarkerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidMarkerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the state of the specified resource is not
@@ -11580,7 +11580,7 @@ func (s InvalidMarkerException) RequestID() string {
 // in the AWS Key Management Service Developer Guide .
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11597,7 +11597,7 @@ func (s InvalidStateException) GoString() string {
 
 func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 	return &InvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11625,12 +11625,12 @@ func (s InvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the signature verification failed. Signature
@@ -11638,7 +11638,7 @@ func (s InvalidStateException) RequestID() string {
 // signing the specified message with the specified CMK and signing algorithm.
 type KMSInvalidSignatureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11655,7 +11655,7 @@ func (s KMSInvalidSignatureException) GoString() string {
 
 func newErrorKMSInvalidSignatureException(v protocol.ResponseMetadata) error {
 	return &KMSInvalidSignatureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11683,12 +11683,12 @@ func (s KMSInvalidSignatureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSInvalidSignatureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSInvalidSignatureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about each entry in the key list.
@@ -11941,7 +11941,7 @@ func (s *KeyMetadata) SetValidTo(v time.Time) *KeyMetadata {
 // can retry the request.
 type KeyUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11958,7 +11958,7 @@ func (s KeyUnavailableException) GoString() string {
 
 func newErrorKeyUnavailableException(v protocol.ResponseMetadata) error {
 	return &KeyUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11986,12 +11986,12 @@ func (s KeyUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KeyUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KeyUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because a quota was exceeded. For more information,
@@ -11999,7 +11999,7 @@ func (s KeyUnavailableException) RequestID() string {
 // in the AWS Key Management Service Developer Guide.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12016,7 +12016,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12044,12 +12044,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAliasesInput struct {
@@ -12741,7 +12741,7 @@ func (s *ListRetirableGrantsInput) SetRetiringPrincipal(v string) *ListRetirable
 // or semantically correct.
 type MalformedPolicyDocumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12758,7 +12758,7 @@ func (s MalformedPolicyDocumentException) GoString() string {
 
 func newErrorMalformedPolicyDocumentException(v protocol.ResponseMetadata) error {
 	return &MalformedPolicyDocumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12786,19 +12786,19 @@ func (s MalformedPolicyDocumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MalformedPolicyDocumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MalformedPolicyDocumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because the specified entity or resource could not
 // be found.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12815,7 +12815,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12843,12 +12843,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutKeyPolicyInput struct {
@@ -13761,7 +13761,7 @@ func (s *Tag) SetTagValue(v string) *Tag {
 // The request was rejected because one or more tags are not valid.
 type TagException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13778,7 +13778,7 @@ func (s TagException) GoString() string {
 
 func newErrorTagException(v protocol.ResponseMetadata) error {
 	return &TagException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13806,12 +13806,12 @@ func (s TagException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {
@@ -13907,7 +13907,7 @@ func (s TagResourceOutput) GoString() string {
 // a specified resource is not valid for this operation.
 type UnsupportedOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13924,7 +13924,7 @@ func (s UnsupportedOperationException) GoString() string {
 
 func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 	return &UnsupportedOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13952,12 +13952,12 @@ func (s UnsupportedOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -6533,8 +6533,8 @@ func (s *AliasListEntry) SetTargetKeyId(v string) *AliasListEntry {
 // The request was rejected because it attempted to create a resource that already
 // exists.
 type AlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6671,8 +6671,8 @@ func (s *CancelKeyDeletionOutput) SetKeyId(v string) *CancelKeyDeletionOutput {
 // view the cluster certificate of a cluster, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
 // operation.
 type CloudHsmClusterInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6756,8 +6756,8 @@ func (s CloudHsmClusterInUseException) RequestID() string {
 // see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
 // in the AWS CloudHSM User Guide .
 type CloudHsmClusterInvalidConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6816,8 +6816,8 @@ func (s CloudHsmClusterInvalidConfigurationException) RequestID() string {
 // (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
 // in the AWS CloudHSM User Guide.
 type CloudHsmClusterNotActiveException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6874,8 +6874,8 @@ func (s CloudHsmClusterNotActiveException) RequestID() string {
 // with the specified cluster ID. Retry the request with a different cluster
 // ID.
 type CloudHsmClusterNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6941,8 +6941,8 @@ func (s CloudHsmClusterNotFoundException) RequestID() string {
 // view the cluster certificate of a cluster, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
 // operation.
 type CloudHsmClusterNotRelatedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7714,8 +7714,8 @@ func (s *CreateKeyOutput) SetKeyMetadata(v *KeyMetadata) *CreateKeyOutput {
 // use the ScheduleKeyDeletion operation to delete the CMKs. After they are
 // deleted, you can delete the custom key store.
 type CustomKeyStoreHasCMKsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7786,8 +7786,8 @@ func (s CustomKeyStoreHasCMKsException) RequestID() string {
 //    with a ConnectionState of DISCONNECTING or FAILED. This operation is valid
 //    for all other ConnectionState values.
 type CustomKeyStoreInvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7844,8 +7844,8 @@ func (s CustomKeyStoreInvalidStateException) RequestID() string {
 // assigned to another custom key store in the account. Try again with a custom
 // key store name that is unique in the account.
 type CustomKeyStoreNameInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7901,8 +7901,8 @@ func (s CustomKeyStoreNameInUseException) RequestID() string {
 // The request was rejected because AWS KMS cannot find a custom key store with
 // the specified key store name or ID.
 type CustomKeyStoreNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8460,8 +8460,8 @@ func (s DeleteImportedKeyMaterialOutput) GoString() string {
 // The system timed out while trying to fulfill the request. The request can
 // be retried.
 type DependencyTimeoutException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8879,8 +8879,8 @@ func (s DisableKeyRotationOutput) GoString() string {
 
 // The request was rejected because the specified CMK is not enabled.
 type DisabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9293,8 +9293,8 @@ func (s *EncryptOutput) SetKeyId(v string) *EncryptOutput {
 // GetParametersForImport to get a new import token and public key, use the
 // new public key to encrypt the key material, and then try the request again.
 type ExpiredImportTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10873,8 +10873,8 @@ func (s ImportKeyMaterialOutput) GoString() string {
 // The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
 // must identify the same CMK that was used to encrypt the ciphertext.
 type IncorrectKeyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10931,8 +10931,8 @@ func (s IncorrectKeyException) RequestID() string {
 // invalid, or is not the same key material that was previously imported into
 // this customer master key (CMK).
 type IncorrectKeyMaterialException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10992,8 +10992,8 @@ func (s IncorrectKeyMaterialException) RequestID() string {
 // you create the trust anchor certificate and save it in the customerCA.crt
 // file.
 type IncorrectTrustAnchorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11049,8 +11049,8 @@ func (s IncorrectTrustAnchorException) RequestID() string {
 // The request was rejected because an internal exception occurred. The request
 // can be retried.
 type InternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11105,8 +11105,8 @@ func (s InternalException) RequestID() string {
 
 // The request was rejected because the specified alias name is not valid.
 type InvalidAliasNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11162,8 +11162,8 @@ func (s InvalidAliasNameException) RequestID() string {
 // The request was rejected because a specified ARN, or an ARN in a key policy,
 // is not valid.
 type InvalidArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11224,8 +11224,8 @@ func (s InvalidArnException) RequestID() string {
 // From the ImportKeyMaterial operation, the request was rejected because AWS
 // KMS could not decrypt the encrypted (wrapped) key material.
 type InvalidCiphertextException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11280,8 +11280,8 @@ func (s InvalidCiphertextException) RequestID() string {
 
 // The request was rejected because the specified GrantId is not valid.
 type InvalidGrantIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11336,8 +11336,8 @@ func (s InvalidGrantIdException) RequestID() string {
 
 // The request was rejected because the specified grant token is not valid.
 type InvalidGrantTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11393,8 +11393,8 @@ func (s InvalidGrantTokenException) RequestID() string {
 // The request was rejected because the provided import token is invalid or
 // is associated with a different customer master key (CMK).
 type InvalidImportTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11461,8 +11461,8 @@ func (s InvalidImportTokenException) RequestID() string {
 // To find the encryption or signing algorithms supported for a particular CMK,
 // use the DescribeKey operation.
 type InvalidKeyUsageException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11518,8 +11518,8 @@ func (s InvalidKeyUsageException) RequestID() string {
 // The request was rejected because the marker that specifies where pagination
 // should next begin is not valid.
 type InvalidMarkerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11579,8 +11579,8 @@ func (s InvalidMarkerException) RequestID() string {
 // Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
 // in the AWS Key Management Service Developer Guide .
 type InvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11637,8 +11637,8 @@ func (s InvalidStateException) RequestID() string {
 // verification fails when it cannot confirm that signature was produced by
 // signing the specified message with the specified CMK and signing algorithm.
 type KMSInvalidSignatureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11940,8 +11940,8 @@ func (s *KeyMetadata) SetValidTo(v time.Time) *KeyMetadata {
 // The request was rejected because the specified CMK was not available. You
 // can retry the request.
 type KeyUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11998,8 +11998,8 @@ func (s KeyUnavailableException) RequestID() string {
 // see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
 // in the AWS Key Management Service Developer Guide.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12740,8 +12740,8 @@ func (s *ListRetirableGrantsInput) SetRetiringPrincipal(v string) *ListRetirable
 // The request was rejected because the specified policy is not syntactically
 // or semantically correct.
 type MalformedPolicyDocumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12797,8 +12797,8 @@ func (s MalformedPolicyDocumentException) RequestID() string {
 // The request was rejected because the specified entity or resource could not
 // be found.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13760,8 +13760,8 @@ func (s *Tag) SetTagValue(v string) *Tag {
 
 // The request was rejected because one or more tags are not valid.
 type TagException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13906,8 +13906,8 @@ func (s TagResourceOutput) GoString() string {
 // The request was rejected because a specified parameter is not supported or
 // a specified resource is not valid for this operation.
 type UnsupportedOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/lakeformation/api.go
+++ b/service/lakeformation/api.go
@@ -1333,8 +1333,8 @@ func (c *LakeFormation) UpdateResourceWithContext(ctx aws.Context, input *Update
 
 // A resource to be created or added already exists.
 type AlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -1725,8 +1725,8 @@ func (s *ColumnWildcard) SetExcludedColumnNames(v []*string) *ColumnWildcard {
 
 // Two processes are trying to modify a resource simultaneously.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2098,8 +2098,8 @@ func (s *DescribeResourceOutput) SetResourceInfo(v *ResourceInfo) *DescribeResou
 
 // A specified entity does not exist
 type EntityNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2528,8 +2528,8 @@ func (s GrantPermissionsOutput) GoString() string {
 
 // An internal service error occurred.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2585,8 +2585,8 @@ func (s InternalServiceException) RequestID() string {
 
 // The input provided was not valid.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2866,8 +2866,8 @@ func (s *ListResourcesOutput) SetResourceInfoList(v []*ResourceInfo) *ListResour
 
 // The operation timed out.
 type OperationTimeoutException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`

--- a/service/lakeformation/api.go
+++ b/service/lakeformation/api.go
@@ -1334,7 +1334,7 @@ func (c *LakeFormation) UpdateResourceWithContext(ctx aws.Context, input *Update
 // A resource to be created or added already exists.
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -1352,7 +1352,7 @@ func (s AlreadyExistsException) GoString() string {
 
 func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &AlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1380,12 +1380,12 @@ func (s AlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type BatchGrantPermissionsInput struct {
@@ -1726,7 +1726,7 @@ func (s *ColumnWildcard) SetExcludedColumnNames(v []*string) *ColumnWildcard {
 // Two processes are trying to modify a resource simultaneously.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -1744,7 +1744,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1772,12 +1772,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The AWS Lake Formation principal.
@@ -2099,7 +2099,7 @@ func (s *DescribeResourceOutput) SetResourceInfo(v *ResourceInfo) *DescribeResou
 // A specified entity does not exist
 type EntityNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2117,7 +2117,7 @@ func (s EntityNotFoundException) GoString() string {
 
 func newErrorEntityNotFoundException(v protocol.ResponseMetadata) error {
 	return &EntityNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2145,12 +2145,12 @@ func (s EntityNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EntityNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EntityNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about an error.
@@ -2529,7 +2529,7 @@ func (s GrantPermissionsOutput) GoString() string {
 // An internal service error occurred.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2547,7 +2547,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2575,18 +2575,18 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input provided was not valid.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2604,7 +2604,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2632,12 +2632,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListPermissionsInput struct {
@@ -2867,7 +2867,7 @@ func (s *ListResourcesOutput) SetResourceInfoList(v []*ResourceInfo) *ListResour
 // The operation timed out.
 type OperationTimeoutException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A message describing the problem.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -2885,7 +2885,7 @@ func (s OperationTimeoutException) GoString() string {
 
 func newErrorOperationTimeoutException(v protocol.ResponseMetadata) error {
 	return &OperationTimeoutException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2913,12 +2913,12 @@ func (s OperationTimeoutException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationTimeoutException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationTimeoutException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Permissions granted to a principal.

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -5781,7 +5781,7 @@ func (s *AliasRoutingConfiguration) SetAdditionalVersionWeights(v map[string]*fl
 // You have exceeded your maximum total code size per account. Learn more (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
 type CodeStorageExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -5801,7 +5801,7 @@ func (s CodeStorageExceededException) GoString() string {
 
 func newErrorCodeStorageExceededException(v protocol.ResponseMetadata) error {
 	return &CodeStorageExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5829,12 +5829,12 @@ func (s CodeStorageExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CodeStorageExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CodeStorageExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateAliasInput struct {
@@ -6925,7 +6925,7 @@ func (s *DestinationConfig) SetOnSuccess(v *OnSuccess) *DestinationConfig {
 // Need additional permissions to configure VPC settings.
 type EC2AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -6944,7 +6944,7 @@ func (s EC2AccessDeniedException) GoString() string {
 
 func newErrorEC2AccessDeniedException(v protocol.ResponseMetadata) error {
 	return &EC2AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6972,19 +6972,19 @@ func (s EC2AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EC2AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EC2AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Lambda was throttled by Amazon EC2 during Lambda function initialization
 // using the execution role provided for the Lambda function.
 type EC2ThrottledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -7003,7 +7003,7 @@ func (s EC2ThrottledException) GoString() string {
 
 func newErrorEC2ThrottledException(v protocol.ResponseMetadata) error {
 	return &EC2ThrottledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7031,19 +7031,19 @@ func (s EC2ThrottledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EC2ThrottledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EC2ThrottledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Lambda received an unexpected EC2 client exception while setting up for
 // the Lambda function.
 type EC2UnexpectedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	EC2ErrorCode *string `type:"string"`
 
@@ -7064,7 +7064,7 @@ func (s EC2UnexpectedException) GoString() string {
 
 func newErrorEC2UnexpectedException(v protocol.ResponseMetadata) error {
 	return &EC2UnexpectedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7092,12 +7092,12 @@ func (s EC2UnexpectedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EC2UnexpectedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EC2UnexpectedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Lambda was not able to create an elastic network interface in the VPC,
@@ -7105,7 +7105,7 @@ func (s EC2UnexpectedException) RequestID() string {
 // network interfaces has been reached.
 type ENILimitReachedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -7124,7 +7124,7 @@ func (s ENILimitReachedException) GoString() string {
 
 func newErrorENILimitReachedException(v protocol.ResponseMetadata) error {
 	return &ENILimitReachedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7152,12 +7152,12 @@ func (s ENILimitReachedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ENILimitReachedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ENILimitReachedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A function's environment variable settings.
@@ -8974,7 +8974,7 @@ func (s *GetProvisionedConcurrencyConfigOutput) SetStatusReason(v string) *GetPr
 // One of the parameters in the request is invalid.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -8995,7 +8995,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9023,18 +9023,18 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request body could not be parsed as JSON.
 type InvalidRequestContentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -9055,7 +9055,7 @@ func (s InvalidRequestContentException) GoString() string {
 
 func newErrorInvalidRequestContentException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestContentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9083,18 +9083,18 @@ func (s InvalidRequestContentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestContentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestContentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The runtime or runtime version specified is not supported.
 type InvalidRuntimeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9113,7 +9113,7 @@ func (s InvalidRuntimeException) GoString() string {
 
 func newErrorInvalidRuntimeException(v protocol.ResponseMetadata) error {
 	return &InvalidRuntimeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9141,19 +9141,19 @@ func (s InvalidRuntimeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRuntimeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRuntimeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Security Group ID provided in the Lambda function VPC configuration is
 // invalid.
 type InvalidSecurityGroupIDException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9172,7 +9172,7 @@ func (s InvalidSecurityGroupIDException) GoString() string {
 
 func newErrorInvalidSecurityGroupIDException(v protocol.ResponseMetadata) error {
 	return &InvalidSecurityGroupIDException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9200,18 +9200,18 @@ func (s InvalidSecurityGroupIDException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSecurityGroupIDException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSecurityGroupIDException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Subnet ID provided in the Lambda function VPC configuration is invalid.
 type InvalidSubnetIDException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9230,7 +9230,7 @@ func (s InvalidSubnetIDException) GoString() string {
 
 func newErrorInvalidSubnetIDException(v protocol.ResponseMetadata) error {
 	return &InvalidSubnetIDException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9258,18 +9258,18 @@ func (s InvalidSubnetIDException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSubnetIDException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSubnetIDException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Lambda could not unzip the deployment package.
 type InvalidZipFileException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9288,7 +9288,7 @@ func (s InvalidZipFileException) GoString() string {
 
 func newErrorInvalidZipFileException(v protocol.ResponseMetadata) error {
 	return &InvalidZipFileException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9316,12 +9316,12 @@ func (s InvalidZipFileException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidZipFileException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidZipFileException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Deprecated: InvokeAsyncInput has been deprecated
@@ -9599,7 +9599,7 @@ func (s *InvokeOutput) SetStatusCode(v int64) *InvokeOutput {
 // was denied. Check the Lambda function's KMS permissions.
 type KMSAccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9618,7 +9618,7 @@ func (s KMSAccessDeniedException) GoString() string {
 
 func newErrorKMSAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &KMSAccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9646,19 +9646,19 @@ func (s KMSAccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSAccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSAccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Lambda was unable to decrypt the environment variables because the KMS key
 // used is disabled. Check the Lambda function's KMS key settings.
 type KMSDisabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9677,7 +9677,7 @@ func (s KMSDisabledException) GoString() string {
 
 func newErrorKMSDisabledException(v protocol.ResponseMetadata) error {
 	return &KMSDisabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9705,19 +9705,19 @@ func (s KMSDisabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSDisabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSDisabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Lambda was unable to decrypt the environment variables because the KMS key
 // used is in an invalid state for Decrypt. Check the function's KMS key settings.
 type KMSInvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9736,7 +9736,7 @@ func (s KMSInvalidStateException) GoString() string {
 
 func newErrorKMSInvalidStateException(v protocol.ResponseMetadata) error {
 	return &KMSInvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9764,19 +9764,19 @@ func (s KMSInvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSInvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSInvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Lambda was unable to decrypt the environment variables because the KMS key
 // was not found. Check the function's KMS key settings.
 type KMSNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9795,7 +9795,7 @@ func (s KMSNotFoundException) GoString() string {
 
 func newErrorKMSNotFoundException(v protocol.ResponseMetadata) error {
 	return &KMSNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9823,12 +9823,12 @@ func (s KMSNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
@@ -11049,7 +11049,7 @@ func (s *OnSuccess) SetDestination(v string) *OnSuccess {
 // The permissions policy for the resource is too large. Learn more (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
 type PolicyLengthExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -11068,7 +11068,7 @@ func (s PolicyLengthExceededException) GoString() string {
 
 func newErrorPolicyLengthExceededException(v protocol.ResponseMetadata) error {
 	return &PolicyLengthExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11096,12 +11096,12 @@ func (s PolicyLengthExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyLengthExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyLengthExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The RevisionId provided does not match the latest RevisionId for the Lambda
@@ -11109,7 +11109,7 @@ func (s PolicyLengthExceededException) RequestID() string {
 // latest RevisionId for your resource.
 type PreconditionFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -11130,7 +11130,7 @@ func (s PreconditionFailedException) GoString() string {
 
 func newErrorPreconditionFailedException(v protocol.ResponseMetadata) error {
 	return &PreconditionFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11158,12 +11158,12 @@ func (s PreconditionFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PreconditionFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PreconditionFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details about the provisioned concurrency configuration for a function alias
@@ -11250,7 +11250,7 @@ func (s *ProvisionedConcurrencyConfigListItem) SetStatusReason(v string) *Provis
 // The specified configuration does not exist.
 type ProvisionedConcurrencyConfigNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -11269,7 +11269,7 @@ func (s ProvisionedConcurrencyConfigNotFoundException) GoString() string {
 
 func newErrorProvisionedConcurrencyConfigNotFoundException(v protocol.ResponseMetadata) error {
 	return &ProvisionedConcurrencyConfigNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11297,12 +11297,12 @@ func (s ProvisionedConcurrencyConfigNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProvisionedConcurrencyConfigNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProvisionedConcurrencyConfigNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PublishLayerVersionInput struct {
@@ -12200,7 +12200,7 @@ func (s RemovePermissionOutput) GoString() string {
 // more information, see Limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html).
 type RequestTooLargeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -12219,7 +12219,7 @@ func (s RequestTooLargeException) GoString() string {
 
 func newErrorRequestTooLargeException(v protocol.ResponseMetadata) error {
 	return &RequestTooLargeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12247,18 +12247,18 @@ func (s RequestTooLargeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestTooLargeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestTooLargeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource already exists, or another operation is in progress.
 type ResourceConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -12279,7 +12279,7 @@ func (s ResourceConflictException) GoString() string {
 
 func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 	return &ResourceConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12307,12 +12307,12 @@ func (s ResourceConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation conflicts with the resource's availability. For example, you
@@ -12320,7 +12320,7 @@ func (s ResourceConflictException) RequestID() string {
 // a EventSource mapping currently in the UPDATING state.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12339,7 +12339,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12367,18 +12367,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource specified in the request does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12397,7 +12397,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12425,19 +12425,19 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The function is inactive and its VPC connection is no longer available. Wait
 // for the VPC connection to reestablish and try again.
 type ResourceNotReadyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -12458,7 +12458,7 @@ func (s ResourceNotReadyException) GoString() string {
 
 func newErrorResourceNotReadyException(v protocol.ResponseMetadata) error {
 	return &ResourceNotReadyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12486,18 +12486,18 @@ func (s ResourceNotReadyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotReadyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotReadyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The AWS Lambda service encountered an internal error.
 type ServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12516,7 +12516,7 @@ func (s ServiceException) GoString() string {
 
 func newErrorServiceException(v protocol.ResponseMetadata) error {
 	return &ServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12544,19 +12544,19 @@ func (s ServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Lambda was not able to set up VPC access for the Lambda function because
 // one or more configured subnets has no available IP addresses.
 type SubnetIPAddressLimitReachedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12575,7 +12575,7 @@ func (s SubnetIPAddressLimitReachedException) GoString() string {
 
 func newErrorSubnetIPAddressLimitReachedException(v protocol.ResponseMetadata) error {
 	return &SubnetIPAddressLimitReachedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12603,12 +12603,12 @@ func (s SubnetIPAddressLimitReachedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubnetIPAddressLimitReachedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubnetIPAddressLimitReachedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {
@@ -12683,7 +12683,7 @@ func (s TagResourceOutput) GoString() string {
 // The request throughput limit was exceeded.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -12707,7 +12707,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12735,12 +12735,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The function's AWS X-Ray tracing configuration. To sample and record incoming
@@ -12795,7 +12795,7 @@ func (s *TracingConfigResponse) SetMode(v string) *TracingConfigResponse {
 // The content type of the Invoke request body is not JSON.
 type UnsupportedMediaTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -12814,7 +12814,7 @@ func (s UnsupportedMediaTypeException) GoString() string {
 
 func newErrorUnsupportedMediaTypeException(v protocol.ResponseMetadata) error {
 	return &UnsupportedMediaTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12842,12 +12842,12 @@ func (s UnsupportedMediaTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedMediaTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedMediaTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -5780,8 +5780,8 @@ func (s *AliasRoutingConfiguration) SetAdditionalVersionWeights(v map[string]*fl
 
 // You have exceeded your maximum total code size per account. Learn more (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
 type CodeStorageExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -6924,8 +6924,8 @@ func (s *DestinationConfig) SetOnSuccess(v *OnSuccess) *DestinationConfig {
 
 // Need additional permissions to configure VPC settings.
 type EC2AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -6983,8 +6983,8 @@ func (s EC2AccessDeniedException) RequestID() string {
 // AWS Lambda was throttled by Amazon EC2 during Lambda function initialization
 // using the execution role provided for the Lambda function.
 type EC2ThrottledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -7042,8 +7042,8 @@ func (s EC2ThrottledException) RequestID() string {
 // AWS Lambda received an unexpected EC2 client exception while setting up for
 // the Lambda function.
 type EC2UnexpectedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	EC2ErrorCode *string `type:"string"`
 
@@ -7104,8 +7104,8 @@ func (s EC2UnexpectedException) RequestID() string {
 // specified as part of Lambda function configuration, because the limit for
 // network interfaces has been reached.
 type ENILimitReachedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -8973,8 +8973,8 @@ func (s *GetProvisionedConcurrencyConfigOutput) SetStatusReason(v string) *GetPr
 
 // One of the parameters in the request is invalid.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -9033,8 +9033,8 @@ func (s InvalidParameterValueException) RequestID() string {
 
 // The request body could not be parsed as JSON.
 type InvalidRequestContentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -9093,8 +9093,8 @@ func (s InvalidRequestContentException) RequestID() string {
 
 // The runtime or runtime version specified is not supported.
 type InvalidRuntimeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9152,8 +9152,8 @@ func (s InvalidRuntimeException) RequestID() string {
 // The Security Group ID provided in the Lambda function VPC configuration is
 // invalid.
 type InvalidSecurityGroupIDException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9210,8 +9210,8 @@ func (s InvalidSecurityGroupIDException) RequestID() string {
 
 // The Subnet ID provided in the Lambda function VPC configuration is invalid.
 type InvalidSubnetIDException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9268,8 +9268,8 @@ func (s InvalidSubnetIDException) RequestID() string {
 
 // AWS Lambda could not unzip the deployment package.
 type InvalidZipFileException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9598,8 +9598,8 @@ func (s *InvokeOutput) SetStatusCode(v int64) *InvokeOutput {
 // Lambda was unable to decrypt the environment variables because KMS access
 // was denied. Check the Lambda function's KMS permissions.
 type KMSAccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9657,8 +9657,8 @@ func (s KMSAccessDeniedException) RequestID() string {
 // Lambda was unable to decrypt the environment variables because the KMS key
 // used is disabled. Check the Lambda function's KMS key settings.
 type KMSDisabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9716,8 +9716,8 @@ func (s KMSDisabledException) RequestID() string {
 // Lambda was unable to decrypt the environment variables because the KMS key
 // used is in an invalid state for Decrypt. Check the function's KMS key settings.
 type KMSInvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9775,8 +9775,8 @@ func (s KMSInvalidStateException) RequestID() string {
 // Lambda was unable to decrypt the environment variables because the KMS key
 // was not found. Check the function's KMS key settings.
 type KMSNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -11048,8 +11048,8 @@ func (s *OnSuccess) SetDestination(v string) *OnSuccess {
 
 // The permissions policy for the resource is too large. Learn more (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
 type PolicyLengthExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -11108,8 +11108,8 @@ func (s PolicyLengthExceededException) RequestID() string {
 // function or alias. Call the GetFunction or the GetAlias API to retrieve the
 // latest RevisionId for your resource.
 type PreconditionFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -11249,8 +11249,8 @@ func (s *ProvisionedConcurrencyConfigListItem) SetStatusReason(v string) *Provis
 
 // The specified configuration does not exist.
 type ProvisionedConcurrencyConfigNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -12199,8 +12199,8 @@ func (s RemovePermissionOutput) GoString() string {
 // The request payload exceeded the Invoke request body JSON input limit. For
 // more information, see Limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html).
 type RequestTooLargeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -12257,8 +12257,8 @@ func (s RequestTooLargeException) RequestID() string {
 
 // The resource already exists, or another operation is in progress.
 type ResourceConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -12319,8 +12319,8 @@ func (s ResourceConflictException) RequestID() string {
 // attempted to update an EventSource Mapping in CREATING, or tried to delete
 // a EventSource mapping currently in the UPDATING state.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12377,8 +12377,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The resource specified in the request does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12436,8 +12436,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // The function is inactive and its VPC connection is no longer available. Wait
 // for the VPC connection to reestablish and try again.
 type ResourceNotReadyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -12496,8 +12496,8 @@ func (s ResourceNotReadyException) RequestID() string {
 
 // The AWS Lambda service encountered an internal error.
 type ServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12555,8 +12555,8 @@ func (s ServiceException) RequestID() string {
 // AWS Lambda was not able to set up VPC access for the Lambda function because
 // one or more configured subnets has no available IP addresses.
 type SubnetIPAddressLimitReachedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12682,8 +12682,8 @@ func (s TagResourceOutput) GoString() string {
 
 // The request throughput limit was exceeded.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -12794,8 +12794,8 @@ func (s *TracingConfigResponse) SetMode(v string) *TracingConfigResponse {
 
 // The content type of the Invoke request body is not JSON.
 type UnsupportedMediaTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 

--- a/service/lexmodelbuildingservice/api.go
+++ b/service/lexmodelbuildingservice/api.go
@@ -4546,7 +4546,7 @@ func (c *LexModelBuildingService) UntagResourceWithContext(ctx aws.Context, inpu
 // field is missing. Check the field values, and try again.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4563,7 +4563,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4591,12 +4591,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information about a bot alias.
@@ -5026,7 +5026,7 @@ func (s *CodeHook) SetUri(v string) *CodeHook {
 // There was a conflict processing the request. Try your request again.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5043,7 +5043,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5071,12 +5071,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides the settings needed for conversation logs.
@@ -9243,7 +9243,7 @@ func (s *IntentMetadata) SetVersion(v string) *IntentMetadata {
 // An internal Amazon Lex error occurred. Try your request again.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9260,7 +9260,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9288,18 +9288,18 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request exceeded a limit. Try your request again.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -9318,7 +9318,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9346,12 +9346,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTagsForResourceInput struct {
@@ -9644,7 +9644,7 @@ func (s *Message) SetGroupNumber(v int64) *Message {
 // try again.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9661,7 +9661,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9689,19 +9689,19 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The checksum of the resource that you are trying to change does not match
 // the checksum in the request. Check the resource's checksum and try again.
 type PreconditionFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9718,7 +9718,7 @@ func (s PreconditionFailedException) GoString() string {
 
 func newErrorPreconditionFailedException(v protocol.ResponseMetadata) error {
 	return &PreconditionFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9746,12 +9746,12 @@ func (s PreconditionFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PreconditionFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PreconditionFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Obtains information from the user. To define a prompt, provide one or more
@@ -11343,7 +11343,7 @@ func (s *PutSlotTypeOutput) SetVersion(v string) *PutSlotTypeOutput {
 // "name": string, "version": string } }
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Describes the resource that refers to the resource that you are attempting
 	// to delete. This object is returned as part of the ResourceInUseException
@@ -11367,7 +11367,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11395,12 +11395,12 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the resource that refers to the resource that you are attempting

--- a/service/lexmodelbuildingservice/api.go
+++ b/service/lexmodelbuildingservice/api.go
@@ -4545,8 +4545,8 @@ func (c *LexModelBuildingService) UntagResourceWithContext(ctx aws.Context, inpu
 // The request is not well formed. For example, a value is invalid or a required
 // field is missing. Check the field values, and try again.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5025,8 +5025,8 @@ func (s *CodeHook) SetUri(v string) *CodeHook {
 
 // There was a conflict processing the request. Try your request again.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9242,8 +9242,8 @@ func (s *IntentMetadata) SetVersion(v string) *IntentMetadata {
 
 // An internal Amazon Lex error occurred. Try your request again.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9298,8 +9298,8 @@ func (s InternalFailureException) RequestID() string {
 
 // The request exceeded a limit. Try your request again.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -9643,8 +9643,8 @@ func (s *Message) SetGroupNumber(v int64) *Message {
 // The resource specified in the request was not found. Check the resource and
 // try again.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9700,8 +9700,8 @@ func (s NotFoundException) RequestID() string {
 // The checksum of the resource that you are trying to change does not match
 // the checksum in the request. Check the resource's checksum and try again.
 type PreconditionFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11342,8 +11342,8 @@ func (s *PutSlotTypeOutput) SetVersion(v string) *PutSlotTypeOutput {
 //
 // "name": string, "version": string } }
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Describes the resource that refers to the resource that you are attempting
 	// to delete. This object is returned as part of the ResourceInUseException

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -639,7 +639,7 @@ func (c *LexRuntimeService) PutSessionWithContext(ctx aws.Context, input *PutSes
 // (Amazon Polly, AWS Lambda) failed with an internal service error.
 type BadGatewayException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -656,7 +656,7 @@ func (s BadGatewayException) GoString() string {
 
 func newErrorBadGatewayException(v protocol.ResponseMetadata) error {
 	return &BadGatewayException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -684,19 +684,19 @@ func (s BadGatewayException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadGatewayException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadGatewayException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Request validation failed, there is no usable message in the context, or
 // the bot build failed, is still in progress, or contains unbuilt changes.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -713,7 +713,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -741,12 +741,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents an option to be shown on the client platform (Facebook, Slack,
@@ -792,7 +792,7 @@ func (s *Button) SetValue(v string) *Button {
 // Two clients are using the same AWS account, Amazon Lex bot, and user ID.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -809,7 +809,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -837,12 +837,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteSessionInput struct {
@@ -982,7 +982,7 @@ func (s *DeleteSessionOutput) SetUserId(v string) *DeleteSessionOutput {
 //    removing any slot values.
 type DependencyFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -999,7 +999,7 @@ func (s DependencyFailedException) GoString() string {
 
 func newErrorDependencyFailedException(v protocol.ResponseMetadata) error {
 	return &DependencyFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1027,12 +1027,12 @@ func (s DependencyFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DependencyFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DependencyFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the next action that the bot should take in its interaction with
@@ -1519,7 +1519,7 @@ func (s *IntentSummary) SetSlots(v map[string]*string) *IntentSummary {
 // Internal service error. Retry the call.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1536,7 +1536,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1564,18 +1564,18 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exceeded a limit.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -1594,7 +1594,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1622,18 +1622,18 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is not used.
 type LoopDetectedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1650,7 +1650,7 @@ func (s LoopDetectedException) GoString() string {
 
 func newErrorLoopDetectedException(v protocol.ResponseMetadata) error {
 	return &LoopDetectedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1678,18 +1678,18 @@ func (s LoopDetectedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LoopDetectedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LoopDetectedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The accept header in the request does not have a valid value.
 type NotAcceptableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1706,7 +1706,7 @@ func (s NotAcceptableException) GoString() string {
 
 func newErrorNotAcceptableException(v protocol.ResponseMetadata) error {
 	return &NotAcceptableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1734,19 +1734,19 @@ func (s NotAcceptableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotAcceptableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotAcceptableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource (such as the Amazon Lex bot or an alias) that is referred to
 // is not found.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1763,7 +1763,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1791,12 +1791,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PostContentInput struct {
@@ -2839,7 +2839,7 @@ func (s *PutSessionOutput) SetSlots(v aws.JSONValue) *PutSessionOutput {
 // The input speech is too long.
 type RequestTimeoutException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2856,7 +2856,7 @@ func (s RequestTimeoutException) GoString() string {
 
 func newErrorRequestTimeoutException(v protocol.ResponseMetadata) error {
 	return &RequestTimeoutException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2884,12 +2884,12 @@ func (s RequestTimeoutException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestTimeoutException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestTimeoutException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // If you configure a response card when creating your bots, Amazon Lex substitutes
@@ -2977,7 +2977,7 @@ func (s *SentimentResponse) SetSentimentScore(v string) *SentimentResponse {
 // The Content-Type header (PostContent API) has an invalid value.
 type UnsupportedMediaTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2994,7 +2994,7 @@ func (s UnsupportedMediaTypeException) GoString() string {
 
 func newErrorUnsupportedMediaTypeException(v protocol.ResponseMetadata) error {
 	return &UnsupportedMediaTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3022,12 +3022,12 @@ func (s UnsupportedMediaTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedMediaTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedMediaTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -638,8 +638,8 @@ func (c *LexRuntimeService) PutSessionWithContext(ctx aws.Context, input *PutSes
 // Either the Amazon Lex bot is still building, or one of the dependent services
 // (Amazon Polly, AWS Lambda) failed with an internal service error.
 type BadGatewayException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -695,8 +695,8 @@ func (s BadGatewayException) RequestID() string {
 // Request validation failed, there is no usable message in the context, or
 // the bot build failed, is still in progress, or contains unbuilt changes.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -791,8 +791,8 @@ func (s *Button) SetValue(v string) *Button {
 
 // Two clients are using the same AWS account, Amazon Lex bot, and user ID.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -981,8 +981,8 @@ func (s *DeleteSessionOutput) SetUserId(v string) *DeleteSessionOutput {
 //    * If a fulfillment Lambda function returns a Delegate dialog action without
 //    removing any slot values.
 type DependencyFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1518,8 +1518,8 @@ func (s *IntentSummary) SetSlots(v map[string]*string) *IntentSummary {
 
 // Internal service error. Retry the call.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1574,8 +1574,8 @@ func (s InternalFailureException) RequestID() string {
 
 // Exceeded a limit.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -1632,8 +1632,8 @@ func (s LimitExceededException) RequestID() string {
 
 // This exception is not used.
 type LoopDetectedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1688,8 +1688,8 @@ func (s LoopDetectedException) RequestID() string {
 
 // The accept header in the request does not have a valid value.
 type NotAcceptableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1745,8 +1745,8 @@ func (s NotAcceptableException) RequestID() string {
 // The resource (such as the Amazon Lex bot or an alias) that is referred to
 // is not found.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2838,8 +2838,8 @@ func (s *PutSessionOutput) SetSlots(v aws.JSONValue) *PutSessionOutput {
 
 // The input speech is too long.
 type RequestTimeoutException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2976,8 +2976,8 @@ func (s *SentimentResponse) SetSentimentScore(v string) *SentimentResponse {
 
 // The Content-Type header (PostContent API) has an invalid value.
 type UnsupportedMediaTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/licensemanager/api.go
+++ b/service/licensemanager/api.go
@@ -1546,7 +1546,7 @@ func (c *LicenseManager) UpdateServiceSettingsWithContext(ctx aws.Context, input
 // Access to resource denied.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1563,7 +1563,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1591,19 +1591,19 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The AWS user account does not have permission to perform the action. Check
 // the IAM policy associated with this account.
 type AuthorizationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1620,7 +1620,7 @@ func (s AuthorizationException) GoString() string {
 
 func newErrorAuthorizationException(v protocol.ResponseMetadata) error {
 	return &AuthorizationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1648,12 +1648,12 @@ func (s AuthorizationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AuthorizationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AuthorizationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes automated discovery.
@@ -1919,7 +1919,7 @@ func (s DeleteLicenseConfigurationOutput) GoString() string {
 // A dependency required to run the API is missing.
 type FailedDependencyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1936,7 +1936,7 @@ func (s FailedDependencyException) GoString() string {
 
 func newErrorFailedDependencyException(v protocol.ResponseMetadata) error {
 	return &FailedDependencyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1964,12 +1964,12 @@ func (s FailedDependencyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FailedDependencyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FailedDependencyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A filter name and value pair that is used to return more specific results
@@ -2010,7 +2010,7 @@ func (s *Filter) SetValues(v []*string) *Filter {
 // The request uses too many filters or too many filter values.
 type FilterLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2027,7 +2027,7 @@ func (s FilterLimitExceededException) GoString() string {
 
 func newErrorFilterLimitExceededException(v protocol.ResponseMetadata) error {
 	return &FilterLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2055,12 +2055,12 @@ func (s FilterLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FilterLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FilterLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetLicenseConfigurationInput struct {
@@ -2338,7 +2338,7 @@ func (s *GetServiceSettingsOutput) SetSnsTopicArn(v string) *GetServiceSettingsO
 // One or more parameter values are not valid.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2355,7 +2355,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2383,12 +2383,12 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // License Manager cannot allocate a license to a resource because of its state.
@@ -2397,7 +2397,7 @@ func (s InvalidParameterValueException) RequestID() string {
 // of shutting down.
 type InvalidResourceStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2414,7 +2414,7 @@ func (s InvalidResourceStateException) GoString() string {
 
 func newErrorInvalidResourceStateException(v protocol.ResponseMetadata) error {
 	return &InvalidResourceStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2442,12 +2442,12 @@ func (s InvalidResourceStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An inventory filter.
@@ -2916,7 +2916,7 @@ func (s *LicenseSpecification) SetLicenseConfigurationArn(v string) *LicenseSpec
 // You do not have enough licenses available to support a new resource launch.
 type LicenseUsageException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2933,7 +2933,7 @@ func (s LicenseUsageException) GoString() string {
 
 func newErrorLicenseUsageException(v protocol.ResponseMetadata) error {
 	return &LicenseUsageException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2961,12 +2961,12 @@ func (s LicenseUsageException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LicenseUsageException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LicenseUsageException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAssociationsForLicenseConfigurationInput struct {
@@ -3859,7 +3859,7 @@ func (s *ProductInformationFilter) SetProductInformationFilterValue(v []*string)
 // Too many requests have been submitted. Try again after a brief wait.
 type RateLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3876,7 +3876,7 @@ func (s RateLimitExceededException) GoString() string {
 
 func newErrorRateLimitExceededException(v protocol.ResponseMetadata) error {
 	return &RateLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3904,12 +3904,12 @@ func (s RateLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RateLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RateLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details about a resource.
@@ -3984,7 +3984,7 @@ func (s *ResourceInventory) SetResourceType(v string) *ResourceInventory {
 // Your resource limits have been exceeded.
 type ResourceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4001,7 +4001,7 @@ func (s ResourceLimitExceededException) GoString() string {
 
 func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4029,18 +4029,18 @@ func (s ResourceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The server experienced an internal error. Try again.
 type ServerInternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4057,7 +4057,7 @@ func (s ServerInternalException) GoString() string {
 
 func newErrorServerInternalException(v protocol.ResponseMetadata) error {
 	return &ServerInternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4085,12 +4085,12 @@ func (s ServerInternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServerInternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServerInternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details about a tag for a license configuration.

--- a/service/licensemanager/api.go
+++ b/service/licensemanager/api.go
@@ -1545,8 +1545,8 @@ func (c *LicenseManager) UpdateServiceSettingsWithContext(ctx aws.Context, input
 
 // Access to resource denied.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1602,8 +1602,8 @@ func (s AccessDeniedException) RequestID() string {
 // The AWS user account does not have permission to perform the action. Check
 // the IAM policy associated with this account.
 type AuthorizationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1918,8 +1918,8 @@ func (s DeleteLicenseConfigurationOutput) GoString() string {
 
 // A dependency required to run the API is missing.
 type FailedDependencyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2009,8 +2009,8 @@ func (s *Filter) SetValues(v []*string) *Filter {
 
 // The request uses too many filters or too many filter values.
 type FilterLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2337,8 +2337,8 @@ func (s *GetServiceSettingsOutput) SetSnsTopicArn(v string) *GetServiceSettingsO
 
 // One or more parameter values are not valid.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2396,8 +2396,8 @@ func (s InvalidParameterValueException) RequestID() string {
 // For example, you cannot allocate a license to an instance in the process
 // of shutting down.
 type InvalidResourceStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2915,8 +2915,8 @@ func (s *LicenseSpecification) SetLicenseConfigurationArn(v string) *LicenseSpec
 
 // You do not have enough licenses available to support a new resource launch.
 type LicenseUsageException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3858,8 +3858,8 @@ func (s *ProductInformationFilter) SetProductInformationFilterValue(v []*string)
 
 // Too many requests have been submitted. Try again after a brief wait.
 type RateLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3983,8 +3983,8 @@ func (s *ResourceInventory) SetResourceType(v string) *ResourceInventory {
 
 // Your resource limits have been exceeded.
 type ResourceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4039,8 +4039,8 @@ func (s ResourceLimitExceededException) RequestID() string {
 
 // The server experienced an internal error. Try again.
 type ServerInternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/lightsail/api.go
+++ b/service/lightsail/api.go
@@ -12167,7 +12167,7 @@ func (c *Lightsail) UpdateRelationalDatabaseParametersWithContext(ctx aws.Contex
 // uses invalid credentials to access a resource.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -12190,7 +12190,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12218,19 +12218,19 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Lightsail throws this exception when an account is still in the setup in
 // progress state.
 type AccountSetupInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -12253,7 +12253,7 @@ func (s AccountSetupInProgressException) GoString() string {
 
 func newErrorAccountSetupInProgressException(v protocol.ResponseMetadata) error {
 	return &AccountSetupInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12281,12 +12281,12 @@ func (s AccountSetupInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccountSetupInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccountSetupInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes an add-on that is enabled for an Amazon Lightsail resource.
@@ -23431,7 +23431,7 @@ func (s *InstanceState) SetName(v string) *InstanceState {
 // edit these resources.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -23454,7 +23454,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23482,12 +23482,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type IsVpcPeeredInput struct {
@@ -24415,7 +24415,7 @@ func (s *MonthlyTransfer) SetGbPerMonthAllocated(v int64) *MonthlyTransfer {
 // Lightsail throws this exception when it cannot find a resource.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -24438,7 +24438,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24466,12 +24466,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type OpenInstancePublicPortsInput struct {
@@ -24677,7 +24677,7 @@ func (s *Operation) SetStatusChangedAt(v time.Time) *Operation {
 // Lightsail throws this exception when an operation fails to execute.
 type OperationFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -24700,7 +24700,7 @@ func (s OperationFailureException) GoString() string {
 
 func newErrorOperationFailureException(v protocol.ResponseMetadata) error {
 	return &OperationFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24728,12 +24728,12 @@ func (s OperationFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The password data for the Windows Server-based instance, including the ciphertext
@@ -26456,7 +26456,7 @@ func (s *SendContactMethodVerificationOutput) SetOperations(v []*Operation) *Sen
 // A general service exception.
 type ServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -26479,7 +26479,7 @@ func (s ServiceException) GoString() string {
 
 func newErrorServiceException(v protocol.ResponseMetadata) error {
 	return &ServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26507,12 +26507,12 @@ func (s ServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartInstanceInput struct {
@@ -27108,7 +27108,7 @@ func (s *TestAlarmOutput) SetOperations(v []*Operation) *TestAlarmOutput {
 // Lightsail throws this exception when the user has not been authenticated.
 type UnauthenticatedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -27131,7 +27131,7 @@ func (s UnauthenticatedException) GoString() string {
 
 func newErrorUnauthenticatedException(v protocol.ResponseMetadata) error {
 	return &UnauthenticatedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27159,12 +27159,12 @@ func (s UnauthenticatedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthenticatedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthenticatedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UnpeerVpcInput struct {

--- a/service/lightsail/api.go
+++ b/service/lightsail/api.go
@@ -12166,8 +12166,8 @@ func (c *Lightsail) UpdateRelationalDatabaseParametersWithContext(ctx aws.Contex
 // Lightsail throws this exception when the user cannot be authenticated or
 // uses invalid credentials to access a resource.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -12229,8 +12229,8 @@ func (s AccessDeniedException) RequestID() string {
 // Lightsail throws this exception when an account is still in the setup in
 // progress state.
 type AccountSetupInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -23430,8 +23430,8 @@ func (s *InstanceState) SetName(v string) *InstanceState {
 // Please set your AWS Region configuration to us-east-1 to create, view, or
 // edit these resources.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -24414,8 +24414,8 @@ func (s *MonthlyTransfer) SetGbPerMonthAllocated(v int64) *MonthlyTransfer {
 
 // Lightsail throws this exception when it cannot find a resource.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -24676,8 +24676,8 @@ func (s *Operation) SetStatusChangedAt(v time.Time) *Operation {
 
 // Lightsail throws this exception when an operation fails to execute.
 type OperationFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -26455,8 +26455,8 @@ func (s *SendContactMethodVerificationOutput) SetOperations(v []*Operation) *Sen
 
 // A general service exception.
 type ServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 
@@ -27107,8 +27107,8 @@ func (s *TestAlarmOutput) SetOperations(v []*Operation) *TestAlarmOutput {
 
 // Lightsail throws this exception when the user has not been authenticated.
 type UnauthenticatedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"code" type:"string"`
 

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -6847,7 +6847,7 @@ func (s *GetMLModelOutput) SetTrainingParameters(v map[string]*string) *GetMLMod
 // request.
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -6866,7 +6866,7 @@ func (s IdempotentParameterMismatchException) GoString() string {
 
 func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6894,18 +6894,18 @@ func (s IdempotentParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An error on the server occurred when trying to process a request.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -6924,7 +6924,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6952,19 +6952,19 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An error on the client occurred. Typically, the cause is an invalid input
 // value.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -6983,7 +6983,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7011,17 +7011,17 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvalidTagException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7038,7 +7038,7 @@ func (s InvalidTagException) GoString() string {
 
 func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 	return &InvalidTagException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7066,19 +7066,19 @@ func (s InvalidTagException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The subscriber exceeded the maximum number of operations. This exception
 // can occur when listing objects such as DataSource.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -7097,7 +7097,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7125,12 +7125,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the output of a GetMLModel operation.
@@ -7589,7 +7589,7 @@ func (s *Prediction) SetPredictedValue(v float64) *Prediction {
 // The exception is thrown when a predict request is made to an unmounted MLModel.
 type PredictorNotMountedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7606,7 +7606,7 @@ func (s PredictorNotMountedException) GoString() string {
 
 func newErrorPredictorNotMountedException(v protocol.ResponseMetadata) error {
 	return &PredictorNotMountedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7634,12 +7634,12 @@ func (s PredictorNotMountedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PredictorNotMountedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PredictorNotMountedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The data specification of an Amazon Relational Database Service (Amazon RDS)
@@ -8578,7 +8578,7 @@ func (s *RedshiftMetadata) SetSelectSqlQuery(v string) *RedshiftMetadata {
 // A specified resource cannot be located.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -8597,7 +8597,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8625,12 +8625,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the data specification of a DataSource.
@@ -8837,7 +8837,7 @@ func (s *Tag) SetValue(v string) *Tag {
 
 type TagLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8854,7 +8854,7 @@ func (s TagLimitExceededException) GoString() string {
 
 func newErrorTagLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TagLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8882,12 +8882,12 @@ func (s TagLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateBatchPredictionInput struct {

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -6846,8 +6846,8 @@ func (s *GetMLModelOutput) SetTrainingParameters(v map[string]*string) *GetMLMod
 // from retrying a request using a parameter that was not present in the original
 // request.
 type IdempotentParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -6904,8 +6904,8 @@ func (s IdempotentParameterMismatchException) RequestID() string {
 
 // An error on the server occurred when trying to process a request.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -6963,8 +6963,8 @@ func (s InternalServerException) RequestID() string {
 // An error on the client occurred. Typically, the cause is an invalid input
 // value.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -7020,8 +7020,8 @@ func (s InvalidInputException) RequestID() string {
 }
 
 type InvalidTagException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7077,8 +7077,8 @@ func (s InvalidTagException) RequestID() string {
 // The subscriber exceeded the maximum number of operations. This exception
 // can occur when listing objects such as DataSource.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -7588,8 +7588,8 @@ func (s *Prediction) SetPredictedValue(v float64) *Prediction {
 
 // The exception is thrown when a predict request is made to an unmounted MLModel.
 type PredictorNotMountedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8577,8 +8577,8 @@ func (s *RedshiftMetadata) SetSelectSqlQuery(v string) *RedshiftMetadata {
 
 // A specified resource cannot be located.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *int64 `locationName:"code" type:"integer"`
 
@@ -8836,8 +8836,8 @@ func (s *Tag) SetValue(v string) *Tag {
 }
 
 type TagLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/macie/api.go
+++ b/service/macie/api.go
@@ -750,7 +750,7 @@ func (c *Macie) UpdateS3ResourcesWithContext(ctx aws.Context, input *UpdateS3Res
 // You do not have required permissions to access the requested resource.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -770,7 +770,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -798,12 +798,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AssociateMemberAccountInput struct {
@@ -1217,7 +1217,7 @@ func (s *FailedS3Resource) SetFailedItem(v *S3Resource) *FailedS3Resource {
 // Internal server error.
 type InternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Error code for the exception
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -1237,7 +1237,7 @@ func (s InternalException) GoString() string {
 
 func newErrorInternalException(v protocol.ResponseMetadata) error {
 	return &InternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1265,19 +1265,19 @@ func (s InternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because an invalid or out-of-range value was supplied
 // for an input parameter.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Error code for the exception
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -1300,7 +1300,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1328,19 +1328,19 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because it attempted to create resources beyond
 // the current AWS account limits. The error code describes the limit exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Error code for the exception
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -1363,7 +1363,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1391,12 +1391,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListMemberAccountsInput struct {

--- a/service/macie/api.go
+++ b/service/macie/api.go
@@ -749,8 +749,8 @@ func (c *Macie) UpdateS3ResourcesWithContext(ctx aws.Context, input *UpdateS3Res
 
 // You do not have required permissions to access the requested resource.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -1216,8 +1216,8 @@ func (s *FailedS3Resource) SetFailedItem(v *S3Resource) *FailedS3Resource {
 
 // Internal server error.
 type InternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Error code for the exception
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -1276,8 +1276,8 @@ func (s InternalException) RequestID() string {
 // The request was rejected because an invalid or out-of-range value was supplied
 // for an input parameter.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Error code for the exception
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -1339,8 +1339,8 @@ func (s InvalidInputException) RequestID() string {
 // The request was rejected because it attempted to create resources beyond
 // the current AWS account limits. The error code describes the limit exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Error code for the exception
 	ErrorCode *string `locationName:"errorCode" type:"string"`

--- a/service/managedblockchain/api.go
+++ b/service/managedblockchain/api.go
@@ -2162,7 +2162,7 @@ func (c *ManagedBlockchain) VoteOnProposalWithContext(ctx aws.Context, input *Vo
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2179,7 +2179,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2207,12 +2207,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A policy type that defines the voting rules for the network. The rules decide
@@ -3314,7 +3314,7 @@ func (s *GetProposalOutput) SetProposal(v *Proposal) *GetProposalOutput {
 
 type IllegalActionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3331,7 +3331,7 @@ func (s IllegalActionException) GoString() string {
 
 func newErrorIllegalActionException(v protocol.ResponseMetadata) error {
 	return &IllegalActionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3359,19 +3359,19 @@ func (s IllegalActionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IllegalActionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IllegalActionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request processing has failed because of an unknown error, exception
 // or failure.
 type InternalServiceErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3388,7 +3388,7 @@ func (s InternalServiceErrorException) GoString() string {
 
 func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServiceErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3416,19 +3416,19 @@ func (s InternalServiceErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The action or operation requested is invalid. Verify that the action is typed
 // correctly.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3445,7 +3445,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3473,12 +3473,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invitation to an AWS account to create a member and join the network.
@@ -5651,7 +5651,7 @@ func (s *RemoveAction) SetMemberId(v string) *RemoveAction {
 // A resource request is issued for a resource that already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5668,7 +5668,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5696,12 +5696,12 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of resources of that type already exist. Ensure the resources
@@ -5709,7 +5709,7 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 // limits.
 type ResourceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5726,7 +5726,7 @@ func (s ResourceLimitExceededException) GoString() string {
 
 func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5754,19 +5754,19 @@ func (s ResourceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A requested resource does not exist on the network. It may have been deleted
 // or referenced inaccurately.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5783,7 +5783,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5811,19 +5811,19 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested resource exists but is not in a status that can complete the
 // operation.
 type ResourceNotReadyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5840,7 +5840,7 @@ func (s ResourceNotReadyException) GoString() string {
 
 func newErrorResourceNotReadyException(v protocol.ResponseMetadata) error {
 	return &ResourceNotReadyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5868,12 +5868,12 @@ func (s ResourceNotReadyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotReadyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotReadyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request or operation could not be performed because a service is throttling
@@ -5882,7 +5882,7 @@ func (s ResourceNotReadyException) RequestID() string {
 // increase or delete unused resources if possible.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5899,7 +5899,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5927,12 +5927,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type VoteOnProposalInput struct {

--- a/service/managedblockchain/api.go
+++ b/service/managedblockchain/api.go
@@ -2161,8 +2161,8 @@ func (c *ManagedBlockchain) VoteOnProposalWithContext(ctx aws.Context, input *Vo
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3313,8 +3313,8 @@ func (s *GetProposalOutput) SetProposal(v *Proposal) *GetProposalOutput {
 }
 
 type IllegalActionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3370,8 +3370,8 @@ func (s IllegalActionException) RequestID() string {
 // The request processing has failed because of an unknown error, exception
 // or failure.
 type InternalServiceErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3427,8 +3427,8 @@ func (s InternalServiceErrorException) RequestID() string {
 // The action or operation requested is invalid. Verify that the action is typed
 // correctly.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5650,8 +5650,8 @@ func (s *RemoveAction) SetMemberId(v string) *RemoveAction {
 
 // A resource request is issued for a resource that already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5708,8 +5708,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 // requested are within the boundaries of the service edition and your account
 // limits.
 type ResourceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5765,8 +5765,8 @@ func (s ResourceLimitExceededException) RequestID() string {
 // A requested resource does not exist on the network. It may have been deleted
 // or referenced inaccurately.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5822,8 +5822,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // The requested resource exists but is not in a status that can complete the
 // operation.
 type ResourceNotReadyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5881,8 +5881,8 @@ func (s ResourceNotReadyException) RequestID() string {
 // such that your service limit for EC2 instances is exceeded. Request a limit
 // increase or delete unused resources if possible.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/marketplacecatalog/api.go
+++ b/service/marketplacecatalog/api.go
@@ -694,7 +694,7 @@ func (c *MarketplaceCatalog) StartChangeSetWithContext(ctx aws.Context, input *S
 // Access is denied.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -711,7 +711,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -739,12 +739,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CancelChangeSetInput struct {
@@ -1555,7 +1555,7 @@ func (s *Filter) SetValueList(v []*string) *Filter {
 // There was an internal service exception.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1572,7 +1572,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1600,12 +1600,12 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListChangeSetsInput struct {
@@ -1899,7 +1899,7 @@ func (s *ListEntitiesOutput) SetNextToken(v string) *ListEntitiesOutput {
 // The resource is currently in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1916,7 +1916,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1944,18 +1944,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource wasn't found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1972,7 +1972,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2000,18 +2000,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Currently, the specified resource is not supported.
 type ResourceNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2028,7 +2028,7 @@ func (s ResourceNotSupportedException) GoString() string {
 
 func newErrorResourceNotSupportedException(v protocol.ResponseMetadata) error {
 	return &ResourceNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2056,18 +2056,18 @@ func (s ResourceNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of open requests per account has been exceeded.
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2084,7 +2084,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2112,12 +2112,12 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that contains two attributes, sortBy and sortOrder.
@@ -2297,7 +2297,7 @@ func (s *StartChangeSetOutput) SetChangeSetId(v string) *StartChangeSetOutput {
 // Too many requests.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2314,7 +2314,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2342,18 +2342,18 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An error occurred during validation.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2370,7 +2370,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2398,12 +2398,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/marketplacecatalog/api.go
+++ b/service/marketplacecatalog/api.go
@@ -693,8 +693,8 @@ func (c *MarketplaceCatalog) StartChangeSetWithContext(ctx aws.Context, input *S
 
 // Access is denied.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1554,8 +1554,8 @@ func (s *Filter) SetValueList(v []*string) *Filter {
 
 // There was an internal service exception.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1898,8 +1898,8 @@ func (s *ListEntitiesOutput) SetNextToken(v string) *ListEntitiesOutput {
 
 // The resource is currently in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1954,8 +1954,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The specified resource wasn't found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2010,8 +2010,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // Currently, the specified resource is not supported.
 type ResourceNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2066,8 +2066,8 @@ func (s ResourceNotSupportedException) RequestID() string {
 
 // The maximum number of open requests per account has been exceeded.
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2296,8 +2296,8 @@ func (s *StartChangeSetOutput) SetChangeSetId(v string) *StartChangeSetOutput {
 
 // Too many requests.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2352,8 +2352,8 @@ func (s ThrottlingException) RequestID() string {
 
 // An error occurred during validation.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/marketplacecommerceanalytics/api.go
+++ b/service/marketplacecommerceanalytics/api.go
@@ -192,7 +192,7 @@ func (c *MarketplaceCommerceAnalytics) StartSupportDataExportWithContext(ctx aws
 // This exception is thrown when an internal service error occurs.
 type Exception struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// This message describes details of the error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -210,7 +210,7 @@ func (s Exception) GoString() string {
 
 func newErrorException(v protocol.ResponseMetadata) error {
 	return &Exception{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -238,12 +238,12 @@ func (s Exception) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s Exception) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s Exception) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Container for the parameters to the GenerateDataSet operation.

--- a/service/marketplacecommerceanalytics/api.go
+++ b/service/marketplacecommerceanalytics/api.go
@@ -191,8 +191,8 @@ func (c *MarketplaceCommerceAnalytics) StartSupportDataExportWithContext(ctx aws
 
 // This exception is thrown when an internal service error occurs.
 type Exception struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// This message describes details of the error.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/marketplaceentitlementservice/api.go
+++ b/service/marketplaceentitlementservice/api.go
@@ -344,7 +344,7 @@ func (s *GetEntitlementsOutput) SetNextToken(v string) *GetEntitlementsOutput {
 // post a message with details on the AWS forums.
 type InternalServiceErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -361,7 +361,7 @@ func (s InternalServiceErrorException) GoString() string {
 
 func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServiceErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -389,18 +389,18 @@ func (s InternalServiceErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more parameters in your request was invalid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -417,7 +417,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -445,18 +445,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The calls to the GetEntitlements API are throttled.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -473,7 +473,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -501,12 +501,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/marketplaceentitlementservice/api.go
+++ b/service/marketplaceentitlementservice/api.go
@@ -343,8 +343,8 @@ func (s *GetEntitlementsOutput) SetNextToken(v string) *GetEntitlementsOutput {
 // An internal error has occurred. Retry your request. If the problem persists,
 // post a message with details on the AWS forums.
 type InternalServiceErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -399,8 +399,8 @@ func (s InternalServiceErrorException) RequestID() string {
 
 // One or more parameters in your request was invalid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -455,8 +455,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // The calls to the GetEntitlements API are throttled.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/marketplacemetering/api.go
+++ b/service/marketplacemetering/api.go
@@ -579,7 +579,7 @@ func (s *BatchMeterUsageOutput) SetUnprocessedRecords(v []*UsageRecord) *BatchMe
 // the product.
 type CustomerNotEntitledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -596,7 +596,7 @@ func (s CustomerNotEntitledException) GoString() string {
 
 func newErrorCustomerNotEntitledException(v protocol.ResponseMetadata) error {
 	return &CustomerNotEntitledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -624,18 +624,18 @@ func (s CustomerNotEntitledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CustomerNotEntitledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CustomerNotEntitledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The API is disabled in the Region.
 type DisabledApiException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -652,7 +652,7 @@ func (s DisabledApiException) GoString() string {
 
 func newErrorDisabledApiException(v protocol.ResponseMetadata) error {
 	return &DisabledApiException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -680,12 +680,12 @@ func (s DisabledApiException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DisabledApiException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DisabledApiException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A metering record has already been emitted by the same EC2 instance, ECS
@@ -693,7 +693,7 @@ func (s DisabledApiException) RequestID() string {
 // usageQuantity.
 type DuplicateRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -710,7 +710,7 @@ func (s DuplicateRequestException) GoString() string {
 
 func newErrorDuplicateRequestException(v protocol.ResponseMetadata) error {
 	return &DuplicateRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -738,12 +738,12 @@ func (s DuplicateRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The submitted registration token has expired. This can happen if the buyer's
@@ -753,7 +753,7 @@ func (s DuplicateRequestException) RequestID() string {
 // as soon as it is submitted by the buyer's browser.
 type ExpiredTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -770,7 +770,7 @@ func (s ExpiredTokenException) GoString() string {
 
 func newErrorExpiredTokenException(v protocol.ResponseMetadata) error {
 	return &ExpiredTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -798,19 +798,19 @@ func (s ExpiredTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExpiredTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExpiredTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An internal error has occurred. Retry your request. If the problem persists,
 // post a message with details on the AWS forums.
 type InternalServiceErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -827,7 +827,7 @@ func (s InternalServiceErrorException) GoString() string {
 
 func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServiceErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -855,18 +855,18 @@ func (s InternalServiceErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have metered usage for a CustomerIdentifier that does not exist.
 type InvalidCustomerIdentifierException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -883,7 +883,7 @@ func (s InvalidCustomerIdentifierException) GoString() string {
 
 func newErrorInvalidCustomerIdentifierException(v protocol.ResponseMetadata) error {
 	return &InvalidCustomerIdentifierException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -911,12 +911,12 @@ func (s InvalidCustomerIdentifierException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCustomerIdentifierException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCustomerIdentifierException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The endpoint being called is in a AWS Region different from your EC2 instance,
@@ -924,7 +924,7 @@ func (s InvalidCustomerIdentifierException) RequestID() string {
 // AWS Region of the resource must match.
 type InvalidEndpointRegionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -941,7 +941,7 @@ func (s InvalidEndpointRegionException) GoString() string {
 
 func newErrorInvalidEndpointRegionException(v protocol.ResponseMetadata) error {
 	return &InvalidEndpointRegionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -969,19 +969,19 @@ func (s InvalidEndpointRegionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidEndpointRegionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidEndpointRegionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The product code passed does not match the product code used for publishing
 // the product.
 type InvalidProductCodeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -998,7 +998,7 @@ func (s InvalidProductCodeException) GoString() string {
 
 func newErrorInvalidProductCodeException(v protocol.ResponseMetadata) error {
 	return &InvalidProductCodeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1026,18 +1026,18 @@ func (s InvalidProductCodeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidProductCodeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidProductCodeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Public Key version is invalid.
 type InvalidPublicKeyVersionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1054,7 +1054,7 @@ func (s InvalidPublicKeyVersionException) GoString() string {
 
 func newErrorInvalidPublicKeyVersionException(v protocol.ResponseMetadata) error {
 	return &InvalidPublicKeyVersionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1082,12 +1082,12 @@ func (s InvalidPublicKeyVersionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPublicKeyVersionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPublicKeyVersionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // RegisterUsage must be called in the same AWS Region the ECS task was launched
@@ -1095,7 +1095,7 @@ func (s InvalidPublicKeyVersionException) RequestID() string {
 // when calling RegisterUsage.
 type InvalidRegionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1112,7 +1112,7 @@ func (s InvalidRegionException) GoString() string {
 
 func newErrorInvalidRegionException(v protocol.ResponseMetadata) error {
 	return &InvalidRegionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1140,18 +1140,18 @@ func (s InvalidRegionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRegionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRegionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Registration token is invalid.
 type InvalidTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1168,7 +1168,7 @@ func (s InvalidTokenException) GoString() string {
 
 func newErrorInvalidTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1196,19 +1196,19 @@ func (s InvalidTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The usage dimension does not match one of the UsageDimensions associated
 // with products.
 type InvalidUsageDimensionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1225,7 +1225,7 @@ func (s InvalidUsageDimensionException) GoString() string {
 
 func newErrorInvalidUsageDimensionException(v protocol.ResponseMetadata) error {
 	return &InvalidUsageDimensionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1253,12 +1253,12 @@ func (s InvalidUsageDimensionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidUsageDimensionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidUsageDimensionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type MeterUsageInput struct {
@@ -1385,7 +1385,7 @@ func (s *MeterUsageOutput) SetMeteringRecordId(v string) *MeterUsageOutput {
 // Currently, only Amazon ECS is supported.
 type PlatformNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1402,7 +1402,7 @@ func (s PlatformNotSupportedException) GoString() string {
 
 func newErrorPlatformNotSupportedException(v protocol.ResponseMetadata) error {
 	return &PlatformNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1430,12 +1430,12 @@ func (s PlatformNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PlatformNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PlatformNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RegisterUsageInput struct {
@@ -1622,7 +1622,7 @@ func (s *ResolveCustomerOutput) SetProductCode(v string) *ResolveCustomerOutput 
 // The calls to the API are throttled.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1639,7 +1639,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1667,18 +1667,18 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The timestamp value passed in the meterUsage() is out of allowed range.
 type TimestampOutOfBoundsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1695,7 +1695,7 @@ func (s TimestampOutOfBoundsException) GoString() string {
 
 func newErrorTimestampOutOfBoundsException(v protocol.ResponseMetadata) error {
 	return &TimestampOutOfBoundsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1723,12 +1723,12 @@ func (s TimestampOutOfBoundsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TimestampOutOfBoundsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TimestampOutOfBoundsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A UsageRecord indicates a quantity of usage for a given product, customer,

--- a/service/marketplacemetering/api.go
+++ b/service/marketplacemetering/api.go
@@ -578,8 +578,8 @@ func (s *BatchMeterUsageOutput) SetUnprocessedRecords(v []*UsageRecord) *BatchMe
 // Exception thrown when the customer does not have a valid subscription for
 // the product.
 type CustomerNotEntitledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -634,8 +634,8 @@ func (s CustomerNotEntitledException) RequestID() string {
 
 // The API is disabled in the Region.
 type DisabledApiException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -692,8 +692,8 @@ func (s DisabledApiException) RequestID() string {
 // task, or EKS pod for the given {usageDimension, timestamp} with a different
 // usageQuantity.
 type DuplicateRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -752,8 +752,8 @@ func (s DuplicateRequestException) RequestID() string {
 // token for too long. Your SaaS registration website should redeem this token
 // as soon as it is submitted by the buyer's browser.
 type ExpiredTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -809,8 +809,8 @@ func (s ExpiredTokenException) RequestID() string {
 // An internal error has occurred. Retry your request. If the problem persists,
 // post a message with details on the AWS forums.
 type InternalServiceErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -865,8 +865,8 @@ func (s InternalServiceErrorException) RequestID() string {
 
 // You have metered usage for a CustomerIdentifier that does not exist.
 type InvalidCustomerIdentifierException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -923,8 +923,8 @@ func (s InvalidCustomerIdentifierException) RequestID() string {
 // ECS task, or EKS pod. The Region of the Metering Service endpoint and the
 // AWS Region of the resource must match.
 type InvalidEndpointRegionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -980,8 +980,8 @@ func (s InvalidEndpointRegionException) RequestID() string {
 // The product code passed does not match the product code used for publishing
 // the product.
 type InvalidProductCodeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1036,8 +1036,8 @@ func (s InvalidProductCodeException) RequestID() string {
 
 // Public Key version is invalid.
 type InvalidPublicKeyVersionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1094,8 +1094,8 @@ func (s InvalidPublicKeyVersionException) RequestID() string {
 // in. This prevents a container from hardcoding a Region (e.g. withRegion(“us-east-1”)
 // when calling RegisterUsage.
 type InvalidRegionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1150,8 +1150,8 @@ func (s InvalidRegionException) RequestID() string {
 
 // Registration token is invalid.
 type InvalidTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1207,8 +1207,8 @@ func (s InvalidTokenException) RequestID() string {
 // The usage dimension does not match one of the UsageDimensions associated
 // with products.
 type InvalidUsageDimensionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1384,8 +1384,8 @@ func (s *MeterUsageOutput) SetMeteringRecordId(v string) *MeterUsageOutput {
 // AWS Marketplace does not support metering usage from the underlying platform.
 // Currently, only Amazon ECS is supported.
 type PlatformNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1621,8 +1621,8 @@ func (s *ResolveCustomerOutput) SetProductCode(v string) *ResolveCustomerOutput 
 
 // The calls to the API are throttled.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1677,8 +1677,8 @@ func (s ThrottlingException) RequestID() string {
 
 // The timestamp value passed in the meterUsage() is out of allowed range.
 type TimestampOutOfBoundsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/mediaconnect/api.go
+++ b/service/mediaconnect/api.go
@@ -2216,7 +2216,7 @@ func (c *MediaConnect) UpdateFlowSourceWithContext(ctx aws.Context, input *Updat
 // exception.
 type AddFlowOutputs420Exception struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2233,7 +2233,7 @@ func (s AddFlowOutputs420Exception) GoString() string {
 
 func newErrorAddFlowOutputs420Exception(v protocol.ResponseMetadata) error {
 	return &AddFlowOutputs420Exception{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2261,12 +2261,12 @@ func (s AddFlowOutputs420Exception) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AddFlowOutputs420Exception) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AddFlowOutputs420Exception) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Adds outputs to an existing flow. You can create up to 50 outputs per flow.
@@ -2609,7 +2609,7 @@ func (s *AddOutputRequest) SetStreamId(v string) *AddOutputRequest {
 // exception.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2626,7 +2626,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2654,12 +2654,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception raised by AWS Elemental MediaConnect. See the error message and
@@ -2667,7 +2667,7 @@ func (s BadRequestException) RequestID() string {
 // exception.
 type CreateFlow420Exception struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2684,7 +2684,7 @@ func (s CreateFlow420Exception) GoString() string {
 
 func newErrorCreateFlow420Exception(v protocol.ResponseMetadata) error {
 	return &CreateFlow420Exception{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2712,12 +2712,12 @@ func (s CreateFlow420Exception) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CreateFlow420Exception) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CreateFlow420Exception) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Creates a new flow. The request must include one source. The request optionally
@@ -3393,7 +3393,7 @@ func (s *Flow) SetStatus(v string) *Flow {
 // exception.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3410,7 +3410,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3438,12 +3438,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The entitlements that you want to grant on a flow.
@@ -3537,7 +3537,7 @@ func (s *GrantEntitlementRequest) SetSubscribers(v []*string) *GrantEntitlementR
 // exception.
 type GrantFlowEntitlements420Exception struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3554,7 +3554,7 @@ func (s GrantFlowEntitlements420Exception) GoString() string {
 
 func newErrorGrantFlowEntitlements420Exception(v protocol.ResponseMetadata) error {
 	return &GrantFlowEntitlements420Exception{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3582,12 +3582,12 @@ func (s GrantFlowEntitlements420Exception) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GrantFlowEntitlements420Exception) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GrantFlowEntitlements420Exception) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Grants an entitlement on a flow.
@@ -3692,7 +3692,7 @@ func (s *GrantFlowEntitlementsOutput) SetFlowArn(v string) *GrantFlowEntitlement
 // exception.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3709,7 +3709,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3737,12 +3737,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListEntitlementsInput struct {
@@ -4134,7 +4134,7 @@ func (s *Messages) SetErrors(v []*string) *Messages {
 // exception.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4151,7 +4151,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4179,12 +4179,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The settings for an output.
@@ -4569,7 +4569,7 @@ func (s *RevokeFlowEntitlementOutput) SetFlowArn(v string) *RevokeFlowEntitlemen
 // exception.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4586,7 +4586,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4614,12 +4614,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The settings for the source of the flow.
@@ -5082,7 +5082,7 @@ func (s TagResourceOutput) GoString() string {
 // exception.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5099,7 +5099,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5127,12 +5127,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Attributes related to the transport stream that are used in a source or output.

--- a/service/mediaconnect/api.go
+++ b/service/mediaconnect/api.go
@@ -2215,8 +2215,8 @@ func (c *MediaConnect) UpdateFlowSourceWithContext(ctx aws.Context, input *Updat
 // documentation for the operation for more information on the cause of this
 // exception.
 type AddFlowOutputs420Exception struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2608,8 +2608,8 @@ func (s *AddOutputRequest) SetStreamId(v string) *AddOutputRequest {
 // documentation for the operation for more information on the cause of this
 // exception.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2666,8 +2666,8 @@ func (s BadRequestException) RequestID() string {
 // documentation for the operation for more information on the cause of this
 // exception.
 type CreateFlow420Exception struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3392,8 +3392,8 @@ func (s *Flow) SetStatus(v string) *Flow {
 // documentation for the operation for more information on the cause of this
 // exception.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3536,8 +3536,8 @@ func (s *GrantEntitlementRequest) SetSubscribers(v []*string) *GrantEntitlementR
 // documentation for the operation for more information on the cause of this
 // exception.
 type GrantFlowEntitlements420Exception struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3691,8 +3691,8 @@ func (s *GrantFlowEntitlementsOutput) SetFlowArn(v string) *GrantFlowEntitlement
 // documentation for the operation for more information on the cause of this
 // exception.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4133,8 +4133,8 @@ func (s *Messages) SetErrors(v []*string) *Messages {
 // documentation for the operation for more information on the cause of this
 // exception.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4568,8 +4568,8 @@ func (s *RevokeFlowEntitlementOutput) SetFlowArn(v string) *RevokeFlowEntitlemen
 // documentation for the operation for more information on the cause of this
 // exception.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5081,8 +5081,8 @@ func (s TagResourceOutput) GoString() string {
 // documentation for the operation for more information on the cause of this
 // exception.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -3907,8 +3907,8 @@ func (s *AvailBlanking) SetAvailBlankingImage(v string) *AvailBlanking {
 }
 
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5347,8 +5347,8 @@ func (s *ColorCorrector) SetSaturation(v int64) *ColorCorrector {
 }
 
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8215,8 +8215,8 @@ func (s *FileSourceSettings) SetTimeDelta(v int64) *FileSourceSettings {
 }
 
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11522,8 +11522,8 @@ func (s *InsertableImage) SetWidth(v int64) *InsertableImage {
 }
 
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14959,8 +14959,8 @@ func (s *NoiseReducerTemporalFilterSettings) SetStrength(v int64) *NoiseReducerT
 }
 
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16969,8 +16969,8 @@ func (s *Timing) SetSubmitTime(v time.Time) *Timing {
 }
 
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -3908,7 +3908,7 @@ func (s *AvailBlanking) SetAvailBlankingImage(v string) *AvailBlanking {
 
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3925,7 +3925,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3953,12 +3953,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Burn-In Destination Settings.
@@ -5348,7 +5348,7 @@ func (s *ColorCorrector) SetSaturation(v int64) *ColorCorrector {
 
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5365,7 +5365,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5393,12 +5393,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Container specific settings.
@@ -8216,7 +8216,7 @@ func (s *FileSourceSettings) SetTimeDelta(v int64) *FileSourceSettings {
 
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8233,7 +8233,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8261,12 +8261,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Required when you set (Codec) under (VideoDescription)>(CodecSettings) to
@@ -11523,7 +11523,7 @@ func (s *InsertableImage) SetWidth(v int64) *InsertableImage {
 
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11540,7 +11540,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11568,12 +11568,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Each job converts an input file into an output file or files. For more information,
@@ -14960,7 +14960,7 @@ func (s *NoiseReducerTemporalFilterSettings) SetStrength(v int64) *NoiseReducerT
 
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14977,7 +14977,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15005,12 +15005,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An output object describes the settings for a single output file or stream
@@ -16970,7 +16970,7 @@ func (s *Timing) SetSubmitTime(v time.Time) *Timing {
 
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16987,7 +16987,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17015,12 +17015,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Settings specific to caption sources that are specified by track number.

--- a/service/medialive/api.go
+++ b/service/medialive/api.go
@@ -5516,7 +5516,7 @@ func (s *AvailSettings) SetScte35TimeSignalApos(v *Scte35TimeSignalApos) *AvailS
 
 type BadGatewayException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5533,7 +5533,7 @@ func (s BadGatewayException) GoString() string {
 
 func newErrorBadGatewayException(v protocol.ResponseMetadata) error {
 	return &BadGatewayException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5561,17 +5561,17 @@ func (s BadGatewayException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadGatewayException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadGatewayException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5588,7 +5588,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5616,12 +5616,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A list of schedule actions to create (in a request) or that have been created
@@ -6985,7 +6985,7 @@ func (s ColorSpacePassthroughSettings) GoString() string {
 
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7002,7 +7002,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7030,12 +7030,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateChannelInput struct {
@@ -10778,7 +10778,7 @@ func (s *FollowModeScheduleActionStartSettings) SetReferenceActionName(v string)
 
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10795,7 +10795,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10823,12 +10823,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Frame Capture Group Settings
@@ -10955,7 +10955,7 @@ func (s *FrameCaptureSettings) SetCaptureIntervalUnits(v string) *FrameCaptureSe
 
 type GatewayTimeoutException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10972,7 +10972,7 @@ func (s GatewayTimeoutException) GoString() string {
 
 func newErrorGatewayTimeoutException(v protocol.ResponseMetadata) error {
 	return &GatewayTimeoutException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11000,12 +11000,12 @@ func (s GatewayTimeoutException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GatewayTimeoutException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GatewayTimeoutException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Global Configuration
@@ -14224,7 +14224,7 @@ func (s *InputWhitelistRuleCidr) SetCidr(v string) *InputWhitelistRuleCidr {
 
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14241,7 +14241,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14269,12 +14269,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Key Provider Settings
@@ -17191,7 +17191,7 @@ func (s *NielsenConfiguration) SetNielsenPcmToId3Tagging(v string) *NielsenConfi
 
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17208,7 +17208,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17236,12 +17236,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Reserved resources available for purchase
@@ -20815,7 +20815,7 @@ func (s *TimecodeConfig) SetSyncThreshold(v int64) *TimecodeConfig {
 
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20832,7 +20832,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20860,12 +20860,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Ttml Destination Settings
@@ -21068,7 +21068,7 @@ func (s *UdpOutputSettings) SetFecOutputSettings(v *FecOutputSettings) *UdpOutpu
 
 type UnprocessableEntityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -21087,7 +21087,7 @@ func (s UnprocessableEntityException) GoString() string {
 
 func newErrorUnprocessableEntityException(v protocol.ResponseMetadata) error {
 	return &UnprocessableEntityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -21115,12 +21115,12 @@ func (s UnprocessableEntityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnprocessableEntityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnprocessableEntityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateChannelClassInput struct {

--- a/service/medialive/api.go
+++ b/service/medialive/api.go
@@ -5515,8 +5515,8 @@ func (s *AvailSettings) SetScte35TimeSignalApos(v *Scte35TimeSignalApos) *AvailS
 }
 
 type BadGatewayException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5570,8 +5570,8 @@ func (s BadGatewayException) RequestID() string {
 }
 
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6984,8 +6984,8 @@ func (s ColorSpacePassthroughSettings) GoString() string {
 }
 
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10777,8 +10777,8 @@ func (s *FollowModeScheduleActionStartSettings) SetReferenceActionName(v string)
 }
 
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10954,8 +10954,8 @@ func (s *FrameCaptureSettings) SetCaptureIntervalUnits(v string) *FrameCaptureSe
 }
 
 type GatewayTimeoutException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14223,8 +14223,8 @@ func (s *InputWhitelistRuleCidr) SetCidr(v string) *InputWhitelistRuleCidr {
 }
 
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17190,8 +17190,8 @@ func (s *NielsenConfiguration) SetNielsenPcmToId3Tagging(v string) *NielsenConfi
 }
 
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -20814,8 +20814,8 @@ func (s *TimecodeConfig) SetSyncThreshold(v int64) *TimecodeConfig {
 }
 
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -21067,8 +21067,8 @@ func (s *UdpOutputSettings) SetFecOutputSettings(v *FecOutputSettings) *UdpOutpu
 }
 
 type UnprocessableEntityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 

--- a/service/mediapackage/api.go
+++ b/service/mediapackage/api.go
@@ -3412,8 +3412,8 @@ func (s *DescribeOriginEndpointOutput) SetWhitelist(v []*string) *DescribeOrigin
 }
 
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4120,8 +4120,8 @@ func (s *IngestEndpoint) SetUsername(v string) *IngestEndpoint {
 }
 
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4590,8 +4590,8 @@ func (s *MssPackage) SetStreamSelection(v *StreamSelection) *MssPackage {
 }
 
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5086,8 +5086,8 @@ func (s *S3Destination) SetRoleArn(v string) *S3Destination {
 }
 
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5342,8 +5342,8 @@ func (s TagResourceOutput) GoString() string {
 }
 
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5397,8 +5397,8 @@ func (s TooManyRequestsException) RequestID() string {
 }
 
 type UnprocessableEntityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/mediapackage/api.go
+++ b/service/mediapackage/api.go
@@ -3413,7 +3413,7 @@ func (s *DescribeOriginEndpointOutput) SetWhitelist(v []*string) *DescribeOrigin
 
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3430,7 +3430,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3458,12 +3458,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A HarvestJob resource configuration
@@ -4121,7 +4121,7 @@ func (s *IngestEndpoint) SetUsername(v string) *IngestEndpoint {
 
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4138,7 +4138,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4166,12 +4166,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListChannelsInput struct {
@@ -4591,7 +4591,7 @@ func (s *MssPackage) SetStreamSelection(v *StreamSelection) *MssPackage {
 
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4608,7 +4608,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4636,12 +4636,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An OriginEndpoint resource configuration.
@@ -5087,7 +5087,7 @@ func (s *S3Destination) SetRoleArn(v string) *S3Destination {
 
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5104,7 +5104,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5132,12 +5132,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A configuration for accessing an external Secure Packager and Encoder Key
@@ -5343,7 +5343,7 @@ func (s TagResourceOutput) GoString() string {
 
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5360,7 +5360,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5388,17 +5388,17 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UnprocessableEntityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5415,7 +5415,7 @@ func (s UnprocessableEntityException) GoString() string {
 
 func newErrorUnprocessableEntityException(v protocol.ResponseMetadata) error {
 	return &UnprocessableEntityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5443,12 +5443,12 @@ func (s UnprocessableEntityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnprocessableEntityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnprocessableEntityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/mediapackagevod/api.go
+++ b/service/mediapackagevod/api.go
@@ -2541,8 +2541,8 @@ func (s *EgressEndpoint) SetUrl(v string) *EgressEndpoint {
 }
 
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2812,8 +2812,8 @@ func (s *HlsPackage) SetUseAudioRenditionGroup(v bool) *HlsPackage {
 }
 
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3242,8 +3242,8 @@ func (s *MssPackage) SetSegmentDurationSeconds(v int64) *MssPackage {
 }
 
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3417,8 +3417,8 @@ func (s *PackagingGroup) SetId(v string) *PackagingGroup {
 }
 
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3583,8 +3583,8 @@ func (s *StreamSelection) SetStreamOrder(v string) *StreamSelection {
 }
 
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3638,8 +3638,8 @@ func (s TooManyRequestsException) RequestID() string {
 }
 
 type UnprocessableEntityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/mediapackagevod/api.go
+++ b/service/mediapackagevod/api.go
@@ -2542,7 +2542,7 @@ func (s *EgressEndpoint) SetUrl(v string) *EgressEndpoint {
 
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2559,7 +2559,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2587,12 +2587,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An HTTP Live Streaming (HLS) encryption configuration.
@@ -2813,7 +2813,7 @@ func (s *HlsPackage) SetUseAudioRenditionGroup(v bool) *HlsPackage {
 
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2830,7 +2830,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2858,12 +2858,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAssetsInput struct {
@@ -3243,7 +3243,7 @@ func (s *MssPackage) SetSegmentDurationSeconds(v int64) *MssPackage {
 
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3260,7 +3260,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3288,12 +3288,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A MediaPackage VOD PackagingConfiguration resource.
@@ -3418,7 +3418,7 @@ func (s *PackagingGroup) SetId(v string) *PackagingGroup {
 
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3435,7 +3435,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3463,12 +3463,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A configuration for accessing an external Secure Packager and Encoder Key
@@ -3584,7 +3584,7 @@ func (s *StreamSelection) SetStreamOrder(v string) *StreamSelection {
 
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3601,7 +3601,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3629,17 +3629,17 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UnprocessableEntityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3656,7 +3656,7 @@ func (s UnprocessableEntityException) GoString() string {
 
 func newErrorUnprocessableEntityException(v protocol.ResponseMetadata) error {
 	return &UnprocessableEntityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3684,12 +3684,12 @@ func (s UnprocessableEntityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnprocessableEntityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnprocessableEntityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/mediastore/api.go
+++ b/service/mediastore/api.go
@@ -1791,7 +1791,7 @@ func (s *Container) SetStatus(v string) *Container {
 // updated.
 type ContainerInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1808,7 +1808,7 @@ func (s ContainerInUseException) GoString() string {
 
 func newErrorContainerInUseException(v protocol.ResponseMetadata) error {
 	return &ContainerInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1836,18 +1836,18 @@ func (s ContainerInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ContainerInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ContainerInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The container that you specified in the request does not exist.
 type ContainerNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1864,7 +1864,7 @@ func (s ContainerNotFoundException) GoString() string {
 
 func newErrorContainerNotFoundException(v protocol.ResponseMetadata) error {
 	return &ContainerNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1892,18 +1892,18 @@ func (s ContainerNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ContainerNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ContainerNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The CORS policy that you specified in the request does not exist.
 type CorsPolicyNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1920,7 +1920,7 @@ func (s CorsPolicyNotFoundException) GoString() string {
 
 func newErrorCorsPolicyNotFoundException(v protocol.ResponseMetadata) error {
 	return &CorsPolicyNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1948,12 +1948,12 @@ func (s CorsPolicyNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CorsPolicyNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CorsPolicyNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A rule for a CORS policy. You can add up to 100 rules to a CORS policy. If
@@ -2651,7 +2651,7 @@ func (s *GetLifecyclePolicyOutput) SetLifecyclePolicy(v string) *GetLifecyclePol
 // The service is temporarily unavailable.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2668,7 +2668,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2696,18 +2696,18 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A service limit has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2724,7 +2724,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2752,12 +2752,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListContainersInput struct {
@@ -2915,7 +2915,7 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 // The policy that you specified in the request does not exist.
 type PolicyNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2932,7 +2932,7 @@ func (s PolicyNotFoundException) GoString() string {
 
 func newErrorPolicyNotFoundException(v protocol.ResponseMetadata) error {
 	return &PolicyNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2960,12 +2960,12 @@ func (s PolicyNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutContainerPolicyInput struct {

--- a/service/mediastore/api.go
+++ b/service/mediastore/api.go
@@ -1790,8 +1790,8 @@ func (s *Container) SetStatus(v string) *Container {
 // The container that you specified in the request already exists or is being
 // updated.
 type ContainerInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1846,8 +1846,8 @@ func (s ContainerInUseException) RequestID() string {
 
 // The container that you specified in the request does not exist.
 type ContainerNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1902,8 +1902,8 @@ func (s ContainerNotFoundException) RequestID() string {
 
 // The CORS policy that you specified in the request does not exist.
 type CorsPolicyNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2650,8 +2650,8 @@ func (s *GetLifecyclePolicyOutput) SetLifecyclePolicy(v string) *GetLifecyclePol
 
 // The service is temporarily unavailable.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2706,8 +2706,8 @@ func (s InternalServerError) RequestID() string {
 
 // A service limit has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2914,8 +2914,8 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 
 // The policy that you specified in the request does not exist.
 type PolicyNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/mediastoredata/api.go
+++ b/service/mediastoredata/api.go
@@ -505,8 +505,8 @@ func (c *MediaStoreData) PutObjectWithContext(ctx aws.Context, input *PutObjectI
 
 // The specified container was not found for the specified account.
 type ContainerNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -892,8 +892,8 @@ func (s *GetObjectOutput) SetStatusCode(v int64) *GetObjectOutput {
 
 // The service is temporarily unavailable.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1122,8 +1122,8 @@ func (s *ListItemsOutput) SetNextToken(v string) *ListItemsOutput {
 
 // Could not perform an operation on an object that does not exist.
 type ObjectNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1356,8 +1356,8 @@ func (s *PutObjectOutput) SetStorageClass(v string) *PutObjectOutput {
 
 // The requested content range is not valid.
 type RequestedRangeNotSatisfiableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/mediastoredata/api.go
+++ b/service/mediastoredata/api.go
@@ -506,7 +506,7 @@ func (c *MediaStoreData) PutObjectWithContext(ctx aws.Context, input *PutObjectI
 // The specified container was not found for the specified account.
 type ContainerNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -523,7 +523,7 @@ func (s ContainerNotFoundException) GoString() string {
 
 func newErrorContainerNotFoundException(v protocol.ResponseMetadata) error {
 	return &ContainerNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -551,12 +551,12 @@ func (s ContainerNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ContainerNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ContainerNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteObjectInput struct {
@@ -893,7 +893,7 @@ func (s *GetObjectOutput) SetStatusCode(v int64) *GetObjectOutput {
 // The service is temporarily unavailable.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -910,7 +910,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -938,12 +938,12 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A metadata entry for a folder or object.
@@ -1123,7 +1123,7 @@ func (s *ListItemsOutput) SetNextToken(v string) *ListItemsOutput {
 // Could not perform an operation on an object that does not exist.
 type ObjectNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1140,7 +1140,7 @@ func (s ObjectNotFoundException) GoString() string {
 
 func newErrorObjectNotFoundException(v protocol.ResponseMetadata) error {
 	return &ObjectNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1168,12 +1168,12 @@ func (s ObjectNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ObjectNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ObjectNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutObjectInput struct {
@@ -1357,7 +1357,7 @@ func (s *PutObjectOutput) SetStorageClass(v string) *PutObjectOutput {
 // The requested content range is not valid.
 type RequestedRangeNotSatisfiableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1374,7 +1374,7 @@ func (s RequestedRangeNotSatisfiableException) GoString() string {
 
 func newErrorRequestedRangeNotSatisfiableException(v protocol.ResponseMetadata) error {
 	return &RequestedRangeNotSatisfiableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1402,12 +1402,12 @@ func (s RequestedRangeNotSatisfiableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestedRangeNotSatisfiableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestedRangeNotSatisfiableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/mediatailor/api.go
+++ b/service/mediatailor/api.go
@@ -557,8 +557,8 @@ func (c *MediaTailor) UntagResourceWithContext(ctx aws.Context, input *UntagReso
 
 // One of the parameters in the request is invalid.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// One of the parameters in the request is invalid.
 	Message_ *string `locationName:"Message" type:"string"`

--- a/service/mediatailor/api.go
+++ b/service/mediatailor/api.go
@@ -558,7 +558,7 @@ func (c *MediaTailor) UntagResourceWithContext(ctx aws.Context, input *UntagReso
 // One of the parameters in the request is invalid.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// One of the parameters in the request is invalid.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -576,7 +576,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -604,12 +604,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The configuration for using a content delivery network (CDN), like Amazon

--- a/service/migrationhub/api.go
+++ b/service/migrationhub/api.go
@@ -2201,7 +2201,7 @@ func (c *MigrationHub) PutResourceAttributesWithContext(ctx aws.Context, input *
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2218,7 +2218,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2246,12 +2246,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The state of an application discovered through Migration Hub import, the
@@ -3102,7 +3102,7 @@ func (s *DiscoveredResource) SetDescription(v string) *DiscoveredResource {
 // flag is set to "true".
 type DryRunOperation struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3119,7 +3119,7 @@ func (s DryRunOperation) GoString() string {
 
 func newErrorDryRunOperation(v protocol.ResponseMetadata) error {
 	return &DryRunOperation{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3147,18 +3147,18 @@ func (s DryRunOperation) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DryRunOperation) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DryRunOperation) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The home region is not set. Set the home region to continue.
 type HomeRegionNotSetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3175,7 +3175,7 @@ func (s HomeRegionNotSetException) GoString() string {
 
 func newErrorHomeRegionNotSetException(v protocol.ResponseMetadata) error {
 	return &HomeRegionNotSetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3203,12 +3203,12 @@ func (s HomeRegionNotSetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s HomeRegionNotSetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s HomeRegionNotSetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ImportMigrationTaskInput struct {
@@ -3298,7 +3298,7 @@ func (s ImportMigrationTaskOutput) GoString() string {
 // encountered.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3315,7 +3315,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3343,19 +3343,19 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception raised when the provided input violates a policy constraint or
 // is entered in the wrong format or data type.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3372,7 +3372,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3400,12 +3400,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListApplicationStatesInput struct {
@@ -4266,7 +4266,7 @@ func (s NotifyMigrationTaskStateOutput) GoString() string {
 // policy or the migrationhub-discovery role is missing or not configured correctly.
 type PolicyErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4283,7 +4283,7 @@ func (s PolicyErrorException) GoString() string {
 
 func newErrorPolicyErrorException(v protocol.ResponseMetadata) error {
 	return &PolicyErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4311,12 +4311,12 @@ func (s PolicyErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Summary of the AWS resource used for access control that is implicitly linked
@@ -4557,7 +4557,7 @@ func (s *ResourceAttribute) SetValue(v string) *ResourceAttribute {
 // in Migration Hub's repository.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4574,7 +4574,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4602,19 +4602,19 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception raised when there is an internal, configuration, or dependency
 // error encountered.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4631,7 +4631,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4659,12 +4659,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Task object encapsulating task information.
@@ -4730,7 +4730,7 @@ func (s *Task) SetStatusDetail(v string) *Task {
 // flag is set to "true".
 type UnauthorizedOperation struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4747,7 +4747,7 @@ func (s UnauthorizedOperation) GoString() string {
 
 func newErrorUnauthorizedOperation(v protocol.ResponseMetadata) error {
 	return &UnauthorizedOperation{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4775,12 +4775,12 @@ func (s UnauthorizedOperation) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedOperation) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedOperation) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/migrationhub/api.go
+++ b/service/migrationhub/api.go
@@ -2200,8 +2200,8 @@ func (c *MigrationHub) PutResourceAttributesWithContext(ctx aws.Context, input *
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3101,8 +3101,8 @@ func (s *DiscoveredResource) SetDescription(v string) *DiscoveredResource {
 // Exception raised to indicate a successfully authorized action when the DryRun
 // flag is set to "true".
 type DryRunOperation struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3157,8 +3157,8 @@ func (s DryRunOperation) RequestID() string {
 
 // The home region is not set. Set the home region to continue.
 type HomeRegionNotSetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3297,8 +3297,8 @@ func (s ImportMigrationTaskOutput) GoString() string {
 // Exception raised when an internal, configuration, or dependency error is
 // encountered.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3354,8 +3354,8 @@ func (s InternalServerError) RequestID() string {
 // Exception raised when the provided input violates a policy constraint or
 // is entered in the wrong format or data type.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4265,8 +4265,8 @@ func (s NotifyMigrationTaskStateOutput) GoString() string {
 // Service (Application Discovery Service); most likely due to a misconfigured
 // policy or the migrationhub-discovery role is missing or not configured correctly.
 type PolicyErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4556,8 +4556,8 @@ func (s *ResourceAttribute) SetValue(v string) *ResourceAttribute {
 // exist in Application Discovery Service (Application Discovery Service) or
 // in Migration Hub's repository.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4613,8 +4613,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // Exception raised when there is an internal, configuration, or dependency
 // error encountered.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4729,8 +4729,8 @@ func (s *Task) SetStatusDetail(v string) *Task {
 // Exception raised to indicate a request was not authorized when the DryRun
 // flag is set to "true".
 type UnauthorizedOperation struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/migrationhubconfig/api.go
+++ b/service/migrationhubconfig/api.go
@@ -354,8 +354,8 @@ func (c *MigrationHubConfig) GetHomeRegionWithContext(ctx aws.Context, input *Ge
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -627,8 +627,8 @@ func (s *DescribeHomeRegionControlsOutput) SetNextToken(v string) *DescribeHomeR
 // Exception raised to indicate that authorization of an action was successful,
 // when the DryRun flag is set to true.
 type DryRunOperation struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -779,8 +779,8 @@ func (s *HomeRegionControl) SetTarget(v *Target) *HomeRegionControl {
 // Exception raised when an internal, configuration, or dependency error is
 // encountered.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -836,8 +836,8 @@ func (s InternalServerError) RequestID() string {
 // Exception raised when the provided input violates a policy constraint or
 // is entered in the wrong format or data type.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -893,8 +893,8 @@ func (s InvalidInputException) RequestID() string {
 // Exception raised when a request fails due to temporary unavailability of
 // the service.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/migrationhubconfig/api.go
+++ b/service/migrationhubconfig/api.go
@@ -355,7 +355,7 @@ func (c *MigrationHubConfig) GetHomeRegionWithContext(ctx aws.Context, input *Ge
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -372,7 +372,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -400,12 +400,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateHomeRegionControlInput struct {
@@ -628,7 +628,7 @@ func (s *DescribeHomeRegionControlsOutput) SetNextToken(v string) *DescribeHomeR
 // when the DryRun flag is set to true.
 type DryRunOperation struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -645,7 +645,7 @@ func (s DryRunOperation) GoString() string {
 
 func newErrorDryRunOperation(v protocol.ResponseMetadata) error {
 	return &DryRunOperation{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -673,12 +673,12 @@ func (s DryRunOperation) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DryRunOperation) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DryRunOperation) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetHomeRegionInput struct {
@@ -780,7 +780,7 @@ func (s *HomeRegionControl) SetTarget(v *Target) *HomeRegionControl {
 // encountered.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -797,7 +797,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -825,19 +825,19 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception raised when the provided input violates a policy constraint or
 // is entered in the wrong format or data type.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -854,7 +854,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -882,19 +882,19 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception raised when a request fails due to temporary unavailability of
 // the service.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -911,7 +911,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -939,12 +939,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The target parameter specifies the identifier to which the home region is

--- a/service/mobile/api.go
+++ b/service/mobile/api.go
@@ -1020,8 +1020,8 @@ func (c *Mobile) UpdateProjectWithContext(ctx aws.Context, input *UpdateProjectI
 
 // Account Action is required in order to continue the request.
 type AccountActionRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1078,8 +1078,8 @@ func (s AccountActionRequiredException) RequestID() string {
 // The request cannot be processed because some parameter is not valid or the
 // project state prevents the operation from being performed.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1678,8 +1678,8 @@ func (s *ExportProjectOutput) SetSnapshotId(v string) *ExportProjectOutput {
 // The service has encountered an unexpected error condition which prevents
 // it from servicing the request.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1738,8 +1738,8 @@ func (s InternalFailureException) RequestID() string {
 // create another sub-account using AWS Organizations or remove some resources
 // and retry your request.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1937,8 +1937,8 @@ func (s *ListProjectsOutput) SetProjects(v []*ProjectSummary) *ListProjectsOutpu
 
 // No entity can be found with the specified identifier.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2176,8 +2176,8 @@ func (s *Resource) SetType(v string) *Resource {
 // The service is temporarily unavailable. The request should be retried after
 // some time delay.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2237,8 +2237,8 @@ func (s ServiceUnavailableException) RequestID() string {
 // Too many requests have been received for this AWS account in too short a
 // time. The request should be retried after some time delay.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2297,8 +2297,8 @@ func (s TooManyRequestsException) RequestID() string {
 
 // Credentials of the caller are insufficient to authorize the request.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/mobile/api.go
+++ b/service/mobile/api.go
@@ -1021,7 +1021,7 @@ func (c *Mobile) UpdateProjectWithContext(ctx aws.Context, input *UpdateProjectI
 // Account Action is required in order to continue the request.
 type AccountActionRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1039,7 +1039,7 @@ func (s AccountActionRequiredException) GoString() string {
 
 func newErrorAccountActionRequiredException(v protocol.ResponseMetadata) error {
 	return &AccountActionRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1067,19 +1067,19 @@ func (s AccountActionRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccountActionRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccountActionRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request cannot be processed because some parameter is not valid or the
 // project state prevents the operation from being performed.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1097,7 +1097,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1125,12 +1125,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The details of the bundle.
@@ -1679,7 +1679,7 @@ func (s *ExportProjectOutput) SetSnapshotId(v string) *ExportProjectOutput {
 // it from servicing the request.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1697,7 +1697,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1725,12 +1725,12 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There are too many AWS Mobile Hub projects in the account or the account
@@ -1739,7 +1739,7 @@ func (s InternalFailureException) RequestID() string {
 // and retry your request.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1760,7 +1760,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1788,12 +1788,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Request structure to request all available bundles.
@@ -1938,7 +1938,7 @@ func (s *ListProjectsOutput) SetProjects(v []*ProjectSummary) *ListProjectsOutpu
 // No entity can be found with the specified identifier.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1956,7 +1956,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1984,12 +1984,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Detailed information about an AWS Mobile Hub project.
@@ -2177,7 +2177,7 @@ func (s *Resource) SetType(v string) *Resource {
 // some time delay.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2198,7 +2198,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2226,19 +2226,19 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Too many requests have been received for this AWS account in too short a
 // time. The request should be retried after some time delay.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2259,7 +2259,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2287,18 +2287,18 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Credentials of the caller are insufficient to authorize the request.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Exception Error Message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2316,7 +2316,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2344,12 +2344,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Request structure used for requests to update project configuration.

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -93,8 +93,8 @@ func (c *MobileAnalytics) PutEventsWithContext(ctx aws.Context, input *PutEvents
 
 // An exception object returned when a request fails.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A text description associated with the BadRequestException object.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -94,7 +94,7 @@ func (c *MobileAnalytics) PutEventsWithContext(ctx aws.Context, input *PutEvents
 // An exception object returned when a request fails.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A text description associated with the BadRequestException object.
 	Message_ *string `locationName:"message" type:"string"`
@@ -112,7 +112,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -140,12 +140,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A JSON object representing a batch of unique event occurrences in your app.

--- a/service/mq/api.go
+++ b/service/mq/api.go
@@ -1985,8 +1985,8 @@ func (s *AvailabilityZone) SetName(v string) *AvailabilityZone {
 
 // Returns information about an error.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -2485,8 +2485,8 @@ func (s *Configurations) SetPending(v *ConfigurationId) *Configurations {
 
 // Returns information about an error.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -4055,8 +4055,8 @@ func (s *EngineVersion) SetName(v string) *EngineVersion {
 
 // Returns information about an error.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -4113,8 +4113,8 @@ func (s ForbiddenException) RequestID() string {
 
 // Returns information about an error.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -4691,8 +4691,8 @@ func (s *LogsSummary) SetPending(v *PendingLogs) *LogsSummary {
 
 // Returns information about an error.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -4879,8 +4879,8 @@ func (s *SanitizationWarning) SetReason(v string) *SanitizationWarning {
 
 // Returns information about an error.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 

--- a/service/mq/api.go
+++ b/service/mq/api.go
@@ -1986,7 +1986,7 @@ func (s *AvailabilityZone) SetName(v string) *AvailabilityZone {
 // Returns information about an error.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -2005,7 +2005,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2033,12 +2033,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Types of broker engines.
@@ -2486,7 +2486,7 @@ func (s *Configurations) SetPending(v *ConfigurationId) *Configurations {
 // Returns information about an error.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -2505,7 +2505,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2533,12 +2533,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateBrokerRequest struct {
@@ -4056,7 +4056,7 @@ func (s *EngineVersion) SetName(v string) *EngineVersion {
 // Returns information about an error.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -4075,7 +4075,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4103,18 +4103,18 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returns information about an error.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -4133,7 +4133,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4161,12 +4161,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListBrokersInput struct {
@@ -4692,7 +4692,7 @@ func (s *LogsSummary) SetPending(v *PendingLogs) *LogsSummary {
 // Returns information about an error.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -4711,7 +4711,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4739,12 +4739,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The list of information about logs to be enabled for the specified broker.
@@ -4880,7 +4880,7 @@ func (s *SanitizationWarning) SetReason(v string) *SanitizationWarning {
 // Returns information about an error.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	ErrorAttribute *string `locationName:"errorAttribute" type:"string"`
 
@@ -4899,7 +4899,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4927,12 +4927,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateBrokerRequest struct {

--- a/service/mturk/api.go
+++ b/service/mturk/api.go
@@ -8636,8 +8636,8 @@ func (s RejectQualificationRequestOutput) GoString() string {
 
 // Your request is invalid.
 type RequestError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9142,8 +9142,8 @@ func (s SendTestEventNotificationOutput) GoString() string {
 // Amazon Mechanical Turk is temporarily unable to process your request. Try
 // your call again.
 type ServiceFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 

--- a/service/mturk/api.go
+++ b/service/mturk/api.go
@@ -8637,7 +8637,7 @@ func (s RejectQualificationRequestOutput) GoString() string {
 // Your request is invalid.
 type RequestError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -8656,7 +8656,7 @@ func (s RequestError) GoString() string {
 
 func newErrorRequestError(v protocol.ResponseMetadata) error {
 	return &RequestError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8684,12 +8684,12 @@ func (s RequestError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Both the AssignmentReviewReport and the HITReviewReport elements contains
@@ -9143,7 +9143,7 @@ func (s SendTestEventNotificationOutput) GoString() string {
 // your call again.
 type ServiceFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -9162,7 +9162,7 @@ func (s ServiceFault) GoString() string {
 
 func newErrorServiceFault(v protocol.ResponseMetadata) error {
 	return &ServiceFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9190,12 +9190,12 @@ func (s ServiceFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateExpirationForHITInput struct {

--- a/service/networkmanager/api.go
+++ b/service/networkmanager/api.go
@@ -3115,7 +3115,7 @@ func (c *NetworkManager) UpdateSiteWithContext(ctx aws.Context, input *UpdateSit
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3132,7 +3132,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3160,12 +3160,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AssociateCustomerGatewayInput struct {
@@ -3399,7 +3399,7 @@ func (s *Bandwidth) SetUploadSpeed(v int64) *Bandwidth {
 // can cause an inconsistent state.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3426,7 +3426,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3454,12 +3454,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateDeviceInput struct {
@@ -5480,7 +5480,7 @@ func (s *GlobalNetwork) SetTags(v []*Tag) *GlobalNetwork {
 // The request has failed due to an internal error.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5500,7 +5500,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5528,12 +5528,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a link.
@@ -5889,7 +5889,7 @@ func (s *RegisterTransitGatewayOutput) SetTransitGatewayRegistration(v *TransitG
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5916,7 +5916,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5944,18 +5944,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A service limit was exceeded.
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The limit code.
 	//
@@ -5989,7 +5989,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6017,12 +6017,12 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a site.
@@ -6221,7 +6221,7 @@ func (s TagResourceOutput) GoString() string {
 // The request was denied due to request throttling.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -6241,7 +6241,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6269,12 +6269,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the registration of a transit gateway to a global network.
@@ -6881,7 +6881,7 @@ func (s *UpdateSiteOutput) SetSite(v *Site) *UpdateSiteOutput {
 // The input fails to satisfy the constraints.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The fields that caused the error, if applicable.
 	Fields []*ValidationExceptionField `type:"list"`
@@ -6904,7 +6904,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6932,12 +6932,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a validation exception for a field.

--- a/service/networkmanager/api.go
+++ b/service/networkmanager/api.go
@@ -3114,8 +3114,8 @@ func (c *NetworkManager) UpdateSiteWithContext(ctx aws.Context, input *UpdateSit
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3398,8 +3398,8 @@ func (s *Bandwidth) SetUploadSpeed(v int64) *Bandwidth {
 // There was a conflict processing the request. Updating or deleting the resource
 // can cause an inconsistent state.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5479,8 +5479,8 @@ func (s *GlobalNetwork) SetTags(v []*Tag) *GlobalNetwork {
 
 // The request has failed due to an internal error.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5888,8 +5888,8 @@ func (s *RegisterTransitGatewayOutput) SetTransitGatewayRegistration(v *TransitG
 
 // The specified resource could not be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5954,8 +5954,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // A service limit was exceeded.
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The limit code.
 	//
@@ -6220,8 +6220,8 @@ func (s TagResourceOutput) GoString() string {
 
 // The request was denied due to request throttling.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -6880,8 +6880,8 @@ func (s *UpdateSiteOutput) SetSite(v *Site) *UpdateSiteOutput {
 
 // The input fails to satisfy the constraints.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The fields that caused the error, if applicable.
 	Fields []*ValidationExceptionField `type:"list"`

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -14324,8 +14324,8 @@ func (s *ReportedOs) SetVersion(v string) *ReportedOs {
 
 // Indicates that a resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -17172,8 +17172,8 @@ func (s *UserProfile) SetSshUsername(v string) *UserProfile {
 
 // Indicates that a request was not valid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -14325,7 +14325,7 @@ func (s *ReportedOs) SetVersion(v string) *ReportedOs {
 // Indicates that a resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14343,7 +14343,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14371,12 +14371,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a user's SSH information.
@@ -17173,7 +17173,7 @@ func (s *UserProfile) SetSshUsername(v string) *UserProfile {
 // Indicates that a request was not valid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -17191,7 +17191,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17219,12 +17219,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes an instance's Amazon EBS volume.

--- a/service/opsworkscm/api.go
+++ b/service/opsworkscm/api.go
@@ -3502,7 +3502,7 @@ func (s *ExportServerEngineAttributeOutput) SetServerName(v string) *ExportServe
 // This occurs when the provided nextToken is not valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Error or informational message that can contain more detail about a nextToken
 	// failure.
@@ -3521,7 +3521,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3549,19 +3549,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource is in a state that does not allow you to perform a specified
 // action.
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Error or informational message that provides more detail if a resource is
 	// in a state that is not valid for performing a specified action.
@@ -3580,7 +3580,7 @@ func (s InvalidStateException) GoString() string {
 
 func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 	return &InvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3608,18 +3608,18 @@ func (s InvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The limit of servers or backups has been reached.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Error or informational message that the maximum allowed number of servers
 	// or backups has been exceeded.
@@ -3638,7 +3638,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3666,12 +3666,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTagsForResourceInput struct {
@@ -3782,7 +3782,7 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 // The requested resource cannot be created because it already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Error or informational message in response to a CreateServer request that
 	// a resource cannot be created because it already exists.
@@ -3801,7 +3801,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3829,18 +3829,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested resource does not exist, or access was denied.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Error or informational message that can contain more detail about problems
 	// locating or accessing a resource.
@@ -3859,7 +3859,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3887,12 +3887,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RestoreServerInput struct {
@@ -4814,7 +4814,7 @@ func (s *UpdateServerOutput) SetServer(v *Server) *UpdateServerOutput {
 // One or more of the provided request parameters are not valid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Error or informational message that can contain more detail about a validation
 	// failure.
@@ -4833,7 +4833,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4861,12 +4861,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/opsworkscm/api.go
+++ b/service/opsworkscm/api.go
@@ -3501,8 +3501,8 @@ func (s *ExportServerEngineAttributeOutput) SetServerName(v string) *ExportServe
 
 // This occurs when the provided nextToken is not valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Error or informational message that can contain more detail about a nextToken
 	// failure.
@@ -3560,8 +3560,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // The resource is in a state that does not allow you to perform a specified
 // action.
 type InvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Error or informational message that provides more detail if a resource is
 	// in a state that is not valid for performing a specified action.
@@ -3618,8 +3618,8 @@ func (s InvalidStateException) RequestID() string {
 
 // The limit of servers or backups has been reached.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Error or informational message that the maximum allowed number of servers
 	// or backups has been exceeded.
@@ -3781,8 +3781,8 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 
 // The requested resource cannot be created because it already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Error or informational message in response to a CreateServer request that
 	// a resource cannot be created because it already exists.
@@ -3839,8 +3839,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The requested resource does not exist, or access was denied.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Error or informational message that can contain more detail about problems
 	// locating or accessing a resource.
@@ -4813,8 +4813,8 @@ func (s *UpdateServerOutput) SetServer(v *Server) *UpdateServerOutput {
 
 // One or more of the provided request parameters are not valid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Error or informational message that can contain more detail about a validation
 	// failure.

--- a/service/organizations/api.go
+++ b/service/organizations/api.go
@@ -11553,7 +11553,7 @@ func (c *Organizations) UpdatePolicyWithContext(ctx aws.Context, input *UpdatePo
 // must use the credentials of an account that belongs to an organization.
 type AWSOrganizationsNotInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11570,7 +11570,7 @@ func (s AWSOrganizationsNotInUseException) GoString() string {
 
 func newErrorAWSOrganizationsNotInUseException(v protocol.ResponseMetadata) error {
 	return &AWSOrganizationsNotInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11598,12 +11598,12 @@ func (s AWSOrganizationsNotInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AWSOrganizationsNotInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AWSOrganizationsNotInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AcceptHandshakeInput struct {
@@ -11677,7 +11677,7 @@ func (s *AcceptHandshakeOutput) SetHandshake(v *Handshake) *AcceptHandshakeOutpu
 // in the IAM User Guide.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11694,7 +11694,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11722,12 +11722,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation that you attempted requires you to have the iam:CreateServiceLinkedRole
@@ -11735,7 +11735,7 @@ func (s AccessDeniedException) RequestID() string {
 // create the required service-linked role. You don't have that permission.
 type AccessDeniedForDependencyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -11754,7 +11754,7 @@ func (s AccessDeniedForDependencyException) GoString() string {
 
 func newErrorAccessDeniedForDependencyException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedForDependencyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11782,12 +11782,12 @@ func (s AccessDeniedForDependencyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedForDependencyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedForDependencyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about an AWS account that is a member of an organization.
@@ -11887,7 +11887,7 @@ func (s *Account) SetStatus(v string) *Account {
 // an organization.
 type AccountNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11904,7 +11904,7 @@ func (s AccountNotFoundException) GoString() string {
 
 func newErrorAccountNotFoundException(v protocol.ResponseMetadata) error {
 	return &AccountNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11932,12 +11932,12 @@ func (s AccountNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccountNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccountNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You can't invite an existing account to your organization until you verify
@@ -11946,7 +11946,7 @@ func (s AccountNotFoundException) RequestID() string {
 // in the AWS Organizations User Guide.
 type AccountOwnerNotVerifiedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11963,7 +11963,7 @@ func (s AccountOwnerNotVerifiedException) GoString() string {
 
 func newErrorAccountOwnerNotVerifiedException(v protocol.ResponseMetadata) error {
 	return &AccountOwnerNotVerifiedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11991,19 +11991,19 @@ func (s AccountOwnerNotVerifiedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccountOwnerNotVerifiedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccountOwnerNotVerifiedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This account is already a member of an organization. An account can belong
 // to only one organization at a time.
 type AlreadyInOrganizationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12020,7 +12020,7 @@ func (s AlreadyInOrganizationException) GoString() string {
 
 func newErrorAlreadyInOrganizationException(v protocol.ResponseMetadata) error {
 	return &AlreadyInOrganizationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12048,12 +12048,12 @@ func (s AlreadyInOrganizationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyInOrganizationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyInOrganizationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AttachPolicyInput struct {
@@ -12254,7 +12254,7 @@ func (s *Child) SetType(v string) *Child {
 // that you specified.
 type ChildNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12271,7 +12271,7 @@ func (s ChildNotFoundException) GoString() string {
 
 func newErrorChildNotFoundException(v protocol.ResponseMetadata) error {
 	return &ChildNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12299,19 +12299,19 @@ func (s ChildNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ChildNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ChildNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The target of the operation is currently being modified by a different request.
 // Try again later.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12328,7 +12328,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12356,12 +12356,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Performing this operation violates a minimum or maximum value limit. Examples
@@ -12466,7 +12466,7 @@ func (s ConcurrentModificationException) RequestID() string {
 //    in the AWS Organizations User Guide.
 type ConstraintViolationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12485,7 +12485,7 @@ func (s ConstraintViolationException) GoString() string {
 
 func newErrorConstraintViolationException(v protocol.ResponseMetadata) error {
 	return &ConstraintViolationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12513,12 +12513,12 @@ func (s ConstraintViolationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConstraintViolationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConstraintViolationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateAccountInput struct {
@@ -12780,7 +12780,7 @@ func (s *CreateAccountStatus) SetState(v string) *CreateAccountStatus {
 // you specified.
 type CreateAccountStatusNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12797,7 +12797,7 @@ func (s CreateAccountStatusNotFoundException) GoString() string {
 
 func newErrorCreateAccountStatusNotFoundException(v protocol.ResponseMetadata) error {
 	return &CreateAccountStatusNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12825,12 +12825,12 @@ func (s CreateAccountStatusNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CreateAccountStatusNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CreateAccountStatusNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateGovCloudAccountInput struct {
@@ -13889,7 +13889,7 @@ func (s *DescribePolicyOutput) SetPolicy(v *Policy) *DescribePolicyOutput {
 // that you specified.
 type DestinationParentNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -13906,7 +13906,7 @@ func (s DestinationParentNotFoundException) GoString() string {
 
 func newErrorDestinationParentNotFoundException(v protocol.ResponseMetadata) error {
 	return &DestinationParentNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13934,12 +13934,12 @@ func (s DestinationParentNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DestinationParentNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DestinationParentNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DetachPolicyInput struct {
@@ -14167,7 +14167,7 @@ func (s *DisablePolicyTypeOutput) SetRoot(v *Root) *DisablePolicyTypeOutput {
 // That account is already present in the specified destination.
 type DuplicateAccountException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14184,7 +14184,7 @@ func (s DuplicateAccountException) GoString() string {
 
 func newErrorDuplicateAccountException(v protocol.ResponseMetadata) error {
 	return &DuplicateAccountException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14212,12 +14212,12 @@ func (s DuplicateAccountException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateAccountException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateAccountException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A handshake with the same action and target already exists. For example,
@@ -14227,7 +14227,7 @@ func (s DuplicateAccountException) RequestID() string {
 // might be considered duplicates are canceled or declined.
 type DuplicateHandshakeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14244,7 +14244,7 @@ func (s DuplicateHandshakeException) GoString() string {
 
 func newErrorDuplicateHandshakeException(v protocol.ResponseMetadata) error {
 	return &DuplicateHandshakeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14272,18 +14272,18 @@ func (s DuplicateHandshakeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateHandshakeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateHandshakeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An OU with the same name already exists.
 type DuplicateOrganizationalUnitException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14300,7 +14300,7 @@ func (s DuplicateOrganizationalUnitException) GoString() string {
 
 func newErrorDuplicateOrganizationalUnitException(v protocol.ResponseMetadata) error {
 	return &DuplicateOrganizationalUnitException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14328,18 +14328,18 @@ func (s DuplicateOrganizationalUnitException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateOrganizationalUnitException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateOrganizationalUnitException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The selected policy is already attached to the specified target.
 type DuplicatePolicyAttachmentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14356,7 +14356,7 @@ func (s DuplicatePolicyAttachmentException) GoString() string {
 
 func newErrorDuplicatePolicyAttachmentException(v protocol.ResponseMetadata) error {
 	return &DuplicatePolicyAttachmentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14384,18 +14384,18 @@ func (s DuplicatePolicyAttachmentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicatePolicyAttachmentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicatePolicyAttachmentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A policy with the same name already exists.
 type DuplicatePolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14412,7 +14412,7 @@ func (s DuplicatePolicyException) GoString() string {
 
 func newErrorDuplicatePolicyException(v protocol.ResponseMetadata) error {
 	return &DuplicatePolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14440,12 +14440,12 @@ func (s DuplicatePolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicatePolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicatePolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains rules to be applied to the affected accounts. The effective policy
@@ -14507,7 +14507,7 @@ func (s *EffectivePolicy) SetTargetId(v string) *EffectivePolicy {
 // attaching a policy of this type to the account.
 type EffectivePolicyNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14524,7 +14524,7 @@ func (s EffectivePolicyNotFoundException) GoString() string {
 
 func newErrorEffectivePolicyNotFoundException(v protocol.ResponseMetadata) error {
 	return &EffectivePolicyNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14552,12 +14552,12 @@ func (s EffectivePolicyNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EffectivePolicyNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EffectivePolicyNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type EnableAWSServiceAccessInput struct {
@@ -14776,7 +14776,7 @@ func (s *EnabledServicePrincipal) SetServicePrincipal(v string) *EnabledServiceP
 // (https://console.aws.amazon.com/support/home#/).
 type FinalizingOrganizationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14793,7 +14793,7 @@ func (s FinalizingOrganizationException) GoString() string {
 
 func newErrorFinalizingOrganizationException(v protocol.ResponseMetadata) error {
 	return &FinalizingOrganizationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14821,12 +14821,12 @@ func (s FinalizingOrganizationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FinalizingOrganizationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FinalizingOrganizationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information that must be exchanged to securely establish a relationship
@@ -14975,7 +14975,7 @@ func (s *Handshake) SetState(v string) *Handshake {
 // can't accept a handshake that was already accepted.
 type HandshakeAlreadyInStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14992,7 +14992,7 @@ func (s HandshakeAlreadyInStateException) GoString() string {
 
 func newErrorHandshakeAlreadyInStateException(v protocol.ResponseMetadata) error {
 	return &HandshakeAlreadyInStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15020,12 +15020,12 @@ func (s HandshakeAlreadyInStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s HandshakeAlreadyInStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s HandshakeAlreadyInStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested operation would violate the constraint identified in the reason
@@ -15068,7 +15068,7 @@ func (s HandshakeAlreadyInStateException) RequestID() string {
 //    associated with it.
 type HandshakeConstraintViolationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15087,7 +15087,7 @@ func (s HandshakeConstraintViolationException) GoString() string {
 
 func newErrorHandshakeConstraintViolationException(v protocol.ResponseMetadata) error {
 	return &HandshakeConstraintViolationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15115,12 +15115,12 @@ func (s HandshakeConstraintViolationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s HandshakeConstraintViolationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s HandshakeConstraintViolationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the criteria that are used to select the handshakes for the operation.
@@ -15167,7 +15167,7 @@ func (s *HandshakeFilter) SetParentHandshakeId(v string) *HandshakeFilter {
 // We can't find a handshake with the HandshakeId that you specified.
 type HandshakeNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15184,7 +15184,7 @@ func (s HandshakeNotFoundException) GoString() string {
 
 func newErrorHandshakeNotFoundException(v protocol.ResponseMetadata) error {
 	return &HandshakeNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15212,12 +15212,12 @@ func (s HandshakeNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s HandshakeNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s HandshakeNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Identifies a participant in a handshake.
@@ -15344,7 +15344,7 @@ func (s *HandshakeResource) SetValue(v string) *HandshakeResource {
 // a handshake that was already declined.
 type InvalidHandshakeTransitionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15361,7 +15361,7 @@ func (s InvalidHandshakeTransitionException) GoString() string {
 
 func newErrorInvalidHandshakeTransitionException(v protocol.ResponseMetadata) error {
 	return &InvalidHandshakeTransitionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15389,12 +15389,12 @@ func (s InvalidHandshakeTransitionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidHandshakeTransitionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidHandshakeTransitionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested operation failed because you provided invalid values for one
@@ -15463,7 +15463,7 @@ func (s InvalidHandshakeTransitionException) RequestID() string {
 //    between entities in the same root.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15482,7 +15482,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15510,12 +15510,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InviteAccountToOrganizationInput struct {
@@ -17152,7 +17152,7 @@ func (s *ListTargetsForPolicyOutput) SetTargets(v []*PolicyTargetSummary) *ListT
 // in the AWS Organizations User Guide.
 type MalformedPolicyDocumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17169,7 +17169,7 @@ func (s MalformedPolicyDocumentException) GoString() string {
 
 func newErrorMalformedPolicyDocumentException(v protocol.ResponseMetadata) error {
 	return &MalformedPolicyDocumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17197,12 +17197,12 @@ func (s MalformedPolicyDocumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MalformedPolicyDocumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MalformedPolicyDocumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You can't remove a master account from an organization. If you want the master
@@ -17210,7 +17210,7 @@ func (s MalformedPolicyDocumentException) RequestID() string {
 // delete the current organization of the master account.
 type MasterCannotLeaveOrganizationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17227,7 +17227,7 @@ func (s MasterCannotLeaveOrganizationException) GoString() string {
 
 func newErrorMasterCannotLeaveOrganizationException(v protocol.ResponseMetadata) error {
 	return &MasterCannotLeaveOrganizationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17255,12 +17255,12 @@ func (s MasterCannotLeaveOrganizationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MasterCannotLeaveOrganizationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MasterCannotLeaveOrganizationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type MoveAccountInput struct {
@@ -17483,7 +17483,7 @@ func (s *Organization) SetMasterAccountId(v string) *Organization {
 // all accounts except the master account, delete all OUs, and delete all policies.
 type OrganizationNotEmptyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17500,7 +17500,7 @@ func (s OrganizationNotEmptyException) GoString() string {
 
 func newErrorOrganizationNotEmptyException(v protocol.ResponseMetadata) error {
 	return &OrganizationNotEmptyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17528,12 +17528,12 @@ func (s OrganizationNotEmptyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationNotEmptyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationNotEmptyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about an organizational unit (OU). An OU is a container
@@ -17597,7 +17597,7 @@ func (s *OrganizationalUnit) SetName(v string) *OrganizationalUnit {
 // OUs, remove all child OUs, and try the operation again.
 type OrganizationalUnitNotEmptyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17614,7 +17614,7 @@ func (s OrganizationalUnitNotEmptyException) GoString() string {
 
 func newErrorOrganizationalUnitNotEmptyException(v protocol.ResponseMetadata) error {
 	return &OrganizationalUnitNotEmptyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17642,18 +17642,18 @@ func (s OrganizationalUnitNotEmptyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationalUnitNotEmptyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationalUnitNotEmptyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // We can't find an OU with the OrganizationalUnitId that you specified.
 type OrganizationalUnitNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17670,7 +17670,7 @@ func (s OrganizationalUnitNotFoundException) GoString() string {
 
 func newErrorOrganizationalUnitNotFoundException(v protocol.ResponseMetadata) error {
 	return &OrganizationalUnitNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17698,12 +17698,12 @@ func (s OrganizationalUnitNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationalUnitNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationalUnitNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about either a root or an organizational unit (OU) that
@@ -17754,7 +17754,7 @@ func (s *Parent) SetType(v string) *Parent {
 // We can't find a root or OU with the ParentId that you specified.
 type ParentNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17771,7 +17771,7 @@ func (s ParentNotFoundException) GoString() string {
 
 func newErrorParentNotFoundException(v protocol.ResponseMetadata) error {
 	return &ParentNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17799,12 +17799,12 @@ func (s ParentNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParentNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParentNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains rules to be applied to the affected accounts. Policies can be attached
@@ -17846,7 +17846,7 @@ func (s *Policy) SetPolicySummary(v *PolicySummary) *Policy {
 // returned. Try the operation again later.
 type PolicyChangesInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17863,7 +17863,7 @@ func (s PolicyChangesInProgressException) GoString() string {
 
 func newErrorPolicyChangesInProgressException(v protocol.ResponseMetadata) error {
 	return &PolicyChangesInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17891,19 +17891,19 @@ func (s PolicyChangesInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyChangesInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyChangesInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The policy is attached to one or more entities. You must detach it from all
 // roots, OUs, and accounts before performing this operation.
 type PolicyInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17920,7 +17920,7 @@ func (s PolicyInUseException) GoString() string {
 
 func newErrorPolicyInUseException(v protocol.ResponseMetadata) error {
 	return &PolicyInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17948,18 +17948,18 @@ func (s PolicyInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The policy isn't attached to the specified target in the specified root.
 type PolicyNotAttachedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17976,7 +17976,7 @@ func (s PolicyNotAttachedException) GoString() string {
 
 func newErrorPolicyNotAttachedException(v protocol.ResponseMetadata) error {
 	return &PolicyNotAttachedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18004,18 +18004,18 @@ func (s PolicyNotAttachedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyNotAttachedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyNotAttachedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // We can't find a policy with the PolicyId that you specified.
 type PolicyNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18032,7 +18032,7 @@ func (s PolicyNotFoundException) GoString() string {
 
 func newErrorPolicyNotFoundException(v protocol.ResponseMetadata) error {
 	return &PolicyNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18060,12 +18060,12 @@ func (s PolicyNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a policy, but does not include the content. To
@@ -18227,7 +18227,7 @@ func (s *PolicyTargetSummary) SetType(v string) *PolicyTargetSummary {
 // The specified policy type is already enabled in the specified root.
 type PolicyTypeAlreadyEnabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18244,7 +18244,7 @@ func (s PolicyTypeAlreadyEnabledException) GoString() string {
 
 func newErrorPolicyTypeAlreadyEnabledException(v protocol.ResponseMetadata) error {
 	return &PolicyTypeAlreadyEnabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18272,12 +18272,12 @@ func (s PolicyTypeAlreadyEnabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyTypeAlreadyEnabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyTypeAlreadyEnabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You can't use the specified policy type with the feature set currently enabled
@@ -18287,7 +18287,7 @@ func (s PolicyTypeAlreadyEnabledException) RequestID() string {
 // in the AWS Organizations User Guide.
 type PolicyTypeNotAvailableForOrganizationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18304,7 +18304,7 @@ func (s PolicyTypeNotAvailableForOrganizationException) GoString() string {
 
 func newErrorPolicyTypeNotAvailableForOrganizationException(v protocol.ResponseMetadata) error {
 	return &PolicyTypeNotAvailableForOrganizationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18332,12 +18332,12 @@ func (s PolicyTypeNotAvailableForOrganizationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyTypeNotAvailableForOrganizationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyTypeNotAvailableForOrganizationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified policy type isn't currently enabled in this root. You can't
@@ -18347,7 +18347,7 @@ func (s PolicyTypeNotAvailableForOrganizationException) RequestID() string {
 // in the AWS Organizations User Guide.
 type PolicyTypeNotEnabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18364,7 +18364,7 @@ func (s PolicyTypeNotEnabledException) GoString() string {
 
 func newErrorPolicyTypeNotEnabledException(v protocol.ResponseMetadata) error {
 	return &PolicyTypeNotEnabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18392,12 +18392,12 @@ func (s PolicyTypeNotEnabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PolicyTypeNotEnabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PolicyTypeNotEnabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains information about a policy type and its status in the associated
@@ -18568,7 +18568,7 @@ func (s *Root) SetPolicyTypes(v []*PolicyTypeSummary) *Root {
 // We can't find a root with the RootId that you specified.
 type RootNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18585,7 +18585,7 @@ func (s RootNotFoundException) GoString() string {
 
 func newErrorRootNotFoundException(v protocol.ResponseMetadata) error {
 	return &RootNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18613,19 +18613,19 @@ func (s RootNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RootNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RootNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Organizations can't complete your request because of an internal service
 // error. Try again later.
 type ServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18642,7 +18642,7 @@ func (s ServiceException) GoString() string {
 
 func newErrorServiceException(v protocol.ResponseMetadata) error {
 	return &ServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18670,18 +18670,18 @@ func (s ServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // We can't find a source root or OU with the ParentId that you specified.
 type SourceParentNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18698,7 +18698,7 @@ func (s SourceParentNotFoundException) GoString() string {
 
 func newErrorSourceParentNotFoundException(v protocol.ResponseMetadata) error {
 	return &SourceParentNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18726,12 +18726,12 @@ func (s SourceParentNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SourceParentNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SourceParentNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A custom key-value pair associated with a resource such as an account within
@@ -18874,7 +18874,7 @@ func (s TagResourceOutput) GoString() string {
 // We can't find a root, OU, or account with the TargetId that you specified.
 type TargetNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18891,7 +18891,7 @@ func (s TargetNotFoundException) GoString() string {
 
 func newErrorTargetNotFoundException(v protocol.ResponseMetadata) error {
 	return &TargetNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18919,12 +18919,12 @@ func (s TargetNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TargetNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TargetNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have sent too many requests in too short a period of time. The limit
@@ -18935,7 +18935,7 @@ func (s TargetNotFoundException) RequestID() string {
 // in the AWS Organizations User Guide.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -18954,7 +18954,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18982,18 +18982,18 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This action isn't available in the current Region.
 type UnsupportedAPIEndpointException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -19010,7 +19010,7 @@ func (s UnsupportedAPIEndpointException) GoString() string {
 
 func newErrorUnsupportedAPIEndpointException(v protocol.ResponseMetadata) error {
 	return &UnsupportedAPIEndpointException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19038,12 +19038,12 @@ func (s UnsupportedAPIEndpointException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedAPIEndpointException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedAPIEndpointException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/organizations/api.go
+++ b/service/organizations/api.go
@@ -11552,8 +11552,8 @@ func (c *Organizations) UpdatePolicyWithContext(ctx aws.Context, input *UpdatePo
 // Your account isn't a member of an organization. To make this request, you
 // must use the credentials of an account that belongs to an organization.
 type AWSOrganizationsNotInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11676,8 +11676,8 @@ func (s *AcceptHandshakeOutput) SetHandshake(v *Handshake) *AcceptHandshakeOutpu
 // Access Management (https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html)
 // in the IAM User Guide.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11734,8 +11734,8 @@ func (s AccessDeniedException) RequestID() string {
 // for organizations.amazonaws.com permission so that AWS Organizations can
 // create the required service-linked role. You don't have that permission.
 type AccessDeniedForDependencyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -11886,8 +11886,8 @@ func (s *Account) SetStatus(v string) *Account {
 // account whose credentials you used to make this request isn't a member of
 // an organization.
 type AccountNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -11945,8 +11945,8 @@ func (s AccountNotFoundException) RequestID() string {
 // information, see Email Address Verification (http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_create.html#about-email-verification)
 // in the AWS Organizations User Guide.
 type AccountOwnerNotVerifiedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12002,8 +12002,8 @@ func (s AccountOwnerNotVerifiedException) RequestID() string {
 // This account is already a member of an organization. An account can belong
 // to only one organization at a time.
 type AlreadyInOrganizationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12253,8 +12253,8 @@ func (s *Child) SetType(v string) *Child {
 // We can't find an organizational unit (OU) or AWS account with the ChildId
 // that you specified.
 type ChildNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12310,8 +12310,8 @@ func (s ChildNotFoundException) RequestID() string {
 // The target of the operation is currently being modified by a different request.
 // Try again later.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12465,8 +12465,8 @@ func (s ConcurrentModificationException) RequestID() string {
 //    see Tag Policies (http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html)
 //    in the AWS Organizations User Guide.
 type ConstraintViolationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -12779,8 +12779,8 @@ func (s *CreateAccountStatus) SetState(v string) *CreateAccountStatus {
 // We can't find a create account request with the CreateAccountRequestId that
 // you specified.
 type CreateAccountStatusNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -13888,8 +13888,8 @@ func (s *DescribePolicyOutput) SetPolicy(v *Policy) *DescribePolicyOutput {
 // We can't find the destination container (a root or OU) with the ParentId
 // that you specified.
 type DestinationParentNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14166,8 +14166,8 @@ func (s *DisablePolicyTypeOutput) SetRoot(v *Root) *DisablePolicyTypeOutput {
 
 // That account is already present in the specified destination.
 type DuplicateAccountException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14226,8 +14226,8 @@ func (s DuplicateAccountException) RequestID() string {
 // to resend an invitation to an account, ensure that existing handshakes that
 // might be considered duplicates are canceled or declined.
 type DuplicateHandshakeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14282,8 +14282,8 @@ func (s DuplicateHandshakeException) RequestID() string {
 
 // An OU with the same name already exists.
 type DuplicateOrganizationalUnitException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14338,8 +14338,8 @@ func (s DuplicateOrganizationalUnitException) RequestID() string {
 
 // The selected policy is already attached to the specified target.
 type DuplicatePolicyAttachmentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14394,8 +14394,8 @@ func (s DuplicatePolicyAttachmentException) RequestID() string {
 
 // A policy with the same name already exists.
 type DuplicatePolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14506,8 +14506,8 @@ func (s *EffectivePolicy) SetTargetId(v string) *EffectivePolicy {
 // policy of this type. Contact the administrator of your organization about
 // attaching a policy of this type to the account.
 type EffectivePolicyNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14775,8 +14775,8 @@ func (s *EnabledServicePrincipal) SetServicePrincipal(v string) *EnabledServiceP
 // If after one hour you continue to receive this error, contact AWS Support
 // (https://console.aws.amazon.com/support/home#/).
 type FinalizingOrganizationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14974,8 +14974,8 @@ func (s *Handshake) SetState(v string) *Handshake {
 // The specified handshake is already in the requested state. For example, you
 // can't accept a handshake that was already accepted.
 type HandshakeAlreadyInStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15067,8 +15067,8 @@ func (s HandshakeAlreadyInStateException) RequestID() string {
 //    account that doesn't have a payment instrument, such as a credit card,
 //    associated with it.
 type HandshakeConstraintViolationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15166,8 +15166,8 @@ func (s *HandshakeFilter) SetParentHandshakeId(v string) *HandshakeFilter {
 
 // We can't find a handshake with the HandshakeId that you specified.
 type HandshakeNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15343,8 +15343,8 @@ func (s *HandshakeResource) SetValue(v string) *HandshakeResource {
 // example, you can't cancel a handshake that was already accepted or accept
 // a handshake that was already declined.
 type InvalidHandshakeTransitionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15462,8 +15462,8 @@ func (s InvalidHandshakeTransitionException) RequestID() string {
 //    * MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS: You can move an account only
 //    between entities in the same root.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -17151,8 +17151,8 @@ func (s *ListTargetsForPolicyOutput) SetTargets(v []*PolicyTargetSummary) *ListT
 // service control policy syntax, see Service Control Policy Syntax (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html)
 // in the AWS Organizations User Guide.
 type MalformedPolicyDocumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17209,8 +17209,8 @@ func (s MalformedPolicyDocumentException) RequestID() string {
 // account to become a member account in another organization, you must first
 // delete the current organization of the master account.
 type MasterCannotLeaveOrganizationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17482,8 +17482,8 @@ func (s *Organization) SetMasterAccountId(v string) *Organization {
 // The organization isn't empty. To delete an organization, you must first remove
 // all accounts except the master account, delete all OUs, and delete all policies.
 type OrganizationNotEmptyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17596,8 +17596,8 @@ func (s *OrganizationalUnit) SetName(v string) *OrganizationalUnit {
 // The specified OU is not empty. Move all accounts to another root or to other
 // OUs, remove all child OUs, and try the operation again.
 type OrganizationalUnitNotEmptyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17652,8 +17652,8 @@ func (s OrganizationalUnitNotEmptyException) RequestID() string {
 
 // We can't find an OU with the OrganizationalUnitId that you specified.
 type OrganizationalUnitNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17753,8 +17753,8 @@ func (s *Parent) SetType(v string) *Parent {
 
 // We can't find a root or OU with the ParentId that you specified.
 type ParentNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17845,8 +17845,8 @@ func (s *Policy) SetPolicySummary(v *PolicySummary) *Policy {
 // Changes to the effective policy are in progress, and its contents can't be
 // returned. Try the operation again later.
 type PolicyChangesInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17902,8 +17902,8 @@ func (s PolicyChangesInProgressException) RequestID() string {
 // The policy is attached to one or more entities. You must detach it from all
 // roots, OUs, and accounts before performing this operation.
 type PolicyInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17958,8 +17958,8 @@ func (s PolicyInUseException) RequestID() string {
 
 // The policy isn't attached to the specified target in the specified root.
 type PolicyNotAttachedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18014,8 +18014,8 @@ func (s PolicyNotAttachedException) RequestID() string {
 
 // We can't find a policy with the PolicyId that you specified.
 type PolicyNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18226,8 +18226,8 @@ func (s *PolicyTargetSummary) SetType(v string) *PolicyTargetSummary {
 
 // The specified policy type is already enabled in the specified root.
 type PolicyTypeAlreadyEnabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18286,8 +18286,8 @@ func (s PolicyTypeAlreadyEnabledException) RequestID() string {
 // Disabling a Policy Type on a Root (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies.html#enable_policies_on_root)
 // in the AWS Organizations User Guide.
 type PolicyTypeNotAvailableForOrganizationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18346,8 +18346,8 @@ func (s PolicyTypeNotAvailableForOrganizationException) RequestID() string {
 // Your Organization (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_org_support-all-features.html)
 // in the AWS Organizations User Guide.
 type PolicyTypeNotEnabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18567,8 +18567,8 @@ func (s *Root) SetPolicyTypes(v []*PolicyTypeSummary) *Root {
 
 // We can't find a root with the RootId that you specified.
 type RootNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18624,8 +18624,8 @@ func (s RootNotFoundException) RequestID() string {
 // AWS Organizations can't complete your request because of an internal service
 // error. Try again later.
 type ServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18680,8 +18680,8 @@ func (s ServiceException) RequestID() string {
 
 // We can't find a source root or OU with the ParentId that you specified.
 type SourceParentNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18873,8 +18873,8 @@ func (s TagResourceOutput) GoString() string {
 
 // We can't find a root, OU, or account with the TargetId that you specified.
 type TargetNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -18934,8 +18934,8 @@ func (s TargetNotFoundException) RequestID() string {
 // Organizations (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html)
 // in the AWS Organizations User Guide.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -18992,8 +18992,8 @@ func (s TooManyRequestsException) RequestID() string {
 
 // This action isn't available in the current Region.
 type UnsupportedAPIEndpointException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/outposts/api.go
+++ b/service/outposts/api.go
@@ -746,7 +746,7 @@ func (c *Outposts) ListSitesPagesWithContext(ctx aws.Context, input *ListSitesIn
 // You do not have permission to perform this operation.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -763,7 +763,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -791,12 +791,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateOutpostInput struct {
@@ -1227,7 +1227,7 @@ func (s *InstanceTypeItem) SetInstanceType(v string) *InstanceTypeItem {
 // An internal error has occurred.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1244,7 +1244,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1272,12 +1272,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListOutpostsInput struct {
@@ -1443,7 +1443,7 @@ func (s *ListSitesOutput) SetSites(v []*Site) *ListSitesOutput {
 // The specified request is not valid.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1460,7 +1460,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1488,12 +1488,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about an Outpost.
@@ -1595,7 +1595,7 @@ func (s *Outpost) SetSiteId(v string) *Outpost {
 // You have exceeded a service quota.
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1612,7 +1612,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1640,12 +1640,12 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a site.
@@ -1702,7 +1702,7 @@ func (s *Site) SetSiteId(v string) *Site {
 // A parameter is not valid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1719,7 +1719,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1747,10 +1747,10 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }

--- a/service/outposts/api.go
+++ b/service/outposts/api.go
@@ -745,8 +745,8 @@ func (c *Outposts) ListSitesPagesWithContext(ctx aws.Context, input *ListSitesIn
 
 // You do not have permission to perform this operation.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1226,8 +1226,8 @@ func (s *InstanceTypeItem) SetInstanceType(v string) *InstanceTypeItem {
 
 // An internal error has occurred.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1442,8 +1442,8 @@ func (s *ListSitesOutput) SetSites(v []*Site) *ListSitesOutput {
 
 // The specified request is not valid.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1594,8 +1594,8 @@ func (s *Outpost) SetSiteId(v string) *Outpost {
 
 // You have exceeded a service quota.
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1701,8 +1701,8 @@ func (s *Site) SetSiteId(v string) *Site {
 
 // A parameter is not valid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/personalize/api.go
+++ b/service/personalize/api.go
@@ -8517,7 +8517,7 @@ func (s *IntegerHyperParameterRange) SetName(v string) *IntegerHyperParameterRan
 // Provide a valid value for the field or parameter.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8534,7 +8534,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8562,18 +8562,18 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The token is not valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8590,7 +8590,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8618,18 +8618,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The limit on the number of requests per second has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8646,7 +8646,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8674,12 +8674,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListBatchInferenceJobsInput struct {
@@ -9709,7 +9709,7 @@ func (s *RecipeSummary) SetStatus(v string) *RecipeSummary {
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9726,7 +9726,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9754,18 +9754,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource is in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9782,7 +9782,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9810,18 +9810,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Could not find the specified resource.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9838,7 +9838,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9866,12 +9866,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The configuration details of an Amazon S3 input or output bucket.

--- a/service/personalize/api.go
+++ b/service/personalize/api.go
@@ -8516,8 +8516,8 @@ func (s *IntegerHyperParameterRange) SetName(v string) *IntegerHyperParameterRan
 
 // Provide a valid value for the field or parameter.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8572,8 +8572,8 @@ func (s InvalidInputException) RequestID() string {
 
 // The token is not valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8628,8 +8628,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // The limit on the number of requests per second has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9708,8 +9708,8 @@ func (s *RecipeSummary) SetStatus(v string) *RecipeSummary {
 
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9764,8 +9764,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The specified resource is in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9820,8 +9820,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // Could not find the specified resource.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/personalizeevents/api.go
+++ b/service/personalizeevents/api.go
@@ -198,8 +198,8 @@ func (s *Event) SetSentAt(v time.Time) *Event {
 
 // Provide a valid value for the field or parameter.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/personalizeevents/api.go
+++ b/service/personalizeevents/api.go
@@ -199,7 +199,7 @@ func (s *Event) SetSentAt(v time.Time) *Event {
 // Provide a valid value for the field or parameter.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -216,7 +216,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -244,12 +244,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutEventsInput struct {

--- a/service/personalizeruntime/api.go
+++ b/service/personalizeruntime/api.go
@@ -400,7 +400,7 @@ func (s *GetRecommendationsOutput) SetItemList(v []*PredictedItem) *GetRecommend
 // Provide a valid value for the field or parameter.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -417,7 +417,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -445,12 +445,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that identifies an item.
@@ -482,7 +482,7 @@ func (s *PredictedItem) SetItemId(v string) *PredictedItem {
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -499,7 +499,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -527,10 +527,10 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }

--- a/service/personalizeruntime/api.go
+++ b/service/personalizeruntime/api.go
@@ -399,8 +399,8 @@ func (s *GetRecommendationsOutput) SetItemList(v []*PredictedItem) *GetRecommend
 
 // Provide a valid value for the field or parameter.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -481,8 +481,8 @@ func (s *PredictedItem) SetItemId(v string) *PredictedItem {
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/pi/api.go
+++ b/service/pi/api.go
@@ -897,7 +897,7 @@ func (s *GetResourceMetricsOutput) SetNextToken(v string) *GetResourceMetricsOut
 // The request failed due to an unknown error.
 type InternalServiceError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -914,7 +914,7 @@ func (s InternalServiceError) GoString() string {
 
 func newErrorInternalServiceError(v protocol.ResponseMetadata) error {
 	return &InternalServiceError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -942,18 +942,18 @@ func (s InternalServiceError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One of the arguments provided is invalid for this request.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -970,7 +970,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -998,12 +998,12 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A time-ordered series of data points, correpsonding to a dimension of a Performance
@@ -1127,7 +1127,7 @@ func (s *MetricQuery) SetMetric(v string) *MetricQuery {
 // The user is not authorized to perform this request.
 type NotAuthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1144,7 +1144,7 @@ func (s NotAuthorizedException) GoString() string {
 
 func newErrorNotAuthorizedException(v protocol.ResponseMetadata) error {
 	return &NotAuthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1172,12 +1172,12 @@ func (s NotAuthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotAuthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotAuthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // If PartitionBy was specified in a DescribeDimensionKeys request, the dimensions

--- a/service/pi/api.go
+++ b/service/pi/api.go
@@ -896,8 +896,8 @@ func (s *GetResourceMetricsOutput) SetNextToken(v string) *GetResourceMetricsOut
 
 // The request failed due to an unknown error.
 type InternalServiceError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -952,8 +952,8 @@ func (s InternalServiceError) RequestID() string {
 
 // One of the arguments provided is invalid for this request.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1126,8 +1126,8 @@ func (s *MetricQuery) SetMetric(v string) *MetricQuery {
 
 // The user is not authorized to perform this request.
 type NotAuthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/pinpoint/api.go
+++ b/service/pinpoint/api.go
@@ -13393,8 +13393,8 @@ func (s *AttributesResource) SetAttributes(v []*string) *AttributesResource {
 
 // Provides information about an API request or response.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -20234,8 +20234,8 @@ func (s *ExportJobsResponse) SetNextToken(v string) *ExportJobsResponse {
 
 // Provides information about an API request or response.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -24810,8 +24810,8 @@ func (s *ImportJobsResponse) SetNextToken(v string) *ImportJobsResponse {
 
 // Provides information about an API request or response.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -26418,8 +26418,8 @@ func (s *MessageResult) SetUpdatedToken(v string) *MessageResult {
 
 // Provides information about an API request or response.
 type MethodNotAllowedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -26648,8 +26648,8 @@ func (s *MultiConditionalSplitActivity) SetEvaluationWaitTime(v *WaitTime) *Mult
 
 // Provides information about an API request or response.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -26893,8 +26893,8 @@ func (s *NumberValidateResponse) SetZipCode(v string) *NumberValidateResponse {
 
 // Provides information about an API request or response.
 type PayloadTooLargeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -30775,8 +30775,8 @@ func (s *TemplatesResponse) SetNextToken(v string) *TemplatesResponse {
 
 // Provides information about an API request or response.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 

--- a/service/pinpoint/api.go
+++ b/service/pinpoint/api.go
@@ -13394,7 +13394,7 @@ func (s *AttributesResource) SetAttributes(v []*string) *AttributesResource {
 // Provides information about an API request or response.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -13413,7 +13413,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13441,12 +13441,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the status and settings of the Baidu (Baidu Cloud Push) channel
@@ -20235,7 +20235,7 @@ func (s *ExportJobsResponse) SetNextToken(v string) *ExportJobsResponse {
 // Provides information about an API request or response.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -20254,7 +20254,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20282,12 +20282,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the status and settings of the GCM channel for an application.
@@ -24811,7 +24811,7 @@ func (s *ImportJobsResponse) SetNextToken(v string) *ImportJobsResponse {
 // Provides information about an API request or response.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -24830,7 +24830,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -24858,12 +24858,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information about the results of a request to create or update an
@@ -26419,7 +26419,7 @@ func (s *MessageResult) SetUpdatedToken(v string) *MessageResult {
 // Provides information about an API request or response.
 type MethodNotAllowedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -26438,7 +26438,7 @@ func (s MethodNotAllowedException) GoString() string {
 
 func newErrorMethodNotAllowedException(v protocol.ResponseMetadata) error {
 	return &MethodNotAllowedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26466,12 +26466,12 @@ func (s MethodNotAllowedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MethodNotAllowedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MethodNotAllowedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies metric-based criteria for including or excluding endpoints from
@@ -26649,7 +26649,7 @@ func (s *MultiConditionalSplitActivity) SetEvaluationWaitTime(v *WaitTime) *Mult
 // Provides information about an API request or response.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -26668,7 +26668,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26696,12 +26696,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies a phone number to validate and retrieve information about.
@@ -26894,7 +26894,7 @@ func (s *NumberValidateResponse) SetZipCode(v string) *NumberValidateResponse {
 // Provides information about an API request or response.
 type PayloadTooLargeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -26913,7 +26913,7 @@ func (s PayloadTooLargeException) GoString() string {
 
 func newErrorPayloadTooLargeException(v protocol.ResponseMetadata) error {
 	return &PayloadTooLargeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26941,12 +26941,12 @@ func (s PayloadTooLargeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PayloadTooLargeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PayloadTooLargeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PhoneNumberValidateInput struct {
@@ -30776,7 +30776,7 @@ func (s *TemplatesResponse) SetNextToken(v string) *TemplatesResponse {
 // Provides information about an API request or response.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -30795,7 +30795,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30823,12 +30823,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the settings for a campaign treatment. A treatment is a variation

--- a/service/pinpointemail/api.go
+++ b/service/pinpointemail/api.go
@@ -4188,8 +4188,8 @@ func (c *PinpointEmail) UpdateConfigurationSetEventDestinationWithContext(ctx aw
 // The message can't be sent because the account's ability to send email has
 // been permanently restricted.
 type AccountSuspendedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4244,8 +4244,8 @@ func (s AccountSuspendedException) RequestID() string {
 
 // The resource specified in your request already exists.
 type AlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4300,8 +4300,8 @@ func (s AlreadyExistsException) RequestID() string {
 
 // The input you provided is invalid.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4595,8 +4595,8 @@ func (s *CloudWatchDimensionConfiguration) SetDimensionValueSource(v string) *Cl
 
 // The resource is being modified by another operation or thread.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7621,8 +7621,8 @@ func (s *KinesisFirehoseDestination) SetIamRoleArn(v string) *KinesisFirehoseDes
 
 // There are too many instances of the specified resource type.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8257,8 +8257,8 @@ func (s *MailFromAttributes) SetMailFromDomainStatus(v string) *MailFromAttribut
 
 // The message can't be sent because the sending domain isn't verified.
 type MailFromDomainNotVerifiedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8380,8 +8380,8 @@ func (s *Message) SetSubject(v *Content) *Message {
 
 // The message can't be sent because it contains invalid content.
 type MessageRejected struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8502,8 +8502,8 @@ func (s *MessageTag) SetValue(v string) *MessageTag {
 
 // The resource you attempted to access doesn't exist.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9864,8 +9864,8 @@ func (s *SendingOptions) SetSendingEnabled(v bool) *SendingOptions {
 // The message can't be sent because the account's ability to send email is
 // currently paused.
 type SendingPausedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10162,8 +10162,8 @@ func (s *Template) SetTemplateData(v string) *Template {
 
 // Too many requests have been made to the operation.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/pinpointemail/api.go
+++ b/service/pinpointemail/api.go
@@ -4189,7 +4189,7 @@ func (c *PinpointEmail) UpdateConfigurationSetEventDestinationWithContext(ctx aw
 // been permanently restricted.
 type AccountSuspendedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4206,7 +4206,7 @@ func (s AccountSuspendedException) GoString() string {
 
 func newErrorAccountSuspendedException(v protocol.ResponseMetadata) error {
 	return &AccountSuspendedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4234,18 +4234,18 @@ func (s AccountSuspendedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccountSuspendedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccountSuspendedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource specified in your request already exists.
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4262,7 +4262,7 @@ func (s AlreadyExistsException) GoString() string {
 
 func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &AlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4290,18 +4290,18 @@ func (s AlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input you provided is invalid.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4318,7 +4318,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4346,12 +4346,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that contains information about a blacklisting event that impacts
@@ -4596,7 +4596,7 @@ func (s *CloudWatchDimensionConfiguration) SetDimensionValueSource(v string) *Cl
 // The resource is being modified by another operation or thread.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4613,7 +4613,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4641,12 +4641,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that represents the content of the email, and optionally a character
@@ -7622,7 +7622,7 @@ func (s *KinesisFirehoseDestination) SetIamRoleArn(v string) *KinesisFirehoseDes
 // There are too many instances of the specified resource type.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7639,7 +7639,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7667,12 +7667,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A request to obtain a list of configuration sets for your Amazon Pinpoint
@@ -8258,7 +8258,7 @@ func (s *MailFromAttributes) SetMailFromDomainStatus(v string) *MailFromAttribut
 // The message can't be sent because the sending domain isn't verified.
 type MailFromDomainNotVerifiedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8275,7 +8275,7 @@ func (s MailFromDomainNotVerifiedException) GoString() string {
 
 func newErrorMailFromDomainNotVerifiedException(v protocol.ResponseMetadata) error {
 	return &MailFromDomainNotVerifiedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8303,12 +8303,12 @@ func (s MailFromDomainNotVerifiedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MailFromDomainNotVerifiedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MailFromDomainNotVerifiedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the email message that you're sending. The Message object consists
@@ -8381,7 +8381,7 @@ func (s *Message) SetSubject(v *Content) *Message {
 // The message can't be sent because it contains invalid content.
 type MessageRejected struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8398,7 +8398,7 @@ func (s MessageRejected) GoString() string {
 
 func newErrorMessageRejected(v protocol.ResponseMetadata) error {
 	return &MessageRejected{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8426,12 +8426,12 @@ func (s MessageRejected) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MessageRejected) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MessageRejected) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the name and value of a tag that you apply to an email. You can
@@ -8503,7 +8503,7 @@ func (s *MessageTag) SetValue(v string) *MessageTag {
 // The resource you attempted to access doesn't exist.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8520,7 +8520,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8548,12 +8548,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that contains information about email that was sent from the selected
@@ -9865,7 +9865,7 @@ func (s *SendingOptions) SetSendingEnabled(v bool) *SendingOptions {
 // currently paused.
 type SendingPausedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9882,7 +9882,7 @@ func (s SendingPausedException) GoString() string {
 
 func newErrorSendingPausedException(v protocol.ResponseMetadata) error {
 	return &SendingPausedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9910,12 +9910,12 @@ func (s SendingPausedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SendingPausedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SendingPausedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that defines an Amazon SNS destination for email events. You can
@@ -10163,7 +10163,7 @@ func (s *Template) SetTemplateData(v string) *Template {
 // Too many requests have been made to the operation.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10180,7 +10180,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10208,12 +10208,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that defines the tracking options for a configuration set. When

--- a/service/pinpointsmsvoice/api.go
+++ b/service/pinpointsmsvoice/api.go
@@ -749,8 +749,8 @@ func (c *PinpointSMSVoice) UpdateConfigurationSetEventDestinationWithContext(ctx
 
 // The resource specified in your request already exists.
 type AlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -805,8 +805,8 @@ func (s AlreadyExistsException) RequestID() string {
 
 // The input you provided is invalid.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1365,8 +1365,8 @@ func (s *GetConfigurationSetEventDestinationsOutput) SetEventDestinations(v []*E
 // The API encountered an unexpected error and couldn't complete the request.
 // You might be able to successfully issue the request again in the future.
 type InternalServiceErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1457,8 +1457,8 @@ func (s *KinesisFirehoseDestination) SetIamRoleArn(v string) *KinesisFirehoseDes
 
 // There are too many instances of the specified resource type.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1579,8 +1579,8 @@ func (s *ListConfigurationSetsOutput) SetNextToken(v string) *ListConfigurationS
 
 // The resource you attempted to access doesn't exist.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1840,8 +1840,8 @@ func (s *SnsDestination) SetTopicArn(v string) *SnsDestination {
 // You've issued too many requests to the resource. Wait a few minutes, and
 // then try again.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/pinpointsmsvoice/api.go
+++ b/service/pinpointsmsvoice/api.go
@@ -750,7 +750,7 @@ func (c *PinpointSMSVoice) UpdateConfigurationSetEventDestinationWithContext(ctx
 // The resource specified in your request already exists.
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -767,7 +767,7 @@ func (s AlreadyExistsException) GoString() string {
 
 func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &AlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -795,18 +795,18 @@ func (s AlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input you provided is invalid.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -823,7 +823,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -851,12 +851,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that defines a message that contains text formatted using Amazon
@@ -1366,7 +1366,7 @@ func (s *GetConfigurationSetEventDestinationsOutput) SetEventDestinations(v []*E
 // You might be able to successfully issue the request again in the future.
 type InternalServiceErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1383,7 +1383,7 @@ func (s InternalServiceErrorException) GoString() string {
 
 func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServiceErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1411,12 +1411,12 @@ func (s InternalServiceErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that contains information about an event destination that sends
@@ -1458,7 +1458,7 @@ func (s *KinesisFirehoseDestination) SetIamRoleArn(v string) *KinesisFirehoseDes
 // There are too many instances of the specified resource type.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1475,7 +1475,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1503,12 +1503,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListConfigurationSetsInput struct {
@@ -1580,7 +1580,7 @@ func (s *ListConfigurationSetsOutput) SetNextToken(v string) *ListConfigurationS
 // The resource you attempted to access doesn't exist.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1597,7 +1597,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1625,12 +1625,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that defines a message that contains unformatted text.
@@ -1841,7 +1841,7 @@ func (s *SnsDestination) SetTopicArn(v string) *SnsDestination {
 // then try again.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1858,7 +1858,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1886,12 +1886,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that defines a request to update an existing event destination.

--- a/service/polly/api.go
+++ b/service/polly/api.go
@@ -1121,8 +1121,8 @@ func (s *DescribeVoicesOutput) SetVoices(v []*Voice) *DescribeVoicesOutput {
 // a new voice that is compatible with the engine or change the engine and restart
 // the operation.
 type EngineNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1318,8 +1318,8 @@ func (s *GetSpeechSynthesisTaskOutput) SetSynthesisTask(v *SynthesisTask) *GetSp
 // Amazon Polly can't find the specified lexicon. Verify that the lexicon's
 // name is spelled correctly, and then try again.
 type InvalidLexiconException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1375,8 +1375,8 @@ func (s InvalidLexiconException) RequestID() string {
 // The NextToken is invalid. Verify that it's spelled correctly, and then try
 // again.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1432,8 +1432,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // The provided Amazon S3 bucket name is invalid. Please check your input with
 // S3 bucket naming requirements and try again.
 type InvalidS3BucketException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1489,8 +1489,8 @@ func (s InvalidS3BucketException) RequestID() string {
 // The provided Amazon S3 key prefix is invalid. Please provide a valid S3 object
 // key name.
 type InvalidS3KeyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1545,8 +1545,8 @@ func (s InvalidS3KeyException) RequestID() string {
 
 // The specified sample rate is not valid.
 type InvalidSampleRateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1602,8 +1602,8 @@ func (s InvalidSampleRateException) RequestID() string {
 // The provided SNS topic ARN is invalid. Please provide a valid SNS topic ARN
 // and try again.
 type InvalidSnsTopicArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1659,8 +1659,8 @@ func (s InvalidSnsTopicArnException) RequestID() string {
 // The SSML you provided is invalid. Verify the SSML syntax, spelling of tags
 // and values, and then try again.
 type InvalidSsmlException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1716,8 +1716,8 @@ func (s InvalidSsmlException) RequestID() string {
 // The provided Task ID is not valid. Please provide a valid Task ID and try
 // again.
 type InvalidTaskIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1773,8 +1773,8 @@ func (s InvalidTaskIdException) RequestID() string {
 // The language specified is not currently supported by Amazon Polly in this
 // capacity.
 type LanguageNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1974,8 +1974,8 @@ func (s *LexiconDescription) SetName(v string) *LexiconDescription {
 // Verify that the lexicon exists, is in the region (see ListLexicons) and that
 // you spelled its name is spelled correctly. Then try again.
 type LexiconNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2030,8 +2030,8 @@ func (s LexiconNotFoundException) RequestID() string {
 
 // The maximum size of the specified lexicon would be exceeded by this operation.
 type LexiconSizeExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2234,8 +2234,8 @@ func (s *ListSpeechSynthesisTasksOutput) SetSynthesisTasks(v []*SynthesisTask) *
 // Speech marks are not supported for the OutputFormat selected. Speech marks
 // are only available for content in json format.
 type MarksNotSupportedForFormatException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2290,8 +2290,8 @@ func (s MarksNotSupportedForFormatException) RequestID() string {
 
 // The maximum size of the lexeme would be exceeded by this operation.
 type MaxLexemeLengthExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2346,8 +2346,8 @@ func (s MaxLexemeLengthExceededException) RequestID() string {
 
 // The maximum number of lexicons would be exceeded by this operation.
 type MaxLexiconsNumberExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2473,8 +2473,8 @@ func (s PutLexiconOutput) GoString() string {
 
 // An unknown condition has caused a service failure.
 type ServiceFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2529,8 +2529,8 @@ func (s ServiceFailureException) RequestID() string {
 
 // SSML speech marks are not supported for plain text-type input.
 type SsmlMarksNotSupportedForTextTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2955,8 +2955,8 @@ func (s *SynthesisTask) SetVoiceId(v string) *SynthesisTask {
 
 // The Speech Synthesis task with requested Task ID cannot be found.
 type SynthesisTaskNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3216,8 +3216,8 @@ func (s *SynthesizeSpeechOutput) SetRequestCharacters(v int64) *SynthesizeSpeech
 // API, the maximum is 200,000 characters, of which no more than 100,000 can
 // be billed characters. SSML tags are not counted as billed characters.
 type TextLengthExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3273,8 +3273,8 @@ func (s TextLengthExceededException) RequestID() string {
 // The alphabet specified by the lexicon is not a supported alphabet. Valid
 // values are x-sampa and ipa.
 type UnsupportedPlsAlphabetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3330,8 +3330,8 @@ func (s UnsupportedPlsAlphabetException) RequestID() string {
 // The language specified in the lexicon is unsupported. For a list of supported
 // languages, see Lexicon Attributes (https://docs.aws.amazon.com/polly/latest/dg/API_LexiconAttributes.html).
 type UnsupportedPlsLanguageException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/polly/api.go
+++ b/service/polly/api.go
@@ -1122,7 +1122,7 @@ func (s *DescribeVoicesOutput) SetVoices(v []*Voice) *DescribeVoicesOutput {
 // the operation.
 type EngineNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1139,7 +1139,7 @@ func (s EngineNotSupportedException) GoString() string {
 
 func newErrorEngineNotSupportedException(v protocol.ResponseMetadata) error {
 	return &EngineNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1167,12 +1167,12 @@ func (s EngineNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EngineNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EngineNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetLexiconInput struct {
@@ -1319,7 +1319,7 @@ func (s *GetSpeechSynthesisTaskOutput) SetSynthesisTask(v *SynthesisTask) *GetSp
 // name is spelled correctly, and then try again.
 type InvalidLexiconException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1336,7 +1336,7 @@ func (s InvalidLexiconException) GoString() string {
 
 func newErrorInvalidLexiconException(v protocol.ResponseMetadata) error {
 	return &InvalidLexiconException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1364,19 +1364,19 @@ func (s InvalidLexiconException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLexiconException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLexiconException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The NextToken is invalid. Verify that it's spelled correctly, and then try
 // again.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1393,7 +1393,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1421,19 +1421,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided Amazon S3 bucket name is invalid. Please check your input with
 // S3 bucket naming requirements and try again.
 type InvalidS3BucketException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1450,7 +1450,7 @@ func (s InvalidS3BucketException) GoString() string {
 
 func newErrorInvalidS3BucketException(v protocol.ResponseMetadata) error {
 	return &InvalidS3BucketException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1478,19 +1478,19 @@ func (s InvalidS3BucketException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidS3BucketException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidS3BucketException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided Amazon S3 key prefix is invalid. Please provide a valid S3 object
 // key name.
 type InvalidS3KeyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1507,7 +1507,7 @@ func (s InvalidS3KeyException) GoString() string {
 
 func newErrorInvalidS3KeyException(v protocol.ResponseMetadata) error {
 	return &InvalidS3KeyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1535,18 +1535,18 @@ func (s InvalidS3KeyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidS3KeyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidS3KeyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified sample rate is not valid.
 type InvalidSampleRateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1563,7 +1563,7 @@ func (s InvalidSampleRateException) GoString() string {
 
 func newErrorInvalidSampleRateException(v protocol.ResponseMetadata) error {
 	return &InvalidSampleRateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1591,19 +1591,19 @@ func (s InvalidSampleRateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSampleRateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSampleRateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided SNS topic ARN is invalid. Please provide a valid SNS topic ARN
 // and try again.
 type InvalidSnsTopicArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1620,7 +1620,7 @@ func (s InvalidSnsTopicArnException) GoString() string {
 
 func newErrorInvalidSnsTopicArnException(v protocol.ResponseMetadata) error {
 	return &InvalidSnsTopicArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1648,19 +1648,19 @@ func (s InvalidSnsTopicArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSnsTopicArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSnsTopicArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The SSML you provided is invalid. Verify the SSML syntax, spelling of tags
 // and values, and then try again.
 type InvalidSsmlException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1677,7 +1677,7 @@ func (s InvalidSsmlException) GoString() string {
 
 func newErrorInvalidSsmlException(v protocol.ResponseMetadata) error {
 	return &InvalidSsmlException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1705,19 +1705,19 @@ func (s InvalidSsmlException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSsmlException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSsmlException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided Task ID is not valid. Please provide a valid Task ID and try
 // again.
 type InvalidTaskIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1734,7 +1734,7 @@ func (s InvalidTaskIdException) GoString() string {
 
 func newErrorInvalidTaskIdException(v protocol.ResponseMetadata) error {
 	return &InvalidTaskIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1762,19 +1762,19 @@ func (s InvalidTaskIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTaskIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTaskIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The language specified is not currently supported by Amazon Polly in this
 // capacity.
 type LanguageNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1791,7 +1791,7 @@ func (s LanguageNotSupportedException) GoString() string {
 
 func newErrorLanguageNotSupportedException(v protocol.ResponseMetadata) error {
 	return &LanguageNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1819,12 +1819,12 @@ func (s LanguageNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LanguageNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LanguageNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides lexicon name and lexicon content in string format. For more information,
@@ -1975,7 +1975,7 @@ func (s *LexiconDescription) SetName(v string) *LexiconDescription {
 // you spelled its name is spelled correctly. Then try again.
 type LexiconNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1992,7 +1992,7 @@ func (s LexiconNotFoundException) GoString() string {
 
 func newErrorLexiconNotFoundException(v protocol.ResponseMetadata) error {
 	return &LexiconNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2020,18 +2020,18 @@ func (s LexiconNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LexiconNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LexiconNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum size of the specified lexicon would be exceeded by this operation.
 type LexiconSizeExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2048,7 +2048,7 @@ func (s LexiconSizeExceededException) GoString() string {
 
 func newErrorLexiconSizeExceededException(v protocol.ResponseMetadata) error {
 	return &LexiconSizeExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2076,12 +2076,12 @@ func (s LexiconSizeExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LexiconSizeExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LexiconSizeExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListLexiconsInput struct {
@@ -2235,7 +2235,7 @@ func (s *ListSpeechSynthesisTasksOutput) SetSynthesisTasks(v []*SynthesisTask) *
 // are only available for content in json format.
 type MarksNotSupportedForFormatException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2252,7 +2252,7 @@ func (s MarksNotSupportedForFormatException) GoString() string {
 
 func newErrorMarksNotSupportedForFormatException(v protocol.ResponseMetadata) error {
 	return &MarksNotSupportedForFormatException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2280,18 +2280,18 @@ func (s MarksNotSupportedForFormatException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MarksNotSupportedForFormatException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MarksNotSupportedForFormatException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum size of the lexeme would be exceeded by this operation.
 type MaxLexemeLengthExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2308,7 +2308,7 @@ func (s MaxLexemeLengthExceededException) GoString() string {
 
 func newErrorMaxLexemeLengthExceededException(v protocol.ResponseMetadata) error {
 	return &MaxLexemeLengthExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2336,18 +2336,18 @@ func (s MaxLexemeLengthExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxLexemeLengthExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxLexemeLengthExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of lexicons would be exceeded by this operation.
 type MaxLexiconsNumberExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2364,7 +2364,7 @@ func (s MaxLexiconsNumberExceededException) GoString() string {
 
 func newErrorMaxLexiconsNumberExceededException(v protocol.ResponseMetadata) error {
 	return &MaxLexiconsNumberExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2392,12 +2392,12 @@ func (s MaxLexiconsNumberExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxLexiconsNumberExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxLexiconsNumberExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutLexiconInput struct {
@@ -2474,7 +2474,7 @@ func (s PutLexiconOutput) GoString() string {
 // An unknown condition has caused a service failure.
 type ServiceFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2491,7 +2491,7 @@ func (s ServiceFailureException) GoString() string {
 
 func newErrorServiceFailureException(v protocol.ResponseMetadata) error {
 	return &ServiceFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2519,18 +2519,18 @@ func (s ServiceFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // SSML speech marks are not supported for plain text-type input.
 type SsmlMarksNotSupportedForTextTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2547,7 +2547,7 @@ func (s SsmlMarksNotSupportedForTextTypeException) GoString() string {
 
 func newErrorSsmlMarksNotSupportedForTextTypeException(v protocol.ResponseMetadata) error {
 	return &SsmlMarksNotSupportedForTextTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2575,12 +2575,12 @@ func (s SsmlMarksNotSupportedForTextTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SsmlMarksNotSupportedForTextTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SsmlMarksNotSupportedForTextTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartSpeechSynthesisTaskInput struct {
@@ -2956,7 +2956,7 @@ func (s *SynthesisTask) SetVoiceId(v string) *SynthesisTask {
 // The Speech Synthesis task with requested Task ID cannot be found.
 type SynthesisTaskNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2973,7 +2973,7 @@ func (s SynthesisTaskNotFoundException) GoString() string {
 
 func newErrorSynthesisTaskNotFoundException(v protocol.ResponseMetadata) error {
 	return &SynthesisTaskNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3001,12 +3001,12 @@ func (s SynthesisTaskNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SynthesisTaskNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SynthesisTaskNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SynthesizeSpeechInput struct {
@@ -3217,7 +3217,7 @@ func (s *SynthesizeSpeechOutput) SetRequestCharacters(v int64) *SynthesizeSpeech
 // be billed characters. SSML tags are not counted as billed characters.
 type TextLengthExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3234,7 +3234,7 @@ func (s TextLengthExceededException) GoString() string {
 
 func newErrorTextLengthExceededException(v protocol.ResponseMetadata) error {
 	return &TextLengthExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3262,19 +3262,19 @@ func (s TextLengthExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TextLengthExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TextLengthExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The alphabet specified by the lexicon is not a supported alphabet. Valid
 // values are x-sampa and ipa.
 type UnsupportedPlsAlphabetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3291,7 +3291,7 @@ func (s UnsupportedPlsAlphabetException) GoString() string {
 
 func newErrorUnsupportedPlsAlphabetException(v protocol.ResponseMetadata) error {
 	return &UnsupportedPlsAlphabetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3319,19 +3319,19 @@ func (s UnsupportedPlsAlphabetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedPlsAlphabetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedPlsAlphabetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The language specified in the lexicon is unsupported. For a list of supported
 // languages, see Lexicon Attributes (https://docs.aws.amazon.com/polly/latest/dg/API_LexiconAttributes.html).
 type UnsupportedPlsLanguageException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3348,7 +3348,7 @@ func (s UnsupportedPlsLanguageException) GoString() string {
 
 func newErrorUnsupportedPlsLanguageException(v protocol.ResponseMetadata) error {
 	return &UnsupportedPlsLanguageException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3376,12 +3376,12 @@ func (s UnsupportedPlsLanguageException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedPlsLanguageException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedPlsLanguageException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Description of the voice.

--- a/service/pricing/api.go
+++ b/service/pricing/api.go
@@ -605,8 +605,8 @@ func (s *DescribeServicesOutput) SetServices(v []*Service) *DescribeServicesOutp
 
 // The pagination token expired. Try again without a pagination token.
 type ExpiredNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -981,8 +981,8 @@ func (s *GetProductsOutput) SetPriceList(v []aws.JSONValue) *GetProductsOutput {
 // An error on the server occurred during the processing of your request. Try
 // again later.
 type InternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1037,8 +1037,8 @@ func (s InternalErrorException) RequestID() string {
 
 // The pagination token is invalid. Try again without a pagination token.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1093,8 +1093,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // One or more parameters had an invalid value.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1149,8 +1149,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // The requested resource can't be found.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/pricing/api.go
+++ b/service/pricing/api.go
@@ -606,7 +606,7 @@ func (s *DescribeServicesOutput) SetServices(v []*Service) *DescribeServicesOutp
 // The pagination token expired. Try again without a pagination token.
 type ExpiredNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -623,7 +623,7 @@ func (s ExpiredNextTokenException) GoString() string {
 
 func newErrorExpiredNextTokenException(v protocol.ResponseMetadata) error {
 	return &ExpiredNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -651,12 +651,12 @@ func (s ExpiredNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExpiredNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExpiredNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The constraints that you want all returned products to match.
@@ -982,7 +982,7 @@ func (s *GetProductsOutput) SetPriceList(v []aws.JSONValue) *GetProductsOutput {
 // again later.
 type InternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -999,7 +999,7 @@ func (s InternalErrorException) GoString() string {
 
 func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 	return &InternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1027,18 +1027,18 @@ func (s InternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The pagination token is invalid. Try again without a pagination token.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1055,7 +1055,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1083,18 +1083,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more parameters had an invalid value.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1111,7 +1111,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1139,18 +1139,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested resource can't be found.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1167,7 +1167,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1195,12 +1195,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The metadata for a service, such as the service code and available attribute

--- a/service/qldb/api.go
+++ b/service/qldb/api.go
@@ -2349,7 +2349,7 @@ func (s *GetRevisionOutput) SetRevision(v *ValueHolder) *GetRevisionOutput {
 // One or more parameters in the request aren't valid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -2369,7 +2369,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2397,12 +2397,12 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The information about a journal export job, including the ledger name, export
@@ -2568,7 +2568,7 @@ func (s *LedgerSummary) SetState(v string) *LedgerSummary {
 // You have reached the limit on the maximum number of resources allowed.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -2588,7 +2588,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2616,12 +2616,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListJournalS3ExportsForLedgerInput struct {
@@ -2980,7 +2980,7 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3003,7 +3003,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3031,18 +3031,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource can't be modified at this time.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3065,7 +3065,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3093,18 +3093,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource doesn't exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3127,7 +3127,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3155,18 +3155,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because a condition wasn't satisfied in advance.
 type ResourcePreconditionNotMetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3189,7 +3189,7 @@ func (s ResourcePreconditionNotMetException) GoString() string {
 
 func newErrorResourcePreconditionNotMetException(v protocol.ResponseMetadata) error {
 	return &ResourcePreconditionNotMetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3217,12 +3217,12 @@ func (s ResourcePreconditionNotMetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourcePreconditionNotMetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourcePreconditionNotMetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The encryption settings that are used by a journal export job to write data

--- a/service/qldb/api.go
+++ b/service/qldb/api.go
@@ -2348,8 +2348,8 @@ func (s *GetRevisionOutput) SetRevision(v *ValueHolder) *GetRevisionOutput {
 
 // One or more parameters in the request aren't valid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -2567,8 +2567,8 @@ func (s *LedgerSummary) SetState(v string) *LedgerSummary {
 
 // You have reached the limit on the maximum number of resources allowed.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -2979,8 +2979,8 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3041,8 +3041,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The specified resource can't be modified at this time.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3103,8 +3103,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The specified resource doesn't exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3165,8 +3165,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The operation failed because a condition wasn't satisfied in advance.
 type ResourcePreconditionNotMetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 

--- a/service/qldbsession/api.go
+++ b/service/qldbsession/api.go
@@ -138,7 +138,7 @@ func (s AbortTransactionResult) GoString() string {
 // parameter value or a missing required parameter.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -157,7 +157,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -185,12 +185,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the details of the transaction to commit.
@@ -507,7 +507,7 @@ func (s *FetchPageResult) SetPage(v *Page) *FetchPageResult {
 // Returned if the session doesn't exist anymore because it timed-out or expired.
 type InvalidSessionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -526,7 +526,7 @@ func (s InvalidSessionException) GoString() string {
 
 func newErrorInvalidSessionException(v protocol.ResponseMetadata) error {
 	return &InvalidSessionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -554,18 +554,18 @@ func (s InvalidSessionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSessionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSessionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if a resource limit such as number of active sessions is exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -582,7 +582,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -610,19 +610,19 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned when a transaction cannot be written to the journal due to a failure
 // in the verification phase of Optimistic Concurrency Control.
 type OccConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -639,7 +639,7 @@ func (s OccConflictException) GoString() string {
 
 func newErrorOccConflictException(v protocol.ResponseMetadata) error {
 	return &OccConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -667,12 +667,12 @@ func (s OccConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OccConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OccConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details of the fetched page.
@@ -711,7 +711,7 @@ func (s *Page) SetValues(v []*ValueHolder) *Page {
 // Returned when the rate of requests exceeds the allowed throughput.
 type RateExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -728,7 +728,7 @@ func (s RateExceededException) GoString() string {
 
 func newErrorRateExceededException(v protocol.ResponseMetadata) error {
 	return &RateExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -756,12 +756,12 @@ func (s RateExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RateExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RateExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SendCommandInput struct {

--- a/service/qldbsession/api.go
+++ b/service/qldbsession/api.go
@@ -137,8 +137,8 @@ func (s AbortTransactionResult) GoString() string {
 // Returned if the request is malformed or contains an error such as an invalid
 // parameter value or a missing required parameter.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -506,8 +506,8 @@ func (s *FetchPageResult) SetPage(v *Page) *FetchPageResult {
 
 // Returned if the session doesn't exist anymore because it timed-out or expired.
 type InvalidSessionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -564,8 +564,8 @@ func (s InvalidSessionException) RequestID() string {
 
 // Returned if a resource limit such as number of active sessions is exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -621,8 +621,8 @@ func (s LimitExceededException) RequestID() string {
 // Returned when a transaction cannot be written to the journal due to a failure
 // in the verification phase of Optimistic Concurrency Control.
 type OccConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -710,8 +710,8 @@ func (s *Page) SetValues(v []*ValueHolder) *Page {
 
 // Returned when the rate of requests exceeds the allowed throughput.
 type RateExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/quicksight/api.go
+++ b/service/quicksight/api.go
@@ -7168,8 +7168,8 @@ func (c *QuickSight) UpdateUserWithContext(ctx aws.Context, input *UpdateUserInp
 // your policies have the correct permissions, and that you are using the correct
 // access keys.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -7993,8 +7993,8 @@ func (s *ColumnTag) SetColumnGeographicRole(v string) *ColumnTag {
 // A resource is already in a state that indicates an action is happening that
 // must complete before a new update can be applied.
 type ConcurrentUpdatingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -8051,8 +8051,8 @@ func (s ConcurrentUpdatingException) RequestID() string {
 
 // Updating or deleting a resource can cause an inconsistent state.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -14208,8 +14208,8 @@ func (s *DescribeUserOutput) SetUser(v *User) *DescribeUserOutput {
 // The domain specified isn't on the allow list. All domains for embedded dashboards
 // must be added to the approved list by an Amazon QuickSight admin.
 type DomainNotWhitelistedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -14797,8 +14797,8 @@ func (s *IAMPolicyAssignmentSummary) SetAssignmentStatus(v string) *IAMPolicyAss
 // The identity type specified isn't supported. Supported identity types include
 // IAM and QUICKSIGHT.
 type IdentityTypeNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15085,8 +15085,8 @@ func (s *IntegerParameter) SetValues(v []*int64) *IntegerParameter {
 
 // An internal failure occurred.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15144,8 +15144,8 @@ func (s InternalFailureException) RequestID() string {
 
 // The NextToken value isn't valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15203,8 +15203,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // One or more parameters has a value that isn't valid.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15394,8 +15394,8 @@ func (s *JoinInstruction) SetType(v string) *JoinInstruction {
 
 // A limit is exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -17973,8 +17973,8 @@ func (s *PostgreSqlParameters) SetPort(v int64) *PostgreSqlParameters {
 
 // One or more preconditions aren't met.
 type PreconditionNotMetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -18684,8 +18684,8 @@ func (s *RenameColumnOperation) SetNewColumnName(v string) *RenameColumnOperatio
 
 // The resource specified already exists.
 type ResourceExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -18746,8 +18746,8 @@ func (s ResourceExistsException) RequestID() string {
 
 // One or more resources can't be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -18870,8 +18870,8 @@ func (s *ResourcePermission) SetPrincipal(v string) *ResourcePermission {
 
 // This resource is currently unavailable.
 type ResourceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -19326,8 +19326,8 @@ func (s *ServiceNowParameters) SetSiteBaseUrl(v string) *ServiceNowParameters {
 // The number of minutes specified for the lifetime of a session isn't valid.
 // The session lifetime must be 15-600 minutes.
 type SessionLifetimeInMinutesInvalidException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -20514,8 +20514,8 @@ func (s *TeradataParameters) SetPort(v int64) *TeradataParameters {
 
 // Access is throttled.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -20747,8 +20747,8 @@ func (s *TwitterParameters) SetQuery(v string) *TwitterParameters {
 // Amazon QuickSight currently has Standard Edition and Enterprise Edition.
 // Not every operation and capability is available in every edition.
 type UnsupportedUserEditionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -23267,8 +23267,8 @@ func (s *User) SetUserName(v string) *User {
 // operation that requires finding a user based on a provided user name, such
 // as DeleteUser, DescribeUser, and so on.
 type UserNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 

--- a/service/quicksight/api.go
+++ b/service/quicksight/api.go
@@ -7169,7 +7169,7 @@ func (c *QuickSight) UpdateUserWithContext(ctx aws.Context, input *UpdateUserInp
 // access keys.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -7189,7 +7189,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7217,12 +7217,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The active AWS Identity and Access Management (IAM) policy assignment.
@@ -7994,7 +7994,7 @@ func (s *ColumnTag) SetColumnGeographicRole(v string) *ColumnTag {
 // must complete before a new update can be applied.
 type ConcurrentUpdatingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -8013,7 +8013,7 @@ func (s ConcurrentUpdatingException) GoString() string {
 
 func newErrorConcurrentUpdatingException(v protocol.ResponseMetadata) error {
 	return &ConcurrentUpdatingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8041,18 +8041,18 @@ func (s ConcurrentUpdatingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentUpdatingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentUpdatingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Updating or deleting a resource can cause an inconsistent state.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -8072,7 +8072,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8100,12 +8100,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A transform operation that creates calculated columns. Columns created in
@@ -14209,7 +14209,7 @@ func (s *DescribeUserOutput) SetUser(v *User) *DescribeUserOutput {
 // must be added to the approved list by an Amazon QuickSight admin.
 type DomainNotWhitelistedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -14229,7 +14229,7 @@ func (s DomainNotWhitelistedException) GoString() string {
 
 func newErrorDomainNotWhitelistedException(v protocol.ResponseMetadata) error {
 	return &DomainNotWhitelistedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14257,12 +14257,12 @@ func (s DomainNotWhitelistedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DomainNotWhitelistedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DomainNotWhitelistedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Error information for the SPICE ingestion of a dataset.
@@ -14798,7 +14798,7 @@ func (s *IAMPolicyAssignmentSummary) SetAssignmentStatus(v string) *IAMPolicyAss
 // IAM and QUICKSIGHT.
 type IdentityTypeNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -14818,7 +14818,7 @@ func (s IdentityTypeNotSupportedException) GoString() string {
 
 func newErrorIdentityTypeNotSupportedException(v protocol.ResponseMetadata) error {
 	return &IdentityTypeNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14846,12 +14846,12 @@ func (s IdentityTypeNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdentityTypeNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdentityTypeNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the SPICE ingestion for a dataset.
@@ -15086,7 +15086,7 @@ func (s *IntegerParameter) SetValues(v []*int64) *IntegerParameter {
 // An internal failure occurred.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15106,7 +15106,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15134,18 +15134,18 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The NextToken value isn't valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15165,7 +15165,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15193,18 +15193,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more parameters has a value that isn't valid.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15224,7 +15224,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15252,12 +15252,12 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Jira parameters.
@@ -15395,7 +15395,7 @@ func (s *JoinInstruction) SetType(v string) *JoinInstruction {
 // A limit is exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -15418,7 +15418,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15446,12 +15446,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDashboardVersionsInput struct {
@@ -17974,7 +17974,7 @@ func (s *PostgreSqlParameters) SetPort(v int64) *PostgreSqlParameters {
 // One or more preconditions aren't met.
 type PreconditionNotMetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -17994,7 +17994,7 @@ func (s PreconditionNotMetException) GoString() string {
 
 func newErrorPreconditionNotMetException(v protocol.ResponseMetadata) error {
 	return &PreconditionNotMetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18022,12 +18022,12 @@ func (s PreconditionNotMetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PreconditionNotMetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PreconditionNotMetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Presto parameters.
@@ -18685,7 +18685,7 @@ func (s *RenameColumnOperation) SetNewColumnName(v string) *RenameColumnOperatio
 // The resource specified already exists.
 type ResourceExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -18708,7 +18708,7 @@ func (s ResourceExistsException) GoString() string {
 
 func newErrorResourceExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18736,18 +18736,18 @@ func (s ResourceExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more resources can't be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -18770,7 +18770,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18798,12 +18798,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Permission for the resource.
@@ -18871,7 +18871,7 @@ func (s *ResourcePermission) SetPrincipal(v string) *ResourcePermission {
 // This resource is currently unavailable.
 type ResourceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -18894,7 +18894,7 @@ func (s ResourceUnavailableException) GoString() string {
 
 func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ResourceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18922,12 +18922,12 @@ func (s ResourceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about rows for a data set SPICE ingestion.
@@ -19327,7 +19327,7 @@ func (s *ServiceNowParameters) SetSiteBaseUrl(v string) *ServiceNowParameters {
 // The session lifetime must be 15-600 minutes.
 type SessionLifetimeInMinutesInvalidException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -19347,7 +19347,7 @@ func (s SessionLifetimeInMinutesInvalidException) GoString() string {
 
 func newErrorSessionLifetimeInMinutesInvalidException(v protocol.ResponseMetadata) error {
 	return &SessionLifetimeInMinutesInvalidException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19375,12 +19375,12 @@ func (s SessionLifetimeInMinutesInvalidException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SessionLifetimeInMinutesInvalidException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SessionLifetimeInMinutesInvalidException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Sheet controls option.
@@ -20515,7 +20515,7 @@ func (s *TeradataParameters) SetPort(v int64) *TeradataParameters {
 // Access is throttled.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -20535,7 +20535,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20563,12 +20563,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A data transformation on a logical table. This is a variant type structure.
@@ -20748,7 +20748,7 @@ func (s *TwitterParameters) SetQuery(v string) *TwitterParameters {
 // Not every operation and capability is available in every edition.
 type UnsupportedUserEditionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -20768,7 +20768,7 @@ func (s UnsupportedUserEditionException) GoString() string {
 
 func newErrorUnsupportedUserEditionException(v protocol.ResponseMetadata) error {
 	return &UnsupportedUserEditionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -20796,12 +20796,12 @@ func (s UnsupportedUserEditionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedUserEditionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedUserEditionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -23268,7 +23268,7 @@ func (s *User) SetUserName(v string) *User {
 // as DeleteUser, DescribeUser, and so on.
 type UserNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -23288,7 +23288,7 @@ func (s UserNotFoundException) GoString() string {
 
 func newErrorUserNotFoundException(v protocol.ResponseMetadata) error {
 	return &UserNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23316,12 +23316,12 @@ func (s UserNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UserNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UserNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // VPC connection properties.

--- a/service/ram/api.go
+++ b/service/ram/api.go
@@ -3971,8 +3971,8 @@ func (s *GetResourceSharesOutput) SetResourceShares(v []*ResourceShare) *GetReso
 // one of the other input parameters is different from the previous call to
 // the operation.
 type IdempotentParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4027,8 +4027,8 @@ func (s IdempotentParameterMismatchException) RequestID() string {
 
 // A client token is not valid.
 type InvalidClientTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4083,8 +4083,8 @@ func (s InvalidClientTokenException) RequestID() string {
 
 // The specified value for MaxResults is not valid.
 type InvalidMaxResultsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4139,8 +4139,8 @@ func (s InvalidMaxResultsException) RequestID() string {
 
 // The specified value for NextToken is not valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4195,8 +4195,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // A parameter is not valid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4251,8 +4251,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // The specified resource type is not valid.
 type InvalidResourceTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4307,8 +4307,8 @@ func (s InvalidResourceTypeException) RequestID() string {
 
 // The requested state transition is not valid.
 type InvalidStateTransitionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4904,8 +4904,8 @@ func (s *ListResourcesOutput) SetResources(v []*Resource) *ListResourcesOutput {
 
 // The format of an Amazon Resource Name (ARN) is not valid.
 type MalformedArnException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4960,8 +4960,8 @@ func (s MalformedArnException) RequestID() string {
 
 // A required input parameter is missing.
 type MissingRequiredParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5016,8 +5016,8 @@ func (s MissingRequiredParameterException) RequestID() string {
 
 // The requested operation is not permitted.
 type OperationNotPermittedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5363,8 +5363,8 @@ func (s *Resource) SetType(v string) *Resource {
 
 // An Amazon Resource Name (ARN) was not found.
 type ResourceArnNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5726,8 +5726,8 @@ func (s *ResourceShareInvitation) SetStatus(v string) *ResourceShareInvitation {
 
 // The invitation was already accepted.
 type ResourceShareInvitationAlreadyAcceptedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5782,8 +5782,8 @@ func (s ResourceShareInvitationAlreadyAcceptedException) RequestID() string {
 
 // The invitation was already rejected.
 type ResourceShareInvitationAlreadyRejectedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5838,8 +5838,8 @@ func (s ResourceShareInvitationAlreadyRejectedException) RequestID() string {
 
 // The Amazon Resource Name (ARN) for an invitation was not found.
 type ResourceShareInvitationArnNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5894,8 +5894,8 @@ func (s ResourceShareInvitationArnNotFoundException) RequestID() string {
 
 // The invitation is expired.
 type ResourceShareInvitationExpiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5950,8 +5950,8 @@ func (s ResourceShareInvitationExpiredException) RequestID() string {
 
 // The requested resource share exceeds the limit for your account.
 type ResourceShareLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6184,8 +6184,8 @@ func (s *ResourceSharePermissionSummary) SetVersion(v string) *ResourceSharePerm
 
 // The service could not respond to the request due to an internal problem.
 type ServerInternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6240,8 +6240,8 @@ func (s ServerInternalException) RequestID() string {
 
 // The service is not available.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6362,8 +6362,8 @@ func (s *TagFilter) SetTagValues(v []*string) *TagFilter {
 
 // The requested tags exceed the limit for your account.
 type TagLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6418,8 +6418,8 @@ func (s TagLimitExceededException) RequestID() string {
 
 // The specified tag is a reserved word and cannot be used.
 type TagPolicyViolationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6540,8 +6540,8 @@ func (s TagResourceOutput) GoString() string {
 
 // A specified resource was not found.
 type UnknownResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/ram/api.go
+++ b/service/ram/api.go
@@ -3972,7 +3972,7 @@ func (s *GetResourceSharesOutput) SetResourceShares(v []*ResourceShare) *GetReso
 // the operation.
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3989,7 +3989,7 @@ func (s IdempotentParameterMismatchException) GoString() string {
 
 func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4017,18 +4017,18 @@ func (s IdempotentParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A client token is not valid.
 type InvalidClientTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4045,7 +4045,7 @@ func (s InvalidClientTokenException) GoString() string {
 
 func newErrorInvalidClientTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidClientTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4073,18 +4073,18 @@ func (s InvalidClientTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidClientTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidClientTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified value for MaxResults is not valid.
 type InvalidMaxResultsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4101,7 +4101,7 @@ func (s InvalidMaxResultsException) GoString() string {
 
 func newErrorInvalidMaxResultsException(v protocol.ResponseMetadata) error {
 	return &InvalidMaxResultsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4129,18 +4129,18 @@ func (s InvalidMaxResultsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidMaxResultsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidMaxResultsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified value for NextToken is not valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4157,7 +4157,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4185,18 +4185,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A parameter is not valid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4213,7 +4213,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4241,18 +4241,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource type is not valid.
 type InvalidResourceTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4269,7 +4269,7 @@ func (s InvalidResourceTypeException) GoString() string {
 
 func newErrorInvalidResourceTypeException(v protocol.ResponseMetadata) error {
 	return &InvalidResourceTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4297,18 +4297,18 @@ func (s InvalidResourceTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested state transition is not valid.
 type InvalidStateTransitionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4325,7 +4325,7 @@ func (s InvalidStateTransitionException) GoString() string {
 
 func newErrorInvalidStateTransitionException(v protocol.ResponseMetadata) error {
 	return &InvalidStateTransitionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4353,12 +4353,12 @@ func (s InvalidStateTransitionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateTransitionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateTransitionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListPendingInvitationResourcesInput struct {
@@ -4905,7 +4905,7 @@ func (s *ListResourcesOutput) SetResources(v []*Resource) *ListResourcesOutput {
 // The format of an Amazon Resource Name (ARN) is not valid.
 type MalformedArnException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4922,7 +4922,7 @@ func (s MalformedArnException) GoString() string {
 
 func newErrorMalformedArnException(v protocol.ResponseMetadata) error {
 	return &MalformedArnException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4950,18 +4950,18 @@ func (s MalformedArnException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MalformedArnException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MalformedArnException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A required input parameter is missing.
 type MissingRequiredParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4978,7 +4978,7 @@ func (s MissingRequiredParameterException) GoString() string {
 
 func newErrorMissingRequiredParameterException(v protocol.ResponseMetadata) error {
 	return &MissingRequiredParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5006,18 +5006,18 @@ func (s MissingRequiredParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MissingRequiredParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MissingRequiredParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested operation is not permitted.
 type OperationNotPermittedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5034,7 +5034,7 @@ func (s OperationNotPermittedException) GoString() string {
 
 func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 	return &OperationNotPermittedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5062,12 +5062,12 @@ func (s OperationNotPermittedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotPermittedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotPermittedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a principal for use with AWS Resource Access Manager.
@@ -5364,7 +5364,7 @@ func (s *Resource) SetType(v string) *Resource {
 // An Amazon Resource Name (ARN) was not found.
 type ResourceArnNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5381,7 +5381,7 @@ func (s ResourceArnNotFoundException) GoString() string {
 
 func newErrorResourceArnNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceArnNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5409,12 +5409,12 @@ func (s ResourceArnNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceArnNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceArnNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a resource share.
@@ -5727,7 +5727,7 @@ func (s *ResourceShareInvitation) SetStatus(v string) *ResourceShareInvitation {
 // The invitation was already accepted.
 type ResourceShareInvitationAlreadyAcceptedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5744,7 +5744,7 @@ func (s ResourceShareInvitationAlreadyAcceptedException) GoString() string {
 
 func newErrorResourceShareInvitationAlreadyAcceptedException(v protocol.ResponseMetadata) error {
 	return &ResourceShareInvitationAlreadyAcceptedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5772,18 +5772,18 @@ func (s ResourceShareInvitationAlreadyAcceptedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceShareInvitationAlreadyAcceptedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceShareInvitationAlreadyAcceptedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The invitation was already rejected.
 type ResourceShareInvitationAlreadyRejectedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5800,7 +5800,7 @@ func (s ResourceShareInvitationAlreadyRejectedException) GoString() string {
 
 func newErrorResourceShareInvitationAlreadyRejectedException(v protocol.ResponseMetadata) error {
 	return &ResourceShareInvitationAlreadyRejectedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5828,18 +5828,18 @@ func (s ResourceShareInvitationAlreadyRejectedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceShareInvitationAlreadyRejectedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceShareInvitationAlreadyRejectedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon Resource Name (ARN) for an invitation was not found.
 type ResourceShareInvitationArnNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5856,7 +5856,7 @@ func (s ResourceShareInvitationArnNotFoundException) GoString() string {
 
 func newErrorResourceShareInvitationArnNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceShareInvitationArnNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5884,18 +5884,18 @@ func (s ResourceShareInvitationArnNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceShareInvitationArnNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceShareInvitationArnNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The invitation is expired.
 type ResourceShareInvitationExpiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5912,7 +5912,7 @@ func (s ResourceShareInvitationExpiredException) GoString() string {
 
 func newErrorResourceShareInvitationExpiredException(v protocol.ResponseMetadata) error {
 	return &ResourceShareInvitationExpiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5940,18 +5940,18 @@ func (s ResourceShareInvitationExpiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceShareInvitationExpiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceShareInvitationExpiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested resource share exceeds the limit for your account.
 type ResourceShareLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5968,7 +5968,7 @@ func (s ResourceShareLimitExceededException) GoString() string {
 
 func newErrorResourceShareLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceShareLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5996,12 +5996,12 @@ func (s ResourceShareLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceShareLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceShareLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about an AWS RAM permission.
@@ -6185,7 +6185,7 @@ func (s *ResourceSharePermissionSummary) SetVersion(v string) *ResourceSharePerm
 // The service could not respond to the request due to an internal problem.
 type ServerInternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6202,7 +6202,7 @@ func (s ServerInternalException) GoString() string {
 
 func newErrorServerInternalException(v protocol.ResponseMetadata) error {
 	return &ServerInternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6230,18 +6230,18 @@ func (s ServerInternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServerInternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServerInternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service is not available.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6258,7 +6258,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6286,12 +6286,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a tag.
@@ -6363,7 +6363,7 @@ func (s *TagFilter) SetTagValues(v []*string) *TagFilter {
 // The requested tags exceed the limit for your account.
 type TagLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6380,7 +6380,7 @@ func (s TagLimitExceededException) GoString() string {
 
 func newErrorTagLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TagLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6408,18 +6408,18 @@ func (s TagLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified tag is a reserved word and cannot be used.
 type TagPolicyViolationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6436,7 +6436,7 @@ func (s TagPolicyViolationException) GoString() string {
 
 func newErrorTagPolicyViolationException(v protocol.ResponseMetadata) error {
 	return &TagPolicyViolationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6464,12 +6464,12 @@ func (s TagPolicyViolationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagPolicyViolationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagPolicyViolationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {
@@ -6541,7 +6541,7 @@ func (s TagResourceOutput) GoString() string {
 // A specified resource was not found.
 type UnknownResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6558,7 +6558,7 @@ func (s UnknownResourceException) GoString() string {
 
 func newErrorUnknownResourceException(v protocol.ResponseMetadata) error {
 	return &UnknownResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6586,12 +6586,12 @@ func (s UnknownResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnknownResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnknownResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/rdsdataservice/api.go
+++ b/service/rdsdataservice/api.go
@@ -658,7 +658,7 @@ func (s *ArrayValue) SetStringValues(v []*string) *ArrayValue {
 // There is an error in the call or in a SQL statement.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message returned by this BadRequestException error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -676,7 +676,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -704,12 +704,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request parameters represent the input of a SQL statement over an array
@@ -1601,7 +1601,7 @@ func (s *Field) SetStringValue(v string) *Field {
 // There are insufficient privileges to make the call.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message returned by this ForbiddenException error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1619,7 +1619,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1647,18 +1647,18 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An internal error occurred.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1675,7 +1675,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1703,18 +1703,18 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resourceArn, secretArn, or transactionId value can't be found.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The error message returned by this NotFoundException error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1732,7 +1732,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1760,12 +1760,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A record returned by a call.
@@ -1991,7 +1991,7 @@ func (s *RollbackTransactionOutput) SetTransactionStatus(v string) *RollbackTran
 // The service specified by the resourceArn parameter is not available.
 type ServiceUnavailableError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2008,7 +2008,7 @@ func (s ServiceUnavailableError) GoString() string {
 
 func newErrorServiceUnavailableError(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2036,12 +2036,12 @@ func (s ServiceUnavailableError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A parameter used in a SQL statement.
@@ -2138,7 +2138,7 @@ func (s *SqlStatementResult) SetResultFrame(v *ResultFrame) *SqlStatementResult 
 // The execution of the SQL statement timed out.
 type StatementTimeoutException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The database connection ID that executed the SQL statement.
 	DbConnectionId *int64 `locationName:"dbConnectionId" type:"long"`
@@ -2159,7 +2159,7 @@ func (s StatementTimeoutException) GoString() string {
 
 func newErrorStatementTimeoutException(v protocol.ResponseMetadata) error {
 	return &StatementTimeoutException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2187,12 +2187,12 @@ func (s StatementTimeoutException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StatementTimeoutException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StatementTimeoutException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A structure value returned by a call.

--- a/service/rdsdataservice/api.go
+++ b/service/rdsdataservice/api.go
@@ -657,8 +657,8 @@ func (s *ArrayValue) SetStringValues(v []*string) *ArrayValue {
 
 // There is an error in the call or in a SQL statement.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message returned by this BadRequestException error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1600,8 +1600,8 @@ func (s *Field) SetStringValue(v string) *Field {
 
 // There are insufficient privileges to make the call.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message returned by this ForbiddenException error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1657,8 +1657,8 @@ func (s ForbiddenException) RequestID() string {
 
 // An internal error occurred.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1713,8 +1713,8 @@ func (s InternalServerErrorException) RequestID() string {
 
 // The resourceArn, secretArn, or transactionId value can't be found.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The error message returned by this NotFoundException error.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1990,8 +1990,8 @@ func (s *RollbackTransactionOutput) SetTransactionStatus(v string) *RollbackTran
 
 // The service specified by the resourceArn parameter is not available.
 type ServiceUnavailableError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2137,8 +2137,8 @@ func (s *SqlStatementResult) SetResultFrame(v *ResultFrame) *SqlStatementResult 
 
 // The execution of the SQL statement timed out.
 type StatementTimeoutException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The database connection ID that executed the SQL statement.
 	DbConnectionId *int64 `locationName:"dbConnectionId" type:"long"`

--- a/service/rekognition/api.go
+++ b/service/rekognition/api.go
@@ -5840,8 +5840,8 @@ func (c *Rekognition) StopStreamProcessorWithContext(ctx aws.Context, input *Sto
 
 // You are not authorized to perform the action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10267,8 +10267,8 @@ func (s *HumanLoopDataAttributes) SetContentClassifiers(v []*string) *HumanLoopD
 // The number of in-progress human reviews you have has exceeded the number
 // allowed.
 type HumanLoopQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -10331,8 +10331,8 @@ func (s HumanLoopQuotaExceededException) RequestID() string {
 // least one of the other input parameters is different from the previous call
 // to the operation.
 type IdempotentParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10501,8 +10501,8 @@ func (s *ImageQuality) SetSharpness(v float64) *ImageQuality {
 // The input image size exceeds the allowed limit. For more information, see
 // Limits in Amazon Rekognition in the Amazon Rekognition Developer Guide.
 type ImageTooLargeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10811,8 +10811,8 @@ func (s *Instance) SetConfidence(v float64) *Instance {
 
 // Amazon Rekognition experienced a service issue. Try your call again.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10867,8 +10867,8 @@ func (s InternalServerError) RequestID() string {
 
 // The provided image format is not supported.
 type InvalidImageFormatException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10923,8 +10923,8 @@ func (s InvalidImageFormatException) RequestID() string {
 
 // Pagination token in the request is not valid.
 type InvalidPaginationTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10980,8 +10980,8 @@ func (s InvalidPaginationTokenException) RequestID() string {
 // Input parameter violated a constraint. Validate your parameter before calling
 // the API operation again.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11036,8 +11036,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // Amazon Rekognition is unable to access the S3 object specified in the request.
 type InvalidS3ObjectException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11282,8 +11282,8 @@ func (s *Landmark) SetY(v float64) *Landmark {
 // (HTTP status code: 400) until the number of concurrently running jobs is
 // below the Amazon Rekognition service limit.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12221,8 +12221,8 @@ func (s *ProjectVersionDescription) SetTrainingEndTimestamp(v time.Time) *Projec
 // The number of requests exceeded your throughput limit. If you want to increase
 // this limit, contact Amazon Rekognition.
 type ProvisionedThroughputExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12407,8 +12407,8 @@ func (s *RegionOfInterest) SetBoundingBox(v *BoundingBox) *RegionOfInterest {
 
 // A collection with the specified ID already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12462,8 +12462,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 }
 
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12518,8 +12518,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The collection specified in the request cannot be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12575,8 +12575,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // The requested resource isn't ready. For example, this exception occurs when
 // you call DetectCustomLabels with a model version that isn't deployed.
 type ResourceNotReadyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14601,8 +14601,8 @@ func (s *TextDetectionResult) SetTimestamp(v int64) *TextDetectionResult {
 // Amazon Rekognition is temporarily unable to process the request. Try your
 // call again.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14898,8 +14898,8 @@ func (s *VideoMetadata) SetFrameWidth(v int64) *VideoMetadata {
 // The file size or duration of the supplied media is too large. The maximum
 // file size is 10GB. The maximum duration is 6 hours.
 type VideoTooLargeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/rekognition/api.go
+++ b/service/rekognition/api.go
@@ -5841,7 +5841,7 @@ func (c *Rekognition) StopStreamProcessorWithContext(ctx aws.Context, input *Sto
 // You are not authorized to perform the action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5858,7 +5858,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5886,12 +5886,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Structure containing the estimated age range, in years, for a face.
@@ -10268,7 +10268,7 @@ func (s *HumanLoopDataAttributes) SetContentClassifiers(v []*string) *HumanLoopD
 // allowed.
 type HumanLoopQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -10291,7 +10291,7 @@ func (s HumanLoopQuotaExceededException) GoString() string {
 
 func newErrorHumanLoopQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &HumanLoopQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10319,12 +10319,12 @@ func (s HumanLoopQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s HumanLoopQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s HumanLoopQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A ClientRequestToken input parameter was reused with an operation, but at
@@ -10332,7 +10332,7 @@ func (s HumanLoopQuotaExceededException) RequestID() string {
 // to the operation.
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10349,7 +10349,7 @@ func (s IdempotentParameterMismatchException) GoString() string {
 
 func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10377,12 +10377,12 @@ func (s IdempotentParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides the input image either as bytes or an S3 object.
@@ -10502,7 +10502,7 @@ func (s *ImageQuality) SetSharpness(v float64) *ImageQuality {
 // Limits in Amazon Rekognition in the Amazon Rekognition Developer Guide.
 type ImageTooLargeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10519,7 +10519,7 @@ func (s ImageTooLargeException) GoString() string {
 
 func newErrorImageTooLargeException(v protocol.ResponseMetadata) error {
 	return &ImageTooLargeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10547,12 +10547,12 @@ func (s ImageTooLargeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ImageTooLargeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ImageTooLargeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type IndexFacesInput struct {
@@ -10812,7 +10812,7 @@ func (s *Instance) SetConfidence(v float64) *Instance {
 // Amazon Rekognition experienced a service issue. Try your call again.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10829,7 +10829,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10857,18 +10857,18 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided image format is not supported.
 type InvalidImageFormatException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10885,7 +10885,7 @@ func (s InvalidImageFormatException) GoString() string {
 
 func newErrorInvalidImageFormatException(v protocol.ResponseMetadata) error {
 	return &InvalidImageFormatException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10913,18 +10913,18 @@ func (s InvalidImageFormatException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidImageFormatException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidImageFormatException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Pagination token in the request is not valid.
 type InvalidPaginationTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10941,7 +10941,7 @@ func (s InvalidPaginationTokenException) GoString() string {
 
 func newErrorInvalidPaginationTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidPaginationTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10969,19 +10969,19 @@ func (s InvalidPaginationTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPaginationTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPaginationTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Input parameter violated a constraint. Validate your parameter before calling
 // the API operation again.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10998,7 +10998,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11026,18 +11026,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Amazon Rekognition is unable to access the S3 object specified in the request.
 type InvalidS3ObjectException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11054,7 +11054,7 @@ func (s InvalidS3ObjectException) GoString() string {
 
 func newErrorInvalidS3ObjectException(v protocol.ResponseMetadata) error {
 	return &InvalidS3ObjectException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11082,12 +11082,12 @@ func (s InvalidS3ObjectException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidS3ObjectException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidS3ObjectException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Kinesis data stream Amazon Rekognition to which the analysis results
@@ -11283,7 +11283,7 @@ func (s *Landmark) SetY(v float64) *Landmark {
 // below the Amazon Rekognition service limit.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11300,7 +11300,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11328,12 +11328,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListCollectionsInput struct {
@@ -12222,7 +12222,7 @@ func (s *ProjectVersionDescription) SetTrainingEndTimestamp(v time.Time) *Projec
 // this limit, contact Amazon Rekognition.
 type ProvisionedThroughputExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12239,7 +12239,7 @@ func (s ProvisionedThroughputExceededException) GoString() string {
 
 func newErrorProvisionedThroughputExceededException(v protocol.ResponseMetadata) error {
 	return &ProvisionedThroughputExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12267,12 +12267,12 @@ func (s ProvisionedThroughputExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProvisionedThroughputExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProvisionedThroughputExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RecognizeCelebritiesInput struct {
@@ -12408,7 +12408,7 @@ func (s *RegionOfInterest) SetBoundingBox(v *BoundingBox) *RegionOfInterest {
 // A collection with the specified ID already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12425,7 +12425,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12453,17 +12453,17 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12480,7 +12480,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12508,18 +12508,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The collection specified in the request cannot be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12536,7 +12536,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12564,19 +12564,19 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested resource isn't ready. For example, this exception occurs when
 // you call DetectCustomLabels with a model version that isn't deployed.
 type ResourceNotReadyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12593,7 +12593,7 @@ func (s ResourceNotReadyException) GoString() string {
 
 func newErrorResourceNotReadyException(v protocol.ResponseMetadata) error {
 	return &ResourceNotReadyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12621,12 +12621,12 @@ func (s ResourceNotReadyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotReadyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotReadyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides the S3 bucket name and object name.
@@ -14602,7 +14602,7 @@ func (s *TextDetectionResult) SetTimestamp(v int64) *TextDetectionResult {
 // call again.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14619,7 +14619,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14647,12 +14647,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The dataset used for training.
@@ -14899,7 +14899,7 @@ func (s *VideoMetadata) SetFrameWidth(v int64) *VideoMetadata {
 // file size is 10GB. The maximum duration is 6 hours.
 type VideoTooLargeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14916,7 +14916,7 @@ func (s VideoTooLargeException) GoString() string {
 
 func newErrorVideoTooLargeException(v protocol.ResponseMetadata) error {
 	return &VideoTooLargeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14944,12 +14944,12 @@ func (s VideoTooLargeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s VideoTooLargeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s VideoTooLargeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/resourcegroups/api.go
+++ b/service/resourcegroups/api.go
@@ -1334,8 +1334,8 @@ func (c *ResourceGroups) UpdateGroupQueryWithContext(ctx aws.Context, input *Upd
 // The request does not comply with validation rules that are defined for the
 // request parameters.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1582,8 +1582,8 @@ func (s *DeleteGroupOutput) SetGroup(v *Group) *DeleteGroupOutput {
 
 // The caller is not authorized to make the request.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2017,8 +2017,8 @@ func (s *GroupQuery) SetResourceQuery(v *ResourceQuery) *GroupQuery {
 
 // An internal error occurred while processing the request.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2324,8 +2324,8 @@ func (s *ListGroupsOutput) SetNextToken(v string) *ListGroupsOutput {
 
 // The request uses an HTTP method which is not allowed for the specified resource.
 type MethodNotAllowedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2380,8 +2380,8 @@ func (s MethodNotAllowedException) RequestID() string {
 
 // One or more resources specified in the request do not exist.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2859,8 +2859,8 @@ func (s *TagOutput) SetTags(v map[string]*string) *TagOutput {
 
 // The caller has exceeded throttling limits.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2916,8 +2916,8 @@ func (s TooManyRequestsException) RequestID() string {
 // The request has not been applied because it lacks valid authentication credentials
 // for the target resource.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/resourcegroups/api.go
+++ b/service/resourcegroups/api.go
@@ -1335,7 +1335,7 @@ func (c *ResourceGroups) UpdateGroupQueryWithContext(ctx aws.Context, input *Upd
 // request parameters.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1352,7 +1352,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1380,12 +1380,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateGroupInput struct {
@@ -1583,7 +1583,7 @@ func (s *DeleteGroupOutput) SetGroup(v *Group) *DeleteGroupOutput {
 // The caller is not authorized to make the request.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -1600,7 +1600,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1628,12 +1628,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetGroupInput struct {
@@ -2018,7 +2018,7 @@ func (s *GroupQuery) SetResourceQuery(v *ResourceQuery) *GroupQuery {
 // An internal error occurred while processing the request.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2035,7 +2035,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2063,12 +2063,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListGroupResourcesInput struct {
@@ -2325,7 +2325,7 @@ func (s *ListGroupsOutput) SetNextToken(v string) *ListGroupsOutput {
 // The request uses an HTTP method which is not allowed for the specified resource.
 type MethodNotAllowedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2342,7 +2342,7 @@ func (s MethodNotAllowedException) GoString() string {
 
 func newErrorMethodNotAllowedException(v protocol.ResponseMetadata) error {
 	return &MethodNotAllowedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2370,18 +2370,18 @@ func (s MethodNotAllowedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MethodNotAllowedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MethodNotAllowedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more resources specified in the request do not exist.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2398,7 +2398,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2426,12 +2426,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A two-part error structure that can occur in ListGroupResources or SearchResources
@@ -2860,7 +2860,7 @@ func (s *TagOutput) SetTags(v map[string]*string) *TagOutput {
 // The caller has exceeded throttling limits.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2877,7 +2877,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2905,19 +2905,19 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request has not been applied because it lacks valid authentication credentials
 // for the target resource.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2934,7 +2934,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2962,12 +2962,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagInput struct {

--- a/service/resourcegroupstaggingapi/api.go
+++ b/service/resourcegroupstaggingapi/api.go
@@ -1213,7 +1213,7 @@ func (s *ComplianceDetails) SetNoncompliantKeys(v []*string) *ComplianceDetails 
 // Try again later.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1230,7 +1230,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1258,12 +1258,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was denied because performing this operation violates a constraint.
@@ -1283,7 +1283,7 @@ func (s ConcurrentModificationException) RequestID() string {
 //    or an account.
 type ConstraintViolationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1300,7 +1300,7 @@ func (s ConstraintViolationException) GoString() string {
 
 func newErrorConstraintViolationException(v protocol.ResponseMetadata) error {
 	return &ConstraintViolationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1328,12 +1328,12 @@ func (s ConstraintViolationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConstraintViolationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConstraintViolationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DescribeReportCreationInput struct {
@@ -1986,7 +1986,7 @@ func (s *GetTagValuesOutput) SetTagValues(v []*string) *GetTagValuesOutput {
 // failure. You can retry the request.
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2003,7 +2003,7 @@ func (s InternalServiceException) GoString() string {
 
 func newErrorInternalServiceException(v protocol.ResponseMetadata) error {
 	return &InternalServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2031,12 +2031,12 @@ func (s InternalServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This error indicates one of the following:
@@ -2055,7 +2055,7 @@ func (s InternalServiceException) RequestID() string {
 //    in the AWS Organizations User Guide.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2072,7 +2072,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2100,19 +2100,19 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A PaginationToken is valid for a maximum of 15 minutes. Your request was
 // denied because the specified PaginationToken has expired.
 type PaginationTokenExpiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2129,7 +2129,7 @@ func (s PaginationTokenExpiredException) GoString() string {
 
 func newErrorPaginationTokenExpiredException(v protocol.ResponseMetadata) error {
 	return &PaginationTokenExpiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2157,12 +2157,12 @@ func (s PaginationTokenExpiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PaginationTokenExpiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PaginationTokenExpiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A list of resource ARNs and the tags (keys and values) that are associated
@@ -2523,7 +2523,7 @@ func (s *TagResourcesOutput) SetFailedResourcesMap(v map[string]*FailureInfo) *T
 // The request was denied to limit the frequency of submitted requests.
 type ThrottledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2540,7 +2540,7 @@ func (s ThrottledException) GoString() string {
 
 func newErrorThrottledException(v protocol.ResponseMetadata) error {
 	return &ThrottledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2568,12 +2568,12 @@ func (s ThrottledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourcesInput struct {

--- a/service/resourcegroupstaggingapi/api.go
+++ b/service/resourcegroupstaggingapi/api.go
@@ -1212,8 +1212,8 @@ func (s *ComplianceDetails) SetNoncompliantKeys(v []*string) *ComplianceDetails 
 // The target of the operation is currently being modified by a different request.
 // Try again later.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1282,8 +1282,8 @@ func (s ConcurrentModificationException) RequestID() string {
 //    * You must have a tag policy attached to the organization root, an OU,
 //    or an account.
 type ConstraintViolationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1985,8 +1985,8 @@ func (s *GetTagValuesOutput) SetTagValues(v []*string) *GetTagValuesOutput {
 // The request processing failed because of an unknown error, exception, or
 // failure. You can retry the request.
 type InternalServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2054,8 +2054,8 @@ func (s InternalServiceException) RequestID() string {
 //    (http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies-prereqs.html#bucket-policies-org-report)
 //    in the AWS Organizations User Guide.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2111,8 +2111,8 @@ func (s InvalidParameterException) RequestID() string {
 // A PaginationToken is valid for a maximum of 15 minutes. Your request was
 // denied because the specified PaginationToken has expired.
 type PaginationTokenExpiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2522,8 +2522,8 @@ func (s *TagResourcesOutput) SetFailedResourcesMap(v map[string]*FailureInfo) *T
 
 // The request was denied to limit the frequency of submitted requests.
 type ThrottledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/robomaker/api.go
+++ b/service/robomaker/api.go
@@ -4404,8 +4404,8 @@ func (s CancelSimulationJobOutput) GoString() string {
 
 // The failure percentage threshold percentage was met.
 type ConcurrentDeploymentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8278,8 +8278,8 @@ func (s *Fleet) SetName(v string) *Fleet {
 // Do not reuse a client token with different requests, unless the requests
 // are identical.
 type IdempotentParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8334,8 +8334,8 @@ func (s IdempotentParameterMismatchException) RequestID() string {
 
 // AWS RoboMaker experienced a service issue. Try your call again.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8391,8 +8391,8 @@ func (s InternalServerException) RequestID() string {
 // A parameter specified in a request is not valid, is unsupported, or cannot
 // be used. The returned message provides an explanation of the error value.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8542,8 +8542,8 @@ func (s *LaunchConfig) SetStreamUI(v bool) *LaunchConfig {
 // The requested resource exceeds the maximum number allowed, or the number
 // of concurrent stream requests exceeds the maximum number allowed.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9945,8 +9945,8 @@ func (s *RenderingEngine) SetVersion(v string) *RenderingEngine {
 
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10001,8 +10001,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10554,8 +10554,8 @@ func (s *S3Object) SetKey(v string) *S3Object {
 
 // The request has failed due to a temporary failure of the server.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12029,8 +12029,8 @@ func (s TagResourceOutput) GoString() string {
 // AWS RoboMaker is temporarily unable to process the request. Try your call
 // again.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/robomaker/api.go
+++ b/service/robomaker/api.go
@@ -4405,7 +4405,7 @@ func (s CancelSimulationJobOutput) GoString() string {
 // The failure percentage threshold percentage was met.
 type ConcurrentDeploymentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4422,7 +4422,7 @@ func (s ConcurrentDeploymentException) GoString() string {
 
 func newErrorConcurrentDeploymentException(v protocol.ResponseMetadata) error {
 	return &ConcurrentDeploymentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4450,12 +4450,12 @@ func (s ConcurrentDeploymentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentDeploymentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentDeploymentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateDeploymentJobInput struct {
@@ -8279,7 +8279,7 @@ func (s *Fleet) SetName(v string) *Fleet {
 // are identical.
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8296,7 +8296,7 @@ func (s IdempotentParameterMismatchException) GoString() string {
 
 func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8324,18 +8324,18 @@ func (s IdempotentParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS RoboMaker experienced a service issue. Try your call again.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8352,7 +8352,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8380,19 +8380,19 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A parameter specified in a request is not valid, is unsupported, or cannot
 // be used. The returned message provides an explanation of the error value.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8409,7 +8409,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8437,12 +8437,12 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a launch configuration.
@@ -8543,7 +8543,7 @@ func (s *LaunchConfig) SetStreamUI(v bool) *LaunchConfig {
 // of concurrent stream requests exceeds the maximum number allowed.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8560,7 +8560,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8588,12 +8588,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDeploymentJobsInput struct {
@@ -9946,7 +9946,7 @@ func (s *RenderingEngine) SetVersion(v string) *RenderingEngine {
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9963,7 +9963,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9991,18 +9991,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10019,7 +10019,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10047,12 +10047,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RestartSimulationJobInput struct {
@@ -10555,7 +10555,7 @@ func (s *S3Object) SetKey(v string) *S3Object {
 // The request has failed due to a temporary failure of the server.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10572,7 +10572,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10600,12 +10600,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a simulation application configuration.
@@ -12030,7 +12030,7 @@ func (s TagResourceOutput) GoString() string {
 // again.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12047,7 +12047,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12075,12 +12075,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -3003,8 +3003,8 @@ func (s *DisableDomainTransferLockOutput) SetOperationId(v string) *DisableDomai
 
 // The number of domains has exceeded the allowed threshold for the account.
 type DomainLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The number of domains has exceeded the allowed threshold for the account.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3233,8 +3233,8 @@ func (s *DomainTransferability) SetTransferable(v string) *DomainTransferability
 
 // The request is already in progress for the domain.
 type DuplicateRequest struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The request is already in progress for the domain.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4054,8 +4054,8 @@ func (s *GetOperationDetailOutput) SetType(v string) *GetOperationDetailOutput {
 // might refer to the ID of an operation that is already completed. For a domain
 // name, it might not be a valid domain name or belong to the requester account.
 type InvalidInput struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The requested item is not acceptable. For example, for an OperationId it
 	// might refer to the ID of an operation that is already completed. For a domain
@@ -4401,8 +4401,8 @@ func (s *Nameserver) SetName(v string) *Nameserver {
 // The number of operations or jobs running exceeded the allowed threshold for
 // the account.
 type OperationLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The number of operations or jobs running exceeded the allowed threshold for
 	// the account.
@@ -4967,8 +4967,8 @@ func (s *RetrieveDomainAuthCodeOutput) SetAuthCode(v string) *RetrieveDomainAuth
 
 // The top-level domain does not support this operation.
 type TLDRulesViolation struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The top-level domain does not support this operation.
 	Message_ *string `locationName:"message" type:"string"`
@@ -5309,8 +5309,8 @@ func (s *TransferDomainOutput) SetOperationId(v string) *TransferDomainOutput {
 
 // Amazon Route 53 does not support this top-level domain (TLD).
 type UnsupportedTLD struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Amazon Route 53 does not support this top-level domain (TLD).
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -3004,7 +3004,7 @@ func (s *DisableDomainTransferLockOutput) SetOperationId(v string) *DisableDomai
 // The number of domains has exceeded the allowed threshold for the account.
 type DomainLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The number of domains has exceeded the allowed threshold for the account.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3022,7 +3022,7 @@ func (s DomainLimitExceeded) GoString() string {
 
 func newErrorDomainLimitExceeded(v protocol.ResponseMetadata) error {
 	return &DomainLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3050,12 +3050,12 @@ func (s DomainLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DomainLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DomainLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about one suggested domain name.
@@ -3234,7 +3234,7 @@ func (s *DomainTransferability) SetTransferable(v string) *DomainTransferability
 // The request is already in progress for the domain.
 type DuplicateRequest struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The request is already in progress for the domain.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3252,7 +3252,7 @@ func (s DuplicateRequest) GoString() string {
 
 func newErrorDuplicateRequest(v protocol.ResponseMetadata) error {
 	return &DuplicateRequest{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3280,12 +3280,12 @@ func (s DuplicateRequest) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateRequest) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateRequest) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type EnableDomainAutoRenewInput struct {
@@ -4055,7 +4055,7 @@ func (s *GetOperationDetailOutput) SetType(v string) *GetOperationDetailOutput {
 // name, it might not be a valid domain name or belong to the requester account.
 type InvalidInput struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The requested item is not acceptable. For example, for an OperationId it
 	// might refer to the ID of an operation that is already completed. For a domain
@@ -4075,7 +4075,7 @@ func (s InvalidInput) GoString() string {
 
 func newErrorInvalidInput(v protocol.ResponseMetadata) error {
 	return &InvalidInput{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4103,12 +4103,12 @@ func (s InvalidInput) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInput) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInput) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The ListDomains request includes the following elements.
@@ -4402,7 +4402,7 @@ func (s *Nameserver) SetName(v string) *Nameserver {
 // the account.
 type OperationLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The number of operations or jobs running exceeded the allowed threshold for
 	// the account.
@@ -4421,7 +4421,7 @@ func (s OperationLimitExceeded) GoString() string {
 
 func newErrorOperationLimitExceeded(v protocol.ResponseMetadata) error {
 	return &OperationLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4449,12 +4449,12 @@ func (s OperationLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // OperationSummary includes the following elements.
@@ -4968,7 +4968,7 @@ func (s *RetrieveDomainAuthCodeOutput) SetAuthCode(v string) *RetrieveDomainAuth
 // The top-level domain does not support this operation.
 type TLDRulesViolation struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The top-level domain does not support this operation.
 	Message_ *string `locationName:"message" type:"string"`
@@ -4986,7 +4986,7 @@ func (s TLDRulesViolation) GoString() string {
 
 func newErrorTLDRulesViolation(v protocol.ResponseMetadata) error {
 	return &TLDRulesViolation{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5014,12 +5014,12 @@ func (s TLDRulesViolation) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TLDRulesViolation) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TLDRulesViolation) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Each tag includes the following elements.
@@ -5310,7 +5310,7 @@ func (s *TransferDomainOutput) SetOperationId(v string) *TransferDomainOutput {
 // Amazon Route 53 does not support this top-level domain (TLD).
 type UnsupportedTLD struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Amazon Route 53 does not support this top-level domain (TLD).
 	Message_ *string `locationName:"message" type:"string"`
@@ -5328,7 +5328,7 @@ func (s UnsupportedTLD) GoString() string {
 
 func newErrorUnsupportedTLD(v protocol.ResponseMetadata) error {
 	return &UnsupportedTLD{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5356,12 +5356,12 @@ func (s UnsupportedTLD) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedTLD) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedTLD) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The UpdateDomainContact request includes the following elements.

--- a/service/route53resolver/api.go
+++ b/service/route53resolver/api.go
@@ -3413,7 +3413,7 @@ func (s *GetResolverRulePolicyOutput) SetResolverRulePolicy(v string) *GetResolv
 // We encountered an unknown error. Try again in a few minutes.
 type InternalServiceErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3430,7 +3430,7 @@ func (s InternalServiceErrorException) GoString() string {
 
 func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServiceErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3458,18 +3458,18 @@ func (s InternalServiceErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The value that you specified for NextToken in a List request isn't valid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3486,7 +3486,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3514,18 +3514,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more parameters in this request are not valid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// For an InvalidParameterException error, the name of the parameter that's
 	// invalid.
@@ -3546,7 +3546,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3574,18 +3574,18 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resolver rule policy is invalid.
 type InvalidPolicyDocument struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3602,7 +3602,7 @@ func (s InvalidPolicyDocument) GoString() string {
 
 func newErrorInvalidPolicyDocument(v protocol.ResponseMetadata) error {
 	return &InvalidPolicyDocument{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3630,18 +3630,18 @@ func (s InvalidPolicyDocument) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPolicyDocument) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPolicyDocument) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request is invalid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3658,7 +3658,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3686,18 +3686,18 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified tag is invalid.
 type InvalidTagException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3714,7 +3714,7 @@ func (s InvalidTagException) GoString() string {
 
 func newErrorInvalidTagException(v protocol.ResponseMetadata) error {
 	return &InvalidTagException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3742,12 +3742,12 @@ func (s InvalidTagException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTagException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTagException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // In an CreateResolverEndpoint request, a subnet and IP address that you want
@@ -3953,7 +3953,7 @@ func (s *IpAddressUpdate) SetSubnetId(v string) *IpAddressUpdate {
 // The request caused one or more limits to be exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3974,7 +3974,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4002,12 +4002,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListResolverEndpointIpAddressesInput struct {
@@ -5089,7 +5089,7 @@ func (s *ResolverRuleConfig) SetTargetIps(v []*TargetAddress) *ResolverRuleConfi
 // The resource that you tried to create already exists.
 type ResourceExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5110,7 +5110,7 @@ func (s ResourceExistsException) GoString() string {
 
 func newErrorResourceExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5138,18 +5138,18 @@ func (s ResourceExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource that you tried to update or delete is currently in use.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5170,7 +5170,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5198,18 +5198,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource doesn't exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5230,7 +5230,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5258,18 +5258,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource isn't available.
 type ResourceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5290,7 +5290,7 @@ func (s ResourceUnavailableException) GoString() string {
 
 func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ResourceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5318,12 +5318,12 @@ func (s ResourceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One tag that you want to add to the specified resource. A tag consists of
@@ -5501,7 +5501,7 @@ func (s *TargetAddress) SetPort(v int64) *TargetAddress {
 // The request was throttled. Try again in a few minutes.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5518,7 +5518,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5546,18 +5546,18 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource doesn't exist.
 type UnknownResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5574,7 +5574,7 @@ func (s UnknownResourceException) GoString() string {
 
 func newErrorUnknownResourceException(v protocol.ResponseMetadata) error {
 	return &UnknownResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5602,12 +5602,12 @@ func (s UnknownResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnknownResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnknownResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/route53resolver/api.go
+++ b/service/route53resolver/api.go
@@ -3412,8 +3412,8 @@ func (s *GetResolverRulePolicyOutput) SetResolverRulePolicy(v string) *GetResolv
 
 // We encountered an unknown error. Try again in a few minutes.
 type InternalServiceErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3468,8 +3468,8 @@ func (s InternalServiceErrorException) RequestID() string {
 
 // The value that you specified for NextToken in a List request isn't valid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3524,8 +3524,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // One or more parameters in this request are not valid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// For an InvalidParameterException error, the name of the parameter that's
 	// invalid.
@@ -3584,8 +3584,8 @@ func (s InvalidParameterException) RequestID() string {
 
 // The specified resolver rule policy is invalid.
 type InvalidPolicyDocument struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3640,8 +3640,8 @@ func (s InvalidPolicyDocument) RequestID() string {
 
 // The request is invalid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3696,8 +3696,8 @@ func (s InvalidRequestException) RequestID() string {
 
 // The specified tag is invalid.
 type InvalidTagException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3952,8 +3952,8 @@ func (s *IpAddressUpdate) SetSubnetId(v string) *IpAddressUpdate {
 
 // The request caused one or more limits to be exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5088,8 +5088,8 @@ func (s *ResolverRuleConfig) SetTargetIps(v []*TargetAddress) *ResolverRuleConfi
 
 // The resource that you tried to create already exists.
 type ResourceExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5148,8 +5148,8 @@ func (s ResourceExistsException) RequestID() string {
 
 // The resource that you tried to update or delete is currently in use.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5208,8 +5208,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The specified resource doesn't exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5268,8 +5268,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The specified resource isn't available.
 type ResourceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -5500,8 +5500,8 @@ func (s *TargetAddress) SetPort(v int64) *TargetAddress {
 
 // The request was throttled. Try again in a few minutes.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5556,8 +5556,8 @@ func (s ThrottlingException) RequestID() string {
 
 // The specified resource doesn't exist.
 type UnknownResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/sagemaker/api.go
+++ b/service/sagemaker/api.go
@@ -15280,8 +15280,8 @@ func (s *CompilationJobSummary) SetLastModifiedTime(v time.Time) *CompilationJob
 // There was a conflict when you attempted to modify an experiment, trial, or
 // trial component.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39254,8 +39254,8 @@ func (s *ResourceConfig) SetVolumeSizeInGB(v int64) *ResourceConfig {
 
 // Resource being accessed is in use.
 type ResourceInUse struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39311,8 +39311,8 @@ func (s ResourceInUse) RequestID() string {
 // You have exceeded an Amazon SageMaker resource limit. For example, you might
 // have too many training jobs created.
 type ResourceLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39429,8 +39429,8 @@ func (s *ResourceLimits) SetMaxParallelTrainingJobs(v int64) *ResourceLimits {
 
 // Resource being access is not found.
 type ResourceNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/sagemaker/api.go
+++ b/service/sagemaker/api.go
@@ -15281,7 +15281,7 @@ func (s *CompilationJobSummary) SetLastModifiedTime(v time.Time) *CompilationJob
 // trial component.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15298,7 +15298,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15326,12 +15326,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the container, as part of model definition.
@@ -39255,7 +39255,7 @@ func (s *ResourceConfig) SetVolumeSizeInGB(v int64) *ResourceConfig {
 // Resource being accessed is in use.
 type ResourceInUse struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39272,7 +39272,7 @@ func (s ResourceInUse) GoString() string {
 
 func newErrorResourceInUse(v protocol.ResponseMetadata) error {
 	return &ResourceInUse{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -39300,19 +39300,19 @@ func (s ResourceInUse) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUse) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUse) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have exceeded an Amazon SageMaker resource limit. For example, you might
 // have too many training jobs created.
 type ResourceLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39329,7 +39329,7 @@ func (s ResourceLimitExceeded) GoString() string {
 
 func newErrorResourceLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -39357,12 +39357,12 @@ func (s ResourceLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the maximum number of training jobs and parallel training jobs
@@ -39430,7 +39430,7 @@ func (s *ResourceLimits) SetMaxParallelTrainingJobs(v int64) *ResourceLimits {
 // Resource being access is not found.
 type ResourceNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39447,7 +39447,7 @@ func (s ResourceNotFound) GoString() string {
 
 func newErrorResourceNotFound(v protocol.ResponseMetadata) error {
 	return &ResourceNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -39475,12 +39475,12 @@ func (s ResourceNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The instance type and quantity.

--- a/service/sagemakerruntime/api.go
+++ b/service/sagemakerruntime/api.go
@@ -125,7 +125,7 @@ func (c *SageMakerRuntime) InvokeEndpointWithContext(ctx aws.Context, input *Inv
 // An internal failure occurred.
 type InternalFailure struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -142,7 +142,7 @@ func (s InternalFailure) GoString() string {
 
 func newErrorInternalFailure(v protocol.ResponseMetadata) error {
 	return &InternalFailure{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -170,12 +170,12 @@ func (s InternalFailure) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailure) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailure) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvokeEndpointInput struct {
@@ -358,7 +358,7 @@ func (s *InvokeEndpointOutput) SetInvokedProductionVariant(v string) *InvokeEndp
 // code.
 type ModelError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The Amazon Resource Name (ARN) of the log stream.
 	LogStreamArn *string `type:"string"`
@@ -384,7 +384,7 @@ func (s ModelError) GoString() string {
 
 func newErrorModelError(v protocol.ResponseMetadata) error {
 	return &ModelError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -412,18 +412,18 @@ func (s ModelError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ModelError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ModelError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The service is unavailable. Try your call again.
 type ServiceUnavailable struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -440,7 +440,7 @@ func (s ServiceUnavailable) GoString() string {
 
 func newErrorServiceUnavailable(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailable{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -468,18 +468,18 @@ func (s ServiceUnavailable) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailable) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailable) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Inspect your request and try again.
 type ValidationError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -496,7 +496,7 @@ func (s ValidationError) GoString() string {
 
 func newErrorValidationError(v protocol.ResponseMetadata) error {
 	return &ValidationError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -524,10 +524,10 @@ func (s ValidationError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }

--- a/service/sagemakerruntime/api.go
+++ b/service/sagemakerruntime/api.go
@@ -124,8 +124,8 @@ func (c *SageMakerRuntime) InvokeEndpointWithContext(ctx aws.Context, input *Inv
 
 // An internal failure occurred.
 type InternalFailure struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -357,8 +357,8 @@ func (s *InvokeEndpointOutput) SetInvokedProductionVariant(v string) *InvokeEndp
 // Model (owned by the customer in the container) returned 4xx or 5xx error
 // code.
 type ModelError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The Amazon Resource Name (ARN) of the log stream.
 	LogStreamArn *string `type:"string"`
@@ -422,8 +422,8 @@ func (s ModelError) RequestID() string {
 
 // The service is unavailable. Try your call again.
 type ServiceUnavailable struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -478,8 +478,8 @@ func (s ServiceUnavailable) RequestID() string {
 
 // Inspect your request and try again.
 type ValidationError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/savingsplans/api.go
+++ b/service/savingsplans/api.go
@@ -1326,7 +1326,7 @@ func (s *DescribeSavingsPlansOutput) SetSavingsPlans(v []*SavingsPlan) *Describe
 // An unexpected error occurred.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1343,7 +1343,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1371,12 +1371,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTagsForResourceInput struct {
@@ -1512,7 +1512,7 @@ func (s *ParentSavingsPlanOffering) SetPlanType(v string) *ParentSavingsPlanOffe
 // The specified resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1529,7 +1529,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1557,12 +1557,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a Savings Plan.
@@ -2264,7 +2264,7 @@ func (s *SavingsPlanRateProperty) SetValue(v string) *SavingsPlanRateProperty {
 // A service quota has been exceeded.
 type ServiceQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2281,7 +2281,7 @@ func (s ServiceQuotaExceededException) GoString() string {
 
 func newErrorServiceQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2309,12 +2309,12 @@ func (s ServiceQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {
@@ -2453,7 +2453,7 @@ func (s UntagResourceOutput) GoString() string {
 // One of the input parameters is not valid.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2470,7 +2470,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2498,12 +2498,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/savingsplans/api.go
+++ b/service/savingsplans/api.go
@@ -1325,8 +1325,8 @@ func (s *DescribeSavingsPlansOutput) SetSavingsPlans(v []*SavingsPlan) *Describe
 
 // An unexpected error occurred.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1511,8 +1511,8 @@ func (s *ParentSavingsPlanOffering) SetPlanType(v string) *ParentSavingsPlanOffe
 
 // The specified resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2263,8 +2263,8 @@ func (s *SavingsPlanRateProperty) SetValue(v string) *SavingsPlanRateProperty {
 
 // A service quota has been exceeded.
 type ServiceQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2452,8 +2452,8 @@ func (s UntagResourceOutput) GoString() string {
 
 // One of the input parameters is not valid.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/schemas/api.go
+++ b/service/schemas/api.go
@@ -2830,7 +2830,7 @@ func (c *Schemas) UpdateSchemaWithContext(ctx aws.Context, input *UpdateSchemaIn
 
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -2849,7 +2849,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2877,17 +2877,17 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -2906,7 +2906,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2934,12 +2934,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateDiscovererInput struct {
@@ -4118,7 +4118,7 @@ func (s *DiscovererSummary) SetTags(v map[string]*string) *DiscovererSummary {
 
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -4137,7 +4137,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4165,12 +4165,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetCodeBindingSourceInput struct {
@@ -4347,7 +4347,7 @@ func (s *GetDiscoveredSchemaOutput) SetContent(v string) *GetDiscoveredSchemaOut
 
 type GoneException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -4366,7 +4366,7 @@ func (s GoneException) GoString() string {
 
 func newErrorGoneException(v protocol.ResponseMetadata) error {
 	return &GoneException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4394,17 +4394,17 @@ func (s GoneException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s GoneException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s GoneException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -4423,7 +4423,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4451,12 +4451,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDiscoverersInput struct {
@@ -4962,7 +4962,7 @@ func (s *LockServiceLinkedRoleOutput) SetRelatedResources(v []*DiscovererSummary
 
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -4981,7 +4981,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5009,12 +5009,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutCodeBindingInput struct {
@@ -5462,7 +5462,7 @@ func (s *SearchSchemasOutput) SetSchemas(v []*SearchSchemaSummary) *SearchSchema
 
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -5481,7 +5481,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5509,12 +5509,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartDiscovererInput struct {
@@ -5724,7 +5724,7 @@ func (s TagResourceOutput) GoString() string {
 
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -5743,7 +5743,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5771,17 +5771,17 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -5800,7 +5800,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5828,12 +5828,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UnlockServiceLinkedRoleInput struct {

--- a/service/schemas/api.go
+++ b/service/schemas/api.go
@@ -2829,8 +2829,8 @@ func (c *Schemas) UpdateSchemaWithContext(ctx aws.Context, input *UpdateSchemaIn
 }
 
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -2886,8 +2886,8 @@ func (s BadRequestException) RequestID() string {
 }
 
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -4117,8 +4117,8 @@ func (s *DiscovererSummary) SetTags(v map[string]*string) *DiscovererSummary {
 }
 
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -4346,8 +4346,8 @@ func (s *GetDiscoveredSchemaOutput) SetContent(v string) *GetDiscoveredSchemaOut
 }
 
 type GoneException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -4403,8 +4403,8 @@ func (s GoneException) RequestID() string {
 }
 
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -4961,8 +4961,8 @@ func (s *LockServiceLinkedRoleOutput) SetRelatedResources(v []*DiscovererSummary
 }
 
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -5461,8 +5461,8 @@ func (s *SearchSchemasOutput) SetSchemas(v []*SearchSchemaSummary) *SearchSchema
 }
 
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -5723,8 +5723,8 @@ func (s TagResourceOutput) GoString() string {
 }
 
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -5780,8 +5780,8 @@ func (s TooManyRequestsException) RequestID() string {
 }
 
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 

--- a/service/secretsmanager/api.go
+++ b/service/secretsmanager/api.go
@@ -2875,7 +2875,7 @@ func (s *CreateSecretOutput) SetVersionId(v string) *CreateSecretOutput {
 // KMS key.
 type DecryptionFailure struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2892,7 +2892,7 @@ func (s DecryptionFailure) GoString() string {
 
 func newErrorDecryptionFailure(v protocol.ResponseMetadata) error {
 	return &DecryptionFailure{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2920,12 +2920,12 @@ func (s DecryptionFailure) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DecryptionFailure) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DecryptionFailure) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteResourcePolicyInput struct {
@@ -3372,7 +3372,7 @@ func (s *DescribeSecretOutput) SetVersionIdsToStages(v map[string][]*string) *De
 // Use of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html).
 type EncryptionFailure struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3389,7 +3389,7 @@ func (s EncryptionFailure) GoString() string {
 
 func newErrorEncryptionFailure(v protocol.ResponseMetadata) error {
 	return &EncryptionFailure{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3417,12 +3417,12 @@ func (s EncryptionFailure) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EncryptionFailure) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EncryptionFailure) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetRandomPasswordInput struct {
@@ -3866,7 +3866,7 @@ func (s *GetSecretValueOutput) SetVersionStages(v []*string) *GetSecretValueOutp
 // An error occurred on the server side.
 type InternalServiceError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3883,7 +3883,7 @@ func (s InternalServiceError) GoString() string {
 
 func newErrorInternalServiceError(v protocol.ResponseMetadata) error {
 	return &InternalServiceError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3911,18 +3911,18 @@ func (s InternalServiceError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You provided an invalid NextToken value.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3939,7 +3939,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3967,18 +3967,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You provided an invalid value for a parameter.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3995,7 +3995,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4023,12 +4023,12 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You provided a parameter value that is not valid for the current state of
@@ -4044,7 +4044,7 @@ func (s InvalidParameterException) RequestID() string {
 //    parameter in this call.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4061,7 +4061,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4089,19 +4089,19 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request failed because it would exceed one of the Secrets Manager internal
 // limits.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4118,7 +4118,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4146,12 +4146,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListSecretVersionIdsInput struct {
@@ -4418,7 +4418,7 @@ func (s *ListSecretsOutput) SetSecretList(v []*SecretListEntry) *ListSecretsOutp
 // The policy document that you provided isn't valid.
 type MalformedPolicyDocumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4435,7 +4435,7 @@ func (s MalformedPolicyDocumentException) GoString() string {
 
 func newErrorMalformedPolicyDocumentException(v protocol.ResponseMetadata) error {
 	return &MalformedPolicyDocumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4463,18 +4463,18 @@ func (s MalformedPolicyDocumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MalformedPolicyDocumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MalformedPolicyDocumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request failed because you did not complete all the prerequisite steps.
 type PreconditionNotMetException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4491,7 +4491,7 @@ func (s PreconditionNotMetException) GoString() string {
 
 func newErrorPreconditionNotMetException(v protocol.ResponseMetadata) error {
 	return &PreconditionNotMetException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4519,12 +4519,12 @@ func (s PreconditionNotMetException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PreconditionNotMetException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PreconditionNotMetException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutResourcePolicyInput struct {
@@ -4857,7 +4857,7 @@ func (s *PutSecretValueOutput) SetVersionStages(v []*string) *PutSecretValueOutp
 // A resource with the ID you requested already exists.
 type ResourceExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4874,7 +4874,7 @@ func (s ResourceExistsException) GoString() string {
 
 func newErrorResourceExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4902,18 +4902,18 @@ func (s ResourceExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // We can't find the resource that you asked for.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4930,7 +4930,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4958,12 +4958,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RestoreSecretInput struct {

--- a/service/secretsmanager/api.go
+++ b/service/secretsmanager/api.go
@@ -2874,8 +2874,8 @@ func (s *CreateSecretOutput) SetVersionId(v string) *CreateSecretOutput {
 // Secrets Manager can't decrypt the protected secret text using the provided
 // KMS key.
 type DecryptionFailure struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3371,8 +3371,8 @@ func (s *DescribeSecretOutput) SetVersionIdsToStages(v map[string][]*string) *De
 // and not in an invalid state. For more information, see How Key State Affects
 // Use of a Customer Master Key (http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html).
 type EncryptionFailure struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3865,8 +3865,8 @@ func (s *GetSecretValueOutput) SetVersionStages(v []*string) *GetSecretValueOutp
 
 // An error occurred on the server side.
 type InternalServiceError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3921,8 +3921,8 @@ func (s InternalServiceError) RequestID() string {
 
 // You provided an invalid NextToken value.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3977,8 +3977,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // You provided an invalid value for a parameter.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4043,8 +4043,8 @@ func (s InvalidParameterException) RequestID() string {
 //    Lambda function ARN configured and you didn't include such an ARN as a
 //    parameter in this call.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4100,8 +4100,8 @@ func (s InvalidRequestException) RequestID() string {
 // The request failed because it would exceed one of the Secrets Manager internal
 // limits.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4417,8 +4417,8 @@ func (s *ListSecretsOutput) SetSecretList(v []*SecretListEntry) *ListSecretsOutp
 
 // The policy document that you provided isn't valid.
 type MalformedPolicyDocumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4473,8 +4473,8 @@ func (s MalformedPolicyDocumentException) RequestID() string {
 
 // The request failed because you did not complete all the prerequisite steps.
 type PreconditionNotMetException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4856,8 +4856,8 @@ func (s *PutSecretValueOutput) SetVersionStages(v []*string) *PutSecretValueOutp
 
 // A resource with the ID you requested already exists.
 type ResourceExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4912,8 +4912,8 @@ func (s ResourceExistsException) RequestID() string {
 
 // We can't find the resource that you asked for.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/securityhub/api.go
+++ b/service/securityhub/api.go
@@ -4500,7 +4500,7 @@ func (s AcceptInvitationOutput) GoString() string {
 // You don't have permission to perform the action specified in the request.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -4519,7 +4519,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4547,12 +4547,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The details of an AWS account.
@@ -11260,7 +11260,7 @@ func (s *InsightResults) SetResultValues(v []*InsightResultValue) *InsightResult
 // Internal server error.
 type InternalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11279,7 +11279,7 @@ func (s InternalException) GoString() string {
 
 func newErrorInternalException(v protocol.ResponseMetadata) error {
 	return &InternalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11307,18 +11307,18 @@ func (s InternalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS Security Hub isn't enabled for the account used to make this request.
 type InvalidAccessException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11337,7 +11337,7 @@ func (s InvalidAccessException) GoString() string {
 
 func newErrorInvalidAccessException(v protocol.ResponseMetadata) error {
 	return &InvalidAccessException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11365,19 +11365,19 @@ func (s InvalidAccessException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAccessException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAccessException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request was rejected because you supplied an invalid or out-of-range
 // value for an input parameter.
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11396,7 +11396,7 @@ func (s InvalidInputException) GoString() string {
 
 func newErrorInvalidInputException(v protocol.ResponseMetadata) error {
 	return &InvalidInputException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11424,12 +11424,12 @@ func (s InvalidInputException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details about an invitation.
@@ -11584,7 +11584,7 @@ func (s *KeywordFilter) SetValue(v string) *KeywordFilter {
 // the current AWS account limits. The error code describes the limit exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11603,7 +11603,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11631,12 +11631,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListEnabledProductsForImportInput struct {
@@ -12851,7 +12851,7 @@ func (s *Resource) SetType(v string) *Resource {
 // The resource specified in the request conflicts with an existing resource.
 type ResourceConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -12870,7 +12870,7 @@ func (s ResourceConflictException) GoString() string {
 
 func newErrorResourceConflictException(v protocol.ResponseMetadata) error {
 	return &ResourceConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12898,12 +12898,12 @@ func (s ResourceConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Additional details about a resource related to a finding.
@@ -13138,7 +13138,7 @@ func (s *ResourceDetails) SetOther(v map[string]*string) *ResourceDetails {
 // The request was rejected because we can't find the specified resource.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -13157,7 +13157,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13185,12 +13185,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details about the account that was not processed.

--- a/service/securityhub/api.go
+++ b/service/securityhub/api.go
@@ -4499,8 +4499,8 @@ func (s AcceptInvitationOutput) GoString() string {
 
 // You don't have permission to perform the action specified in the request.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11259,8 +11259,8 @@ func (s *InsightResults) SetResultValues(v []*InsightResultValue) *InsightResult
 
 // Internal server error.
 type InternalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11317,8 +11317,8 @@ func (s InternalException) RequestID() string {
 
 // AWS Security Hub isn't enabled for the account used to make this request.
 type InvalidAccessException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11376,8 +11376,8 @@ func (s InvalidAccessException) RequestID() string {
 // The request was rejected because you supplied an invalid or out-of-range
 // value for an input parameter.
 type InvalidInputException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -11583,8 +11583,8 @@ func (s *KeywordFilter) SetValue(v string) *KeywordFilter {
 // The request was rejected because it attempted to create resources beyond
 // the current AWS account limits. The error code describes the limit exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -12850,8 +12850,8 @@ func (s *Resource) SetType(v string) *Resource {
 
 // The resource specified in the request conflicts with an existing resource.
 type ResourceConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 
@@ -13137,8 +13137,8 @@ func (s *ResourceDetails) SetOther(v map[string]*string) *ResourceDetails {
 
 // The request was rejected because we can't find the specified resource.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Code_ *string `locationName:"Code" type:"string"`
 

--- a/service/serverlessapplicationrepository/api.go
+++ b/service/serverlessapplicationrepository/api.go
@@ -1727,8 +1727,8 @@ func (s *ApplicationSummary) SetSpdxLicenseId(v string) *ApplicationSummary {
 
 // One of the parameters in the request is invalid.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 400
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -1787,8 +1787,8 @@ func (s BadRequestException) RequestID() string {
 
 // The resource already exists.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 409
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -2677,8 +2677,8 @@ func (s DeleteApplicationOutput) GoString() string {
 
 // The client is not authenticated.
 type ForbiddenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 403
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -3089,8 +3089,8 @@ func (s *GetCloudFormationTemplateOutput) SetTemplateUrl(v string) *GetCloudForm
 // The AWS Serverless Application Repository service encountered an internal
 // error.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 500
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -3408,8 +3408,8 @@ func (s *ListApplicationsOutput) SetNextToken(v string) *ListApplicationsOutput 
 // The resource (for example, an access policy statement) specified in the request
 // doesn't exist.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 404
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -3966,8 +3966,8 @@ func (s *Tag) SetValue(v string) *Tag {
 // The client is sending more than the allowed number of requests per unit of
 // time.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// 429
 	ErrorCode *string `locationName:"errorCode" type:"string"`

--- a/service/serverlessapplicationrepository/api.go
+++ b/service/serverlessapplicationrepository/api.go
@@ -1728,7 +1728,7 @@ func (s *ApplicationSummary) SetSpdxLicenseId(v string) *ApplicationSummary {
 // One of the parameters in the request is invalid.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 400
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -1749,7 +1749,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1777,18 +1777,18 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource already exists.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 409
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -1809,7 +1809,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1837,12 +1837,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateApplicationOutput struct {
@@ -2678,7 +2678,7 @@ func (s DeleteApplicationOutput) GoString() string {
 // The client is not authenticated.
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 403
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -2699,7 +2699,7 @@ func (s ForbiddenException) GoString() string {
 
 func newErrorForbiddenException(v protocol.ResponseMetadata) error {
 	return &ForbiddenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2727,12 +2727,12 @@ func (s ForbiddenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ForbiddenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ForbiddenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetApplicationInput struct {
@@ -3090,7 +3090,7 @@ func (s *GetCloudFormationTemplateOutput) SetTemplateUrl(v string) *GetCloudForm
 // error.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 500
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -3112,7 +3112,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3140,12 +3140,12 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListApplicationDependenciesInput struct {
@@ -3409,7 +3409,7 @@ func (s *ListApplicationsOutput) SetNextToken(v string) *ListApplicationsOutput 
 // doesn't exist.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 404
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -3431,7 +3431,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3459,12 +3459,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Parameters supported by the application.
@@ -3967,7 +3967,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // time.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// 429
 	ErrorCode *string `locationName:"errorCode" type:"string"`
@@ -3989,7 +3989,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4017,12 +4017,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UnshareApplicationInput struct {

--- a/service/servicecatalog/api.go
+++ b/service/servicecatalog/api.go
@@ -13029,8 +13029,8 @@ func (s DisassociateTagOptionFromResourceOutput) GoString() string {
 
 // The specified resource is a duplicate.
 type DuplicateResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13472,8 +13472,8 @@ func (s *GetAWSOrganizationsAccessStatusOutput) SetAccessStatus(v string) *GetAW
 
 // One or more parameters provided to the operation are not valid.
 type InvalidParametersException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13530,8 +13530,8 @@ func (s InvalidParametersException) RequestID() string {
 // Check your resources to ensure that they are in valid states before retrying
 // the operation.
 type InvalidStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13639,8 +13639,8 @@ func (s *LaunchPathSummary) SetTags(v []*Tag) *LaunchPathSummary {
 // Decrease your resource use or increase your service limits and retry the
 // operation.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15693,8 +15693,8 @@ func (s *ListTagOptionsOutput) SetTagOptionDetails(v []*TagOptionDetail) *ListTa
 
 // The operation is not supported.
 type OperationNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18043,8 +18043,8 @@ func (s *ResourceDetail) SetName(v string) *ResourceDetail {
 // A resource that is currently in use. Ensure that the resource is not in use
 // and retry the operation.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18099,8 +18099,8 @@ func (s ResourceInUseException) RequestID() string {
 
 // The specified resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19091,8 +19091,8 @@ func (s *TagOptionDetail) SetValue(v string) *TagOptionDetail {
 // process has not been performed for this account. Please use the AWS console
 // to perform the migration process before retrying the operation.
 type TagOptionNotMigratedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/servicecatalog/api.go
+++ b/service/servicecatalog/api.go
@@ -13030,7 +13030,7 @@ func (s DisassociateTagOptionFromResourceOutput) GoString() string {
 // The specified resource is a duplicate.
 type DuplicateResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13047,7 +13047,7 @@ func (s DuplicateResourceException) GoString() string {
 
 func newErrorDuplicateResourceException(v protocol.ResponseMetadata) error {
 	return &DuplicateResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13075,12 +13075,12 @@ func (s DuplicateResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type EnableAWSOrganizationsAccessInput struct {
@@ -13473,7 +13473,7 @@ func (s *GetAWSOrganizationsAccessStatusOutput) SetAccessStatus(v string) *GetAW
 // One or more parameters provided to the operation are not valid.
 type InvalidParametersException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13490,7 +13490,7 @@ func (s InvalidParametersException) GoString() string {
 
 func newErrorInvalidParametersException(v protocol.ResponseMetadata) error {
 	return &InvalidParametersException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13518,12 +13518,12 @@ func (s InvalidParametersException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParametersException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParametersException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An attempt was made to modify a resource that is in a state that is not valid.
@@ -13531,7 +13531,7 @@ func (s InvalidParametersException) RequestID() string {
 // the operation.
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13548,7 +13548,7 @@ func (s InvalidStateException) GoString() string {
 
 func newErrorInvalidStateException(v protocol.ResponseMetadata) error {
 	return &InvalidStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13576,12 +13576,12 @@ func (s InvalidStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Summary information about a product path for a user.
@@ -13640,7 +13640,7 @@ func (s *LaunchPathSummary) SetTags(v []*Tag) *LaunchPathSummary {
 // operation.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13657,7 +13657,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13685,12 +13685,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAcceptedPortfolioSharesInput struct {
@@ -15694,7 +15694,7 @@ func (s *ListTagOptionsOutput) SetTagOptionDetails(v []*TagOptionDetail) *ListTa
 // The operation is not supported.
 type OperationNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -15711,7 +15711,7 @@ func (s OperationNotSupportedException) GoString() string {
 
 func newErrorOperationNotSupportedException(v protocol.ResponseMetadata) error {
 	return &OperationNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15739,12 +15739,12 @@ func (s OperationNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the organization node.
@@ -18044,7 +18044,7 @@ func (s *ResourceDetail) SetName(v string) *ResourceDetail {
 // and retry the operation.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18061,7 +18061,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18089,18 +18089,18 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18117,7 +18117,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18145,12 +18145,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a change to a resource attribute.
@@ -19092,7 +19092,7 @@ func (s *TagOptionDetail) SetValue(v string) *TagOptionDetail {
 // to perform the migration process before retrying the operation.
 type TagOptionNotMigratedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19109,7 +19109,7 @@ func (s TagOptionNotMigratedException) GoString() string {
 
 func newErrorTagOptionNotMigratedException(v protocol.ResponseMetadata) error {
 	return &TagOptionNotMigratedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19137,12 +19137,12 @@ func (s TagOptionNotMigratedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagOptionNotMigratedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagOptionNotMigratedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Summary information about a TagOption.

--- a/service/servicediscovery/api.go
+++ b/service/servicediscovery/api.go
@@ -2573,7 +2573,7 @@ func (s *CreateServiceOutput) SetService(v *Service) *CreateServiceOutput {
 // is not a custom health check.
 type CustomHealthNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2590,7 +2590,7 @@ func (s CustomHealthNotFound) GoString() string {
 
 func newErrorCustomHealthNotFound(v protocol.ResponseMetadata) error {
 	return &CustomHealthNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2618,12 +2618,12 @@ func (s CustomHealthNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CustomHealthNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CustomHealthNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteNamespaceInput struct {
@@ -3249,7 +3249,7 @@ func (s *DnsRecord) SetType(v string) *DnsRecord {
 // The operation is already in progress.
 type DuplicateRequest struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The ID of the operation that is already in progress.
 	DuplicateOperationId *string `type:"string"`
@@ -3269,7 +3269,7 @@ func (s DuplicateRequest) GoString() string {
 
 func newErrorDuplicateRequest(v protocol.ResponseMetadata) error {
 	return &DuplicateRequest{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3297,12 +3297,12 @@ func (s DuplicateRequest) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateRequest) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateRequest) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetInstanceInput struct {
@@ -4152,7 +4152,7 @@ func (s *Instance) SetId(v string) *Instance {
 // and information about the instance hasn't propagated yet.
 type InstanceNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4169,7 +4169,7 @@ func (s InstanceNotFound) GoString() string {
 
 func newErrorInstanceNotFound(v protocol.ResponseMetadata) error {
 	return &InstanceNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4197,12 +4197,12 @@ func (s InstanceNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InstanceNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InstanceNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A complex type that contains information about the instances that you registered
@@ -4267,7 +4267,7 @@ func (s *InstanceSummary) SetId(v string) *InstanceSummary {
 // a string value might exceed length constraints.
 type InvalidInput struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4284,7 +4284,7 @@ func (s InvalidInput) GoString() string {
 
 func newErrorInvalidInput(v protocol.ResponseMetadata) error {
 	return &InvalidInput{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4312,12 +4312,12 @@ func (s InvalidInput) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInput) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInput) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListInstancesInput struct {
@@ -4882,7 +4882,7 @@ func (s *Namespace) SetType(v string) *Namespace {
 // The namespace that you're trying to create already exists.
 type NamespaceAlreadyExists struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The CreatorRequestId that was used to create the namespace.
 	CreatorRequestId *string `type:"string"`
@@ -4905,7 +4905,7 @@ func (s NamespaceAlreadyExists) GoString() string {
 
 func newErrorNamespaceAlreadyExists(v protocol.ResponseMetadata) error {
 	return &NamespaceAlreadyExists{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4933,12 +4933,12 @@ func (s NamespaceAlreadyExists) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NamespaceAlreadyExists) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NamespaceAlreadyExists) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A complex type that identifies the namespaces that you want to list. You
@@ -5020,7 +5020,7 @@ func (s *NamespaceFilter) SetValues(v []*string) *NamespaceFilter {
 // No namespace exists with the specified ID.
 type NamespaceNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5037,7 +5037,7 @@ func (s NamespaceNotFound) GoString() string {
 
 func newErrorNamespaceNotFound(v protocol.ResponseMetadata) error {
 	return &NamespaceNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5065,12 +5065,12 @@ func (s NamespaceNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NamespaceNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NamespaceNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A complex type that contains information that is specific to the namespace
@@ -5424,7 +5424,7 @@ func (s *OperationFilter) SetValues(v []*string) *OperationFilter {
 // No operation exists with the specified ID.
 type OperationNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5441,7 +5441,7 @@ func (s OperationNotFound) GoString() string {
 
 func newErrorOperationNotFound(v protocol.ResponseMetadata) error {
 	return &OperationNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5469,12 +5469,12 @@ func (s OperationNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A complex type that contains information about an operation that matches
@@ -5726,7 +5726,7 @@ func (s *RegisterInstanceOutput) SetOperationId(v string) *RegisterInstanceOutpu
 // For example, you can't delete a service that contains any instances.
 type ResourceInUse struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5743,7 +5743,7 @@ func (s ResourceInUse) GoString() string {
 
 func newErrorResourceInUse(v protocol.ResponseMetadata) error {
 	return &ResourceInUse{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5771,19 +5771,19 @@ func (s ResourceInUse) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUse) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUse) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource can't be created because you've reached the limit on the number
 // of resources.
 type ResourceLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5800,7 +5800,7 @@ func (s ResourceLimitExceeded) GoString() string {
 
 func newErrorResourceLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5828,12 +5828,12 @@ func (s ResourceLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A complex type that contains information about the specified service.
@@ -5972,7 +5972,7 @@ func (s *Service) SetNamespaceId(v string) *Service {
 // exists.
 type ServiceAlreadyExists struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The CreatorRequestId that was used to create the service.
 	CreatorRequestId *string `type:"string"`
@@ -5995,7 +5995,7 @@ func (s ServiceAlreadyExists) GoString() string {
 
 func newErrorServiceAlreadyExists(v protocol.ResponseMetadata) error {
 	return &ServiceAlreadyExists{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6023,12 +6023,12 @@ func (s ServiceAlreadyExists) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceAlreadyExists) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceAlreadyExists) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A complex type that contains changes to an existing service.
@@ -6232,7 +6232,7 @@ func (s *ServiceFilter) SetValues(v []*string) *ServiceFilter {
 // No service exists with the specified ID.
 type ServiceNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6249,7 +6249,7 @@ func (s ServiceNotFound) GoString() string {
 
 func newErrorServiceNotFound(v protocol.ResponseMetadata) error {
 	return &ServiceNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6277,12 +6277,12 @@ func (s ServiceNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A complex type that contains information about a specified service.

--- a/service/servicediscovery/api.go
+++ b/service/servicediscovery/api.go
@@ -2572,8 +2572,8 @@ func (s *CreateServiceOutput) SetService(v *Service) *CreateServiceOutput {
 // The health check for the instance that is specified by ServiceId and InstanceId
 // is not a custom health check.
 type CustomHealthNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3248,8 +3248,8 @@ func (s *DnsRecord) SetType(v string) *DnsRecord {
 
 // The operation is already in progress.
 type DuplicateRequest struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The ID of the operation that is already in progress.
 	DuplicateOperationId *string `type:"string"`
@@ -4151,8 +4151,8 @@ func (s *Instance) SetId(v string) *Instance {
 // No instance exists with the specified ID, or the instance was recently registered,
 // and information about the instance hasn't propagated yet.
 type InstanceNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4266,8 +4266,8 @@ func (s *InstanceSummary) SetId(v string) *InstanceSummary {
 // might be missing, a numeric value might be outside the allowed range, or
 // a string value might exceed length constraints.
 type InvalidInput struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4881,8 +4881,8 @@ func (s *Namespace) SetType(v string) *Namespace {
 
 // The namespace that you're trying to create already exists.
 type NamespaceAlreadyExists struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The CreatorRequestId that was used to create the namespace.
 	CreatorRequestId *string `type:"string"`
@@ -5019,8 +5019,8 @@ func (s *NamespaceFilter) SetValues(v []*string) *NamespaceFilter {
 
 // No namespace exists with the specified ID.
 type NamespaceNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5423,8 +5423,8 @@ func (s *OperationFilter) SetValues(v []*string) *OperationFilter {
 
 // No operation exists with the specified ID.
 type OperationNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5725,8 +5725,8 @@ func (s *RegisterInstanceOutput) SetOperationId(v string) *RegisterInstanceOutpu
 // The specified resource can't be deleted because it contains other resources.
 // For example, you can't delete a service that contains any instances.
 type ResourceInUse struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5782,8 +5782,8 @@ func (s ResourceInUse) RequestID() string {
 // The resource can't be created because you've reached the limit on the number
 // of resources.
 type ResourceLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5971,8 +5971,8 @@ func (s *Service) SetNamespaceId(v string) *Service {
 // The service can't be created because a service with the same name already
 // exists.
 type ServiceAlreadyExists struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The CreatorRequestId that was used to create the service.
 	CreatorRequestId *string `type:"string"`
@@ -6231,8 +6231,8 @@ func (s *ServiceFilter) SetValues(v []*string) *ServiceFilter {
 
 // No service exists with the specified ID.
 type ServiceNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/servicequotas/api.go
+++ b/service/servicequotas/api.go
@@ -2008,8 +2008,8 @@ func (c *ServiceQuotas) RequestServiceQuotaIncreaseWithContext(ctx aws.Context, 
 // The action you attempted is not allowed unless Service Access with Service
 // Quotas is enabled in your organization. To enable, call AssociateServiceQuotaTemplate.
 type AWSServiceAccessNotEnabledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2064,8 +2064,8 @@ func (s AWSServiceAccessNotEnabledException) RequestID() string {
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2237,8 +2237,8 @@ func (s DeleteServiceQuotaIncreaseRequestFromTemplateOutput) GoString() string {
 
 // You can't perform this action because a dependency does not have access.
 type DependencyAccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2731,8 +2731,8 @@ func (s *GetServiceQuotaOutput) SetQuota(v *ServiceQuota) *GetServiceQuotaOutput
 
 // Invalid input was provided.
 type IllegalArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2787,8 +2787,8 @@ func (s IllegalArgumentException) RequestID() string {
 
 // Invalid input was provided.
 type InvalidPaginationTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2843,8 +2843,8 @@ func (s InvalidPaginationTokenException) RequestID() string {
 
 // Invalid input was provided for the .
 type InvalidResourceStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3638,8 +3638,8 @@ func (s *MetricInfo) SetMetricStatisticRecommendation(v string) *MetricInfo {
 
 // The account making this call is not a member of an organization.
 type NoAvailableOrganizationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3694,8 +3694,8 @@ func (s NoAvailableOrganizationException) RequestID() string {
 
 // The specified resource does not exist.
 type NoSuchResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3751,8 +3751,8 @@ func (s NoSuchResourceException) RequestID() string {
 // The organization that your account belongs to, is not in All Features mode.
 // To enable all features mode, see EnableAllFeatures (https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnableAllFeatures.html).
 type OrganizationNotInAllFeaturesModeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3921,8 +3921,8 @@ func (s *PutServiceQuotaIncreaseRequestIntoTemplateOutput) SetServiceQuotaIncrea
 // some of the relevant resources, or use Service Quotas to request a service
 // quota increase.
 type QuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4248,8 +4248,8 @@ func (s *RequestedServiceQuotaChange) SetUnit(v string) *RequestedServiceQuotaCh
 
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4304,8 +4304,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // Something went wrong.
 type ServiceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4609,8 +4609,8 @@ func (s *ServiceQuotaIncreaseRequestInTemplate) SetUnit(v string) *ServiceQuotaI
 //
 // To use the template, call AssociateServiceQuotaTemplate.
 type ServiceQuotaTemplateNotInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4666,8 +4666,8 @@ func (s ServiceQuotaTemplateNotInUseException) RequestID() string {
 // The Service Quotas template is not available in the Region where you are
 // making the request. Please make the request in us-east-1.
 type TemplatesNotAvailableInRegionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4723,8 +4723,8 @@ func (s TemplatesNotAvailableInRegionException) RequestID() string {
 // Due to throttling, the request was denied. Slow down the rate of request
 // calls, or request an increase for this quota.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/servicequotas/api.go
+++ b/service/servicequotas/api.go
@@ -2009,7 +2009,7 @@ func (c *ServiceQuotas) RequestServiceQuotaIncreaseWithContext(ctx aws.Context, 
 // Quotas is enabled in your organization. To enable, call AssociateServiceQuotaTemplate.
 type AWSServiceAccessNotEnabledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2026,7 +2026,7 @@ func (s AWSServiceAccessNotEnabledException) GoString() string {
 
 func newErrorAWSServiceAccessNotEnabledException(v protocol.ResponseMetadata) error {
 	return &AWSServiceAccessNotEnabledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2054,18 +2054,18 @@ func (s AWSServiceAccessNotEnabledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AWSServiceAccessNotEnabledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AWSServiceAccessNotEnabledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2082,7 +2082,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2110,12 +2110,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AssociateServiceQuotaTemplateInput struct {
@@ -2238,7 +2238,7 @@ func (s DeleteServiceQuotaIncreaseRequestFromTemplateOutput) GoString() string {
 // You can't perform this action because a dependency does not have access.
 type DependencyAccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2255,7 +2255,7 @@ func (s DependencyAccessDeniedException) GoString() string {
 
 func newErrorDependencyAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &DependencyAccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2283,12 +2283,12 @@ func (s DependencyAccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DependencyAccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DependencyAccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DisassociateServiceQuotaTemplateInput struct {
@@ -2732,7 +2732,7 @@ func (s *GetServiceQuotaOutput) SetQuota(v *ServiceQuota) *GetServiceQuotaOutput
 // Invalid input was provided.
 type IllegalArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2749,7 +2749,7 @@ func (s IllegalArgumentException) GoString() string {
 
 func newErrorIllegalArgumentException(v protocol.ResponseMetadata) error {
 	return &IllegalArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2777,18 +2777,18 @@ func (s IllegalArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IllegalArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IllegalArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Invalid input was provided.
 type InvalidPaginationTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2805,7 +2805,7 @@ func (s InvalidPaginationTokenException) GoString() string {
 
 func newErrorInvalidPaginationTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidPaginationTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2833,18 +2833,18 @@ func (s InvalidPaginationTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPaginationTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPaginationTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Invalid input was provided for the .
 type InvalidResourceStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2861,7 +2861,7 @@ func (s InvalidResourceStateException) GoString() string {
 
 func newErrorInvalidResourceStateException(v protocol.ResponseMetadata) error {
 	return &InvalidResourceStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2889,12 +2889,12 @@ func (s InvalidResourceStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAWSDefaultServiceQuotasInput struct {
@@ -3639,7 +3639,7 @@ func (s *MetricInfo) SetMetricStatisticRecommendation(v string) *MetricInfo {
 // The account making this call is not a member of an organization.
 type NoAvailableOrganizationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3656,7 +3656,7 @@ func (s NoAvailableOrganizationException) GoString() string {
 
 func newErrorNoAvailableOrganizationException(v protocol.ResponseMetadata) error {
 	return &NoAvailableOrganizationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3684,18 +3684,18 @@ func (s NoAvailableOrganizationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoAvailableOrganizationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoAvailableOrganizationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource does not exist.
 type NoSuchResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3712,7 +3712,7 @@ func (s NoSuchResourceException) GoString() string {
 
 func newErrorNoSuchResourceException(v protocol.ResponseMetadata) error {
 	return &NoSuchResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3740,19 +3740,19 @@ func (s NoSuchResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoSuchResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoSuchResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The organization that your account belongs to, is not in All Features mode.
 // To enable all features mode, see EnableAllFeatures (https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnableAllFeatures.html).
 type OrganizationNotInAllFeaturesModeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3769,7 +3769,7 @@ func (s OrganizationNotInAllFeaturesModeException) GoString() string {
 
 func newErrorOrganizationNotInAllFeaturesModeException(v protocol.ResponseMetadata) error {
 	return &OrganizationNotInAllFeaturesModeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3797,12 +3797,12 @@ func (s OrganizationNotInAllFeaturesModeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationNotInAllFeaturesModeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationNotInAllFeaturesModeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutServiceQuotaIncreaseRequestIntoTemplateInput struct {
@@ -3922,7 +3922,7 @@ func (s *PutServiceQuotaIncreaseRequestIntoTemplateOutput) SetServiceQuotaIncrea
 // quota increase.
 type QuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3939,7 +3939,7 @@ func (s QuotaExceededException) GoString() string {
 
 func newErrorQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &QuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3967,12 +3967,12 @@ func (s QuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s QuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s QuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A structure that contains information about the quota period.
@@ -4249,7 +4249,7 @@ func (s *RequestedServiceQuotaChange) SetUnit(v string) *RequestedServiceQuotaCh
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4266,7 +4266,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4294,18 +4294,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Something went wrong.
 type ServiceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4322,7 +4322,7 @@ func (s ServiceException) GoString() string {
 
 func newErrorServiceException(v protocol.ResponseMetadata) error {
 	return &ServiceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4350,12 +4350,12 @@ func (s ServiceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A structure that contains the ServiceName and ServiceCode. It does not include
@@ -4610,7 +4610,7 @@ func (s *ServiceQuotaIncreaseRequestInTemplate) SetUnit(v string) *ServiceQuotaI
 // To use the template, call AssociateServiceQuotaTemplate.
 type ServiceQuotaTemplateNotInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4627,7 +4627,7 @@ func (s ServiceQuotaTemplateNotInUseException) GoString() string {
 
 func newErrorServiceQuotaTemplateNotInUseException(v protocol.ResponseMetadata) error {
 	return &ServiceQuotaTemplateNotInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4655,19 +4655,19 @@ func (s ServiceQuotaTemplateNotInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceQuotaTemplateNotInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceQuotaTemplateNotInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Service Quotas template is not available in the Region where you are
 // making the request. Please make the request in us-east-1.
 type TemplatesNotAvailableInRegionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4684,7 +4684,7 @@ func (s TemplatesNotAvailableInRegionException) GoString() string {
 
 func newErrorTemplatesNotAvailableInRegionException(v protocol.ResponseMetadata) error {
 	return &TemplatesNotAvailableInRegionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4712,19 +4712,19 @@ func (s TemplatesNotAvailableInRegionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TemplatesNotAvailableInRegionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TemplatesNotAvailableInRegionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Due to throttling, the request was denied. Slow down the rate of request
 // calls, or request an increase for this quota.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4741,7 +4741,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4769,12 +4769,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/sesv2/api.go
+++ b/service/sesv2/api.go
@@ -4856,7 +4856,7 @@ func (c *SESV2) UpdateConfigurationSetEventDestinationWithContext(ctx aws.Contex
 // been permanently restricted.
 type AccountSuspendedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4873,7 +4873,7 @@ func (s AccountSuspendedException) GoString() string {
 
 func newErrorAccountSuspendedException(v protocol.ResponseMetadata) error {
 	return &AccountSuspendedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4901,18 +4901,18 @@ func (s AccountSuspendedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccountSuspendedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccountSuspendedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource specified in your request already exists.
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4929,7 +4929,7 @@ func (s AlreadyExistsException) GoString() string {
 
 func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &AlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4957,18 +4957,18 @@ func (s AlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The input you provided is invalid.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4985,7 +4985,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5013,12 +5013,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that contains information about a blacklisting event that impacts
@@ -5262,7 +5262,7 @@ func (s *CloudWatchDimensionConfiguration) SetDimensionValueSource(v string) *Cl
 // The resource is being modified by another operation or thread.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5279,7 +5279,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5307,12 +5307,12 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that represents the content of the email, and optionally a character
@@ -8457,7 +8457,7 @@ func (s *InboxPlacementTrackingOption) SetTrackedIsps(v []*string) *InboxPlaceme
 // The specified request includes an invalid or expired token.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8474,7 +8474,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8502,12 +8502,12 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that describes how email sent during the predictive inbox placement
@@ -8604,7 +8604,7 @@ func (s *KinesisFirehoseDestination) SetIamRoleArn(v string) *KinesisFirehoseDes
 // There are too many instances of the specified resource type.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8621,7 +8621,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8649,12 +8649,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A request to obtain a list of configuration sets for your Amazon SES account
@@ -9342,7 +9342,7 @@ func (s *MailFromAttributes) SetMailFromDomainStatus(v string) *MailFromAttribut
 // The message can't be sent because the sending domain isn't verified.
 type MailFromDomainNotVerifiedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9359,7 +9359,7 @@ func (s MailFromDomainNotVerifiedException) GoString() string {
 
 func newErrorMailFromDomainNotVerifiedException(v protocol.ResponseMetadata) error {
 	return &MailFromDomainNotVerifiedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9387,12 +9387,12 @@ func (s MailFromDomainNotVerifiedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MailFromDomainNotVerifiedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MailFromDomainNotVerifiedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents the email message that you're sending. The Message object consists
@@ -9465,7 +9465,7 @@ func (s *Message) SetSubject(v *Content) *Message {
 // The message can't be sent because it contains invalid content.
 type MessageRejected struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9482,7 +9482,7 @@ func (s MessageRejected) GoString() string {
 
 func newErrorMessageRejected(v protocol.ResponseMetadata) error {
 	return &MessageRejected{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9510,12 +9510,12 @@ func (s MessageRejected) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MessageRejected) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MessageRejected) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the name and value of a tag that you apply to an email. You can
@@ -9587,7 +9587,7 @@ func (s *MessageTag) SetValue(v string) *MessageTag {
 // The resource you attempted to access doesn't exist.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9604,7 +9604,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9632,12 +9632,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that contains information about email that was sent from the selected
@@ -11293,7 +11293,7 @@ func (s *SendingOptions) SetSendingEnabled(v bool) *SendingOptions {
 // currently paused.
 type SendingPausedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11310,7 +11310,7 @@ func (s SendingPausedException) GoString() string {
 
 func newErrorSendingPausedException(v protocol.ResponseMetadata) error {
 	return &SendingPausedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11338,12 +11338,12 @@ func (s SendingPausedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SendingPausedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SendingPausedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that defines an Amazon SNS destination for email events. You can
@@ -11808,7 +11808,7 @@ func (s *Template) SetTemplateData(v string) *Template {
 // Too many requests have been made to the operation.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11825,7 +11825,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11853,12 +11853,12 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that defines the tracking options for a configuration set. When

--- a/service/sesv2/api.go
+++ b/service/sesv2/api.go
@@ -4855,8 +4855,8 @@ func (c *SESV2) UpdateConfigurationSetEventDestinationWithContext(ctx aws.Contex
 // The message can't be sent because the account's ability to send email has
 // been permanently restricted.
 type AccountSuspendedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4911,8 +4911,8 @@ func (s AccountSuspendedException) RequestID() string {
 
 // The resource specified in your request already exists.
 type AlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4967,8 +4967,8 @@ func (s AlreadyExistsException) RequestID() string {
 
 // The input you provided is invalid.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5261,8 +5261,8 @@ func (s *CloudWatchDimensionConfiguration) SetDimensionValueSource(v string) *Cl
 
 // The resource is being modified by another operation or thread.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8456,8 +8456,8 @@ func (s *InboxPlacementTrackingOption) SetTrackedIsps(v []*string) *InboxPlaceme
 
 // The specified request includes an invalid or expired token.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8603,8 +8603,8 @@ func (s *KinesisFirehoseDestination) SetIamRoleArn(v string) *KinesisFirehoseDes
 
 // There are too many instances of the specified resource type.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9341,8 +9341,8 @@ func (s *MailFromAttributes) SetMailFromDomainStatus(v string) *MailFromAttribut
 
 // The message can't be sent because the sending domain isn't verified.
 type MailFromDomainNotVerifiedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9464,8 +9464,8 @@ func (s *Message) SetSubject(v *Content) *Message {
 
 // The message can't be sent because it contains invalid content.
 type MessageRejected struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9586,8 +9586,8 @@ func (s *MessageTag) SetValue(v string) *MessageTag {
 
 // The resource you attempted to access doesn't exist.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11292,8 +11292,8 @@ func (s *SendingOptions) SetSendingEnabled(v bool) *SendingOptions {
 // The message can't be sent because the account's ability to send email is
 // currently paused.
 type SendingPausedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11807,8 +11807,8 @@ func (s *Template) SetTemplateData(v string) *Template {
 
 // Too many requests have been made to the operation.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/sfn/api.go
+++ b/service/sfn/api.go
@@ -2278,7 +2278,7 @@ func (c *SFN) UpdateStateMachineWithContext(ctx aws.Context, input *UpdateStateM
 // The specified activity does not exist.
 type ActivityDoesNotExist struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2295,7 +2295,7 @@ func (s ActivityDoesNotExist) GoString() string {
 
 func newErrorActivityDoesNotExist(v protocol.ResponseMetadata) error {
 	return &ActivityDoesNotExist{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2323,12 +2323,12 @@ func (s ActivityDoesNotExist) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ActivityDoesNotExist) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ActivityDoesNotExist) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about an activity that failed during an execution.
@@ -2368,7 +2368,7 @@ func (s *ActivityFailedEventDetails) SetError(v string) *ActivityFailedEventDeta
 // be deleted before a new activity can be created.
 type ActivityLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2385,7 +2385,7 @@ func (s ActivityLimitExceeded) GoString() string {
 
 func newErrorActivityLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ActivityLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2413,12 +2413,12 @@ func (s ActivityLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ActivityLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ActivityLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about an activity.
@@ -2658,7 +2658,7 @@ func (s *ActivityTimedOutEventDetails) SetError(v string) *ActivityTimedOutEvent
 // been reached.
 type ActivityWorkerLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2675,7 +2675,7 @@ func (s ActivityWorkerLimitExceeded) GoString() string {
 
 func newErrorActivityWorkerLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ActivityWorkerLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2703,12 +2703,12 @@ func (s ActivityWorkerLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ActivityWorkerLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ActivityWorkerLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CloudWatchLogsLogGroup struct {
@@ -3739,7 +3739,7 @@ func (s *ExecutionAbortedEventDetails) SetError(v string) *ExecutionAbortedEvent
 // Executions with the same name and input are considered idempotent.
 type ExecutionAlreadyExists struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3756,7 +3756,7 @@ func (s ExecutionAlreadyExists) GoString() string {
 
 func newErrorExecutionAlreadyExists(v protocol.ResponseMetadata) error {
 	return &ExecutionAlreadyExists{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3784,18 +3784,18 @@ func (s ExecutionAlreadyExists) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExecutionAlreadyExists) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExecutionAlreadyExists) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified execution does not exist.
 type ExecutionDoesNotExist struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3812,7 +3812,7 @@ func (s ExecutionDoesNotExist) GoString() string {
 
 func newErrorExecutionDoesNotExist(v protocol.ResponseMetadata) error {
 	return &ExecutionDoesNotExist{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3840,12 +3840,12 @@ func (s ExecutionDoesNotExist) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExecutionDoesNotExist) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExecutionDoesNotExist) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about an execution failure event.
@@ -3885,7 +3885,7 @@ func (s *ExecutionFailedEventDetails) SetError(v string) *ExecutionFailedEventDe
 // must end or be stopped before a new execution can be started.
 type ExecutionLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3902,7 +3902,7 @@ func (s ExecutionLimitExceeded) GoString() string {
 
 func newErrorExecutionLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ExecutionLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3930,12 +3930,12 @@ func (s ExecutionLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExecutionLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExecutionLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about an execution.
@@ -4683,7 +4683,7 @@ func (s *HistoryEvent) SetType(v string) *HistoryEvent {
 // The provided Amazon Resource Name (ARN) is invalid.
 type InvalidArn struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4700,7 +4700,7 @@ func (s InvalidArn) GoString() string {
 
 func newErrorInvalidArn(v protocol.ResponseMetadata) error {
 	return &InvalidArn{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4728,18 +4728,18 @@ func (s InvalidArn) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArn) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArn) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided Amazon States Language definition is invalid.
 type InvalidDefinition struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4756,7 +4756,7 @@ func (s InvalidDefinition) GoString() string {
 
 func newErrorInvalidDefinition(v protocol.ResponseMetadata) error {
 	return &InvalidDefinition{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4784,18 +4784,18 @@ func (s InvalidDefinition) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDefinition) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDefinition) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided JSON input data is invalid.
 type InvalidExecutionInput struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4812,7 +4812,7 @@ func (s InvalidExecutionInput) GoString() string {
 
 func newErrorInvalidExecutionInput(v protocol.ResponseMetadata) error {
 	return &InvalidExecutionInput{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4840,17 +4840,17 @@ func (s InvalidExecutionInput) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidExecutionInput) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidExecutionInput) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvalidLoggingConfiguration struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4867,7 +4867,7 @@ func (s InvalidLoggingConfiguration) GoString() string {
 
 func newErrorInvalidLoggingConfiguration(v protocol.ResponseMetadata) error {
 	return &InvalidLoggingConfiguration{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4895,18 +4895,18 @@ func (s InvalidLoggingConfiguration) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidLoggingConfiguration) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidLoggingConfiguration) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided name is invalid.
 type InvalidName struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4923,7 +4923,7 @@ func (s InvalidName) GoString() string {
 
 func newErrorInvalidName(v protocol.ResponseMetadata) error {
 	return &InvalidName{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4951,18 +4951,18 @@ func (s InvalidName) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidName) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidName) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided JSON output data is invalid.
 type InvalidOutput struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4979,7 +4979,7 @@ func (s InvalidOutput) GoString() string {
 
 func newErrorInvalidOutput(v protocol.ResponseMetadata) error {
 	return &InvalidOutput{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5007,18 +5007,18 @@ func (s InvalidOutput) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOutput) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOutput) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The provided token is invalid.
 type InvalidToken struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5035,7 +5035,7 @@ func (s InvalidToken) GoString() string {
 
 func newErrorInvalidToken(v protocol.ResponseMetadata) error {
 	return &InvalidToken{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5063,12 +5063,12 @@ func (s InvalidToken) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidToken) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidToken) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about a lambda function that failed during an execution.
@@ -5804,7 +5804,7 @@ func (s *MapStateStartedEventDetails) SetLength(v int64) *MapStateStartedEventDe
 // and roleArn are not specified.
 type MissingRequiredParameter struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5821,7 +5821,7 @@ func (s MissingRequiredParameter) GoString() string {
 
 func newErrorMissingRequiredParameter(v protocol.ResponseMetadata) error {
 	return &MissingRequiredParameter{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5849,19 +5849,19 @@ func (s MissingRequiredParameter) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MissingRequiredParameter) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MissingRequiredParameter) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Could not find the referenced resource. Only state machine and activity ARNs
 // are supported.
 type ResourceNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -5880,7 +5880,7 @@ func (s ResourceNotFound) GoString() string {
 
 func newErrorResourceNotFound(v protocol.ResponseMetadata) error {
 	return &ResourceNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5908,12 +5908,12 @@ func (s ResourceNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type SendTaskFailureInput struct {
@@ -6329,7 +6329,7 @@ func (s *StateExitedEventDetails) SetOutput(v string) *StateExitedEventDetails {
 // already exists.
 type StateMachineAlreadyExists struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6346,7 +6346,7 @@ func (s StateMachineAlreadyExists) GoString() string {
 
 func newErrorStateMachineAlreadyExists(v protocol.ResponseMetadata) error {
 	return &StateMachineAlreadyExists{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6374,18 +6374,18 @@ func (s StateMachineAlreadyExists) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StateMachineAlreadyExists) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StateMachineAlreadyExists) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified state machine is being deleted.
 type StateMachineDeleting struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6402,7 +6402,7 @@ func (s StateMachineDeleting) GoString() string {
 
 func newErrorStateMachineDeleting(v protocol.ResponseMetadata) error {
 	return &StateMachineDeleting{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6430,18 +6430,18 @@ func (s StateMachineDeleting) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StateMachineDeleting) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StateMachineDeleting) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified state machine does not exist.
 type StateMachineDoesNotExist struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6458,7 +6458,7 @@ func (s StateMachineDoesNotExist) GoString() string {
 
 func newErrorStateMachineDoesNotExist(v protocol.ResponseMetadata) error {
 	return &StateMachineDoesNotExist{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6486,19 +6486,19 @@ func (s StateMachineDoesNotExist) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StateMachineDoesNotExist) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StateMachineDoesNotExist) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum number of state machines has been reached. Existing state machines
 // must be deleted before a new state machine can be created.
 type StateMachineLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6515,7 +6515,7 @@ func (s StateMachineLimitExceeded) GoString() string {
 
 func newErrorStateMachineLimitExceeded(v protocol.ResponseMetadata) error {
 	return &StateMachineLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6543,12 +6543,12 @@ func (s StateMachineLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StateMachineLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StateMachineLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about the state machine.
@@ -6625,7 +6625,7 @@ func (s *StateMachineListItem) SetType(v string) *StateMachineListItem {
 
 type StateMachineTypeNotSupported struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6642,7 +6642,7 @@ func (s StateMachineTypeNotSupported) GoString() string {
 
 func newErrorStateMachineTypeNotSupported(v protocol.ResponseMetadata) error {
 	return &StateMachineTypeNotSupported{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6670,12 +6670,12 @@ func (s StateMachineTypeNotSupported) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StateMachineTypeNotSupported) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StateMachineTypeNotSupported) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StopExecutionInput struct {
@@ -6901,7 +6901,7 @@ func (s TagResourceOutput) GoString() string {
 
 type TaskDoesNotExist struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6918,7 +6918,7 @@ func (s TaskDoesNotExist) GoString() string {
 
 func newErrorTaskDoesNotExist(v protocol.ResponseMetadata) error {
 	return &TaskDoesNotExist{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6946,12 +6946,12 @@ func (s TaskDoesNotExist) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TaskDoesNotExist) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TaskDoesNotExist) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about a task failure event.
@@ -7319,7 +7319,7 @@ func (s *TaskSucceededEventDetails) SetResourceType(v string) *TaskSucceededEven
 
 type TaskTimedOut struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7336,7 +7336,7 @@ func (s TaskTimedOut) GoString() string {
 
 func newErrorTaskTimedOut(v protocol.ResponseMetadata) error {
 	return &TaskTimedOut{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7364,12 +7364,12 @@ func (s TaskTimedOut) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TaskTimedOut) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TaskTimedOut) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains details about a resource timeout that occurred during an execution.
@@ -7432,7 +7432,7 @@ func (s *TaskTimedOutEventDetails) SetResourceType(v string) *TaskTimedOutEventD
 // in the AWS Step Functions Developer Guide.
 type TooManyTags struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -7451,7 +7451,7 @@ func (s TooManyTags) GoString() string {
 
 func newErrorTooManyTags(v protocol.ResponseMetadata) error {
 	return &TooManyTags{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7479,12 +7479,12 @@ func (s TooManyTags) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTags) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTags) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/sfn/api.go
+++ b/service/sfn/api.go
@@ -2277,8 +2277,8 @@ func (c *SFN) UpdateStateMachineWithContext(ctx aws.Context, input *UpdateStateM
 
 // The specified activity does not exist.
 type ActivityDoesNotExist struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2367,8 +2367,8 @@ func (s *ActivityFailedEventDetails) SetError(v string) *ActivityFailedEventDeta
 // The maximum number of activities has been reached. Existing activities must
 // be deleted before a new activity can be created.
 type ActivityLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2657,8 +2657,8 @@ func (s *ActivityTimedOutEventDetails) SetError(v string) *ActivityTimedOutEvent
 // The maximum number of workers concurrently polling for activity tasks has
 // been reached.
 type ActivityWorkerLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3738,8 +3738,8 @@ func (s *ExecutionAbortedEventDetails) SetError(v string) *ExecutionAbortedEvent
 //
 // Executions with the same name and input are considered idempotent.
 type ExecutionAlreadyExists struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3794,8 +3794,8 @@ func (s ExecutionAlreadyExists) RequestID() string {
 
 // The specified execution does not exist.
 type ExecutionDoesNotExist struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3884,8 +3884,8 @@ func (s *ExecutionFailedEventDetails) SetError(v string) *ExecutionFailedEventDe
 // The maximum number of running executions has been reached. Running executions
 // must end or be stopped before a new execution can be started.
 type ExecutionLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4682,8 +4682,8 @@ func (s *HistoryEvent) SetType(v string) *HistoryEvent {
 
 // The provided Amazon Resource Name (ARN) is invalid.
 type InvalidArn struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4738,8 +4738,8 @@ func (s InvalidArn) RequestID() string {
 
 // The provided Amazon States Language definition is invalid.
 type InvalidDefinition struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4794,8 +4794,8 @@ func (s InvalidDefinition) RequestID() string {
 
 // The provided JSON input data is invalid.
 type InvalidExecutionInput struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4849,8 +4849,8 @@ func (s InvalidExecutionInput) RequestID() string {
 }
 
 type InvalidLoggingConfiguration struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4905,8 +4905,8 @@ func (s InvalidLoggingConfiguration) RequestID() string {
 
 // The provided name is invalid.
 type InvalidName struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4961,8 +4961,8 @@ func (s InvalidName) RequestID() string {
 
 // The provided JSON output data is invalid.
 type InvalidOutput struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5017,8 +5017,8 @@ func (s InvalidOutput) RequestID() string {
 
 // The provided token is invalid.
 type InvalidToken struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5803,8 +5803,8 @@ func (s *MapStateStartedEventDetails) SetLength(v int64) *MapStateStartedEventDe
 // Request is missing a required parameter. This error occurs if both definition
 // and roleArn are not specified.
 type MissingRequiredParameter struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5860,8 +5860,8 @@ func (s MissingRequiredParameter) RequestID() string {
 // Could not find the referenced resource. Only state machine and activity ARNs
 // are supported.
 type ResourceNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -6328,8 +6328,8 @@ func (s *StateExitedEventDetails) SetOutput(v string) *StateExitedEventDetails {
 // A state machine with the same name but a different definition or role ARN
 // already exists.
 type StateMachineAlreadyExists struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6384,8 +6384,8 @@ func (s StateMachineAlreadyExists) RequestID() string {
 
 // The specified state machine is being deleted.
 type StateMachineDeleting struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6440,8 +6440,8 @@ func (s StateMachineDeleting) RequestID() string {
 
 // The specified state machine does not exist.
 type StateMachineDoesNotExist struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6497,8 +6497,8 @@ func (s StateMachineDoesNotExist) RequestID() string {
 // The maximum number of state machines has been reached. Existing state machines
 // must be deleted before a new state machine can be created.
 type StateMachineLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6624,8 +6624,8 @@ func (s *StateMachineListItem) SetType(v string) *StateMachineListItem {
 }
 
 type StateMachineTypeNotSupported struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6900,8 +6900,8 @@ func (s TagResourceOutput) GoString() string {
 }
 
 type TaskDoesNotExist struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7318,8 +7318,8 @@ func (s *TaskSucceededEventDetails) SetResourceType(v string) *TaskSucceededEven
 }
 
 type TaskTimedOut struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7431,8 +7431,8 @@ func (s *TaskTimedOutEventDetails) SetResourceType(v string) *TaskTimedOutEventD
 // Topic (https://docs.aws.amazon.com/step-functions/latest/dg/limits.html)
 // in the AWS Step Functions Developer Guide.
 type TooManyTags struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 

--- a/service/shield/api.go
+++ b/service/shield/api.go
@@ -1941,7 +1941,7 @@ func (c *Shield) UpdateSubscriptionWithContext(ctx aws.Context, input *UpdateSub
 // does not have the appropriate permissions to access the AttackId.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1958,7 +1958,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1986,12 +1986,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // In order to grant the necessary access to the DDoS Response Team, the user
@@ -2000,7 +2000,7 @@ func (s AccessDeniedException) RequestID() string {
 // see Granting a User Permissions to Pass a Role to an AWS Service (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html).
 type AccessDeniedForDependencyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2017,7 +2017,7 @@ func (s AccessDeniedForDependencyException) GoString() string {
 
 func newErrorAccessDeniedForDependencyException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedForDependencyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2045,12 +2045,12 @@ func (s AccessDeniedForDependencyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedForDependencyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedForDependencyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AssociateDRTLogBucketInput struct {
@@ -3271,7 +3271,7 @@ func (s *GetSubscriptionStateOutput) SetSubscriptionState(v string) *GetSubscrip
 // You can retry the request.
 type InternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3288,7 +3288,7 @@ func (s InternalErrorException) GoString() string {
 
 func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 	return &InternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3316,19 +3316,19 @@ func (s InternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception that indicates that the operation would not cause any change to
 // occur.
 type InvalidOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3345,7 +3345,7 @@ func (s InvalidOperationException) GoString() string {
 
 func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 	return &InvalidOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3373,19 +3373,19 @@ func (s InvalidOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception that indicates that the NextToken specified in the request is invalid.
 // Submit the request using the NextToken value that was returned in the response.
 type InvalidPaginationTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3402,7 +3402,7 @@ func (s InvalidPaginationTokenException) GoString() string {
 
 func newErrorInvalidPaginationTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidPaginationTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3430,18 +3430,18 @@ func (s InvalidPaginationTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPaginationTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPaginationTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception that indicates that the parameters passed to the API are invalid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3458,7 +3458,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3486,19 +3486,19 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception that indicates that the resource is invalid. You might not have
 // access to the resource, or the resource might not exist.
 type InvalidResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3515,7 +3515,7 @@ func (s InvalidResourceException) GoString() string {
 
 func newErrorInvalidResourceException(v protocol.ResponseMetadata) error {
 	return &InvalidResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3543,12 +3543,12 @@ func (s InvalidResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies how many protections of a given type you can create.
@@ -3591,7 +3591,7 @@ func (s *Limit) SetType(v string) *Limit {
 // Limit is the threshold that would be exceeded.
 type LimitsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Limit *int64 `type:"long"`
 
@@ -3612,7 +3612,7 @@ func (s LimitsExceededException) GoString() string {
 
 func newErrorLimitsExceededException(v protocol.ResponseMetadata) error {
 	return &LimitsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3640,12 +3640,12 @@ func (s LimitsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAttacksInput struct {
@@ -3873,7 +3873,7 @@ func (s *ListProtectionsOutput) SetProtections(v []*Protection) *ListProtections
 // change AutoRenew prior to that period.
 type LockedSubscriptionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3890,7 +3890,7 @@ func (s LockedSubscriptionException) GoString() string {
 
 func newErrorLockedSubscriptionException(v protocol.ResponseMetadata) error {
 	return &LockedSubscriptionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3918,12 +3918,12 @@ func (s LockedSubscriptionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LockedSubscriptionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LockedSubscriptionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The mitigation applied to a DDoS attack.
@@ -3953,7 +3953,7 @@ func (s *Mitigation) SetMitigationName(v string) *Mitigation {
 // The ARN of the role that you specifed does not exist.
 type NoAssociatedRoleException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3970,7 +3970,7 @@ func (s NoAssociatedRoleException) GoString() string {
 
 func newErrorNoAssociatedRoleException(v protocol.ResponseMetadata) error {
 	return &NoAssociatedRoleException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3998,19 +3998,19 @@ func (s NoAssociatedRoleException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoAssociatedRoleException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoAssociatedRoleException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception that indicates that the protection state has been modified by another
 // client. You can retry the request.
 type OptimisticLockException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4027,7 +4027,7 @@ func (s OptimisticLockException) GoString() string {
 
 func newErrorOptimisticLockException(v protocol.ResponseMetadata) error {
 	return &OptimisticLockException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4055,12 +4055,12 @@ func (s OptimisticLockException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OptimisticLockException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OptimisticLockException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that represents a resource that is under DDoS protection.
@@ -4118,7 +4118,7 @@ func (s *Protection) SetResourceArn(v string) *Protection {
 // Exception indicating the specified resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4135,7 +4135,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4163,18 +4163,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Exception indicating the specified resource does not exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4191,7 +4191,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4219,12 +4219,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The attack information for the specified SubResource.

--- a/service/shield/api.go
+++ b/service/shield/api.go
@@ -1940,8 +1940,8 @@ func (c *Shield) UpdateSubscriptionWithContext(ctx aws.Context, input *UpdateSub
 // Exception that indicates the specified AttackId does not exist, or the requester
 // does not have the appropriate permissions to access the AttackId.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1999,8 +1999,8 @@ func (s AccessDeniedException) RequestID() string {
 // indicates the user did not have the appropriate permissions. For more information,
 // see Granting a User Permissions to Pass a Role to an AWS Service (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html).
 type AccessDeniedForDependencyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3270,8 +3270,8 @@ func (s *GetSubscriptionStateOutput) SetSubscriptionState(v string) *GetSubscrip
 // Exception that indicates that a problem occurred with the service infrastructure.
 // You can retry the request.
 type InternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3327,8 +3327,8 @@ func (s InternalErrorException) RequestID() string {
 // Exception that indicates that the operation would not cause any change to
 // occur.
 type InvalidOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3384,8 +3384,8 @@ func (s InvalidOperationException) RequestID() string {
 // Exception that indicates that the NextToken specified in the request is invalid.
 // Submit the request using the NextToken value that was returned in the response.
 type InvalidPaginationTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3440,8 +3440,8 @@ func (s InvalidPaginationTokenException) RequestID() string {
 
 // Exception that indicates that the parameters passed to the API are invalid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3497,8 +3497,8 @@ func (s InvalidParameterException) RequestID() string {
 // Exception that indicates that the resource is invalid. You might not have
 // access to the resource, or the resource might not exist.
 type InvalidResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3590,8 +3590,8 @@ func (s *Limit) SetType(v string) *Limit {
 //
 // Limit is the threshold that would be exceeded.
 type LimitsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Limit *int64 `type:"long"`
 
@@ -3872,8 +3872,8 @@ func (s *ListProtectionsOutput) SetProtections(v []*Protection) *ListProtections
 // of your subscription. This exception indicates that you are attempting to
 // change AutoRenew prior to that period.
 type LockedSubscriptionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3952,8 +3952,8 @@ func (s *Mitigation) SetMitigationName(v string) *Mitigation {
 
 // The ARN of the role that you specifed does not exist.
 type NoAssociatedRoleException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4009,8 +4009,8 @@ func (s NoAssociatedRoleException) RequestID() string {
 // Exception that indicates that the protection state has been modified by another
 // client. You can retry the request.
 type OptimisticLockException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4117,8 +4117,8 @@ func (s *Protection) SetResourceArn(v string) *Protection {
 
 // Exception indicating the specified resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4173,8 +4173,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // Exception indicating the specified resource does not exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/signer/api.go
+++ b/service/signer/api.go
@@ -1290,7 +1290,7 @@ func (c *Signer) UntagResourceWithContext(ctx aws.Context, input *UntagResourceI
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1307,7 +1307,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1335,19 +1335,19 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request contains invalid parameters for the ARN or tags. This exception
 // also occurs when you call a tagging API on a cancelled signing profile.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1364,7 +1364,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1392,12 +1392,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CancelSigningProfileInput struct {
@@ -1987,7 +1987,7 @@ func (s *HashAlgorithmOptions) SetDefaultValue(v string) *HashAlgorithmOptions {
 // An internal error occurred.
 type InternalServiceErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2004,7 +2004,7 @@ func (s InternalServiceErrorException) GoString() string {
 
 func newErrorInternalServiceErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServiceErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2032,12 +2032,12 @@ func (s InternalServiceErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListSigningJobsInput struct {
@@ -2415,7 +2415,7 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 // The signing profile was not found.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2432,7 +2432,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2460,12 +2460,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutSigningProfileInput struct {
@@ -2602,7 +2602,7 @@ func (s *PutSigningProfileOutput) SetArn(v string) *PutSigningProfileOutput {
 // A specified resource could not be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2619,7 +2619,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2647,12 +2647,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The name and prefix of the S3 bucket where code signing saves your signed
@@ -3462,7 +3462,7 @@ func (s TagResourceOutput) GoString() string {
 // The signing job has been throttled.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3479,7 +3479,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3507,12 +3507,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -3590,7 +3590,7 @@ func (s UntagResourceOutput) GoString() string {
 // You signing certificate could not be validated.
 type ValidationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3607,7 +3607,7 @@ func (s ValidationException) GoString() string {
 
 func newErrorValidationException(v protocol.ResponseMetadata) error {
 	return &ValidationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3635,12 +3635,12 @@ func (s ValidationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ValidationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ValidationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/signer/api.go
+++ b/service/signer/api.go
@@ -1289,8 +1289,8 @@ func (c *Signer) UntagResourceWithContext(ctx aws.Context, input *UntagResourceI
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1346,8 +1346,8 @@ func (s AccessDeniedException) RequestID() string {
 // The request contains invalid parameters for the ARN or tags. This exception
 // also occurs when you call a tagging API on a cancelled signing profile.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1986,8 +1986,8 @@ func (s *HashAlgorithmOptions) SetDefaultValue(v string) *HashAlgorithmOptions {
 
 // An internal error occurred.
 type InternalServiceErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2414,8 +2414,8 @@ func (s *ListTagsForResourceOutput) SetTags(v map[string]*string) *ListTagsForRe
 
 // The signing profile was not found.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2601,8 +2601,8 @@ func (s *PutSigningProfileOutput) SetArn(v string) *PutSigningProfileOutput {
 
 // A specified resource could not be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3461,8 +3461,8 @@ func (s TagResourceOutput) GoString() string {
 
 // The signing job has been throttled.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3589,8 +3589,8 @@ func (s UntagResourceOutput) GoString() string {
 
 // You signing certificate could not be validated.
 type ValidationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/sms/api.go
+++ b/service/sms/api.go
@@ -4290,8 +4290,8 @@ func (s ImportServerCatalogOutput) GoString() string {
 
 // An internal error occurred.
 type InternalError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4346,8 +4346,8 @@ func (s InternalError) RequestID() string {
 
 // A specified parameter is not valid.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4556,8 +4556,8 @@ func (s *ListAppsOutput) SetNextToken(v string) *ListAppsOutput {
 
 // A required parameter is missing.
 type MissingRequiredParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4612,8 +4612,8 @@ func (s MissingRequiredParameterException) RequestID() string {
 
 // There are no connectors available.
 type NoConnectorsAvailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4668,8 +4668,8 @@ func (s NoConnectorsAvailableException) RequestID() string {
 
 // This operation is not allowed.
 type OperationNotPermittedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5017,8 +5017,8 @@ func (s *ReplicationJob) SetVmServer(v *VmServer) *ReplicationJob {
 
 // The specified replication job already exists.
 type ReplicationJobAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5073,8 +5073,8 @@ func (s ReplicationJobAlreadyExistsException) RequestID() string {
 
 // The specified replication job does not exist.
 type ReplicationJobNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5257,8 +5257,8 @@ func (s *ReplicationRun) SetType(v string) *ReplicationRun {
 // You have exceeded the number of on-demand replication runs you can request
 // in a 24-hour period.
 type ReplicationRunLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5439,8 +5439,8 @@ func (s *Server) SetVmServer(v *VmServer) *Server {
 
 // The specified server cannot be replicated.
 type ServerCannotBeReplicatedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6009,8 +6009,8 @@ func (s *Tag) SetValue(v string) *Tag {
 
 // The service is temporarily unavailable.
 type TemporarilyUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6103,8 +6103,8 @@ func (s TerminateAppOutput) GoString() string {
 // You lack permissions needed to perform this operation. Check your IAM policies,
 // and ensure that you are using the correct access keys.
 type UnauthorizedOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/sms/api.go
+++ b/service/sms/api.go
@@ -4291,7 +4291,7 @@ func (s ImportServerCatalogOutput) GoString() string {
 // An internal error occurred.
 type InternalError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4308,7 +4308,7 @@ func (s InternalError) GoString() string {
 
 func newErrorInternalError(v protocol.ResponseMetadata) error {
 	return &InternalError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4336,18 +4336,18 @@ func (s InternalError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A specified parameter is not valid.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4364,7 +4364,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4392,12 +4392,12 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type LaunchAppInput struct {
@@ -4557,7 +4557,7 @@ func (s *ListAppsOutput) SetNextToken(v string) *ListAppsOutput {
 // A required parameter is missing.
 type MissingRequiredParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4574,7 +4574,7 @@ func (s MissingRequiredParameterException) GoString() string {
 
 func newErrorMissingRequiredParameterException(v protocol.ResponseMetadata) error {
 	return &MissingRequiredParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4602,18 +4602,18 @@ func (s MissingRequiredParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MissingRequiredParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MissingRequiredParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There are no connectors available.
 type NoConnectorsAvailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4630,7 +4630,7 @@ func (s NoConnectorsAvailableException) GoString() string {
 
 func newErrorNoConnectorsAvailableException(v protocol.ResponseMetadata) error {
 	return &NoConnectorsAvailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4658,18 +4658,18 @@ func (s NoConnectorsAvailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NoConnectorsAvailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NoConnectorsAvailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This operation is not allowed.
 type OperationNotPermittedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -4686,7 +4686,7 @@ func (s OperationNotPermittedException) GoString() string {
 
 func newErrorOperationNotPermittedException(v protocol.ResponseMetadata) error {
 	return &OperationNotPermittedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4714,12 +4714,12 @@ func (s OperationNotPermittedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotPermittedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotPermittedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutAppLaunchConfigurationInput struct {
@@ -5018,7 +5018,7 @@ func (s *ReplicationJob) SetVmServer(v *VmServer) *ReplicationJob {
 // The specified replication job already exists.
 type ReplicationJobAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5035,7 +5035,7 @@ func (s ReplicationJobAlreadyExistsException) GoString() string {
 
 func newErrorReplicationJobAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ReplicationJobAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5063,18 +5063,18 @@ func (s ReplicationJobAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReplicationJobAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReplicationJobAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified replication job does not exist.
 type ReplicationJobNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5091,7 +5091,7 @@ func (s ReplicationJobNotFoundException) GoString() string {
 
 func newErrorReplicationJobNotFoundException(v protocol.ResponseMetadata) error {
 	return &ReplicationJobNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5119,12 +5119,12 @@ func (s ReplicationJobNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReplicationJobNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReplicationJobNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Represents a replication run.
@@ -5258,7 +5258,7 @@ func (s *ReplicationRun) SetType(v string) *ReplicationRun {
 // in a 24-hour period.
 type ReplicationRunLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5275,7 +5275,7 @@ func (s ReplicationRunLimitExceededException) GoString() string {
 
 func newErrorReplicationRunLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ReplicationRunLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5303,12 +5303,12 @@ func (s ReplicationRunLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReplicationRunLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReplicationRunLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details of the current stage of a replication run.
@@ -5440,7 +5440,7 @@ func (s *Server) SetVmServer(v *VmServer) *Server {
 // The specified server cannot be replicated.
 type ServerCannotBeReplicatedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5457,7 +5457,7 @@ func (s ServerCannotBeReplicatedException) GoString() string {
 
 func newErrorServerCannotBeReplicatedException(v protocol.ResponseMetadata) error {
 	return &ServerCannotBeReplicatedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5485,12 +5485,12 @@ func (s ServerCannotBeReplicatedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServerCannotBeReplicatedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServerCannotBeReplicatedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A logical grouping of servers.
@@ -6010,7 +6010,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // The service is temporarily unavailable.
 type TemporarilyUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6027,7 +6027,7 @@ func (s TemporarilyUnavailableException) GoString() string {
 
 func newErrorTemporarilyUnavailableException(v protocol.ResponseMetadata) error {
 	return &TemporarilyUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6055,12 +6055,12 @@ func (s TemporarilyUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TemporarilyUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TemporarilyUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TerminateAppInput struct {
@@ -6104,7 +6104,7 @@ func (s TerminateAppOutput) GoString() string {
 // and ensure that you are using the correct access keys.
 type UnauthorizedOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6121,7 +6121,7 @@ func (s UnauthorizedOperationException) GoString() string {
 
 func newErrorUnauthorizedOperationException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6149,12 +6149,12 @@ func (s UnauthorizedOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateAppInput struct {

--- a/service/snowball/api.go
+++ b/service/snowball/api.go
@@ -2146,8 +2146,8 @@ func (s CancelJobOutput) GoString() string {
 // this cluster, try again and create jobs until your cluster has exactly five
 // notes.
 type ClusterLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3360,8 +3360,8 @@ func (s *Ec2AmiResource) SetSnowballAmiId(v string) *Ec2AmiResource {
 // Your IAM user lacks the necessary Amazon EC2 permissions to perform the attempted
 // action.
 type Ec2RequestFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3713,8 +3713,8 @@ func (s *INDTaxDocuments) SetGSTIN(v string) *INDTaxDocuments {
 // The address provided was invalid. Check the address with your region's carrier,
 // and try again.
 type InvalidAddressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3771,8 +3771,8 @@ func (s InvalidAddressException) RequestID() string {
 // that the CreateClusterRequest$SnowballType value supports your CreateJobRequest$JobType,
 // and try again.
 type InvalidInputCombinationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3828,8 +3828,8 @@ func (s InvalidInputCombinationException) RequestID() string {
 // The action can't be performed because the job's current state doesn't allow
 // that action to be performed.
 type InvalidJobStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3885,8 +3885,8 @@ func (s InvalidJobStateException) RequestID() string {
 // The NextToken string was altered unexpectedly, and the operation has stopped.
 // Run the operation without changing the NextToken string, and try again.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3942,8 +3942,8 @@ func (s InvalidNextTokenException) RequestID() string {
 // The specified resource can't be found. Check the information you provided
 // in your last request, and try again.
 type InvalidResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 
@@ -4418,8 +4418,8 @@ func (s *JobResource) SetS3Resources(v []*S3Resource) *JobResource {
 // The provided AWS Key Management Service key lacks the permissions to perform
 // the specified CreateJob or UpdateJob action.
 type KMSRequestFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -5143,8 +5143,8 @@ func (s *TaxDocuments) SetIND(v *INDTaxDocuments) *TaxDocuments {
 // error occurred. Check the address with your region's carrier and try again.
 // If the issue persists, contact AWS Support.
 type UnsupportedAddressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }

--- a/service/snowball/api.go
+++ b/service/snowball/api.go
@@ -2147,7 +2147,7 @@ func (s CancelJobOutput) GoString() string {
 // notes.
 type ClusterLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -2164,7 +2164,7 @@ func (s ClusterLimitExceededException) GoString() string {
 
 func newErrorClusterLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ClusterLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2192,12 +2192,12 @@ func (s ClusterLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ClusterLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ClusterLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains a cluster's state, a cluster's ID, and other important information.
@@ -3361,7 +3361,7 @@ func (s *Ec2AmiResource) SetSnowballAmiId(v string) *Ec2AmiResource {
 // action.
 type Ec2RequestFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3378,7 +3378,7 @@ func (s Ec2RequestFailedException) GoString() string {
 
 func newErrorEc2RequestFailedException(v protocol.ResponseMetadata) error {
 	return &Ec2RequestFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3406,12 +3406,12 @@ func (s Ec2RequestFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s Ec2RequestFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s Ec2RequestFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The container for the EventTriggerDefinition$EventResourceARN.
@@ -3714,7 +3714,7 @@ func (s *INDTaxDocuments) SetGSTIN(v string) *INDTaxDocuments {
 // and try again.
 type InvalidAddressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3731,7 +3731,7 @@ func (s InvalidAddressException) GoString() string {
 
 func newErrorInvalidAddressException(v protocol.ResponseMetadata) error {
 	return &InvalidAddressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3759,12 +3759,12 @@ func (s InvalidAddressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAddressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAddressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Job or cluster creation failed. One ore more inputs were invalid. Confirm
@@ -3772,7 +3772,7 @@ func (s InvalidAddressException) RequestID() string {
 // and try again.
 type InvalidInputCombinationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3789,7 +3789,7 @@ func (s InvalidInputCombinationException) GoString() string {
 
 func newErrorInvalidInputCombinationException(v protocol.ResponseMetadata) error {
 	return &InvalidInputCombinationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3817,19 +3817,19 @@ func (s InvalidInputCombinationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInputCombinationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInputCombinationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The action can't be performed because the job's current state doesn't allow
 // that action to be performed.
 type InvalidJobStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3846,7 +3846,7 @@ func (s InvalidJobStateException) GoString() string {
 
 func newErrorInvalidJobStateException(v protocol.ResponseMetadata) error {
 	return &InvalidJobStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3874,19 +3874,19 @@ func (s InvalidJobStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidJobStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidJobStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The NextToken string was altered unexpectedly, and the operation has stopped.
 // Run the operation without changing the NextToken string, and try again.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -3903,7 +3903,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3931,19 +3931,19 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource can't be found. Check the information you provided
 // in your last request, and try again.
 type InvalidResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 
@@ -3963,7 +3963,7 @@ func (s InvalidResourceException) GoString() string {
 
 func newErrorInvalidResourceException(v protocol.ResponseMetadata) error {
 	return &InvalidResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3991,12 +3991,12 @@ func (s InvalidResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Each JobListEntry object contains a job's state, a job's ID, and a value
@@ -4419,7 +4419,7 @@ func (s *JobResource) SetS3Resources(v []*S3Resource) *JobResource {
 // the specified CreateJob or UpdateJob action.
 type KMSRequestFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -4436,7 +4436,7 @@ func (s KMSRequestFailedException) GoString() string {
 
 func newErrorKMSRequestFailedException(v protocol.ResponseMetadata) error {
 	return &KMSRequestFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4464,12 +4464,12 @@ func (s KMSRequestFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s KMSRequestFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s KMSRequestFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains a key range. For export jobs, a S3Resource object can have an optional
@@ -5144,7 +5144,7 @@ func (s *TaxDocuments) SetIND(v *INDTaxDocuments) *TaxDocuments {
 // If the issue persists, contact AWS Support.
 type UnsupportedAddressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" min:"1" type:"string"`
 }
@@ -5161,7 +5161,7 @@ func (s UnsupportedAddressException) GoString() string {
 
 func newErrorUnsupportedAddressException(v protocol.ResponseMetadata) error {
 	return &UnsupportedAddressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5189,12 +5189,12 @@ func (s UnsupportedAddressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedAddressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedAddressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateClusterInput struct {

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -12326,7 +12326,7 @@ func (s AddTagsToResourceOutput) GoString() string {
 // baseline that is already registered with a different patch baseline.
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12343,7 +12343,7 @@ func (s AlreadyExistsException) GoString() string {
 
 func newErrorAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &AlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12371,19 +12371,19 @@ func (s AlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You must disassociate a document from all instances before you can delete
 // it.
 type AssociatedInstances struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12400,7 +12400,7 @@ func (s AssociatedInstances) GoString() string {
 
 func newErrorAssociatedInstances(v protocol.ResponseMetadata) error {
 	return &AssociatedInstances{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12428,12 +12428,12 @@ func (s AssociatedInstances) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AssociatedInstances) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AssociatedInstances) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes an association of a Systems Manager document and an instance.
@@ -12545,7 +12545,7 @@ func (s *Association) SetTargets(v []*Target) *Association {
 // The specified association already exists.
 type AssociationAlreadyExists struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12562,7 +12562,7 @@ func (s AssociationAlreadyExists) GoString() string {
 
 func newErrorAssociationAlreadyExists(v protocol.ResponseMetadata) error {
 	return &AssociationAlreadyExists{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12590,12 +12590,12 @@ func (s AssociationAlreadyExists) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AssociationAlreadyExists) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AssociationAlreadyExists) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the parameters for a document.
@@ -12817,7 +12817,7 @@ func (s *AssociationDescription) SetTargets(v []*Target) *AssociationDescription
 // The specified association does not exist.
 type AssociationDoesNotExist struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12834,7 +12834,7 @@ func (s AssociationDoesNotExist) GoString() string {
 
 func newErrorAssociationDoesNotExist(v protocol.ResponseMetadata) error {
 	return &AssociationDoesNotExist{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12862,12 +12862,12 @@ func (s AssociationDoesNotExist) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AssociationDoesNotExist) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AssociationDoesNotExist) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Includes information about the specified association.
@@ -12961,7 +12961,7 @@ func (s *AssociationExecution) SetStatus(v string) *AssociationExecution {
 // The specified execution ID does not exist. Verify the ID number and try again.
 type AssociationExecutionDoesNotExist struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12978,7 +12978,7 @@ func (s AssociationExecutionDoesNotExist) GoString() string {
 
 func newErrorAssociationExecutionDoesNotExist(v protocol.ResponseMetadata) error {
 	return &AssociationExecutionDoesNotExist{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13006,12 +13006,12 @@ func (s AssociationExecutionDoesNotExist) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AssociationExecutionDoesNotExist) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AssociationExecutionDoesNotExist) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Filters used in the request.
@@ -13295,7 +13295,7 @@ func (s *AssociationFilter) SetValue(v string) *AssociationFilter {
 // You can have at most 2,000 active associations.
 type AssociationLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13312,7 +13312,7 @@ func (s AssociationLimitExceeded) GoString() string {
 
 func newErrorAssociationLimitExceeded(v protocol.ResponseMetadata) error {
 	return &AssociationLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13340,12 +13340,12 @@ func (s AssociationLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AssociationLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AssociationLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the association.
@@ -13632,7 +13632,7 @@ func (s *AssociationVersionInfo) SetTargets(v []*Target) *AssociationVersionInfo
 // Each association has a limit of 1,000 versions.
 type AssociationVersionLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -13649,7 +13649,7 @@ func (s AssociationVersionLimitExceeded) GoString() string {
 
 func newErrorAssociationVersionLimitExceeded(v protocol.ResponseMetadata) error {
 	return &AssociationVersionLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13677,12 +13677,12 @@ func (s AssociationVersionLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AssociationVersionLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AssociationVersionLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A structure that includes attributes that describe a document attachment.
@@ -13845,7 +13845,7 @@ func (s *AttachmentsSource) SetValues(v []*string) *AttachmentsSource {
 // An Automation document with the specified name could not be found.
 type AutomationDefinitionNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -13862,7 +13862,7 @@ func (s AutomationDefinitionNotFoundException) GoString() string {
 
 func newErrorAutomationDefinitionNotFoundException(v protocol.ResponseMetadata) error {
 	return &AutomationDefinitionNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13890,18 +13890,18 @@ func (s AutomationDefinitionNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AutomationDefinitionNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AutomationDefinitionNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An Automation document with the specified name and version could not be found.
 type AutomationDefinitionVersionNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -13918,7 +13918,7 @@ func (s AutomationDefinitionVersionNotFoundException) GoString() string {
 
 func newErrorAutomationDefinitionVersionNotFoundException(v protocol.ResponseMetadata) error {
 	return &AutomationDefinitionVersionNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13946,12 +13946,12 @@ func (s AutomationDefinitionVersionNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AutomationDefinitionVersionNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AutomationDefinitionVersionNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Detailed information about the current state of an individual Automation
@@ -14266,7 +14266,7 @@ func (s *AutomationExecutionFilter) SetValues(v []*string) *AutomationExecutionF
 // limit.
 type AutomationExecutionLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14283,7 +14283,7 @@ func (s AutomationExecutionLimitExceededException) GoString() string {
 
 func newErrorAutomationExecutionLimitExceededException(v protocol.ResponseMetadata) error {
 	return &AutomationExecutionLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14311,12 +14311,12 @@ func (s AutomationExecutionLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AutomationExecutionLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AutomationExecutionLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Details about a specific Automation execution.
@@ -14541,7 +14541,7 @@ func (s *AutomationExecutionMetadata) SetTargets(v []*Target) *AutomationExecuti
 // execution ID.
 type AutomationExecutionNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14558,7 +14558,7 @@ func (s AutomationExecutionNotFoundException) GoString() string {
 
 func newErrorAutomationExecutionNotFoundException(v protocol.ResponseMetadata) error {
 	return &AutomationExecutionNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14586,19 +14586,19 @@ func (s AutomationExecutionNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AutomationExecutionNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AutomationExecutionNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified step name and execution ID don't exist. Verify the information
 // and try again.
 type AutomationStepNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14615,7 +14615,7 @@ func (s AutomationStepNotFoundException) GoString() string {
 
 func newErrorAutomationStepNotFoundException(v protocol.ResponseMetadata) error {
 	return &AutomationStepNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14643,12 +14643,12 @@ func (s AutomationStepNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AutomationStepNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AutomationStepNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CancelCommandInput struct {
@@ -15956,7 +15956,7 @@ func (s *ComplianceSummaryItem) SetNonCompliantSummary(v *NonCompliantSummary) *
 // of 10 different types.
 type ComplianceTypeCountLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15973,7 +15973,7 @@ func (s ComplianceTypeCountLimitExceededException) GoString() string {
 
 func newErrorComplianceTypeCountLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ComplianceTypeCountLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16001,12 +16001,12 @@ func (s ComplianceTypeCountLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ComplianceTypeCountLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ComplianceTypeCountLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A summary of resources that are compliant. The summary is organized according
@@ -17726,7 +17726,7 @@ func (s CreateResourceDataSyncOutput) GoString() string {
 // schemas and try again.
 type CustomSchemaCountLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17743,7 +17743,7 @@ func (s CustomSchemaCountLimitExceededException) GoString() string {
 
 func newErrorCustomSchemaCountLimitExceededException(v protocol.ResponseMetadata) error {
 	return &CustomSchemaCountLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17771,12 +17771,12 @@ func (s CustomSchemaCountLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CustomSchemaCountLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CustomSchemaCountLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteActivationInput struct {
@@ -22383,7 +22383,7 @@ func (s *DescribeSessionsOutput) SetSessions(v []*Session) *DescribeSessionsOutp
 // The specified document already exists.
 type DocumentAlreadyExists struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -22400,7 +22400,7 @@ func (s DocumentAlreadyExists) GoString() string {
 
 func newErrorDocumentAlreadyExists(v protocol.ResponseMetadata) error {
 	return &DocumentAlreadyExists{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22428,12 +22428,12 @@ func (s DocumentAlreadyExists) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DocumentAlreadyExists) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DocumentAlreadyExists) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A default version of a document.
@@ -22952,7 +22952,7 @@ func (s *DocumentKeyValuesFilter) SetValues(v []*string) *DocumentKeyValuesFilte
 // You can have at most 500 active Systems Manager documents.
 type DocumentLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -22969,7 +22969,7 @@ func (s DocumentLimitExceeded) GoString() string {
 
 func newErrorDocumentLimitExceeded(v protocol.ResponseMetadata) error {
 	return &DocumentLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -22997,12 +22997,12 @@ func (s DocumentLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DocumentLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DocumentLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Parameters specified in a System Manager document that run on the server
@@ -23064,7 +23064,7 @@ func (s *DocumentParameter) SetType(v string) *DocumentParameter {
 // documents. If you need to increase this limit, contact AWS Support.
 type DocumentPermissionLimit struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23081,7 +23081,7 @@ func (s DocumentPermissionLimit) GoString() string {
 
 func newErrorDocumentPermissionLimit(v protocol.ResponseMetadata) error {
 	return &DocumentPermissionLimit{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23109,12 +23109,12 @@ func (s DocumentPermissionLimit) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DocumentPermissionLimit) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DocumentPermissionLimit) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An SSM document required by the current document.
@@ -23263,7 +23263,7 @@ func (s *DocumentVersionInfo) SetVersionName(v string) *DocumentVersionInfo {
 // and try again.
 type DocumentVersionLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23280,7 +23280,7 @@ func (s DocumentVersionLimitExceeded) GoString() string {
 
 func newErrorDocumentVersionLimitExceeded(v protocol.ResponseMetadata) error {
 	return &DocumentVersionLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23308,12 +23308,12 @@ func (s DocumentVersionLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DocumentVersionLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DocumentVersionLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Error returned when the ID specified for a resource, such as a maintenance
@@ -23324,7 +23324,7 @@ func (s DocumentVersionLimitExceeded) RequestID() string {
 // in the AWS General Reference.
 type DoesNotExistException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23341,7 +23341,7 @@ func (s DoesNotExistException) GoString() string {
 
 func newErrorDoesNotExistException(v protocol.ResponseMetadata) error {
 	return &DoesNotExistException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23369,19 +23369,19 @@ func (s DoesNotExistException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DoesNotExistException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DoesNotExistException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The content of the association document matches another document. Change
 // the content of the document and try again.
 type DuplicateDocumentContent struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23398,7 +23398,7 @@ func (s DuplicateDocumentContent) GoString() string {
 
 func newErrorDuplicateDocumentContent(v protocol.ResponseMetadata) error {
 	return &DuplicateDocumentContent{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23426,19 +23426,19 @@ func (s DuplicateDocumentContent) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateDocumentContent) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateDocumentContent) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The version name has already been used in this document. Specify a different
 // version name, and then try again.
 type DuplicateDocumentVersionName struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23455,7 +23455,7 @@ func (s DuplicateDocumentVersionName) GoString() string {
 
 func newErrorDuplicateDocumentVersionName(v protocol.ResponseMetadata) error {
 	return &DuplicateDocumentVersionName{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23483,18 +23483,18 @@ func (s DuplicateDocumentVersionName) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateDocumentVersionName) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateDocumentVersionName) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You cannot specify an instance ID in more than one association.
 type DuplicateInstanceId struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23511,7 +23511,7 @@ func (s DuplicateInstanceId) GoString() string {
 
 func newErrorDuplicateInstanceId(v protocol.ResponseMetadata) error {
 	return &DuplicateInstanceId{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23539,12 +23539,12 @@ func (s DuplicateInstanceId) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DuplicateInstanceId) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DuplicateInstanceId) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The EffectivePatch structure defines metadata about a patch along with the
@@ -23678,7 +23678,7 @@ func (s *FailureDetails) SetFailureType(v string) *FailureDetails {
 // the corresponding service is not available.
 type FeatureNotAvailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23695,7 +23695,7 @@ func (s FeatureNotAvailableException) GoString() string {
 
 func newErrorFeatureNotAvailableException(v protocol.ResponseMetadata) error {
 	return &FeatureNotAvailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -23723,12 +23723,12 @@ func (s FeatureNotAvailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FeatureNotAvailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FeatureNotAvailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetAutomationExecutionInput struct {
@@ -26783,7 +26783,7 @@ func (s *GetServiceSettingOutput) SetServiceSetting(v *ServiceSetting) *GetServi
 // in the AWS Systems Manager User Guide.
 type HierarchyLevelLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A hierarchy can have a maximum of 15 levels. For more information, see Requirements
 	// and Constraints for Parameter Names (http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html)
@@ -26803,7 +26803,7 @@ func (s HierarchyLevelLimitExceededException) GoString() string {
 
 func newErrorHierarchyLevelLimitExceededException(v protocol.ResponseMetadata) error {
 	return &HierarchyLevelLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26831,12 +26831,12 @@ func (s HierarchyLevelLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s HierarchyLevelLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s HierarchyLevelLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Parameter Store does not support changing a parameter type in a hierarchy.
@@ -26844,7 +26844,7 @@ func (s HierarchyLevelLimitExceededException) RequestID() string {
 // type. You must create a new, unique parameter.
 type HierarchyTypeMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// Parameter Store does not support changing a parameter type in a hierarchy.
 	// For example, you can't change a parameter from a String type to a SecureString
@@ -26864,7 +26864,7 @@ func (s HierarchyTypeMismatchException) GoString() string {
 
 func newErrorHierarchyTypeMismatchException(v protocol.ResponseMetadata) error {
 	return &HierarchyTypeMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26892,19 +26892,19 @@ func (s HierarchyTypeMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s HierarchyTypeMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s HierarchyTypeMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Error returned when an idempotent operation is retried and the parameters
 // don't match the original call to the API with the same idempotency token.
 type IdempotentParameterMismatch struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -26921,7 +26921,7 @@ func (s IdempotentParameterMismatch) GoString() string {
 
 func newErrorIdempotentParameterMismatch(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatch{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -26949,12 +26949,12 @@ func (s IdempotentParameterMismatch) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatch) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatch) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There is a conflict in the policies specified for this parameter. You can't,
@@ -26962,7 +26962,7 @@ func (s IdempotentParameterMismatch) RequestID() string {
 // policies, and try again.
 type IncompatiblePolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -26979,7 +26979,7 @@ func (s IncompatiblePolicyException) GoString() string {
 
 func newErrorIncompatiblePolicyException(v protocol.ResponseMetadata) error {
 	return &IncompatiblePolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27007,12 +27007,12 @@ func (s IncompatiblePolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IncompatiblePolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IncompatiblePolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Status information about the aggregated associations.
@@ -27916,7 +27916,7 @@ func (s *InstancePatchStateFilter) SetValues(v []*string) *InstancePatchStateFil
 // An error occurred on the server side.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -27933,7 +27933,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -27961,19 +27961,19 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The activation is not valid. The activation might have been deleted, or the
 // ActivationId and the ActivationCode do not match.
 type InvalidActivation struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -27990,7 +27990,7 @@ func (s InvalidActivation) GoString() string {
 
 func newErrorInvalidActivation(v protocol.ResponseMetadata) error {
 	return &InvalidActivation{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28018,19 +28018,19 @@ func (s InvalidActivation) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidActivation) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidActivation) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The activation ID is not valid. Verify the you entered the correct ActivationId
 // or ActivationCode and try again.
 type InvalidActivationId struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28047,7 +28047,7 @@ func (s InvalidActivationId) GoString() string {
 
 func newErrorInvalidActivationId(v protocol.ResponseMetadata) error {
 	return &InvalidActivationId{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28075,19 +28075,19 @@ func (s InvalidActivationId) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidActivationId) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidActivationId) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified aggregator is not valid for inventory groups. Verify that the
 // aggregator uses a valid inventory type such as AWS:Application or AWS:InstanceInformation.
 type InvalidAggregatorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28104,7 +28104,7 @@ func (s InvalidAggregatorException) GoString() string {
 
 func newErrorInvalidAggregatorException(v protocol.ResponseMetadata) error {
 	return &InvalidAggregatorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28132,18 +28132,18 @@ func (s InvalidAggregatorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAggregatorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAggregatorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request does not meet the regular expression requirement.
 type InvalidAllowedPatternException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The request does not meet the regular expression requirement.
 	Message_ *string `locationName:"message" type:"string"`
@@ -28161,7 +28161,7 @@ func (s InvalidAllowedPatternException) GoString() string {
 
 func newErrorInvalidAllowedPatternException(v protocol.ResponseMetadata) error {
 	return &InvalidAllowedPatternException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28189,18 +28189,18 @@ func (s InvalidAllowedPatternException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAllowedPatternException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAllowedPatternException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The association is not valid or does not exist.
 type InvalidAssociation struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28217,7 +28217,7 @@ func (s InvalidAssociation) GoString() string {
 
 func newErrorInvalidAssociation(v protocol.ResponseMetadata) error {
 	return &InvalidAssociation{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28245,12 +28245,12 @@ func (s InvalidAssociation) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAssociation) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAssociation) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The version you specified is not valid. Use ListAssociationVersions to view
@@ -28258,7 +28258,7 @@ func (s InvalidAssociation) RequestID() string {
 // $LATEST parameter to view the latest version of the association.
 type InvalidAssociationVersion struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28275,7 +28275,7 @@ func (s InvalidAssociationVersion) GoString() string {
 
 func newErrorInvalidAssociationVersion(v protocol.ResponseMetadata) error {
 	return &InvalidAssociationVersion{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28303,12 +28303,12 @@ func (s InvalidAssociationVersion) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAssociationVersion) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAssociationVersion) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The supplied parameters for invoking the specified Automation document are
@@ -28316,7 +28316,7 @@ func (s InvalidAssociationVersion) RequestID() string {
 // for the specified Automation document.
 type InvalidAutomationExecutionParametersException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28333,7 +28333,7 @@ func (s InvalidAutomationExecutionParametersException) GoString() string {
 
 func newErrorInvalidAutomationExecutionParametersException(v protocol.ResponseMetadata) error {
 	return &InvalidAutomationExecutionParametersException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28361,18 +28361,18 @@ func (s InvalidAutomationExecutionParametersException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAutomationExecutionParametersException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAutomationExecutionParametersException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The signal is not valid for the current Automation execution.
 type InvalidAutomationSignalException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28389,7 +28389,7 @@ func (s InvalidAutomationSignalException) GoString() string {
 
 func newErrorInvalidAutomationSignalException(v protocol.ResponseMetadata) error {
 	return &InvalidAutomationSignalException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28417,18 +28417,18 @@ func (s InvalidAutomationSignalException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAutomationSignalException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAutomationSignalException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified update status operation is not valid.
 type InvalidAutomationStatusUpdateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28445,7 +28445,7 @@ func (s InvalidAutomationStatusUpdateException) GoString() string {
 
 func newErrorInvalidAutomationStatusUpdateException(v protocol.ResponseMetadata) error {
 	return &InvalidAutomationStatusUpdateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28473,17 +28473,17 @@ func (s InvalidAutomationStatusUpdateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAutomationStatusUpdateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAutomationStatusUpdateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InvalidCommandId struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28500,7 +28500,7 @@ func (s InvalidCommandId) GoString() string {
 
 func newErrorInvalidCommandId(v protocol.ResponseMetadata) error {
 	return &InvalidCommandId{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28528,19 +28528,19 @@ func (s InvalidCommandId) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCommandId) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCommandId) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more of the parameters specified for the delete operation is not valid.
 // Verify all parameters and try again.
 type InvalidDeleteInventoryParametersException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28557,7 +28557,7 @@ func (s InvalidDeleteInventoryParametersException) GoString() string {
 
 func newErrorInvalidDeleteInventoryParametersException(v protocol.ResponseMetadata) error {
 	return &InvalidDeleteInventoryParametersException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28585,19 +28585,19 @@ func (s InvalidDeleteInventoryParametersException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeleteInventoryParametersException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeleteInventoryParametersException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The ID specified for the delete operation does not exist or is not valid.
 // Verify the ID and try again.
 type InvalidDeletionIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28614,7 +28614,7 @@ func (s InvalidDeletionIdException) GoString() string {
 
 func newErrorInvalidDeletionIdException(v protocol.ResponseMetadata) error {
 	return &InvalidDeletionIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28642,18 +28642,18 @@ func (s InvalidDeletionIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDeletionIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDeletionIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified document does not exist.
 type InvalidDocument struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The document does not exist or the document is not available to the user.
 	// This exception can be issued by CreateAssociation, CreateAssociationBatch,
@@ -28674,7 +28674,7 @@ func (s InvalidDocument) GoString() string {
 
 func newErrorInvalidDocument(v protocol.ResponseMetadata) error {
 	return &InvalidDocument{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28702,18 +28702,18 @@ func (s InvalidDocument) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDocument) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDocument) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The content for the document is not valid.
 type InvalidDocumentContent struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description of the validation error.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28731,7 +28731,7 @@ func (s InvalidDocumentContent) GoString() string {
 
 func newErrorInvalidDocumentContent(v protocol.ResponseMetadata) error {
 	return &InvalidDocumentContent{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28759,19 +28759,19 @@ func (s InvalidDocumentContent) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDocumentContent) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDocumentContent) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You attempted to delete a document while it is still shared. You must stop
 // sharing the document before you can delete it.
 type InvalidDocumentOperation struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28788,7 +28788,7 @@ func (s InvalidDocumentOperation) GoString() string {
 
 func newErrorInvalidDocumentOperation(v protocol.ResponseMetadata) error {
 	return &InvalidDocumentOperation{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28816,18 +28816,18 @@ func (s InvalidDocumentOperation) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDocumentOperation) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDocumentOperation) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The version of the document schema is not supported.
 type InvalidDocumentSchemaVersion struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28844,7 +28844,7 @@ func (s InvalidDocumentSchemaVersion) GoString() string {
 
 func newErrorInvalidDocumentSchemaVersion(v protocol.ResponseMetadata) error {
 	return &InvalidDocumentSchemaVersion{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28872,19 +28872,19 @@ func (s InvalidDocumentSchemaVersion) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDocumentSchemaVersion) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDocumentSchemaVersion) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The document type is not valid. Valid document types are described in the
 // DocumentType property.
 type InvalidDocumentType struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28901,7 +28901,7 @@ func (s InvalidDocumentType) GoString() string {
 
 func newErrorInvalidDocumentType(v protocol.ResponseMetadata) error {
 	return &InvalidDocumentType{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28929,18 +28929,18 @@ func (s InvalidDocumentType) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDocumentType) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDocumentType) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The document version is not valid or does not exist.
 type InvalidDocumentVersion struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28957,7 +28957,7 @@ func (s InvalidDocumentVersion) GoString() string {
 
 func newErrorInvalidDocumentVersion(v protocol.ResponseMetadata) error {
 	return &InvalidDocumentVersion{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -28985,19 +28985,19 @@ func (s InvalidDocumentVersion) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidDocumentVersion) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidDocumentVersion) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The filter name is not valid. Verify the you entered the correct name and
 // try again.
 type InvalidFilter struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29014,7 +29014,7 @@ func (s InvalidFilter) GoString() string {
 
 func newErrorInvalidFilter(v protocol.ResponseMetadata) error {
 	return &InvalidFilter{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29042,18 +29042,18 @@ func (s InvalidFilter) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFilter) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFilter) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified key is not valid.
 type InvalidFilterKey struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29070,7 +29070,7 @@ func (s InvalidFilterKey) GoString() string {
 
 func newErrorInvalidFilterKey(v protocol.ResponseMetadata) error {
 	return &InvalidFilterKey{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29098,19 +29098,19 @@ func (s InvalidFilterKey) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFilterKey) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFilterKey) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified filter option is not valid. Valid options are Equals and BeginsWith.
 // For Path filter, valid options are Recursive and OneLevel.
 type InvalidFilterOption struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The specified filter option is not valid. Valid options are Equals and BeginsWith.
 	// For Path filter, valid options are Recursive and OneLevel.
@@ -29129,7 +29129,7 @@ func (s InvalidFilterOption) GoString() string {
 
 func newErrorInvalidFilterOption(v protocol.ResponseMetadata) error {
 	return &InvalidFilterOption{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29157,18 +29157,18 @@ func (s InvalidFilterOption) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFilterOption) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFilterOption) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The filter value is not valid. Verify the value and try again.
 type InvalidFilterValue struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29185,7 +29185,7 @@ func (s InvalidFilterValue) GoString() string {
 
 func newErrorInvalidFilterValue(v protocol.ResponseMetadata) error {
 	return &InvalidFilterValue{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29213,12 +29213,12 @@ func (s InvalidFilterValue) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFilterValue) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFilterValue) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The following problems can cause this exception:
@@ -29233,7 +29233,7 @@ func (s InvalidFilterValue) RequestID() string {
 // Stopping. Invalid states are: Shutting-down and Terminated.
 type InvalidInstanceId struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29250,7 +29250,7 @@ func (s InvalidInstanceId) GoString() string {
 
 func newErrorInvalidInstanceId(v protocol.ResponseMetadata) error {
 	return &InvalidInstanceId{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29278,18 +29278,18 @@ func (s InvalidInstanceId) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInstanceId) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInstanceId) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified filter value is not valid.
 type InvalidInstanceInformationFilterValue struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29306,7 +29306,7 @@ func (s InvalidInstanceInformationFilterValue) GoString() string {
 
 func newErrorInvalidInstanceInformationFilterValue(v protocol.ResponseMetadata) error {
 	return &InvalidInstanceInformationFilterValue{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29334,18 +29334,18 @@ func (s InvalidInstanceInformationFilterValue) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInstanceInformationFilterValue) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInstanceInformationFilterValue) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified inventory group is not valid.
 type InvalidInventoryGroupException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29362,7 +29362,7 @@ func (s InvalidInventoryGroupException) GoString() string {
 
 func newErrorInvalidInventoryGroupException(v protocol.ResponseMetadata) error {
 	return &InvalidInventoryGroupException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29390,19 +29390,19 @@ func (s InvalidInventoryGroupException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInventoryGroupException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInventoryGroupException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You specified invalid keys or values in the Context attribute for InventoryItem.
 // Verify the keys and values, and try again.
 type InvalidInventoryItemContextException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29419,7 +29419,7 @@ func (s InvalidInventoryItemContextException) GoString() string {
 
 func newErrorInvalidInventoryItemContextException(v protocol.ResponseMetadata) error {
 	return &InvalidInventoryItemContextException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29447,18 +29447,18 @@ func (s InvalidInventoryItemContextException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInventoryItemContextException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInventoryItemContextException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request is not valid.
 type InvalidInventoryRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29475,7 +29475,7 @@ func (s InvalidInventoryRequestException) GoString() string {
 
 func newErrorInvalidInventoryRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidInventoryRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29503,18 +29503,18 @@ func (s InvalidInventoryRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidInventoryRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidInventoryRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more content items is not valid.
 type InvalidItemContentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -29533,7 +29533,7 @@ func (s InvalidItemContentException) GoString() string {
 
 func newErrorInvalidItemContentException(v protocol.ResponseMetadata) error {
 	return &InvalidItemContentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29561,18 +29561,18 @@ func (s InvalidItemContentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidItemContentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidItemContentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The query key ID is not valid.
 type InvalidKeyId struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29589,7 +29589,7 @@ func (s InvalidKeyId) GoString() string {
 
 func newErrorInvalidKeyId(v protocol.ResponseMetadata) error {
 	return &InvalidKeyId{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29617,18 +29617,18 @@ func (s InvalidKeyId) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidKeyId) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidKeyId) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified token is not valid.
 type InvalidNextToken struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29645,7 +29645,7 @@ func (s InvalidNextToken) GoString() string {
 
 func newErrorInvalidNextToken(v protocol.ResponseMetadata) error {
 	return &InvalidNextToken{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29673,19 +29673,19 @@ func (s InvalidNextToken) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextToken) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextToken) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more configuration items is not valid. Verify that a valid Amazon
 // Resource Name (ARN) was provided for an Amazon SNS topic.
 type InvalidNotificationConfig struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29702,7 +29702,7 @@ func (s InvalidNotificationConfig) GoString() string {
 
 func newErrorInvalidNotificationConfig(v protocol.ResponseMetadata) error {
 	return &InvalidNotificationConfig{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29730,19 +29730,19 @@ func (s InvalidNotificationConfig) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNotificationConfig) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNotificationConfig) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The delete inventory option specified is not valid. Verify the option and
 // try again.
 type InvalidOptionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29759,7 +29759,7 @@ func (s InvalidOptionException) GoString() string {
 
 func newErrorInvalidOptionException(v protocol.ResponseMetadata) error {
 	return &InvalidOptionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29787,18 +29787,18 @@ func (s InvalidOptionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOptionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOptionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The S3 bucket does not exist.
 type InvalidOutputFolder struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29815,7 +29815,7 @@ func (s InvalidOutputFolder) GoString() string {
 
 func newErrorInvalidOutputFolder(v protocol.ResponseMetadata) error {
 	return &InvalidOutputFolder{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29843,18 +29843,18 @@ func (s InvalidOutputFolder) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOutputFolder) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOutputFolder) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The output location is not valid or does not exist.
 type InvalidOutputLocation struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29871,7 +29871,7 @@ func (s InvalidOutputLocation) GoString() string {
 
 func newErrorInvalidOutputLocation(v protocol.ResponseMetadata) error {
 	return &InvalidOutputLocation{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29899,12 +29899,12 @@ func (s InvalidOutputLocation) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOutputLocation) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOutputLocation) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You must specify values for all required parameters in the Systems Manager
@@ -29912,7 +29912,7 @@ func (s InvalidOutputLocation) RequestID() string {
 // Manager document.
 type InvalidParameters struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29929,7 +29929,7 @@ func (s InvalidParameters) GoString() string {
 
 func newErrorInvalidParameters(v protocol.ResponseMetadata) error {
 	return &InvalidParameters{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -29957,19 +29957,19 @@ func (s InvalidParameters) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameters) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameters) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The permission type is not supported. Share is the only supported permission
 // type.
 type InvalidPermissionType struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29986,7 +29986,7 @@ func (s InvalidPermissionType) GoString() string {
 
 func newErrorInvalidPermissionType(v protocol.ResponseMetadata) error {
 	return &InvalidPermissionType{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30014,18 +30014,18 @@ func (s InvalidPermissionType) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPermissionType) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPermissionType) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The plugin name is not valid.
 type InvalidPluginName struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30042,7 +30042,7 @@ func (s InvalidPluginName) GoString() string {
 
 func newErrorInvalidPluginName(v protocol.ResponseMetadata) error {
 	return &InvalidPluginName{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30070,18 +30070,18 @@ func (s InvalidPluginName) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPluginName) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPluginName) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A policy attribute or its value is invalid.
 type InvalidPolicyAttributeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30098,7 +30098,7 @@ func (s InvalidPolicyAttributeException) GoString() string {
 
 func newErrorInvalidPolicyAttributeException(v protocol.ResponseMetadata) error {
 	return &InvalidPolicyAttributeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30126,19 +30126,19 @@ func (s InvalidPolicyAttributeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPolicyAttributeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPolicyAttributeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The policy type is not supported. Parameter Store supports the following
 // policy types: Expiration, ExpirationNotification, and NoChangeNotification.
 type InvalidPolicyTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30155,7 +30155,7 @@ func (s InvalidPolicyTypeException) GoString() string {
 
 func newErrorInvalidPolicyTypeException(v protocol.ResponseMetadata) error {
 	return &InvalidPolicyTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30183,19 +30183,19 @@ func (s InvalidPolicyTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPolicyTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPolicyTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource ID is not valid. Verify that you entered the correct ID and
 // try again.
 type InvalidResourceId struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30212,7 +30212,7 @@ func (s InvalidResourceId) GoString() string {
 
 func newErrorInvalidResourceId(v protocol.ResponseMetadata) error {
 	return &InvalidResourceId{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30240,19 +30240,19 @@ func (s InvalidResourceId) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceId) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceId) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource type is not valid. For example, if you are attempting to tag
 // an instance, the instance must be a registered, managed instance.
 type InvalidResourceType struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30269,7 +30269,7 @@ func (s InvalidResourceType) GoString() string {
 
 func newErrorInvalidResourceType(v protocol.ResponseMetadata) error {
 	return &InvalidResourceType{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30297,18 +30297,18 @@ func (s InvalidResourceType) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceType) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceType) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified inventory item result attribute is not valid.
 type InvalidResultAttributeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30325,7 +30325,7 @@ func (s InvalidResultAttributeException) GoString() string {
 
 func newErrorInvalidResultAttributeException(v protocol.ResponseMetadata) error {
 	return &InvalidResultAttributeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30353,12 +30353,12 @@ func (s InvalidResultAttributeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResultAttributeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResultAttributeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The role name can't contain invalid characters. Also verify that you specified
@@ -30368,7 +30368,7 @@ func (s InvalidResultAttributeException) RequestID() string {
 // in the AWS Systems Manager User Guide.
 type InvalidRole struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30385,7 +30385,7 @@ func (s InvalidRole) GoString() string {
 
 func newErrorInvalidRole(v protocol.ResponseMetadata) error {
 	return &InvalidRole{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30413,18 +30413,18 @@ func (s InvalidRole) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRole) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRole) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The schedule is invalid. Verify your cron or rate expression and try again.
 type InvalidSchedule struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30441,7 +30441,7 @@ func (s InvalidSchedule) GoString() string {
 
 func newErrorInvalidSchedule(v protocol.ResponseMetadata) error {
 	return &InvalidSchedule{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30469,19 +30469,19 @@ func (s InvalidSchedule) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidSchedule) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidSchedule) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The target is not valid or does not exist. It might not be configured for
 // EC2 Systems Manager or you might not have permission to perform the operation.
 type InvalidTarget struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30498,7 +30498,7 @@ func (s InvalidTarget) GoString() string {
 
 func newErrorInvalidTarget(v protocol.ResponseMetadata) error {
 	return &InvalidTarget{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30526,18 +30526,18 @@ func (s InvalidTarget) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTarget) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTarget) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The parameter type name is not valid.
 type InvalidTypeNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30554,7 +30554,7 @@ func (s InvalidTypeNameException) GoString() string {
 
 func newErrorInvalidTypeNameException(v protocol.ResponseMetadata) error {
 	return &InvalidTypeNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30582,18 +30582,18 @@ func (s InvalidTypeNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidTypeNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidTypeNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The update is not valid.
 type InvalidUpdate struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30610,7 +30610,7 @@ func (s InvalidUpdate) GoString() string {
 
 func newErrorInvalidUpdate(v protocol.ResponseMetadata) error {
 	return &InvalidUpdate{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -30638,12 +30638,12 @@ func (s InvalidUpdate) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidUpdate) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidUpdate) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the inventory type and attribute for the aggregation execution.
@@ -31352,7 +31352,7 @@ func (s *InventoryResultItem) SetTypeName(v string) *InventoryResultItem {
 // Verify the command ID and the instance ID and try again.
 type InvocationDoesNotExist struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -31369,7 +31369,7 @@ func (s InvocationDoesNotExist) GoString() string {
 
 func newErrorInvocationDoesNotExist(v protocol.ResponseMetadata) error {
 	return &InvocationDoesNotExist{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -31397,18 +31397,18 @@ func (s InvocationDoesNotExist) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvocationDoesNotExist) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvocationDoesNotExist) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The inventory item has invalid content.
 type ItemContentMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -31427,7 +31427,7 @@ func (s ItemContentMismatchException) GoString() string {
 
 func newErrorItemContentMismatchException(v protocol.ResponseMetadata) error {
 	return &ItemContentMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -31455,18 +31455,18 @@ func (s ItemContentMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ItemContentMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ItemContentMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The inventory item size has exceeded the size limit.
 type ItemSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -31485,7 +31485,7 @@ func (s ItemSizeLimitExceededException) GoString() string {
 
 func newErrorItemSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ItemSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -31513,12 +31513,12 @@ func (s ItemSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ItemSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ItemSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type LabelParameterVersionInput struct {
@@ -34242,7 +34242,7 @@ func (s *MaintenanceWindowTaskParameterValueExpression) SetValues(v []*string) *
 // The size limit of a document is 64 KB.
 type MaxDocumentSizeExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -34259,7 +34259,7 @@ func (s MaxDocumentSizeExceeded) GoString() string {
 
 func newErrorMaxDocumentSizeExceeded(v protocol.ResponseMetadata) error {
 	return &MaxDocumentSizeExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -34287,12 +34287,12 @@ func (s MaxDocumentSizeExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MaxDocumentSizeExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MaxDocumentSizeExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ModifyDocumentPermissionInput struct {
@@ -34918,7 +34918,7 @@ func (s *OpsItem) SetVersion(v string) *OpsItem {
 // The OpsItem already exists.
 type OpsItemAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -34937,7 +34937,7 @@ func (s OpsItemAlreadyExistsException) GoString() string {
 
 func newErrorOpsItemAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &OpsItemAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -34965,12 +34965,12 @@ func (s OpsItemAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OpsItemAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OpsItemAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An object that defines the value of the key and its type in the OperationalData
@@ -35078,7 +35078,7 @@ func (s *OpsItemFilter) SetValues(v []*string) *OpsItemFilter {
 // and try again.
 type OpsItemInvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -35097,7 +35097,7 @@ func (s OpsItemInvalidParameterException) GoString() string {
 
 func newErrorOpsItemInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &OpsItemInvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -35125,19 +35125,19 @@ func (s OpsItemInvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OpsItemInvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OpsItemInvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request caused OpsItems to exceed one or more quotas. For information
 // about OpsItem quotas, see What are the resource limits for OpsCenter? (http://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-learn-more.html#OpsCenter-learn-more-limits).
 type OpsItemLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Limit *int64 `type:"integer"`
 
@@ -35160,7 +35160,7 @@ func (s OpsItemLimitExceededException) GoString() string {
 
 func newErrorOpsItemLimitExceededException(v protocol.ResponseMetadata) error {
 	return &OpsItemLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -35188,18 +35188,18 @@ func (s OpsItemLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OpsItemLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OpsItemLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified OpsItem ID doesn't exist. Verify the ID and try again.
 type OpsItemNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -35216,7 +35216,7 @@ func (s OpsItemNotFoundException) GoString() string {
 
 func newErrorOpsItemNotFoundException(v protocol.ResponseMetadata) error {
 	return &OpsItemNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -35244,12 +35244,12 @@ func (s OpsItemNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OpsItemNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OpsItemNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A notification about the OpsItem.
@@ -35578,7 +35578,7 @@ func (s *Parameter) SetVersion(v int64) *Parameter {
 // The parameter already exists. You can't create duplicate parameters.
 type ParameterAlreadyExists struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -35595,7 +35595,7 @@ func (s ParameterAlreadyExists) GoString() string {
 
 func newErrorParameterAlreadyExists(v protocol.ResponseMetadata) error {
 	return &ParameterAlreadyExists{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -35623,12 +35623,12 @@ func (s ParameterAlreadyExists) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterAlreadyExists) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterAlreadyExists) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about parameter usage.
@@ -35809,7 +35809,7 @@ func (s *ParameterInlinePolicy) SetPolicyType(v string) *ParameterInlinePolicy {
 // or more parameters and try again.
 type ParameterLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -35826,7 +35826,7 @@ func (s ParameterLimitExceeded) GoString() string {
 
 func newErrorParameterLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ParameterLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -35854,18 +35854,18 @@ func (s ParameterLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The parameter exceeded the maximum number of allowed versions.
 type ParameterMaxVersionLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -35882,7 +35882,7 @@ func (s ParameterMaxVersionLimitExceeded) GoString() string {
 
 func newErrorParameterMaxVersionLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ParameterMaxVersionLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -35910,12 +35910,12 @@ func (s ParameterMaxVersionLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterMaxVersionLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterMaxVersionLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Metadata includes information like the ARN of the last user and the date/time
@@ -36030,7 +36030,7 @@ func (s *ParameterMetadata) SetVersion(v int64) *ParameterMetadata {
 // The parameter could not be found. Verify the name and try again.
 type ParameterNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -36047,7 +36047,7 @@ func (s ParameterNotFound) GoString() string {
 
 func newErrorParameterNotFound(v protocol.ResponseMetadata) error {
 	return &ParameterNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -36075,18 +36075,18 @@ func (s ParameterNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The parameter name is not valid.
 type ParameterPatternMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The parameter name is not valid.
 	Message_ *string `locationName:"message" type:"string"`
@@ -36104,7 +36104,7 @@ func (s ParameterPatternMismatchException) GoString() string {
 
 func newErrorParameterPatternMismatchException(v protocol.ResponseMetadata) error {
 	return &ParameterPatternMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -36132,12 +36132,12 @@ func (s ParameterPatternMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterPatternMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterPatternMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more filters. Use a filter to return a more specific list of results.
@@ -36230,7 +36230,7 @@ func (s *ParameterStringFilter) SetValues(v []*string) *ParameterStringFilter {
 // A parameter version can have a maximum of ten labels.
 type ParameterVersionLabelLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -36247,7 +36247,7 @@ func (s ParameterVersionLabelLimitExceeded) GoString() string {
 
 func newErrorParameterVersionLabelLimitExceeded(v protocol.ResponseMetadata) error {
 	return &ParameterVersionLabelLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -36275,19 +36275,19 @@ func (s ParameterVersionLabelLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterVersionLabelLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterVersionLabelLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified parameter version was not found. Verify the parameter name
 // and version, and try again.
 type ParameterVersionNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -36304,7 +36304,7 @@ func (s ParameterVersionNotFound) GoString() string {
 
 func newErrorParameterVersionNotFound(v protocol.ResponseMetadata) error {
 	return &ParameterVersionNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -36332,12 +36332,12 @@ func (s ParameterVersionNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ParameterVersionNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ParameterVersionNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This data type is deprecated. Instead, use ParameterStringFilter.
@@ -37152,7 +37152,7 @@ func (s *PatchStatus) SetDeploymentStatus(v string) *PatchStatus {
 // The maximum is 10.
 type PoliciesLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -37169,7 +37169,7 @@ func (s PoliciesLimitExceededException) GoString() string {
 
 func newErrorPoliciesLimitExceededException(v protocol.ResponseMetadata) error {
 	return &PoliciesLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -37197,12 +37197,12 @@ func (s PoliciesLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s PoliciesLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s PoliciesLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An aggregate of step execution statuses displayed in the AWS Console for
@@ -38791,7 +38791,7 @@ func (s *ResourceComplianceSummaryItem) SetStatus(v string) *ResourceComplianceS
 // A sync configuration with the same name already exists.
 type ResourceDataSyncAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -38810,7 +38810,7 @@ func (s ResourceDataSyncAlreadyExistsException) GoString() string {
 
 func newErrorResourceDataSyncAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceDataSyncAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -38838,12 +38838,12 @@ func (s ResourceDataSyncAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceDataSyncAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceDataSyncAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about the AwsOrganizationsSource resource data sync source. A
@@ -38919,7 +38919,7 @@ func (s *ResourceDataSyncAwsOrganizationsSource) SetOrganizationalUnits(v []*Res
 // and try again.
 type ResourceDataSyncConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -38936,7 +38936,7 @@ func (s ResourceDataSyncConflictException) GoString() string {
 
 func newErrorResourceDataSyncConflictException(v protocol.ResponseMetadata) error {
 	return &ResourceDataSyncConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -38964,18 +38964,18 @@ func (s ResourceDataSyncConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceDataSyncConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceDataSyncConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You have exceeded the allowed maximum sync configurations.
 type ResourceDataSyncCountExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -38992,7 +38992,7 @@ func (s ResourceDataSyncCountExceededException) GoString() string {
 
 func newErrorResourceDataSyncCountExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceDataSyncCountExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -39020,12 +39020,12 @@ func (s ResourceDataSyncCountExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceDataSyncCountExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceDataSyncCountExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Synchronize Systems Manager Inventory data from multiple AWS accounts defined
@@ -39071,7 +39071,7 @@ func (s *ResourceDataSyncDestinationDataSharing) SetDestinationDataSharingType(v
 // The specified sync configuration is invalid.
 type ResourceDataSyncInvalidConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39088,7 +39088,7 @@ func (s ResourceDataSyncInvalidConfigurationException) GoString() string {
 
 func newErrorResourceDataSyncInvalidConfigurationException(v protocol.ResponseMetadata) error {
 	return &ResourceDataSyncInvalidConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -39116,12 +39116,12 @@ func (s ResourceDataSyncInvalidConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceDataSyncInvalidConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceDataSyncInvalidConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a Resource Data Sync configuration, including its current
@@ -39236,7 +39236,7 @@ func (s *ResourceDataSyncItem) SetSyncType(v string) *ResourceDataSyncItem {
 // The specified sync name was not found.
 type ResourceDataSyncNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -39257,7 +39257,7 @@ func (s ResourceDataSyncNotFoundException) GoString() string {
 
 func newErrorResourceDataSyncNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceDataSyncNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -39285,12 +39285,12 @@ func (s ResourceDataSyncNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceDataSyncNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceDataSyncNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The AWS Organizations organizational unit data source for the sync.
@@ -39617,7 +39617,7 @@ func (s *ResourceDataSyncSourceWithState) SetState(v string) *ResourceDataSyncSo
 // for a patch group.
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39634,7 +39634,7 @@ func (s ResourceInUseException) GoString() string {
 
 func newErrorResourceInUseException(v protocol.ResponseMetadata) error {
 	return &ResourceInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -39662,12 +39662,12 @@ func (s ResourceInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Error returned when the caller has exceeded the default resource quotas.
@@ -39678,7 +39678,7 @@ func (s ResourceInUseException) RequestID() string {
 // in the AWS General Reference.
 type ResourceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39695,7 +39695,7 @@ func (s ResourceLimitExceededException) GoString() string {
 
 func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -39723,12 +39723,12 @@ func (s ResourceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The inventory item result attribute.
@@ -40466,7 +40466,7 @@ func (s *ServiceSetting) SetStatus(v string) *ServiceSetting {
 // setting has not been provisioned by the AWS service team.
 type ServiceSettingNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -40483,7 +40483,7 @@ func (s ServiceSettingNotFound) GoString() string {
 
 func newErrorServiceSettingNotFound(v protocol.ResponseMetadata) error {
 	return &ServiceSettingNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -40511,12 +40511,12 @@ func (s ServiceSettingNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceSettingNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceSettingNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about a Session Manager connection to an instance.
@@ -41216,7 +41216,7 @@ func (s *StartSessionOutput) SetTokenValue(v string) *StartSessionOutput {
 // The updated status is the same as the current status.
 type StatusUnchanged struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -41233,7 +41233,7 @@ func (s StatusUnchanged) GoString() string {
 
 func newErrorStatusUnchanged(v protocol.ResponseMetadata) error {
 	return &StatusUnchanged{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -41261,12 +41261,12 @@ func (s StatusUnchanged) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StatusUnchanged) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StatusUnchanged) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Detailed information about an the execution state of an Automation step.
@@ -41620,7 +41620,7 @@ func (s StopAutomationExecutionOutput) GoString() string {
 // The sub-type count exceeded the limit for the inventory type.
 type SubTypeCountLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -41637,7 +41637,7 @@ func (s SubTypeCountLimitExceededException) GoString() string {
 
 func newErrorSubTypeCountLimitExceededException(v protocol.ResponseMetadata) error {
 	return &SubTypeCountLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -41665,12 +41665,12 @@ func (s SubTypeCountLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubTypeCountLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubTypeCountLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Metadata that you assign to your AWS resources. Tags enable you to categorize
@@ -41826,7 +41826,7 @@ func (s *Target) SetValues(v []*string) *Target {
 // operation, but the target is still referenced in a task.
 type TargetInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -41843,7 +41843,7 @@ func (s TargetInUseException) GoString() string {
 
 func newErrorTargetInUseException(v protocol.ResponseMetadata) error {
 	return &TargetInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -41871,12 +41871,12 @@ func (s TargetInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TargetInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TargetInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The combination of AWS Regions and accounts targeted by the current Automation
@@ -41973,7 +41973,7 @@ func (s *TargetLocation) SetTargetLocationMaxErrors(v string) *TargetLocation {
 // in the AWS Systems Manager User Guide.
 type TargetNotConnected struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -41990,7 +41990,7 @@ func (s TargetNotConnected) GoString() string {
 
 func newErrorTargetNotConnected(v protocol.ResponseMetadata) error {
 	return &TargetNotConnected{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42018,12 +42018,12 @@ func (s TargetNotConnected) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TargetNotConnected) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TargetNotConnected) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TerminateSessionInput struct {
@@ -42094,7 +42094,7 @@ func (s *TerminateSessionOutput) SetSessionId(v string) *TerminateSessionOutput 
 // try the command again.
 type TooManyTagsError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -42111,7 +42111,7 @@ func (s TooManyTagsError) GoString() string {
 
 func newErrorTooManyTagsError(v protocol.ResponseMetadata) error {
 	return &TooManyTagsError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42139,19 +42139,19 @@ func (s TooManyTagsError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // There are concurrent updates for a resource that supports one update at a
 // time.
 type TooManyUpdates struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42168,7 +42168,7 @@ func (s TooManyUpdates) GoString() string {
 
 func newErrorTooManyUpdates(v protocol.ResponseMetadata) error {
 	return &TooManyUpdates{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42196,18 +42196,18 @@ func (s TooManyUpdates) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyUpdates) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyUpdates) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The size of inventory data has exceeded the total size limit for the resource.
 type TotalSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42224,7 +42224,7 @@ func (s TotalSizeLimitExceededException) GoString() string {
 
 func newErrorTotalSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TotalSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42252,19 +42252,19 @@ func (s TotalSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TotalSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TotalSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The calendar entry contained in the specified Systems Manager document is
 // not supported.
 type UnsupportedCalendarException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42281,7 +42281,7 @@ func (s UnsupportedCalendarException) GoString() string {
 
 func newErrorUnsupportedCalendarException(v protocol.ResponseMetadata) error {
 	return &UnsupportedCalendarException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42309,12 +42309,12 @@ func (s UnsupportedCalendarException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedCalendarException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedCalendarException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Microsoft application patching is only available on EC2 instances and Advanced
@@ -42324,7 +42324,7 @@ func (s UnsupportedCalendarException) RequestID() string {
 // in the AWS Systems Manager User Guide.
 type UnsupportedFeatureRequiredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42341,7 +42341,7 @@ func (s UnsupportedFeatureRequiredException) GoString() string {
 
 func newErrorUnsupportedFeatureRequiredException(v protocol.ResponseMetadata) error {
 	return &UnsupportedFeatureRequiredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42369,12 +42369,12 @@ func (s UnsupportedFeatureRequiredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedFeatureRequiredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedFeatureRequiredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Context attribute that you specified for the InventoryItem is not allowed
@@ -42382,7 +42382,7 @@ func (s UnsupportedFeatureRequiredException) RequestID() string {
 // types like AWS:ComplianceItem.
 type UnsupportedInventoryItemContextException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -42401,7 +42401,7 @@ func (s UnsupportedInventoryItemContextException) GoString() string {
 
 func newErrorUnsupportedInventoryItemContextException(v protocol.ResponseMetadata) error {
 	return &UnsupportedInventoryItemContextException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42429,12 +42429,12 @@ func (s UnsupportedInventoryItemContextException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedInventoryItemContextException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedInventoryItemContextException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Inventory item type schema version has to match supported versions in the
@@ -42442,7 +42442,7 @@ func (s UnsupportedInventoryItemContextException) RequestID() string {
 // for each type.
 type UnsupportedInventorySchemaVersionException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42459,7 +42459,7 @@ func (s UnsupportedInventorySchemaVersionException) GoString() string {
 
 func newErrorUnsupportedInventorySchemaVersionException(v protocol.ResponseMetadata) error {
 	return &UnsupportedInventorySchemaVersionException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42487,12 +42487,12 @@ func (s UnsupportedInventorySchemaVersionException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedInventorySchemaVersionException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedInventorySchemaVersionException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operating systems you specified is not supported, or the operation is
@@ -42500,7 +42500,7 @@ func (s UnsupportedInventorySchemaVersionException) RequestID() string {
 // Windows, AmazonLinux, RedhatEnterpriseLinux, and Ubuntu.
 type UnsupportedOperatingSystem struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42517,7 +42517,7 @@ func (s UnsupportedOperatingSystem) GoString() string {
 
 func newErrorUnsupportedOperatingSystem(v protocol.ResponseMetadata) error {
 	return &UnsupportedOperatingSystem{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42545,18 +42545,18 @@ func (s UnsupportedOperatingSystem) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedOperatingSystem) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedOperatingSystem) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The parameter type is not supported.
 type UnsupportedParameterType struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -42573,7 +42573,7 @@ func (s UnsupportedParameterType) GoString() string {
 
 func newErrorUnsupportedParameterType(v protocol.ResponseMetadata) error {
 	return &UnsupportedParameterType{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42601,19 +42601,19 @@ func (s UnsupportedParameterType) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedParameterType) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedParameterType) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The document does not support the platform type of the given instance ID(s).
 // For example, you sent an document for a Windows instance to a Linux instance.
 type UnsupportedPlatformType struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42630,7 +42630,7 @@ func (s UnsupportedPlatformType) GoString() string {
 
 func newErrorUnsupportedPlatformType(v protocol.ResponseMetadata) error {
 	return &UnsupportedPlatformType{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -42658,12 +42658,12 @@ func (s UnsupportedPlatformType) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedPlatformType) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedPlatformType) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateAssociationInput struct {

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -12325,8 +12325,8 @@ func (s AddTagsToResourceOutput) GoString() string {
 // Error returned if an attempt is made to register a patch group with a patch
 // baseline that is already registered with a different patch baseline.
 type AlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12382,8 +12382,8 @@ func (s AlreadyExistsException) RequestID() string {
 // You must disassociate a document from all instances before you can delete
 // it.
 type AssociatedInstances struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12544,8 +12544,8 @@ func (s *Association) SetTargets(v []*Target) *Association {
 
 // The specified association already exists.
 type AssociationAlreadyExists struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12816,8 +12816,8 @@ func (s *AssociationDescription) SetTargets(v []*Target) *AssociationDescription
 
 // The specified association does not exist.
 type AssociationDoesNotExist struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12960,8 +12960,8 @@ func (s *AssociationExecution) SetStatus(v string) *AssociationExecution {
 
 // The specified execution ID does not exist. Verify the ID number and try again.
 type AssociationExecutionDoesNotExist struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -13294,8 +13294,8 @@ func (s *AssociationFilter) SetValue(v string) *AssociationFilter {
 
 // You can have at most 2,000 active associations.
 type AssociationLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -13631,8 +13631,8 @@ func (s *AssociationVersionInfo) SetTargets(v []*Target) *AssociationVersionInfo
 // You have reached the maximum number versions allowed for an association.
 // Each association has a limit of 1,000 versions.
 type AssociationVersionLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -13844,8 +13844,8 @@ func (s *AttachmentsSource) SetValues(v []*string) *AttachmentsSource {
 
 // An Automation document with the specified name could not be found.
 type AutomationDefinitionNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -13900,8 +13900,8 @@ func (s AutomationDefinitionNotFoundException) RequestID() string {
 
 // An Automation document with the specified name and version could not be found.
 type AutomationDefinitionVersionNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14265,8 +14265,8 @@ func (s *AutomationExecutionFilter) SetValues(v []*string) *AutomationExecutionF
 // The number of simultaneously running Automation executions exceeded the allowable
 // limit.
 type AutomationExecutionLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14540,8 +14540,8 @@ func (s *AutomationExecutionMetadata) SetTargets(v []*Target) *AutomationExecuti
 // There is no automation execution information for the requested automation
 // execution ID.
 type AutomationExecutionNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -14597,8 +14597,8 @@ func (s AutomationExecutionNotFoundException) RequestID() string {
 // The specified step name and execution ID don't exist. Verify the information
 // and try again.
 type AutomationStepNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -15955,8 +15955,8 @@ func (s *ComplianceSummaryItem) SetNonCompliantSummary(v *NonCompliantSummary) *
 // You specified too many custom compliance types. You can specify a maximum
 // of 10 different types.
 type ComplianceTypeCountLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -17725,8 +17725,8 @@ func (s CreateResourceDataSyncOutput) GoString() string {
 // You have exceeded the limit for custom schemas. Delete one or more custom
 // schemas and try again.
 type CustomSchemaCountLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -22382,8 +22382,8 @@ func (s *DescribeSessionsOutput) SetSessions(v []*Session) *DescribeSessionsOutp
 
 // The specified document already exists.
 type DocumentAlreadyExists struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -22951,8 +22951,8 @@ func (s *DocumentKeyValuesFilter) SetValues(v []*string) *DocumentKeyValuesFilte
 
 // You can have at most 500 active Systems Manager documents.
 type DocumentLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23063,8 +23063,8 @@ func (s *DocumentParameter) SetType(v string) *DocumentParameter {
 // a document with a maximum of 20 accounts. You can publicly share up to five
 // documents. If you need to increase this limit, contact AWS Support.
 type DocumentPermissionLimit struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23262,8 +23262,8 @@ func (s *DocumentVersionInfo) SetVersionName(v string) *DocumentVersionInfo {
 // The document has too many versions. Delete one or more document versions
 // and try again.
 type DocumentVersionLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23323,8 +23323,8 @@ func (s DocumentVersionLimitExceeded) RequestID() string {
 // Service Quotas (http://docs.aws.amazon.com/general/latest/gr/ssm.html#limits_ssm)
 // in the AWS General Reference.
 type DoesNotExistException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23380,8 +23380,8 @@ func (s DoesNotExistException) RequestID() string {
 // The content of the association document matches another document. Change
 // the content of the document and try again.
 type DuplicateDocumentContent struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23437,8 +23437,8 @@ func (s DuplicateDocumentContent) RequestID() string {
 // The version name has already been used in this document. Specify a different
 // version name, and then try again.
 type DuplicateDocumentVersionName struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -23493,8 +23493,8 @@ func (s DuplicateDocumentVersionName) RequestID() string {
 
 // You cannot specify an instance ID in more than one association.
 type DuplicateInstanceId struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -23677,8 +23677,8 @@ func (s *FailureDetails) SetFailureType(v string) *FailureDetails {
 // You attempted to register a LAMBDA or STEP_FUNCTIONS task in a region where
 // the corresponding service is not available.
 type FeatureNotAvailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -26782,8 +26782,8 @@ func (s *GetServiceSettingOutput) SetServiceSetting(v *ServiceSetting) *GetServi
 // and Constraints for Parameter Names (http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html)
 // in the AWS Systems Manager User Guide.
 type HierarchyLevelLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A hierarchy can have a maximum of 15 levels. For more information, see Requirements
 	// and Constraints for Parameter Names (http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html)
@@ -26843,8 +26843,8 @@ func (s HierarchyLevelLimitExceededException) RequestID() string {
 // For example, you can't change a parameter from a String type to a SecureString
 // type. You must create a new, unique parameter.
 type HierarchyTypeMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// Parameter Store does not support changing a parameter type in a hierarchy.
 	// For example, you can't change a parameter from a String type to a SecureString
@@ -26903,8 +26903,8 @@ func (s HierarchyTypeMismatchException) RequestID() string {
 // Error returned when an idempotent operation is retried and the parameters
 // don't match the original call to the API with the same idempotency token.
 type IdempotentParameterMismatch struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -26961,8 +26961,8 @@ func (s IdempotentParameterMismatch) RequestID() string {
 // for example, specify two Expiration policies for a parameter. Review your
 // policies, and try again.
 type IncompatiblePolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -27915,8 +27915,8 @@ func (s *InstancePatchStateFilter) SetValues(v []*string) *InstancePatchStateFil
 
 // An error occurred on the server side.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -27972,8 +27972,8 @@ func (s InternalServerError) RequestID() string {
 // The activation is not valid. The activation might have been deleted, or the
 // ActivationId and the ActivationCode do not match.
 type InvalidActivation struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28029,8 +28029,8 @@ func (s InvalidActivation) RequestID() string {
 // The activation ID is not valid. Verify the you entered the correct ActivationId
 // or ActivationCode and try again.
 type InvalidActivationId struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28086,8 +28086,8 @@ func (s InvalidActivationId) RequestID() string {
 // The specified aggregator is not valid for inventory groups. Verify that the
 // aggregator uses a valid inventory type such as AWS:Application or AWS:InstanceInformation.
 type InvalidAggregatorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28142,8 +28142,8 @@ func (s InvalidAggregatorException) RequestID() string {
 
 // The request does not meet the regular expression requirement.
 type InvalidAllowedPatternException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The request does not meet the regular expression requirement.
 	Message_ *string `locationName:"message" type:"string"`
@@ -28199,8 +28199,8 @@ func (s InvalidAllowedPatternException) RequestID() string {
 
 // The association is not valid or does not exist.
 type InvalidAssociation struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28257,8 +28257,8 @@ func (s InvalidAssociation) RequestID() string {
 // all versions of an association according to the association ID. Or, use the
 // $LATEST parameter to view the latest version of the association.
 type InvalidAssociationVersion struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28315,8 +28315,8 @@ func (s InvalidAssociationVersion) RequestID() string {
 // incorrect. For example, they may not match the set of parameters permitted
 // for the specified Automation document.
 type InvalidAutomationExecutionParametersException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28371,8 +28371,8 @@ func (s InvalidAutomationExecutionParametersException) RequestID() string {
 
 // The signal is not valid for the current Automation execution.
 type InvalidAutomationSignalException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28427,8 +28427,8 @@ func (s InvalidAutomationSignalException) RequestID() string {
 
 // The specified update status operation is not valid.
 type InvalidAutomationStatusUpdateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28482,8 +28482,8 @@ func (s InvalidAutomationStatusUpdateException) RequestID() string {
 }
 
 type InvalidCommandId struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -28539,8 +28539,8 @@ func (s InvalidCommandId) RequestID() string {
 // One or more of the parameters specified for the delete operation is not valid.
 // Verify all parameters and try again.
 type InvalidDeleteInventoryParametersException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28596,8 +28596,8 @@ func (s InvalidDeleteInventoryParametersException) RequestID() string {
 // The ID specified for the delete operation does not exist or is not valid.
 // Verify the ID and try again.
 type InvalidDeletionIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28652,8 +28652,8 @@ func (s InvalidDeletionIdException) RequestID() string {
 
 // The specified document does not exist.
 type InvalidDocument struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The document does not exist or the document is not available to the user.
 	// This exception can be issued by CreateAssociation, CreateAssociationBatch,
@@ -28712,8 +28712,8 @@ func (s InvalidDocument) RequestID() string {
 
 // The content for the document is not valid.
 type InvalidDocumentContent struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description of the validation error.
 	Message_ *string `locationName:"Message" type:"string"`
@@ -28770,8 +28770,8 @@ func (s InvalidDocumentContent) RequestID() string {
 // You attempted to delete a document while it is still shared. You must stop
 // sharing the document before you can delete it.
 type InvalidDocumentOperation struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28826,8 +28826,8 @@ func (s InvalidDocumentOperation) RequestID() string {
 
 // The version of the document schema is not supported.
 type InvalidDocumentSchemaVersion struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28883,8 +28883,8 @@ func (s InvalidDocumentSchemaVersion) RequestID() string {
 // The document type is not valid. Valid document types are described in the
 // DocumentType property.
 type InvalidDocumentType struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28939,8 +28939,8 @@ func (s InvalidDocumentType) RequestID() string {
 
 // The document version is not valid or does not exist.
 type InvalidDocumentVersion struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -28996,8 +28996,8 @@ func (s InvalidDocumentVersion) RequestID() string {
 // The filter name is not valid. Verify the you entered the correct name and
 // try again.
 type InvalidFilter struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29052,8 +29052,8 @@ func (s InvalidFilter) RequestID() string {
 
 // The specified key is not valid.
 type InvalidFilterKey struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29109,8 +29109,8 @@ func (s InvalidFilterKey) RequestID() string {
 // The specified filter option is not valid. Valid options are Equals and BeginsWith.
 // For Path filter, valid options are Recursive and OneLevel.
 type InvalidFilterOption struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The specified filter option is not valid. Valid options are Equals and BeginsWith.
 	// For Path filter, valid options are Recursive and OneLevel.
@@ -29167,8 +29167,8 @@ func (s InvalidFilterOption) RequestID() string {
 
 // The filter value is not valid. Verify the value and try again.
 type InvalidFilterValue struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29232,8 +29232,8 @@ func (s InvalidFilterValue) RequestID() string {
 // The instance is not in valid state. Valid states are: Running, Pending, Stopped,
 // Stopping. Invalid states are: Shutting-down and Terminated.
 type InvalidInstanceId struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29288,8 +29288,8 @@ func (s InvalidInstanceId) RequestID() string {
 
 // The specified filter value is not valid.
 type InvalidInstanceInformationFilterValue struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29344,8 +29344,8 @@ func (s InvalidInstanceInformationFilterValue) RequestID() string {
 
 // The specified inventory group is not valid.
 type InvalidInventoryGroupException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29401,8 +29401,8 @@ func (s InvalidInventoryGroupException) RequestID() string {
 // You specified invalid keys or values in the Context attribute for InventoryItem.
 // Verify the keys and values, and try again.
 type InvalidInventoryItemContextException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29457,8 +29457,8 @@ func (s InvalidInventoryItemContextException) RequestID() string {
 
 // The request is not valid.
 type InvalidInventoryRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29513,8 +29513,8 @@ func (s InvalidInventoryRequestException) RequestID() string {
 
 // One or more content items is not valid.
 type InvalidItemContentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -29571,8 +29571,8 @@ func (s InvalidItemContentException) RequestID() string {
 
 // The query key ID is not valid.
 type InvalidKeyId struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29627,8 +29627,8 @@ func (s InvalidKeyId) RequestID() string {
 
 // The specified token is not valid.
 type InvalidNextToken struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29684,8 +29684,8 @@ func (s InvalidNextToken) RequestID() string {
 // One or more configuration items is not valid. Verify that a valid Amazon
 // Resource Name (ARN) was provided for an Amazon SNS topic.
 type InvalidNotificationConfig struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29741,8 +29741,8 @@ func (s InvalidNotificationConfig) RequestID() string {
 // The delete inventory option specified is not valid. Verify the option and
 // try again.
 type InvalidOptionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29797,8 +29797,8 @@ func (s InvalidOptionException) RequestID() string {
 
 // The S3 bucket does not exist.
 type InvalidOutputFolder struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29853,8 +29853,8 @@ func (s InvalidOutputFolder) RequestID() string {
 
 // The output location is not valid or does not exist.
 type InvalidOutputLocation struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -29911,8 +29911,8 @@ func (s InvalidOutputLocation) RequestID() string {
 // document. You can only supply values to parameters defined in the Systems
 // Manager document.
 type InvalidParameters struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -29968,8 +29968,8 @@ func (s InvalidParameters) RequestID() string {
 // The permission type is not supported. Share is the only supported permission
 // type.
 type InvalidPermissionType struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30024,8 +30024,8 @@ func (s InvalidPermissionType) RequestID() string {
 
 // The plugin name is not valid.
 type InvalidPluginName struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30080,8 +30080,8 @@ func (s InvalidPluginName) RequestID() string {
 
 // A policy attribute or its value is invalid.
 type InvalidPolicyAttributeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30137,8 +30137,8 @@ func (s InvalidPolicyAttributeException) RequestID() string {
 // The policy type is not supported. Parameter Store supports the following
 // policy types: Expiration, ExpirationNotification, and NoChangeNotification.
 type InvalidPolicyTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30194,8 +30194,8 @@ func (s InvalidPolicyTypeException) RequestID() string {
 // The resource ID is not valid. Verify that you entered the correct ID and
 // try again.
 type InvalidResourceId struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30251,8 +30251,8 @@ func (s InvalidResourceId) RequestID() string {
 // The resource type is not valid. For example, if you are attempting to tag
 // an instance, the instance must be a registered, managed instance.
 type InvalidResourceType struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -30307,8 +30307,8 @@ func (s InvalidResourceType) RequestID() string {
 
 // The specified inventory item result attribute is not valid.
 type InvalidResultAttributeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30367,8 +30367,8 @@ func (s InvalidResultAttributeException) RequestID() string {
 // see Configuring Amazon SNS Notifications for Run Command (http://docs.aws.amazon.com/systems-manager/latest/userguide/rc-sns-notifications.html)
 // in the AWS Systems Manager User Guide.
 type InvalidRole struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30423,8 +30423,8 @@ func (s InvalidRole) RequestID() string {
 
 // The schedule is invalid. Verify your cron or rate expression and try again.
 type InvalidSchedule struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30480,8 +30480,8 @@ func (s InvalidSchedule) RequestID() string {
 // The target is not valid or does not exist. It might not be configured for
 // EC2 Systems Manager or you might not have permission to perform the operation.
 type InvalidTarget struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30536,8 +30536,8 @@ func (s InvalidTarget) RequestID() string {
 
 // The parameter type name is not valid.
 type InvalidTypeNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -30592,8 +30592,8 @@ func (s InvalidTypeNameException) RequestID() string {
 
 // The update is not valid.
 type InvalidUpdate struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -31351,8 +31351,8 @@ func (s *InventoryResultItem) SetTypeName(v string) *InventoryResultItem {
 // The command ID and instance ID you specified did not match any invocations.
 // Verify the command ID and the instance ID and try again.
 type InvocationDoesNotExist struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -31407,8 +31407,8 @@ func (s InvocationDoesNotExist) RequestID() string {
 
 // The inventory item has invalid content.
 type ItemContentMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -31465,8 +31465,8 @@ func (s ItemContentMismatchException) RequestID() string {
 
 // The inventory item size has exceeded the size limit.
 type ItemSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -34241,8 +34241,8 @@ func (s *MaintenanceWindowTaskParameterValueExpression) SetValues(v []*string) *
 
 // The size limit of a document is 64 KB.
 type MaxDocumentSizeExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -34917,8 +34917,8 @@ func (s *OpsItem) SetVersion(v string) *OpsItem {
 
 // The OpsItem already exists.
 type OpsItemAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -35077,8 +35077,8 @@ func (s *OpsItemFilter) SetValues(v []*string) *OpsItemFilter {
 // A specified parameter argument isn't valid. Verify the available arguments
 // and try again.
 type OpsItemInvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -35136,8 +35136,8 @@ func (s OpsItemInvalidParameterException) RequestID() string {
 // The request caused OpsItems to exceed one or more quotas. For information
 // about OpsItem quotas, see What are the resource limits for OpsCenter? (http://docs.aws.amazon.com/systems-manager/latest/userguide/OpsCenter-learn-more.html#OpsCenter-learn-more-limits).
 type OpsItemLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Limit *int64 `type:"integer"`
 
@@ -35198,8 +35198,8 @@ func (s OpsItemLimitExceededException) RequestID() string {
 
 // The specified OpsItem ID doesn't exist. Verify the ID and try again.
 type OpsItemNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -35577,8 +35577,8 @@ func (s *Parameter) SetVersion(v int64) *Parameter {
 
 // The parameter already exists. You can't create duplicate parameters.
 type ParameterAlreadyExists struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -35808,8 +35808,8 @@ func (s *ParameterInlinePolicy) SetPolicyType(v string) *ParameterInlinePolicy {
 // You have exceeded the number of parameters for this AWS account. Delete one
 // or more parameters and try again.
 type ParameterLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -35864,8 +35864,8 @@ func (s ParameterLimitExceeded) RequestID() string {
 
 // The parameter exceeded the maximum number of allowed versions.
 type ParameterMaxVersionLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -36029,8 +36029,8 @@ func (s *ParameterMetadata) SetVersion(v int64) *ParameterMetadata {
 
 // The parameter could not be found. Verify the name and try again.
 type ParameterNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -36085,8 +36085,8 @@ func (s ParameterNotFound) RequestID() string {
 
 // The parameter name is not valid.
 type ParameterPatternMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The parameter name is not valid.
 	Message_ *string `locationName:"message" type:"string"`
@@ -36229,8 +36229,8 @@ func (s *ParameterStringFilter) SetValues(v []*string) *ParameterStringFilter {
 
 // A parameter version can have a maximum of ten labels.
 type ParameterVersionLabelLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -36286,8 +36286,8 @@ func (s ParameterVersionLabelLimitExceeded) RequestID() string {
 // The specified parameter version was not found. Verify the parameter name
 // and version, and try again.
 type ParameterVersionNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -37151,8 +37151,8 @@ func (s *PatchStatus) SetDeploymentStatus(v string) *PatchStatus {
 // You specified more than the maximum number of allowed policies for the parameter.
 // The maximum is 10.
 type PoliciesLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -38790,8 +38790,8 @@ func (s *ResourceComplianceSummaryItem) SetStatus(v string) *ResourceComplianceS
 
 // A sync configuration with the same name already exists.
 type ResourceDataSyncAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -38918,8 +38918,8 @@ func (s *ResourceDataSyncAwsOrganizationsSource) SetOrganizationalUnits(v []*Res
 // Another UpdateResourceDataSync request is being processed. Wait a few minutes
 // and try again.
 type ResourceDataSyncConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -38974,8 +38974,8 @@ func (s ResourceDataSyncConflictException) RequestID() string {
 
 // You have exceeded the allowed maximum sync configurations.
 type ResourceDataSyncCountExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39070,8 +39070,8 @@ func (s *ResourceDataSyncDestinationDataSharing) SetDestinationDataSharingType(v
 
 // The specified sync configuration is invalid.
 type ResourceDataSyncInvalidConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39235,8 +39235,8 @@ func (s *ResourceDataSyncItem) SetSyncType(v string) *ResourceDataSyncItem {
 
 // The specified sync name was not found.
 type ResourceDataSyncNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -39616,8 +39616,8 @@ func (s *ResourceDataSyncSourceWithState) SetState(v string) *ResourceDataSyncSo
 // Error returned if an attempt is made to delete a patch baseline that is registered
 // for a patch group.
 type ResourceInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -39677,8 +39677,8 @@ func (s ResourceInUseException) RequestID() string {
 // Service Quotas (http://docs.aws.amazon.com/general/latest/gr/ssm.html#limits_ssm)
 // in the AWS General Reference.
 type ResourceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -40465,8 +40465,8 @@ func (s *ServiceSetting) SetStatus(v string) *ServiceSetting {
 // The specified service setting was not found. Either the service name or the
 // setting has not been provisioned by the AWS service team.
 type ServiceSettingNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -41215,8 +41215,8 @@ func (s *StartSessionOutput) SetTokenValue(v string) *StartSessionOutput {
 
 // The updated status is the same as the current status.
 type StatusUnchanged struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -41619,8 +41619,8 @@ func (s StopAutomationExecutionOutput) GoString() string {
 
 // The sub-type count exceeded the limit for the inventory type.
 type SubTypeCountLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -41825,8 +41825,8 @@ func (s *Target) SetValues(v []*string) *Target {
 // You specified the Safe option for the DeregisterTargetFromMaintenanceWindow
 // operation, but the target is still referenced in a task.
 type TargetInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -41972,8 +41972,8 @@ func (s *TargetLocation) SetTargetLocationMaxErrors(v string) *TargetLocation {
 // Session Manager (http://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started.html)
 // in the AWS Systems Manager User Guide.
 type TargetNotConnected struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42093,8 +42093,8 @@ func (s *TerminateSessionOutput) SetSessionId(v string) *TerminateSessionOutput 
 // The Targets parameter includes too many tags. Remove one or more tags and
 // try the command again.
 type TooManyTagsError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -42150,8 +42150,8 @@ func (s TooManyTagsError) RequestID() string {
 // There are concurrent updates for a resource that supports one update at a
 // time.
 type TooManyUpdates struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42206,8 +42206,8 @@ func (s TooManyUpdates) RequestID() string {
 
 // The size of inventory data has exceeded the total size limit for the resource.
 type TotalSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42263,8 +42263,8 @@ func (s TotalSizeLimitExceededException) RequestID() string {
 // The calendar entry contained in the specified Systems Manager document is
 // not supported.
 type UnsupportedCalendarException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42323,8 +42323,8 @@ func (s UnsupportedCalendarException) RequestID() string {
 // Tier (http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-managedinstances-advanced.html)
 // in the AWS Systems Manager User Guide.
 type UnsupportedFeatureRequiredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42381,8 +42381,8 @@ func (s UnsupportedFeatureRequiredException) RequestID() string {
 // for this inventory type. You can only use the Context attribute with inventory
 // types like AWS:ComplianceItem.
 type UnsupportedInventoryItemContextException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -42441,8 +42441,8 @@ func (s UnsupportedInventoryItemContextException) RequestID() string {
 // service. Check output of GetInventorySchema to see the available schema version
 // for each type.
 type UnsupportedInventorySchemaVersionException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42499,8 +42499,8 @@ func (s UnsupportedInventorySchemaVersionException) RequestID() string {
 // not supported for the operating system. Valid operating systems include:
 // Windows, AmazonLinux, RedhatEnterpriseLinux, and Ubuntu.
 type UnsupportedOperatingSystem struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -42555,8 +42555,8 @@ func (s UnsupportedOperatingSystem) RequestID() string {
 
 // The parameter type is not supported.
 type UnsupportedParameterType struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -42612,8 +42612,8 @@ func (s UnsupportedParameterType) RequestID() string {
 // The document does not support the platform type of the given instance ID(s).
 // For example, you sent an document for a Windows instance to a Linux instance.
 type UnsupportedPlatformType struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/sso/api.go
+++ b/service/sso/api.go
@@ -636,7 +636,7 @@ func (s *GetRoleCredentialsOutput) SetRoleCredentials(v *RoleCredentials) *GetRo
 // a required parameter might be missing or out of range.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -653,7 +653,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -681,12 +681,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAccountRolesInput struct {
@@ -950,7 +950,7 @@ func (s LogoutOutput) GoString() string {
 // The specified resource doesn't exist.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -967,7 +967,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -995,12 +995,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information about the role credentials that are assigned to the
@@ -1099,7 +1099,7 @@ func (s *RoleInfo) SetRoleName(v string) *RoleInfo {
 // what the server can handle.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1116,7 +1116,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1144,19 +1144,19 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the request is not authorized. This can happen due to an invalid
 // access token in the request.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1173,7 +1173,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1201,10 +1201,10 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }

--- a/service/sso/api.go
+++ b/service/sso/api.go
@@ -635,8 +635,8 @@ func (s *GetRoleCredentialsOutput) SetRoleCredentials(v *RoleCredentials) *GetRo
 // Indicates that a problem occurred with the input to the request. For example,
 // a required parameter might be missing or out of range.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -949,8 +949,8 @@ func (s LogoutOutput) GoString() string {
 
 // The specified resource doesn't exist.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1098,8 +1098,8 @@ func (s *RoleInfo) SetRoleName(v string) *RoleInfo {
 // Indicates that the request is being made too frequently and is more than
 // what the server can handle.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1155,8 +1155,8 @@ func (s TooManyRequestsException) RequestID() string {
 // Indicates that the request is not authorized. This can happen due to an invalid
 // access token in the request.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/ssooidc/api.go
+++ b/service/ssooidc/api.go
@@ -327,8 +327,8 @@ func (c *SSOOIDC) StartDeviceAuthorizationWithContext(ctx aws.Context, input *St
 
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -388,8 +388,8 @@ func (s AccessDeniedException) RequestID() string {
 // Indicates that a request to authorize a client with an access user session
 // token is pending.
 type AuthorizationPendingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -636,8 +636,8 @@ func (s *CreateTokenOutput) SetTokenType(v string) *CreateTokenOutput {
 // Indicates that the token issued by the service is expired and is no longer
 // valid.
 type ExpiredTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -697,8 +697,8 @@ func (s ExpiredTokenException) RequestID() string {
 // Indicates that an error from the service occurred while trying to process
 // a request.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -759,8 +759,8 @@ func (s InternalServerException) RequestID() string {
 // example, this can occur when a client sends an incorrect clientId or an expired
 // clientSecret.
 type InvalidClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -820,8 +820,8 @@ func (s InvalidClientException) RequestID() string {
 // Indicates that the client information sent in the request during registration
 // is invalid.
 type InvalidClientMetadataException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -881,8 +881,8 @@ func (s InvalidClientMetadataException) RequestID() string {
 // Indicates that a request contains an invalid grant. This can occur if a client
 // makes a CreateToken request with an invalid grant type.
 type InvalidGrantException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -942,8 +942,8 @@ func (s InvalidGrantException) RequestID() string {
 // Indicates that something is wrong with the input to the request. For example,
 // a required parameter might be missing or out of range.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -1002,8 +1002,8 @@ func (s InvalidRequestException) RequestID() string {
 
 // Indicates that the scope provided in the request is invalid.
 type InvalidScopeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -1196,8 +1196,8 @@ func (s *RegisterClientOutput) SetTokenEndpoint(v string) *RegisterClientOutput 
 // Indicates that the client is making the request too frequently and is more
 // than the service can handle.
 type SlowDownException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -1403,8 +1403,8 @@ func (s *StartDeviceAuthorizationOutput) SetVerificationUriComplete(v string) *S
 // Indicates that the client is not currently authorized to make the request.
 // This can happen when a clientId is not issued for a public client.
 type UnauthorizedClientException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -1463,8 +1463,8 @@ func (s UnauthorizedClientException) RequestID() string {
 
 // Indicates that the grant type in the request is not supported by the service.
 type UnsupportedGrantTypeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Error_ *string `locationName:"error" type:"string"`
 

--- a/service/ssooidc/api.go
+++ b/service/ssooidc/api.go
@@ -328,7 +328,7 @@ func (c *SSOOIDC) StartDeviceAuthorizationWithContext(ctx aws.Context, input *St
 // You do not have sufficient access to perform this action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -349,7 +349,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -377,19 +377,19 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that a request to authorize a client with an access user session
 // token is pending.
 type AuthorizationPendingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -410,7 +410,7 @@ func (s AuthorizationPendingException) GoString() string {
 
 func newErrorAuthorizationPendingException(v protocol.ResponseMetadata) error {
 	return &AuthorizationPendingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -438,12 +438,12 @@ func (s AuthorizationPendingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AuthorizationPendingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AuthorizationPendingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateTokenInput struct {
@@ -637,7 +637,7 @@ func (s *CreateTokenOutput) SetTokenType(v string) *CreateTokenOutput {
 // valid.
 type ExpiredTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -658,7 +658,7 @@ func (s ExpiredTokenException) GoString() string {
 
 func newErrorExpiredTokenException(v protocol.ResponseMetadata) error {
 	return &ExpiredTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -686,19 +686,19 @@ func (s ExpiredTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ExpiredTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ExpiredTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that an error from the service occurred while trying to process
 // a request.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -719,7 +719,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -747,12 +747,12 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the clientId or clientSecret in the request is invalid. For
@@ -760,7 +760,7 @@ func (s InternalServerException) RequestID() string {
 // clientSecret.
 type InvalidClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -781,7 +781,7 @@ func (s InvalidClientException) GoString() string {
 
 func newErrorInvalidClientException(v protocol.ResponseMetadata) error {
 	return &InvalidClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -809,19 +809,19 @@ func (s InvalidClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the client information sent in the request during registration
 // is invalid.
 type InvalidClientMetadataException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -842,7 +842,7 @@ func (s InvalidClientMetadataException) GoString() string {
 
 func newErrorInvalidClientMetadataException(v protocol.ResponseMetadata) error {
 	return &InvalidClientMetadataException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -870,19 +870,19 @@ func (s InvalidClientMetadataException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidClientMetadataException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidClientMetadataException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that a request contains an invalid grant. This can occur if a client
 // makes a CreateToken request with an invalid grant type.
 type InvalidGrantException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -903,7 +903,7 @@ func (s InvalidGrantException) GoString() string {
 
 func newErrorInvalidGrantException(v protocol.ResponseMetadata) error {
 	return &InvalidGrantException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -931,19 +931,19 @@ func (s InvalidGrantException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidGrantException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidGrantException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that something is wrong with the input to the request. For example,
 // a required parameter might be missing or out of range.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -964,7 +964,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -992,18 +992,18 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the scope provided in the request is invalid.
 type InvalidScopeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -1024,7 +1024,7 @@ func (s InvalidScopeException) GoString() string {
 
 func newErrorInvalidScopeException(v protocol.ResponseMetadata) error {
 	return &InvalidScopeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1052,12 +1052,12 @@ func (s InvalidScopeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidScopeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidScopeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RegisterClientInput struct {
@@ -1197,7 +1197,7 @@ func (s *RegisterClientOutput) SetTokenEndpoint(v string) *RegisterClientOutput 
 // than the service can handle.
 type SlowDownException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -1218,7 +1218,7 @@ func (s SlowDownException) GoString() string {
 
 func newErrorSlowDownException(v protocol.ResponseMetadata) error {
 	return &SlowDownException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1246,12 +1246,12 @@ func (s SlowDownException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SlowDownException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SlowDownException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartDeviceAuthorizationInput struct {
@@ -1404,7 +1404,7 @@ func (s *StartDeviceAuthorizationOutput) SetVerificationUriComplete(v string) *S
 // This can happen when a clientId is not issued for a public client.
 type UnauthorizedClientException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -1425,7 +1425,7 @@ func (s UnauthorizedClientException) GoString() string {
 
 func newErrorUnauthorizedClientException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedClientException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1453,18 +1453,18 @@ func (s UnauthorizedClientException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedClientException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedClientException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Indicates that the grant type in the request is not supported by the service.
 type UnsupportedGrantTypeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Error_ *string `locationName:"error" type:"string"`
 
@@ -1485,7 +1485,7 @@ func (s UnsupportedGrantTypeException) GoString() string {
 
 func newErrorUnsupportedGrantTypeException(v protocol.ResponseMetadata) error {
 	return &UnsupportedGrantTypeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1513,10 +1513,10 @@ func (s UnsupportedGrantTypeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedGrantTypeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedGrantTypeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -13262,8 +13262,8 @@ func (s *GatewayInfo) SetGatewayType(v string) *GatewayInfo {
 // An internal server error has occurred during the request. For more information,
 // see the error and message fields.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A StorageGatewayError that provides more information about the cause of the
 	// error.
@@ -13324,8 +13324,8 @@ func (s InternalServerError) RequestID() string {
 // An exception occurred because an invalid gateway request was issued to the
 // service. For more information, see the error and message fields.
 type InvalidGatewayRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A StorageGatewayError that provides more detail about the cause of the error.
 	Error_ *Error `locationName:"error" type:"structure"`
@@ -15398,8 +15398,8 @@ func (s *SMBFileShareInfo) SetValidUserList(v []*string) *SMBFileShareInfo {
 // An internal server error has occurred because the service is unavailable.
 // For more information, see the error and message fields.
 type ServiceUnavailableError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A StorageGatewayError that provides more information about the cause of the
 	// error.

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -13263,7 +13263,7 @@ func (s *GatewayInfo) SetGatewayType(v string) *GatewayInfo {
 // see the error and message fields.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A StorageGatewayError that provides more information about the cause of the
 	// error.
@@ -13285,7 +13285,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13313,19 +13313,19 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An exception occurred because an invalid gateway request was issued to the
 // service. For more information, see the error and message fields.
 type InvalidGatewayRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A StorageGatewayError that provides more detail about the cause of the error.
 	Error_ *Error `locationName:"error" type:"structure"`
@@ -13346,7 +13346,7 @@ func (s InvalidGatewayRequestException) GoString() string {
 
 func newErrorInvalidGatewayRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidGatewayRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -13374,12 +13374,12 @@ func (s InvalidGatewayRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidGatewayRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidGatewayRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // JoinDomainInput
@@ -15399,7 +15399,7 @@ func (s *SMBFileShareInfo) SetValidUserList(v []*string) *SMBFileShareInfo {
 // For more information, see the error and message fields.
 type ServiceUnavailableError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A StorageGatewayError that provides more information about the cause of the
 	// error.
@@ -15421,7 +15421,7 @@ func (s ServiceUnavailableError) GoString() string {
 
 func newErrorServiceUnavailableError(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15449,12 +15449,12 @@ func (s ServiceUnavailableError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // SetLocalConsolePasswordInput

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -1693,7 +1693,7 @@ func (s *AttachmentDetails) SetFileName(v string) *AttachmentDetails {
 // An attachment with the specified ID could not be found.
 type AttachmentIdNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// An attachment with the specified ID could not be found.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1711,7 +1711,7 @@ func (s AttachmentIdNotFound) GoString() string {
 
 func newErrorAttachmentIdNotFound(v protocol.ResponseMetadata) error {
 	return &AttachmentIdNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1739,19 +1739,19 @@ func (s AttachmentIdNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AttachmentIdNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AttachmentIdNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The limit for the number of attachment sets created in a short period of
 // time has been exceeded.
 type AttachmentLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The limit for the number of attachment sets created in a short period of
 	// time has been exceeded.
@@ -1770,7 +1770,7 @@ func (s AttachmentLimitExceeded) GoString() string {
 
 func newErrorAttachmentLimitExceeded(v protocol.ResponseMetadata) error {
 	return &AttachmentLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1798,19 +1798,19 @@ func (s AttachmentLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AttachmentLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AttachmentLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The expiration time of the attachment set has passed. The set expires 1 hour
 // after it is created.
 type AttachmentSetExpired struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The expiration time of the attachment set has passed. The set expires 1 hour
 	// after it is created.
@@ -1829,7 +1829,7 @@ func (s AttachmentSetExpired) GoString() string {
 
 func newErrorAttachmentSetExpired(v protocol.ResponseMetadata) error {
 	return &AttachmentSetExpired{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1857,18 +1857,18 @@ func (s AttachmentSetExpired) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AttachmentSetExpired) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AttachmentSetExpired) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An attachment set with the specified ID could not be found.
 type AttachmentSetIdNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// An attachment set with the specified ID could not be found.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1886,7 +1886,7 @@ func (s AttachmentSetIdNotFound) GoString() string {
 
 func newErrorAttachmentSetIdNotFound(v protocol.ResponseMetadata) error {
 	return &AttachmentSetIdNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1914,19 +1914,19 @@ func (s AttachmentSetIdNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AttachmentSetIdNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AttachmentSetIdNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A limit for the size of an attachment set has been exceeded. The limits are
 // 3 attachments and 5 MB per attachment.
 type AttachmentSetSizeLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A limit for the size of an attachment set has been exceeded. The limits are
 	// 3 attachments and 5 MB per attachment.
@@ -1945,7 +1945,7 @@ func (s AttachmentSetSizeLimitExceeded) GoString() string {
 
 func newErrorAttachmentSetSizeLimitExceeded(v protocol.ResponseMetadata) error {
 	return &AttachmentSetSizeLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1973,18 +1973,18 @@ func (s AttachmentSetSizeLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AttachmentSetSizeLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AttachmentSetSizeLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The case creation limit for the account has been exceeded.
 type CaseCreationLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// An error message that indicates that you have exceeded the number of cases
 	// you can have open.
@@ -2003,7 +2003,7 @@ func (s CaseCreationLimitExceeded) GoString() string {
 
 func newErrorCaseCreationLimitExceeded(v protocol.ResponseMetadata) error {
 	return &CaseCreationLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2031,12 +2031,12 @@ func (s CaseCreationLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CaseCreationLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CaseCreationLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A JSON-formatted object that contains the metadata for a support case. It
@@ -2211,7 +2211,7 @@ func (s *CaseDetails) SetTimeCreated(v string) *CaseDetails {
 // The requested caseId could not be located.
 type CaseIdNotFound struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The requested CaseId could not be located.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2229,7 +2229,7 @@ func (s CaseIdNotFound) GoString() string {
 
 func newErrorCaseIdNotFound(v protocol.ResponseMetadata) error {
 	return &CaseIdNotFound{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2257,12 +2257,12 @@ func (s CaseIdNotFound) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CaseIdNotFound) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CaseIdNotFound) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A JSON-formatted name/value pair that represents the category name and category
@@ -2564,7 +2564,7 @@ func (s *DescribeAttachmentInput) SetAttachmentId(v string) *DescribeAttachmentI
 // of time has been exceeded.
 type DescribeAttachmentLimitExceeded struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The limit for the number of DescribeAttachment requests in a short period
 	// of time has been exceeded.
@@ -2583,7 +2583,7 @@ func (s DescribeAttachmentLimitExceeded) GoString() string {
 
 func newErrorDescribeAttachmentLimitExceeded(v protocol.ResponseMetadata) error {
 	return &DescribeAttachmentLimitExceeded{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2611,12 +2611,12 @@ func (s DescribeAttachmentLimitExceeded) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DescribeAttachmentLimitExceeded) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DescribeAttachmentLimitExceeded) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The content and file name of the attachment returned by the DescribeAttachment
@@ -3290,7 +3290,7 @@ func (s *DescribeTrustedAdvisorChecksOutput) SetChecks(v []*TrustedAdvisorCheckD
 // An internal server error occurred.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// An internal server error occurred.
 	Message_ *string `locationName:"message" type:"string"`
@@ -3308,7 +3308,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3336,12 +3336,12 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The five most recent communications associated with the case.

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -1692,8 +1692,8 @@ func (s *AttachmentDetails) SetFileName(v string) *AttachmentDetails {
 
 // An attachment with the specified ID could not be found.
 type AttachmentIdNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// An attachment with the specified ID could not be found.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1750,8 +1750,8 @@ func (s AttachmentIdNotFound) RequestID() string {
 // The limit for the number of attachment sets created in a short period of
 // time has been exceeded.
 type AttachmentLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The limit for the number of attachment sets created in a short period of
 	// time has been exceeded.
@@ -1809,8 +1809,8 @@ func (s AttachmentLimitExceeded) RequestID() string {
 // The expiration time of the attachment set has passed. The set expires 1 hour
 // after it is created.
 type AttachmentSetExpired struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The expiration time of the attachment set has passed. The set expires 1 hour
 	// after it is created.
@@ -1867,8 +1867,8 @@ func (s AttachmentSetExpired) RequestID() string {
 
 // An attachment set with the specified ID could not be found.
 type AttachmentSetIdNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// An attachment set with the specified ID could not be found.
 	Message_ *string `locationName:"message" type:"string"`
@@ -1925,8 +1925,8 @@ func (s AttachmentSetIdNotFound) RequestID() string {
 // A limit for the size of an attachment set has been exceeded. The limits are
 // 3 attachments and 5 MB per attachment.
 type AttachmentSetSizeLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A limit for the size of an attachment set has been exceeded. The limits are
 	// 3 attachments and 5 MB per attachment.
@@ -1983,8 +1983,8 @@ func (s AttachmentSetSizeLimitExceeded) RequestID() string {
 
 // The case creation limit for the account has been exceeded.
 type CaseCreationLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// An error message that indicates that you have exceeded the number of cases
 	// you can have open.
@@ -2210,8 +2210,8 @@ func (s *CaseDetails) SetTimeCreated(v string) *CaseDetails {
 
 // The requested caseId could not be located.
 type CaseIdNotFound struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The requested CaseId could not be located.
 	Message_ *string `locationName:"message" type:"string"`
@@ -2563,8 +2563,8 @@ func (s *DescribeAttachmentInput) SetAttachmentId(v string) *DescribeAttachmentI
 // The limit for the number of DescribeAttachment requests in a short period
 // of time has been exceeded.
 type DescribeAttachmentLimitExceeded struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The limit for the number of DescribeAttachment requests in a short period
 	// of time has been exceeded.
@@ -3289,8 +3289,8 @@ func (s *DescribeTrustedAdvisorChecksOutput) SetChecks(v []*TrustedAdvisorCheckD
 
 // An internal server error occurred.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// An internal server error occurred.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -7143,8 +7143,8 @@ func (s *DecisionTaskTimedOutEventAttributes) SetTimeoutType(v string) *Decision
 // If these parameters aren't set and no default parameters were defined in
 // the workflow type, this error is displayed.
 type DefaultUndefinedFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7830,8 +7830,8 @@ func (s *DescribeWorkflowTypeOutput) SetTypeInfo(v *WorkflowTypeInfo) *DescribeW
 // registering a domain that is either already registered or deprecated, or
 // if you undeprecate a domain that is currently registered.
 type DomainAlreadyExistsFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7913,8 +7913,8 @@ func (s *DomainConfiguration) SetWorkflowExecutionRetentionPeriodInDays(v string
 
 // Returned when the specified domain has been deprecated.
 type DomainDeprecatedFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -9438,8 +9438,8 @@ func (s *LambdaFunctionTimedOutEventAttributes) SetTimeoutType(v string) *Lambda
 // To address this fault you should either clean up unused resources or increase
 // the limit by contacting AWS.
 type LimitExceededFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -10352,8 +10352,8 @@ func (s *MarkerRecordedEventAttributes) SetMarkerName(v string) *MarkerRecordedE
 // Returned when the caller doesn't have sufficient permissions to invoke the
 // action.
 type OperationNotPermittedFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14603,8 +14603,8 @@ func (s *TimerStartedEventAttributes) SetTimerId(v string) *TimerStartedEventAtt
 
 // You've exceeded the number of tags allowed for a domain.
 type TooManyTagsFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14661,8 +14661,8 @@ func (s TooManyTagsFault) RequestID() string {
 // this fault if you are registering a type that is either already registered
 // or deprecated, or if you undeprecate a type that is currently registered.
 type TypeAlreadyExistsFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14718,8 +14718,8 @@ func (s TypeAlreadyExistsFault) RequestID() string {
 
 // Returned when the specified activity or workflow type was already deprecated.
 type TypeDeprecatedFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14980,8 +14980,8 @@ func (s UndeprecateWorkflowTypeOutput) GoString() string {
 // operation (region or domain). This could happen if the named resource was
 // never created or is no longer available for this operation.
 type UnknownResourceFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15166,8 +15166,8 @@ func (s *WorkflowExecution) SetWorkflowId(v string) *WorkflowExecution {
 // Returned by StartWorkflowExecution when an open execution with the same workflowId
 // is already running in the specified domain.
 type WorkflowExecutionAlreadyStartedFault struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -7144,7 +7144,7 @@ func (s *DecisionTaskTimedOutEventAttributes) SetTimeoutType(v string) *Decision
 // the workflow type, this error is displayed.
 type DefaultUndefinedFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7161,7 +7161,7 @@ func (s DefaultUndefinedFault) GoString() string {
 
 func newErrorDefaultUndefinedFault(v protocol.ResponseMetadata) error {
 	return &DefaultUndefinedFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7189,12 +7189,12 @@ func (s DefaultUndefinedFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DefaultUndefinedFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DefaultUndefinedFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeprecateActivityTypeInput struct {
@@ -7831,7 +7831,7 @@ func (s *DescribeWorkflowTypeOutput) SetTypeInfo(v *WorkflowTypeInfo) *DescribeW
 // if you undeprecate a domain that is currently registered.
 type DomainAlreadyExistsFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7849,7 +7849,7 @@ func (s DomainAlreadyExistsFault) GoString() string {
 
 func newErrorDomainAlreadyExistsFault(v protocol.ResponseMetadata) error {
 	return &DomainAlreadyExistsFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7877,12 +7877,12 @@ func (s DomainAlreadyExistsFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DomainAlreadyExistsFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DomainAlreadyExistsFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the configuration settings of a domain.
@@ -7914,7 +7914,7 @@ func (s *DomainConfiguration) SetWorkflowExecutionRetentionPeriodInDays(v string
 // Returned when the specified domain has been deprecated.
 type DomainDeprecatedFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7932,7 +7932,7 @@ func (s DomainDeprecatedFault) GoString() string {
 
 func newErrorDomainDeprecatedFault(v protocol.ResponseMetadata) error {
 	return &DomainDeprecatedFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7960,12 +7960,12 @@ func (s DomainDeprecatedFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DomainDeprecatedFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DomainDeprecatedFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains general information about a domain.
@@ -9439,7 +9439,7 @@ func (s *LambdaFunctionTimedOutEventAttributes) SetTimeoutType(v string) *Lambda
 // the limit by contacting AWS.
 type LimitExceededFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -9457,7 +9457,7 @@ func (s LimitExceededFault) GoString() string {
 
 func newErrorLimitExceededFault(v protocol.ResponseMetadata) error {
 	return &LimitExceededFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9485,12 +9485,12 @@ func (s LimitExceededFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListActivityTypesInput struct {
@@ -10353,7 +10353,7 @@ func (s *MarkerRecordedEventAttributes) SetMarkerName(v string) *MarkerRecordedE
 // action.
 type OperationNotPermittedFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -10371,7 +10371,7 @@ func (s OperationNotPermittedFault) GoString() string {
 
 func newErrorOperationNotPermittedFault(v protocol.ResponseMetadata) error {
 	return &OperationNotPermittedFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10399,12 +10399,12 @@ func (s OperationNotPermittedFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotPermittedFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotPermittedFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Contains the count of tasks in a task list.
@@ -14604,7 +14604,7 @@ func (s *TimerStartedEventAttributes) SetTimerId(v string) *TimerStartedEventAtt
 // You've exceeded the number of tags allowed for a domain.
 type TooManyTagsFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14621,7 +14621,7 @@ func (s TooManyTagsFault) GoString() string {
 
 func newErrorTooManyTagsFault(v protocol.ResponseMetadata) error {
 	return &TooManyTagsFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14649,12 +14649,12 @@ func (s TooManyTagsFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned if the type already exists in the specified domain. You may get
@@ -14662,7 +14662,7 @@ func (s TooManyTagsFault) RequestID() string {
 // or deprecated, or if you undeprecate a type that is currently registered.
 type TypeAlreadyExistsFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14680,7 +14680,7 @@ func (s TypeAlreadyExistsFault) GoString() string {
 
 func newErrorTypeAlreadyExistsFault(v protocol.ResponseMetadata) error {
 	return &TypeAlreadyExistsFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14708,18 +14708,18 @@ func (s TypeAlreadyExistsFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TypeAlreadyExistsFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TypeAlreadyExistsFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Returned when the specified activity or workflow type was already deprecated.
 type TypeDeprecatedFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14737,7 +14737,7 @@ func (s TypeDeprecatedFault) GoString() string {
 
 func newErrorTypeDeprecatedFault(v protocol.ResponseMetadata) error {
 	return &TypeDeprecatedFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14765,12 +14765,12 @@ func (s TypeDeprecatedFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TypeDeprecatedFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TypeDeprecatedFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UndeprecateActivityTypeInput struct {
@@ -14981,7 +14981,7 @@ func (s UndeprecateWorkflowTypeOutput) GoString() string {
 // never created or is no longer available for this operation.
 type UnknownResourceFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -14999,7 +14999,7 @@ func (s UnknownResourceFault) GoString() string {
 
 func newErrorUnknownResourceFault(v protocol.ResponseMetadata) error {
 	return &UnknownResourceFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15027,12 +15027,12 @@ func (s UnknownResourceFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnknownResourceFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnknownResourceFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {
@@ -15167,7 +15167,7 @@ func (s *WorkflowExecution) SetWorkflowId(v string) *WorkflowExecution {
 // is already running in the specified domain.
 type WorkflowExecutionAlreadyStartedFault struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// A description that may help with diagnosing the cause of the fault.
 	Message_ *string `locationName:"message" type:"string"`
@@ -15185,7 +15185,7 @@ func (s WorkflowExecutionAlreadyStartedFault) GoString() string {
 
 func newErrorWorkflowExecutionAlreadyStartedFault(v protocol.ResponseMetadata) error {
 	return &WorkflowExecutionAlreadyStartedFault{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -15213,12 +15213,12 @@ func (s WorkflowExecutionAlreadyStartedFault) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WorkflowExecutionAlreadyStartedFault) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WorkflowExecutionAlreadyStartedFault) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides the details of the WorkflowExecutionCancelRequested event.

--- a/service/textract/api.go
+++ b/service/textract/api.go
@@ -831,8 +831,8 @@ func (c *Textract) StartDocumentTextDetectionWithContext(ctx aws.Context, input 
 
 // You aren't authorized to perform the action.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1018,8 +1018,8 @@ func (s *AnalyzeDocumentOutput) SetHumanLoopActivationOutput(v *HumanLoopActivat
 
 // Amazon Textract isn't able to read the document.
 type BadDocumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1589,8 +1589,8 @@ func (s *DocumentMetadata) SetPages(v int64) *DocumentMetadata {
 // size for synchronous operations 5 MB. The maximum document size for asynchronous
 // operations is 500 MB for PDF files.
 type DocumentTooLargeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2121,8 +2121,8 @@ func (s *HumanLoopDataAttributes) SetContentClassifiers(v []*string) *HumanLoopD
 // Indicates you have exceeded the maximum number of active human in the loop
 // workflows available
 type HumanLoopQuotaExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -2185,8 +2185,8 @@ func (s HumanLoopQuotaExceededException) RequestID() string {
 // least one of the other input parameters is different from the previous call
 // to the operation.
 type IdempotentParameterMismatchException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2241,8 +2241,8 @@ func (s IdempotentParameterMismatchException) RequestID() string {
 
 // Amazon Textract experienced a service issue. Try your call again.
 type InternalServerError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2297,8 +2297,8 @@ func (s InternalServerError) RequestID() string {
 
 // An invalid job identifier was passed to GetDocumentAnalysis or to GetDocumentAnalysis.
 type InvalidJobIdException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2356,8 +2356,8 @@ func (s InvalidJobIdException) RequestID() string {
 // or Bytes values are supplied in the Document request parameter. Validate
 // your parameter before calling the API operation again.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2413,8 +2413,8 @@ func (s InvalidParameterException) RequestID() string {
 // Amazon Textract is unable to access the S3 object that's specified in the
 // request.
 type InvalidS3ObjectException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2473,8 +2473,8 @@ func (s InvalidS3ObjectException) RequestID() string {
 // 400) until the number of concurrently running jobs is below the Amazon Textract
 // service limit.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2632,8 +2632,8 @@ func (s *Point) SetY(v float64) *Point {
 // The number of requests exceeded your throughput limit. If you want to increase
 // this limit, contact Amazon Textract.
 type ProvisionedThroughputExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3048,8 +3048,8 @@ func (s *StartDocumentTextDetectionOutput) SetJobId(v string) *StartDocumentText
 // Amazon Textract is temporarily unable to process the request. Try your call
 // again.
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3106,8 +3106,8 @@ func (s ThrottlingException) RequestID() string {
 // operations can be in PNG or JPEG format. Documents for asynchronous operations
 // can also be in PDF format.
 type UnsupportedDocumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/textract/api.go
+++ b/service/textract/api.go
@@ -832,7 +832,7 @@ func (c *Textract) StartDocumentTextDetectionWithContext(ctx aws.Context, input 
 // You aren't authorized to perform the action.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -849,7 +849,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -877,12 +877,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type AnalyzeDocumentInput struct {
@@ -1019,7 +1019,7 @@ func (s *AnalyzeDocumentOutput) SetHumanLoopActivationOutput(v *HumanLoopActivat
 // Amazon Textract isn't able to read the document.
 type BadDocumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1036,7 +1036,7 @@ func (s BadDocumentException) GoString() string {
 
 func newErrorBadDocumentException(v protocol.ResponseMetadata) error {
 	return &BadDocumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1064,12 +1064,12 @@ func (s BadDocumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadDocumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadDocumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A Block represents items that are recognized in a document within a group
@@ -1590,7 +1590,7 @@ func (s *DocumentMetadata) SetPages(v int64) *DocumentMetadata {
 // operations is 500 MB for PDF files.
 type DocumentTooLargeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -1607,7 +1607,7 @@ func (s DocumentTooLargeException) GoString() string {
 
 func newErrorDocumentTooLargeException(v protocol.ResponseMetadata) error {
 	return &DocumentTooLargeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1635,12 +1635,12 @@ func (s DocumentTooLargeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DocumentTooLargeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DocumentTooLargeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about where the following items are located on a document page:
@@ -2122,7 +2122,7 @@ func (s *HumanLoopDataAttributes) SetContentClassifiers(v []*string) *HumanLoopD
 // workflows available
 type HumanLoopQuotaExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -2145,7 +2145,7 @@ func (s HumanLoopQuotaExceededException) GoString() string {
 
 func newErrorHumanLoopQuotaExceededException(v protocol.ResponseMetadata) error {
 	return &HumanLoopQuotaExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2173,12 +2173,12 @@ func (s HumanLoopQuotaExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s HumanLoopQuotaExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s HumanLoopQuotaExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A ClientRequestToken input parameter was reused with an operation, but at
@@ -2186,7 +2186,7 @@ func (s HumanLoopQuotaExceededException) RequestID() string {
 // to the operation.
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2203,7 +2203,7 @@ func (s IdempotentParameterMismatchException) GoString() string {
 
 func newErrorIdempotentParameterMismatchException(v protocol.ResponseMetadata) error {
 	return &IdempotentParameterMismatchException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2231,18 +2231,18 @@ func (s IdempotentParameterMismatchException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IdempotentParameterMismatchException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IdempotentParameterMismatchException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Amazon Textract experienced a service issue. Try your call again.
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2259,7 +2259,7 @@ func (s InternalServerError) GoString() string {
 
 func newErrorInternalServerError(v protocol.ResponseMetadata) error {
 	return &InternalServerError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2287,18 +2287,18 @@ func (s InternalServerError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An invalid job identifier was passed to GetDocumentAnalysis or to GetDocumentAnalysis.
 type InvalidJobIdException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2315,7 +2315,7 @@ func (s InvalidJobIdException) GoString() string {
 
 func newErrorInvalidJobIdException(v protocol.ResponseMetadata) error {
 	return &InvalidJobIdException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2343,12 +2343,12 @@ func (s InvalidJobIdException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidJobIdException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidJobIdException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An input parameter violated a constraint. For example, in synchronous operations,
@@ -2357,7 +2357,7 @@ func (s InvalidJobIdException) RequestID() string {
 // your parameter before calling the API operation again.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2374,7 +2374,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2402,19 +2402,19 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Amazon Textract is unable to access the S3 object that's specified in the
 // request.
 type InvalidS3ObjectException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2431,7 +2431,7 @@ func (s InvalidS3ObjectException) GoString() string {
 
 func newErrorInvalidS3ObjectException(v protocol.ResponseMetadata) error {
 	return &InvalidS3ObjectException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2459,12 +2459,12 @@ func (s InvalidS3ObjectException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidS3ObjectException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidS3ObjectException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An Amazon Textract service limit was exceeded. For example, if you start
@@ -2474,7 +2474,7 @@ func (s InvalidS3ObjectException) RequestID() string {
 // service limit.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2491,7 +2491,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2519,12 +2519,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon Simple Notification Service (Amazon SNS) topic to which Amazon
@@ -2633,7 +2633,7 @@ func (s *Point) SetY(v float64) *Point {
 // this limit, contact Amazon Textract.
 type ProvisionedThroughputExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -2650,7 +2650,7 @@ func (s ProvisionedThroughputExceededException) GoString() string {
 
 func newErrorProvisionedThroughputExceededException(v protocol.ResponseMetadata) error {
 	return &ProvisionedThroughputExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2678,12 +2678,12 @@ func (s ProvisionedThroughputExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProvisionedThroughputExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProvisionedThroughputExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Information about how blocks are related to each other. A Block object contains
@@ -3049,7 +3049,7 @@ func (s *StartDocumentTextDetectionOutput) SetJobId(v string) *StartDocumentText
 // again.
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3066,7 +3066,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3094,12 +3094,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The format of the input document isn't supported. Documents for synchronous
@@ -3107,7 +3107,7 @@ func (s ThrottlingException) RequestID() string {
 // can also be in PDF format.
 type UnsupportedDocumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3124,7 +3124,7 @@ func (s UnsupportedDocumentException) GoString() string {
 
 func newErrorUnsupportedDocumentException(v protocol.ResponseMetadata) error {
 	return &UnsupportedDocumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3152,12 +3152,12 @@ func (s UnsupportedDocumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedDocumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedDocumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A warning about an issue that occurred during asynchronous text analysis

--- a/service/transcribeservice/api.go
+++ b/service/transcribeservice/api.go
@@ -1526,7 +1526,7 @@ func (c *TranscribeService) UpdateVocabularyFilterWithContext(ctx aws.Context, i
 // for more information.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1543,7 +1543,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1571,12 +1571,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // When you are using the CreateVocabulary operation, the JobName field is a
@@ -1587,7 +1587,7 @@ func (s BadRequestException) RequestID() string {
 // at the same time. Resend the second request later.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1604,7 +1604,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1632,12 +1632,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Settings for content redaction within a transcription job.
@@ -2428,7 +2428,7 @@ func (s *GetVocabularyOutput) SetVocabularyState(v string) *GetVocabularyOutput 
 // again.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2445,7 +2445,7 @@ func (s InternalFailureException) GoString() string {
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2473,12 +2473,12 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information about when a transcription job should be executed.
@@ -2532,7 +2532,7 @@ func (s *JobExecutionSettings) SetDataAccessRoleArn(v string) *JobExecutionSetti
 // before you resend your request, or use a smaller file and resend the request.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2549,7 +2549,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2577,12 +2577,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTranscriptionJobsInput struct {
@@ -2972,7 +2972,7 @@ func (s *Media) SetMediaFileUri(v string) *Media {
 // again.
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2989,7 +2989,7 @@ func (s NotFoundException) GoString() string {
 
 func newErrorNotFoundException(v protocol.ResponseMetadata) error {
 	return &NotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3017,12 +3017,12 @@ func (s NotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides optional settings for the StartTranscriptionJob operation.

--- a/service/transcribeservice/api.go
+++ b/service/transcribeservice/api.go
@@ -1525,8 +1525,8 @@ func (c *TranscribeService) UpdateVocabularyFilterWithContext(ctx aws.Context, i
 // state (for example, it's "in progress"). See the exception Message field
 // for more information.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1586,8 +1586,8 @@ func (s BadRequestException) RequestID() string {
 // When you are using the UpdateVocabulary operation, there are two jobs running
 // at the same time. Resend the second request later.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2427,8 +2427,8 @@ func (s *GetVocabularyOutput) SetVocabularyState(v string) *GetVocabularyOutput 
 // There was an internal error. Check the error message and try your request
 // again.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2531,8 +2531,8 @@ func (s *JobExecutionSettings) SetDataAccessRoleArn(v string) *JobExecutionSetti
 // Either you have sent too many requests or your input file is too long. Wait
 // before you resend your request, or use a smaller file and resend the request.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2971,8 +2971,8 @@ func (s *Media) SetMediaFileUri(v string) *Media {
 // We can't find the requested resource. Check the name and try your request
 // again.
 type NotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/transcribestreamingservice/api.go
+++ b/service/transcribestreamingservice/api.go
@@ -503,7 +503,7 @@ func eventTypeForAudioStreamEvent(event eventstreamapi.Marshaler) (string, error
 // to a valid code. Check the parameters and try your request again.
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -547,7 +547,7 @@ func (s *BadRequestException) MarshalEvent(pm protocol.PayloadMarshaler) (msg ev
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -575,19 +575,19 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A new stream started with the same session ID. The current stream has been
 // terminated.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -631,7 +631,7 @@ func (s *ConflictException) MarshalEvent(pm protocol.PayloadMarshaler) (msg even
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -659,19 +659,19 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A problem occurred while processing the audio. Amazon Transcribe terminated
 // processing. Try your request again.
 type InternalFailureException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -715,7 +715,7 @@ func (s *InternalFailureException) MarshalEvent(pm protocol.PayloadMarshaler) (m
 
 func newErrorInternalFailureException(v protocol.ResponseMetadata) error {
 	return &InternalFailureException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -743,12 +743,12 @@ func (s InternalFailureException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalFailureException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalFailureException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A word or phrase transcribed from the input audio.
@@ -812,7 +812,7 @@ func (s *Item) SetType(v string) *Item {
 // stream into smaller chunks and try your request again.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -856,7 +856,7 @@ func (s *LimitExceededException) MarshalEvent(pm protocol.PayloadMarshaler) (msg
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -884,12 +884,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The result of transcribing a portion of the input audio stream.

--- a/service/transcribestreamingservice/api.go
+++ b/service/transcribestreamingservice/api.go
@@ -502,8 +502,8 @@ func eventTypeForAudioStreamEvent(event eventstreamapi.Marshaler) (string, error
 // For example, MediaEncoding was not set to pcm or LanguageCode was not set
 // to a valid code. Check the parameters and try your request again.
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -586,8 +586,8 @@ func (s BadRequestException) RequestID() string {
 // A new stream started with the same session ID. The current stream has been
 // terminated.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -670,8 +670,8 @@ func (s ConflictException) RequestID() string {
 // A problem occurred while processing the audio. Amazon Transcribe terminated
 // processing. Try your request again.
 type InternalFailureException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -811,8 +811,8 @@ func (s *Item) SetType(v string) *Item {
 // of 4 hours. Wait until a stream has finished processing, or break your audio
 // stream into smaller chunks and try your request again.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/transcribestreamingservice/eventstream_test.go
+++ b/service/transcribestreamingservice/eventstream_test.go
@@ -424,7 +424,7 @@ func mockStartStreamTranscriptionReadEvents() (
 func TestStartStreamTranscription_ReadException(t *testing.T) {
 	expectEvents := []TranscriptResultStreamEvent{
 		&BadRequestException{
-			respMetadata: protocol.ResponseMetadata{
+			RespMetadata: protocol.ResponseMetadata{
 				StatusCode: 200,
 			},
 			Message_: aws.String("string value goes here"),
@@ -478,7 +478,7 @@ func TestStartStreamTranscription_ReadException(t *testing.T) {
 	}
 
 	expectErr := &BadRequestException{
-		respMetadata: protocol.ResponseMetadata{
+		RespMetadata: protocol.ResponseMetadata{
 			StatusCode: 200,
 		},
 		Message_: aws.String("string value goes here"),

--- a/service/transfer/api.go
+++ b/service/transfer/api.go
@@ -1928,7 +1928,7 @@ func (c *Transfer) UpdateUserWithContext(ctx aws.Context, input *UpdateUserInput
 // available state.
 type ConflictException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1945,7 +1945,7 @@ func (s ConflictException) GoString() string {
 
 func newErrorConflictException(v protocol.ResponseMetadata) error {
 	return &ConflictException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1973,12 +1973,12 @@ func (s ConflictException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateServerInput struct {
@@ -3338,7 +3338,7 @@ func (s *ImportSshPublicKeyOutput) SetUserName(v string) *ImportSshPublicKeyOutp
 // service.
 type InternalServiceError struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3355,7 +3355,7 @@ func (s InternalServiceError) GoString() string {
 
 func newErrorInternalServiceError(v protocol.ResponseMetadata) error {
 	return &InternalServiceError{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3383,18 +3383,18 @@ func (s InternalServiceError) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServiceError) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServiceError) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The NextToken parameter that was passed is invalid.
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3411,7 +3411,7 @@ func (s InvalidNextTokenException) GoString() string {
 
 func newErrorInvalidNextTokenException(v protocol.ResponseMetadata) error {
 	return &InvalidNextTokenException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3439,18 +3439,18 @@ func (s InvalidNextTokenException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidNextTokenException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidNextTokenException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when the client submits a malformed request.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3467,7 +3467,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3495,12 +3495,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListServersInput struct {
@@ -4000,7 +4000,7 @@ func (s *ListedUser) SetUserName(v string) *ListedUser {
 // The requested resource does not exist.
 type ResourceExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -4023,7 +4023,7 @@ func (s ResourceExistsException) GoString() string {
 
 func newErrorResourceExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4051,19 +4051,19 @@ func (s ResourceExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This exception is thrown when a resource is not found by the AWS Transfer
 // for SFTP service.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -4086,7 +4086,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4114,18 +4114,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request has failed because the AWS Transfer for SFTP service is not available.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4142,7 +4142,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4170,12 +4170,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information about the public Secure Shell (SSH) key that is associated
@@ -4611,7 +4611,7 @@ func (s *TestIdentityProviderOutput) SetUrl(v string) *TestIdentityProviderOutpu
 // HTTP Status Code: 400
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 
@@ -4630,7 +4630,7 @@ func (s ThrottlingException) GoString() string {
 
 func newErrorThrottlingException(v protocol.ResponseMetadata) error {
 	return &ThrottlingException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4658,12 +4658,12 @@ func (s ThrottlingException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottlingException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottlingException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/transfer/api.go
+++ b/service/transfer/api.go
@@ -1927,8 +1927,8 @@ func (c *Transfer) UpdateUserWithContext(ctx aws.Context, input *UpdateUserInput
 // has VPC as the endpoint type and the server's VpcEndpointID is not in the
 // available state.
 type ConflictException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3337,8 +3337,8 @@ func (s *ImportSshPublicKeyOutput) SetUserName(v string) *ImportSshPublicKeyOutp
 // This exception is thrown when an error occurs in the AWS Transfer for SFTP
 // service.
 type InternalServiceError struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3393,8 +3393,8 @@ func (s InternalServiceError) RequestID() string {
 
 // The NextToken parameter that was passed is invalid.
 type InvalidNextTokenException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3449,8 +3449,8 @@ func (s InvalidNextTokenException) RequestID() string {
 
 // This exception is thrown when the client submits a malformed request.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3999,8 +3999,8 @@ func (s *ListedUser) SetUserName(v string) *ListedUser {
 
 // The requested resource does not exist.
 type ResourceExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -4062,8 +4062,8 @@ func (s ResourceExistsException) RequestID() string {
 // This exception is thrown when a resource is not found by the AWS Transfer
 // for SFTP service.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -4124,8 +4124,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The request has failed because the AWS Transfer for SFTP service is not available.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4610,8 +4610,8 @@ func (s *TestIdentityProviderOutput) SetUrl(v string) *TestIdentityProviderOutpu
 //
 // HTTP Status Code: 400
 type ThrottlingException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 

--- a/service/translate/api.go
+++ b/service/translate/api.go
@@ -1159,7 +1159,7 @@ func (s *DescribeTextTranslationJobOutput) SetTextTranslationJobProperties(v *Te
 // operation in the Amazon Comprehend Developer Guide.
 type DetectedLanguageLowConfidenceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The language code of the auto-detected language from Amazon Comprehend.
 	DetectedLanguageCode *string `min:"2" type:"string"`
@@ -1179,7 +1179,7 @@ func (s DetectedLanguageLowConfidenceException) GoString() string {
 
 func newErrorDetectedLanguageLowConfidenceException(v protocol.ResponseMetadata) error {
 	return &DetectedLanguageLowConfidenceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1207,12 +1207,12 @@ func (s DetectedLanguageLowConfidenceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DetectedLanguageLowConfidenceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DetectedLanguageLowConfidenceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The encryption key used to encrypt the custom terminologies used by Amazon
@@ -1542,7 +1542,7 @@ func (s *InputDataConfig) SetS3Uri(v string) *InputDataConfig {
 // An internal server error occurred. Retry your request.
 type InternalServerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1559,7 +1559,7 @@ func (s InternalServerException) GoString() string {
 
 func newErrorInternalServerException(v protocol.ResponseMetadata) error {
 	return &InternalServerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1587,18 +1587,18 @@ func (s InternalServerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The filter specified for the operation is invalid. Specify a different filter.
 type InvalidFilterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1615,7 +1615,7 @@ func (s InvalidFilterException) GoString() string {
 
 func newErrorInvalidFilterException(v protocol.ResponseMetadata) error {
 	return &InvalidFilterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1643,19 +1643,19 @@ func (s InvalidFilterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidFilterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidFilterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The value of the parameter is invalid. Review the value of the parameter
 // you are using to correct it, and then retry your operation.
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1672,7 +1672,7 @@ func (s InvalidParameterValueException) GoString() string {
 
 func newErrorInvalidParameterValueException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValueException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1700,19 +1700,19 @@ func (s InvalidParameterValueException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValueException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValueException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request that you made is invalid. Check your request to determine why
 // it's invalid and then retry the request.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1729,7 +1729,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1757,12 +1757,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The number of documents successfully and unsuccessfully processed during
@@ -1813,7 +1813,7 @@ func (s *JobDetails) SetTranslatedDocumentsCount(v int64) *JobDetails {
 // a quantity below the stated limit.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1830,7 +1830,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -1858,12 +1858,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListTerminologiesInput struct {
@@ -2085,7 +2085,7 @@ func (s *OutputDataConfig) SetS3Uri(v string) *OutputDataConfig {
 // before retrying the revised request.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2102,7 +2102,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2130,19 +2130,19 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The Amazon Translate service is temporarily unavailable. Please wait a bit
 // and then retry your request.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2159,7 +2159,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2187,12 +2187,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type StartTextTranslationJobInput struct {
@@ -2868,7 +2868,7 @@ func (s *TextOutput) SetTranslatedText(v string) *TextOutput {
 // of the text or use a smaller document and then retry your request.
 type TextSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2885,7 +2885,7 @@ func (s TextSizeLimitExceededException) GoString() string {
 
 func newErrorTextSizeLimitExceededException(v protocol.ResponseMetadata) error {
 	return &TextSizeLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -2913,12 +2913,12 @@ func (s TextSizeLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TextSizeLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TextSizeLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Provides information for filtering a list of translation jobs. For more information,
@@ -3134,7 +3134,7 @@ func (s *TextTranslationJobProperties) SetTerminologyNames(v []*string) *TextTra
 // short time and then try your request again.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3151,7 +3151,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3179,19 +3179,19 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Amazon Translate does not support translation from the language of the source
 // text into the requested target language. For more information, see how-to-error-msg.
 type UnsupportedLanguagePairException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 
@@ -3214,7 +3214,7 @@ func (s UnsupportedLanguagePairException) GoString() string {
 
 func newErrorUnsupportedLanguagePairException(v protocol.ResponseMetadata) error {
 	return &UnsupportedLanguagePairException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3242,12 +3242,12 @@ func (s UnsupportedLanguagePairException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedLanguagePairException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedLanguagePairException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/translate/api.go
+++ b/service/translate/api.go
@@ -1158,8 +1158,8 @@ func (s *DescribeTextTranslationJobOutput) SetTextTranslationJobProperties(v *Te
 // more information, see the DetectDominantLanguage (https://docs.aws.amazon.com/comprehend/latest/dg/API_DetectDominantLanguage.html)
 // operation in the Amazon Comprehend Developer Guide.
 type DetectedLanguageLowConfidenceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The language code of the auto-detected language from Amazon Comprehend.
 	DetectedLanguageCode *string `min:"2" type:"string"`
@@ -1541,8 +1541,8 @@ func (s *InputDataConfig) SetS3Uri(v string) *InputDataConfig {
 
 // An internal server error occurred. Retry your request.
 type InternalServerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1597,8 +1597,8 @@ func (s InternalServerException) RequestID() string {
 
 // The filter specified for the operation is invalid. Specify a different filter.
 type InvalidFilterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1654,8 +1654,8 @@ func (s InvalidFilterException) RequestID() string {
 // The value of the parameter is invalid. Review the value of the parameter
 // you are using to correct it, and then retry your operation.
 type InvalidParameterValueException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1711,8 +1711,8 @@ func (s InvalidParameterValueException) RequestID() string {
 // The request that you made is invalid. Check your request to determine why
 // it's invalid and then retry the request.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -1812,8 +1812,8 @@ func (s *JobDetails) SetTranslatedDocumentsCount(v int64) *JobDetails {
 // The specified limit has been exceeded. Review your request and retry it with
 // a quantity below the stated limit.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2084,8 +2084,8 @@ func (s *OutputDataConfig) SetS3Uri(v string) *OutputDataConfig {
 // you're looking for and see if a different resource will accomplish your needs
 // before retrying the revised request.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2141,8 +2141,8 @@ func (s ResourceNotFoundException) RequestID() string {
 // The Amazon Translate service is temporarily unavailable. Please wait a bit
 // and then retry your request.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -2867,8 +2867,8 @@ func (s *TextOutput) SetTranslatedText(v string) *TextOutput {
 // The size of the text you submitted exceeds the size limit. Reduce the size
 // of the text or use a smaller document and then retry your request.
 type TextSizeLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3133,8 +3133,8 @@ func (s *TextTranslationJobProperties) SetTerminologyNames(v []*string) *TextTra
 // You have made too many requests within a short period of time. Wait for a
 // short time and then try your request again.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -3190,8 +3190,8 @@ func (s TooManyRequestsException) RequestID() string {
 // Amazon Translate does not support translation from the language of the source
 // text into the requested target language. For more information, see how-to-error-msg.
 type UnsupportedLanguagePairException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -9517,8 +9517,8 @@ func (s *ActivatedRule) SetType(v string) *ActivatedRule {
 }
 
 type BadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12462,8 +12462,8 @@ func (s *DeleteXssMatchSetOutput) SetChangeToken(v string) *DeleteXssMatchSetOut
 
 // The name specified is invalid.
 type DisallowedNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14532,8 +14532,8 @@ func (s *IPSetUpdate) SetIPSetDescriptor(v *IPSetDescriptor) *IPSetUpdate {
 // The operation failed because of a system problem, even though the request
 // was valid. Retry your request.
 type InternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14589,8 +14589,8 @@ func (s InternalErrorException) RequestID() string {
 // The operation failed because you tried to create, update, or delete an object
 // by using an invalid account identifier.
 type InvalidAccountException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14660,8 +14660,8 @@ func (s InvalidAccountException) RequestID() string {
 //    * You tried to add a ByteMatchTuple to a ByteMatchSet, but the ByteMatchTuple
 //    already exists in the specified WebACL.
 type InvalidOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14742,8 +14742,8 @@ func (s InvalidOperationException) RequestID() string {
 //    * Your request references an ARN that is malformed, or corresponds to
 //    a resource with which a web ACL cannot be associated.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Field *string `locationName:"field" type:"string" enum:"ParameterExceptionField"`
 
@@ -14825,8 +14825,8 @@ func (s InvalidParameterException) RequestID() string {
 //
 //    * Your policy must be composed using IAM Policy version 2012-10-17.
 type InvalidPermissionPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14881,8 +14881,8 @@ func (s InvalidPermissionPolicyException) RequestID() string {
 
 // The regular expression (regex) you specified in RegexPatternString is invalid.
 type InvalidRegexPatternException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14940,8 +14940,8 @@ func (s InvalidRegexPatternException) RequestID() string {
 // see Limits (https://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
 // in the AWS WAF Developer Guide.
 type LimitsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16507,8 +16507,8 @@ func (s *LoggingConfiguration) SetResourceArn(v string) *LoggingConfiguration {
 //
 //    * You tried to delete an IPSet that references one or more IP addresses.
 type NonEmptyEntityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16576,8 +16576,8 @@ func (s NonEmptyEntityException) RequestID() string {
 //    * You tried to add a ByteMatchTuple to or delete a ByteMatchTuple from
 //    a ByteMatchSet that doesn't exist.
 type NonexistentContainerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16632,8 +16632,8 @@ func (s NonexistentContainerException) RequestID() string {
 
 // The operation failed because the referenced object doesn't exist.
 type NonexistentItemException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17029,8 +17029,8 @@ func (s *RateBasedRule) SetRuleId(v string) *RateBasedRule {
 //
 //    * You tried to delete a Rule that is still referenced by a WebACL.
 type ReferencedItemException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18006,8 +18006,8 @@ func (s *SampledHTTPRequest) SetWeight(v int64) *SampledHTTPRequest {
 // exception again, you will have to wait additional time until the role is
 // unlocked.
 type ServiceLinkedRoleErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18709,8 +18709,8 @@ func (s *SqlInjectionMatchTuple) SetTextTransformation(v string) *SqlInjectionMa
 // The operation failed because you tried to create, update, or delete an object
 // by using a change token that has already been used.
 type StaleDataException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18818,8 +18818,8 @@ func (s *SubscribedRuleGroupSummary) SetRuleGroupId(v string) *SubscribedRuleGro
 
 // The specified subscription does not exist.
 type SubscriptionNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18946,8 +18946,8 @@ func (s *TagInfoForResource) SetTagList(v []*Tag) *TagInfoForResource {
 }
 
 type TagOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19001,8 +19001,8 @@ func (s TagOperationException) RequestID() string {
 }
 
 type TagOperationInternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -9518,7 +9518,7 @@ func (s *ActivatedRule) SetType(v string) *ActivatedRule {
 
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9535,7 +9535,7 @@ func (s BadRequestException) GoString() string {
 
 func newErrorBadRequestException(v protocol.ResponseMetadata) error {
 	return &BadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9563,12 +9563,12 @@ func (s BadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s BadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s BadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // In a GetByteMatchSet request, ByteMatchSet is a complex type that contains
@@ -12463,7 +12463,7 @@ func (s *DeleteXssMatchSetOutput) SetChangeToken(v string) *DeleteXssMatchSetOut
 // The name specified is invalid.
 type DisallowedNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12480,7 +12480,7 @@ func (s DisallowedNameException) GoString() string {
 
 func newErrorDisallowedNameException(v protocol.ResponseMetadata) error {
 	return &DisallowedNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12508,12 +12508,12 @@ func (s DisallowedNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DisallowedNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DisallowedNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The rule to exclude from a rule group. This is applicable only when the ActivatedRule
@@ -14533,7 +14533,7 @@ func (s *IPSetUpdate) SetIPSetDescriptor(v *IPSetDescriptor) *IPSetUpdate {
 // was valid. Retry your request.
 type InternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14550,7 +14550,7 @@ func (s InternalErrorException) GoString() string {
 
 func newErrorInternalErrorException(v protocol.ResponseMetadata) error {
 	return &InternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14578,19 +14578,19 @@ func (s InternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because you tried to create, update, or delete an object
 // by using an invalid account identifier.
 type InvalidAccountException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14607,7 +14607,7 @@ func (s InvalidAccountException) GoString() string {
 
 func newErrorInvalidAccountException(v protocol.ResponseMetadata) error {
 	return &InvalidAccountException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14635,12 +14635,12 @@ func (s InvalidAccountException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidAccountException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidAccountException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because there was nothing to do. For example:
@@ -14661,7 +14661,7 @@ func (s InvalidAccountException) RequestID() string {
 //    already exists in the specified WebACL.
 type InvalidOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14678,7 +14678,7 @@ func (s InvalidOperationException) GoString() string {
 
 func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 	return &InvalidOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14706,12 +14706,12 @@ func (s InvalidOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because AWS WAF didn't recognize a parameter in the
@@ -14743,7 +14743,7 @@ func (s InvalidOperationException) RequestID() string {
 //    a resource with which a web ACL cannot be associated.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Field *string `locationName:"field" type:"string" enum:"ParameterExceptionField"`
 
@@ -14766,7 +14766,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14794,12 +14794,12 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because the specified policy is not in the proper format.
@@ -14826,7 +14826,7 @@ func (s InvalidParameterException) RequestID() string {
 //    * Your policy must be composed using IAM Policy version 2012-10-17.
 type InvalidPermissionPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14843,7 +14843,7 @@ func (s InvalidPermissionPolicyException) GoString() string {
 
 func newErrorInvalidPermissionPolicyException(v protocol.ResponseMetadata) error {
 	return &InvalidPermissionPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14871,18 +14871,18 @@ func (s InvalidPermissionPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPermissionPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPermissionPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The regular expression (regex) you specified in RegexPatternString is invalid.
 type InvalidRegexPatternException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14899,7 +14899,7 @@ func (s InvalidRegexPatternException) GoString() string {
 
 func newErrorInvalidRegexPatternException(v protocol.ResponseMetadata) error {
 	return &InvalidRegexPatternException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14927,12 +14927,12 @@ func (s InvalidRegexPatternException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRegexPatternException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRegexPatternException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation exceeds a resource limit, for example, the maximum number of
@@ -14941,7 +14941,7 @@ func (s InvalidRegexPatternException) RequestID() string {
 // in the AWS WAF Developer Guide.
 type LimitsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -14958,7 +14958,7 @@ func (s LimitsExceededException) GoString() string {
 
 func newErrorLimitsExceededException(v protocol.ResponseMetadata) error {
 	return &LimitsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -14986,12 +14986,12 @@ func (s LimitsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListActivatedRulesInRuleGroupInput struct {
@@ -16508,7 +16508,7 @@ func (s *LoggingConfiguration) SetResourceArn(v string) *LoggingConfiguration {
 //    * You tried to delete an IPSet that references one or more IP addresses.
 type NonEmptyEntityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16525,7 +16525,7 @@ func (s NonEmptyEntityException) GoString() string {
 
 func newErrorNonEmptyEntityException(v protocol.ResponseMetadata) error {
 	return &NonEmptyEntityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16553,12 +16553,12 @@ func (s NonEmptyEntityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NonEmptyEntityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NonEmptyEntityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because you tried to add an object to or delete an object
@@ -16577,7 +16577,7 @@ func (s NonEmptyEntityException) RequestID() string {
 //    a ByteMatchSet that doesn't exist.
 type NonexistentContainerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16594,7 +16594,7 @@ func (s NonexistentContainerException) GoString() string {
 
 func newErrorNonexistentContainerException(v protocol.ResponseMetadata) error {
 	return &NonexistentContainerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16622,18 +16622,18 @@ func (s NonexistentContainerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NonexistentContainerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NonexistentContainerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because the referenced object doesn't exist.
 type NonexistentItemException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -16650,7 +16650,7 @@ func (s NonexistentItemException) GoString() string {
 
 func newErrorNonexistentItemException(v protocol.ResponseMetadata) error {
 	return &NonexistentItemException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -16678,12 +16678,12 @@ func (s NonexistentItemException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NonexistentItemException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NonexistentItemException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies the ByteMatchSet, IPSet, SqlInjectionMatchSet, XssMatchSet, RegexMatchSet,
@@ -17030,7 +17030,7 @@ func (s *RateBasedRule) SetRuleId(v string) *RateBasedRule {
 //    * You tried to delete a Rule that is still referenced by a WebACL.
 type ReferencedItemException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -17047,7 +17047,7 @@ func (s ReferencedItemException) GoString() string {
 
 func newErrorReferencedItemException(v protocol.ResponseMetadata) error {
 	return &ReferencedItemException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -17075,12 +17075,12 @@ func (s ReferencedItemException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReferencedItemException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReferencedItemException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // In a GetRegexMatchSet request, RegexMatchSet is a complex type that contains
@@ -18007,7 +18007,7 @@ func (s *SampledHTTPRequest) SetWeight(v int64) *SampledHTTPRequest {
 // unlocked.
 type ServiceLinkedRoleErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18024,7 +18024,7 @@ func (s ServiceLinkedRoleErrorException) GoString() string {
 
 func newErrorServiceLinkedRoleErrorException(v protocol.ResponseMetadata) error {
 	return &ServiceLinkedRoleErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18052,12 +18052,12 @@ func (s ServiceLinkedRoleErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceLinkedRoleErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceLinkedRoleErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Specifies a constraint on the size of a part of the web request. AWS WAF
@@ -18710,7 +18710,7 @@ func (s *SqlInjectionMatchTuple) SetTextTransformation(v string) *SqlInjectionMa
 // by using a change token that has already been used.
 type StaleDataException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18727,7 +18727,7 @@ func (s StaleDataException) GoString() string {
 
 func newErrorStaleDataException(v protocol.ResponseMetadata) error {
 	return &StaleDataException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18755,12 +18755,12 @@ func (s StaleDataException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StaleDataException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StaleDataException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A summary of the rule groups you are subscribed to.
@@ -18819,7 +18819,7 @@ func (s *SubscribedRuleGroupSummary) SetRuleGroupId(v string) *SubscribedRuleGro
 // The specified subscription does not exist.
 type SubscriptionNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18836,7 +18836,7 @@ func (s SubscriptionNotFoundException) GoString() string {
 
 func newErrorSubscriptionNotFoundException(v protocol.ResponseMetadata) error {
 	return &SubscriptionNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18864,12 +18864,12 @@ func (s SubscriptionNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s SubscriptionNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s SubscriptionNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type Tag struct {
@@ -18947,7 +18947,7 @@ func (s *TagInfoForResource) SetTagList(v []*Tag) *TagInfoForResource {
 
 type TagOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -18964,7 +18964,7 @@ func (s TagOperationException) GoString() string {
 
 func newErrorTagOperationException(v protocol.ResponseMetadata) error {
 	return &TagOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -18992,17 +18992,17 @@ func (s TagOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagOperationInternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -19019,7 +19019,7 @@ func (s TagOperationInternalErrorException) GoString() string {
 
 func newErrorTagOperationInternalErrorException(v protocol.ResponseMetadata) error {
 	return &TagOperationInternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -19047,12 +19047,12 @@ func (s TagOperationInternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TagOperationInternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TagOperationInternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type TagResourceInput struct {

--- a/service/wafregional/api.go
+++ b/service/wafregional/api.go
@@ -10097,7 +10097,7 @@ func (s *ListResourcesForWebACLOutput) SetResourceArns(v []*string) *ListResourc
 
 type WAFBadRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10114,7 +10114,7 @@ func (s WAFBadRequestException) GoString() string {
 
 func newErrorWAFBadRequestException(v protocol.ResponseMetadata) error {
 	return &WAFBadRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10142,18 +10142,18 @@ func (s WAFBadRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFBadRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFBadRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The name specified is invalid.
 type WAFDisallowedNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10170,7 +10170,7 @@ func (s WAFDisallowedNameException) GoString() string {
 
 func newErrorWAFDisallowedNameException(v protocol.ResponseMetadata) error {
 	return &WAFDisallowedNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10198,19 +10198,19 @@ func (s WAFDisallowedNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFDisallowedNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFDisallowedNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because of a system problem, even though the request
 // was valid. Retry your request.
 type WAFInternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10227,7 +10227,7 @@ func (s WAFInternalErrorException) GoString() string {
 
 func newErrorWAFInternalErrorException(v protocol.ResponseMetadata) error {
 	return &WAFInternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10255,19 +10255,19 @@ func (s WAFInternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFInternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFInternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because you tried to create, update, or delete an object
 // by using an invalid account identifier.
 type WAFInvalidAccountException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10284,7 +10284,7 @@ func (s WAFInvalidAccountException) GoString() string {
 
 func newErrorWAFInvalidAccountException(v protocol.ResponseMetadata) error {
 	return &WAFInvalidAccountException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10312,12 +10312,12 @@ func (s WAFInvalidAccountException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFInvalidAccountException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFInvalidAccountException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because there was nothing to do. For example:
@@ -10338,7 +10338,7 @@ func (s WAFInvalidAccountException) RequestID() string {
 //    already exists in the specified WebACL.
 type WAFInvalidOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10355,7 +10355,7 @@ func (s WAFInvalidOperationException) GoString() string {
 
 func newErrorWAFInvalidOperationException(v protocol.ResponseMetadata) error {
 	return &WAFInvalidOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10383,12 +10383,12 @@ func (s WAFInvalidOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFInvalidOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFInvalidOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because AWS WAF didn't recognize a parameter in the
@@ -10420,7 +10420,7 @@ func (s WAFInvalidOperationException) RequestID() string {
 //    a resource with which a web ACL cannot be associated.
 type WAFInvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Field *string `locationName:"field" type:"string" enum:"ParameterExceptionField"`
 
@@ -10443,7 +10443,7 @@ func (s WAFInvalidParameterException) GoString() string {
 
 func newErrorWAFInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &WAFInvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10471,12 +10471,12 @@ func (s WAFInvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFInvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFInvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because the specified policy is not in the proper format.
@@ -10503,7 +10503,7 @@ func (s WAFInvalidParameterException) RequestID() string {
 //    * Your policy must be composed using IAM Policy version 2012-10-17.
 type WAFInvalidPermissionPolicyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10520,7 +10520,7 @@ func (s WAFInvalidPermissionPolicyException) GoString() string {
 
 func newErrorWAFInvalidPermissionPolicyException(v protocol.ResponseMetadata) error {
 	return &WAFInvalidPermissionPolicyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10548,18 +10548,18 @@ func (s WAFInvalidPermissionPolicyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFInvalidPermissionPolicyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFInvalidPermissionPolicyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The regular expression (regex) you specified in RegexPatternString is invalid.
 type WAFInvalidRegexPatternException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10576,7 +10576,7 @@ func (s WAFInvalidRegexPatternException) GoString() string {
 
 func newErrorWAFInvalidRegexPatternException(v protocol.ResponseMetadata) error {
 	return &WAFInvalidRegexPatternException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10604,12 +10604,12 @@ func (s WAFInvalidRegexPatternException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFInvalidRegexPatternException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFInvalidRegexPatternException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation exceeds a resource limit, for example, the maximum number of
@@ -10618,7 +10618,7 @@ func (s WAFInvalidRegexPatternException) RequestID() string {
 // in the AWS WAF Developer Guide.
 type WAFLimitsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10635,7 +10635,7 @@ func (s WAFLimitsExceededException) GoString() string {
 
 func newErrorWAFLimitsExceededException(v protocol.ResponseMetadata) error {
 	return &WAFLimitsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10663,12 +10663,12 @@ func (s WAFLimitsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFLimitsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFLimitsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because you tried to delete an object that isn't empty.
@@ -10685,7 +10685,7 @@ func (s WAFLimitsExceededException) RequestID() string {
 //    * You tried to delete an IPSet that references one or more IP addresses.
 type WAFNonEmptyEntityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10702,7 +10702,7 @@ func (s WAFNonEmptyEntityException) GoString() string {
 
 func newErrorWAFNonEmptyEntityException(v protocol.ResponseMetadata) error {
 	return &WAFNonEmptyEntityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10730,12 +10730,12 @@ func (s WAFNonEmptyEntityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFNonEmptyEntityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFNonEmptyEntityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because you tried to add an object to or delete an object
@@ -10754,7 +10754,7 @@ func (s WAFNonEmptyEntityException) RequestID() string {
 //    a ByteMatchSet that doesn't exist.
 type WAFNonexistentContainerException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10771,7 +10771,7 @@ func (s WAFNonexistentContainerException) GoString() string {
 
 func newErrorWAFNonexistentContainerException(v protocol.ResponseMetadata) error {
 	return &WAFNonexistentContainerException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10799,18 +10799,18 @@ func (s WAFNonexistentContainerException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFNonexistentContainerException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFNonexistentContainerException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because the referenced object doesn't exist.
 type WAFNonexistentItemException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10827,7 +10827,7 @@ func (s WAFNonexistentItemException) GoString() string {
 
 func newErrorWAFNonexistentItemException(v protocol.ResponseMetadata) error {
 	return &WAFNonexistentItemException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10855,12 +10855,12 @@ func (s WAFNonexistentItemException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFNonexistentItemException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFNonexistentItemException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because you tried to delete an object that is still
@@ -10871,7 +10871,7 @@ func (s WAFNonexistentItemException) RequestID() string {
 //    * You tried to delete a Rule that is still referenced by a WebACL.
 type WAFReferencedItemException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10888,7 +10888,7 @@ func (s WAFReferencedItemException) GoString() string {
 
 func newErrorWAFReferencedItemException(v protocol.ResponseMetadata) error {
 	return &WAFReferencedItemException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10916,12 +10916,12 @@ func (s WAFReferencedItemException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFReferencedItemException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFReferencedItemException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS WAF is not able to access the service linked role. This can be caused
@@ -10934,7 +10934,7 @@ func (s WAFReferencedItemException) RequestID() string {
 // unlocked.
 type WAFServiceLinkedRoleErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10951,7 +10951,7 @@ func (s WAFServiceLinkedRoleErrorException) GoString() string {
 
 func newErrorWAFServiceLinkedRoleErrorException(v protocol.ResponseMetadata) error {
 	return &WAFServiceLinkedRoleErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10979,19 +10979,19 @@ func (s WAFServiceLinkedRoleErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFServiceLinkedRoleErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFServiceLinkedRoleErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because you tried to create, update, or delete an object
 // by using a change token that has already been used.
 type WAFStaleDataException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11008,7 +11008,7 @@ func (s WAFStaleDataException) GoString() string {
 
 func newErrorWAFStaleDataException(v protocol.ResponseMetadata) error {
 	return &WAFStaleDataException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11036,18 +11036,18 @@ func (s WAFStaleDataException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFStaleDataException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFStaleDataException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified subscription does not exist.
 type WAFSubscriptionNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11064,7 +11064,7 @@ func (s WAFSubscriptionNotFoundException) GoString() string {
 
 func newErrorWAFSubscriptionNotFoundException(v protocol.ResponseMetadata) error {
 	return &WAFSubscriptionNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11092,17 +11092,17 @@ func (s WAFSubscriptionNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFSubscriptionNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFSubscriptionNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type WAFTagOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11119,7 +11119,7 @@ func (s WAFTagOperationException) GoString() string {
 
 func newErrorWAFTagOperationException(v protocol.ResponseMetadata) error {
 	return &WAFTagOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11147,17 +11147,17 @@ func (s WAFTagOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFTagOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFTagOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type WAFTagOperationInternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11174,7 +11174,7 @@ func (s WAFTagOperationInternalErrorException) GoString() string {
 
 func newErrorWAFTagOperationInternalErrorException(v protocol.ResponseMetadata) error {
 	return &WAFTagOperationInternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11202,19 +11202,19 @@ func (s WAFTagOperationInternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFTagOperationInternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFTagOperationInternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because the entity referenced is temporarily unavailable.
 // Retry your request.
 type WAFUnavailableEntityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11231,7 +11231,7 @@ func (s WAFUnavailableEntityException) GoString() string {
 
 func newErrorWAFUnavailableEntityException(v protocol.ResponseMetadata) error {
 	return &WAFUnavailableEntityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -11259,12 +11259,12 @@ func (s WAFUnavailableEntityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFUnavailableEntityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFUnavailableEntityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/wafregional/api.go
+++ b/service/wafregional/api.go
@@ -10096,8 +10096,8 @@ func (s *ListResourcesForWebACLOutput) SetResourceArns(v []*string) *ListResourc
 }
 
 type WAFBadRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10152,8 +10152,8 @@ func (s WAFBadRequestException) RequestID() string {
 
 // The name specified is invalid.
 type WAFDisallowedNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10209,8 +10209,8 @@ func (s WAFDisallowedNameException) RequestID() string {
 // The operation failed because of a system problem, even though the request
 // was valid. Retry your request.
 type WAFInternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10266,8 +10266,8 @@ func (s WAFInternalErrorException) RequestID() string {
 // The operation failed because you tried to create, update, or delete an object
 // by using an invalid account identifier.
 type WAFInvalidAccountException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10337,8 +10337,8 @@ func (s WAFInvalidAccountException) RequestID() string {
 //    * You tried to add a ByteMatchTuple to a ByteMatchSet, but the ByteMatchTuple
 //    already exists in the specified WebACL.
 type WAFInvalidOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10419,8 +10419,8 @@ func (s WAFInvalidOperationException) RequestID() string {
 //    * Your request references an ARN that is malformed, or corresponds to
 //    a resource with which a web ACL cannot be associated.
 type WAFInvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Field *string `locationName:"field" type:"string" enum:"ParameterExceptionField"`
 
@@ -10502,8 +10502,8 @@ func (s WAFInvalidParameterException) RequestID() string {
 //
 //    * Your policy must be composed using IAM Policy version 2012-10-17.
 type WAFInvalidPermissionPolicyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10558,8 +10558,8 @@ func (s WAFInvalidPermissionPolicyException) RequestID() string {
 
 // The regular expression (regex) you specified in RegexPatternString is invalid.
 type WAFInvalidRegexPatternException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10617,8 +10617,8 @@ func (s WAFInvalidRegexPatternException) RequestID() string {
 // see Limits (https://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
 // in the AWS WAF Developer Guide.
 type WAFLimitsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10684,8 +10684,8 @@ func (s WAFLimitsExceededException) RequestID() string {
 //
 //    * You tried to delete an IPSet that references one or more IP addresses.
 type WAFNonEmptyEntityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10753,8 +10753,8 @@ func (s WAFNonEmptyEntityException) RequestID() string {
 //    * You tried to add a ByteMatchTuple to or delete a ByteMatchTuple from
 //    a ByteMatchSet that doesn't exist.
 type WAFNonexistentContainerException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10809,8 +10809,8 @@ func (s WAFNonexistentContainerException) RequestID() string {
 
 // The operation failed because the referenced object doesn't exist.
 type WAFNonexistentItemException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10870,8 +10870,8 @@ func (s WAFNonexistentItemException) RequestID() string {
 //
 //    * You tried to delete a Rule that is still referenced by a WebACL.
 type WAFReferencedItemException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10933,8 +10933,8 @@ func (s WAFReferencedItemException) RequestID() string {
 // exception again, you will have to wait additional time until the role is
 // unlocked.
 type WAFServiceLinkedRoleErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10990,8 +10990,8 @@ func (s WAFServiceLinkedRoleErrorException) RequestID() string {
 // The operation failed because you tried to create, update, or delete an object
 // by using a change token that has already been used.
 type WAFStaleDataException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11046,8 +11046,8 @@ func (s WAFStaleDataException) RequestID() string {
 
 // The specified subscription does not exist.
 type WAFSubscriptionNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11101,8 +11101,8 @@ func (s WAFSubscriptionNotFoundException) RequestID() string {
 }
 
 type WAFTagOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11156,8 +11156,8 @@ func (s WAFTagOperationException) RequestID() string {
 }
 
 type WAFTagOperationInternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -11213,8 +11213,8 @@ func (s WAFTagOperationInternalErrorException) RequestID() string {
 // The operation failed because the entity referenced is temporarily unavailable.
 // Retry your request.
 type WAFUnavailableEntityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/wafv2/api.go
+++ b/service/wafv2/api.go
@@ -11983,8 +11983,8 @@ func (s *VisibilityConfig) SetSampledRequestsEnabled(v bool) *VisibilityConfig {
 // AWS WAF couldn’t perform the operation because your resource is being used
 // by another resource or it’s associated with another resource.
 type WAFAssociatedItemException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12040,8 +12040,8 @@ func (s WAFAssociatedItemException) RequestID() string {
 // AWS WAF couldn’t perform the operation because the resource that you tried
 // to save is a duplicate of an existing one.
 type WAFDuplicateItemException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12097,8 +12097,8 @@ func (s WAFDuplicateItemException) RequestID() string {
 // Your request is valid, but AWS WAF couldn’t perform the operation because
 // of a system problem. Retry your request.
 type WAFInternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12165,8 +12165,8 @@ func (s WAFInternalErrorException) RequestID() string {
 //    * Your request references an ARN that is malformed, or corresponds to
 //    a resource with which a Web ACL cannot be associated.
 type WAFInvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Field *string `type:"string" enum:"ParameterExceptionField"`
 
@@ -12228,8 +12228,8 @@ func (s WAFInvalidParameterException) RequestID() string {
 // AWS WAF couldn’t perform the operation because the resource that you requested
 // isn’t valid. Check the resource, and try again.
 type WAFInvalidResourceException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12287,8 +12287,8 @@ func (s WAFInvalidResourceException) RequestID() string {
 // for an AWS account. For more information, see Limits (https://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
 // in the AWS WAF Developer Guide.
 type WAFLimitsExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12344,8 +12344,8 @@ func (s WAFLimitsExceededException) RequestID() string {
 // AWS WAF couldn’t perform the operation because your resource doesn’t
 // exist.
 type WAFNonexistentItemException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12403,8 +12403,8 @@ func (s WAFNonexistentItemException) RequestID() string {
 // again, make any changes you need to make to the new copy, and retry your
 // operation.
 type WAFOptimisticLockException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12466,8 +12466,8 @@ func (s WAFOptimisticLockException) RequestID() string {
 // again. If you receive this same exception again, you will have to wait additional
 // time until the role is unlocked.
 type WAFServiceLinkedRoleErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12521,8 +12521,8 @@ func (s WAFServiceLinkedRoleErrorException) RequestID() string {
 }
 
 type WAFSubscriptionNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12577,8 +12577,8 @@ func (s WAFSubscriptionNotFoundException) RequestID() string {
 
 // An error occurred during the tagging operation. Retry your request.
 type WAFTagOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12634,8 +12634,8 @@ func (s WAFTagOperationException) RequestID() string {
 // AWS WAF couldn’t perform your tagging operation because of an internal
 // error. Retry your request.
 type WAFTagOperationInternalErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12690,8 +12690,8 @@ func (s WAFTagOperationInternalErrorException) RequestID() string {
 
 // AWS WAF couldn’t retrieve the resource that you requested. Retry your request.
 type WAFUnavailableEntityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/wafv2/api.go
+++ b/service/wafv2/api.go
@@ -11984,7 +11984,7 @@ func (s *VisibilityConfig) SetSampledRequestsEnabled(v bool) *VisibilityConfig {
 // by another resource or it’s associated with another resource.
 type WAFAssociatedItemException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12001,7 +12001,7 @@ func (s WAFAssociatedItemException) GoString() string {
 
 func newErrorWAFAssociatedItemException(v protocol.ResponseMetadata) error {
 	return &WAFAssociatedItemException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12029,19 +12029,19 @@ func (s WAFAssociatedItemException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFAssociatedItemException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFAssociatedItemException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS WAF couldn’t perform the operation because the resource that you tried
 // to save is a duplicate of an existing one.
 type WAFDuplicateItemException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12058,7 +12058,7 @@ func (s WAFDuplicateItemException) GoString() string {
 
 func newErrorWAFDuplicateItemException(v protocol.ResponseMetadata) error {
 	return &WAFDuplicateItemException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12086,19 +12086,19 @@ func (s WAFDuplicateItemException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFDuplicateItemException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFDuplicateItemException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Your request is valid, but AWS WAF couldn’t perform the operation because
 // of a system problem. Retry your request.
 type WAFInternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12115,7 +12115,7 @@ func (s WAFInternalErrorException) GoString() string {
 
 func newErrorWAFInternalErrorException(v protocol.ResponseMetadata) error {
 	return &WAFInternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12143,12 +12143,12 @@ func (s WAFInternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFInternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFInternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation failed because AWS WAF didn't recognize a parameter in the
@@ -12166,7 +12166,7 @@ func (s WAFInternalErrorException) RequestID() string {
 //    a resource with which a Web ACL cannot be associated.
 type WAFInvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Field *string `type:"string" enum:"ParameterExceptionField"`
 
@@ -12189,7 +12189,7 @@ func (s WAFInvalidParameterException) GoString() string {
 
 func newErrorWAFInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &WAFInvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12217,19 +12217,19 @@ func (s WAFInvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFInvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFInvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS WAF couldn’t perform the operation because the resource that you requested
 // isn’t valid. Check the resource, and try again.
 type WAFInvalidResourceException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12246,7 +12246,7 @@ func (s WAFInvalidResourceException) GoString() string {
 
 func newErrorWAFInvalidResourceException(v protocol.ResponseMetadata) error {
 	return &WAFInvalidResourceException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12274,12 +12274,12 @@ func (s WAFInvalidResourceException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFInvalidResourceException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFInvalidResourceException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS WAF couldn’t perform the operation because you exceeded your resource
@@ -12288,7 +12288,7 @@ func (s WAFInvalidResourceException) RequestID() string {
 // in the AWS WAF Developer Guide.
 type WAFLimitsExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12305,7 +12305,7 @@ func (s WAFLimitsExceededException) GoString() string {
 
 func newErrorWAFLimitsExceededException(v protocol.ResponseMetadata) error {
 	return &WAFLimitsExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12333,19 +12333,19 @@ func (s WAFLimitsExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFLimitsExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFLimitsExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS WAF couldn’t perform the operation because your resource doesn’t
 // exist.
 type WAFNonexistentItemException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12362,7 +12362,7 @@ func (s WAFNonexistentItemException) GoString() string {
 
 func newErrorWAFNonexistentItemException(v protocol.ResponseMetadata) error {
 	return &WAFNonexistentItemException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12390,12 +12390,12 @@ func (s WAFNonexistentItemException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFNonexistentItemException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFNonexistentItemException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS WAF couldn’t save your changes because you tried to update or delete
@@ -12404,7 +12404,7 @@ func (s WAFNonexistentItemException) RequestID() string {
 // operation.
 type WAFOptimisticLockException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12421,7 +12421,7 @@ func (s WAFOptimisticLockException) GoString() string {
 
 func newErrorWAFOptimisticLockException(v protocol.ResponseMetadata) error {
 	return &WAFOptimisticLockException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12449,12 +12449,12 @@ func (s WAFOptimisticLockException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFOptimisticLockException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFOptimisticLockException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS WAF is not able to access the service linked role. This can be caused
@@ -12467,7 +12467,7 @@ func (s WAFOptimisticLockException) RequestID() string {
 // time until the role is unlocked.
 type WAFServiceLinkedRoleErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -12484,7 +12484,7 @@ func (s WAFServiceLinkedRoleErrorException) GoString() string {
 
 func newErrorWAFServiceLinkedRoleErrorException(v protocol.ResponseMetadata) error {
 	return &WAFServiceLinkedRoleErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12512,17 +12512,17 @@ func (s WAFServiceLinkedRoleErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFServiceLinkedRoleErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFServiceLinkedRoleErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type WAFSubscriptionNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12539,7 +12539,7 @@ func (s WAFSubscriptionNotFoundException) GoString() string {
 
 func newErrorWAFSubscriptionNotFoundException(v protocol.ResponseMetadata) error {
 	return &WAFSubscriptionNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12567,18 +12567,18 @@ func (s WAFSubscriptionNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFSubscriptionNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFSubscriptionNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An error occurred during the tagging operation. Retry your request.
 type WAFTagOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12595,7 +12595,7 @@ func (s WAFTagOperationException) GoString() string {
 
 func newErrorWAFTagOperationException(v protocol.ResponseMetadata) error {
 	return &WAFTagOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12623,19 +12623,19 @@ func (s WAFTagOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFTagOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFTagOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS WAF couldn’t perform your tagging operation because of an internal
 // error. Retry your request.
 type WAFTagOperationInternalErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12652,7 +12652,7 @@ func (s WAFTagOperationInternalErrorException) GoString() string {
 
 func newErrorWAFTagOperationInternalErrorException(v protocol.ResponseMetadata) error {
 	return &WAFTagOperationInternalErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12680,18 +12680,18 @@ func (s WAFTagOperationInternalErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFTagOperationInternalErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFTagOperationInternalErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // AWS WAF couldn’t retrieve the resource that you requested. Retry your request.
 type WAFUnavailableEntityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -12708,7 +12708,7 @@ func (s WAFUnavailableEntityException) GoString() string {
 
 func newErrorWAFUnavailableEntityException(v protocol.ResponseMetadata) error {
 	return &WAFUnavailableEntityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -12736,12 +12736,12 @@ func (s WAFUnavailableEntityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WAFUnavailableEntityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WAFUnavailableEntityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 //

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -4765,7 +4765,7 @@ func (s *CommentMetadata) SetRecipientId(v string) *CommentMetadata {
 // The resource hierarchy is changing.
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4782,7 +4782,7 @@ func (s ConcurrentModificationException) GoString() string {
 
 func newErrorConcurrentModificationException(v protocol.ResponseMetadata) error {
 	return &ConcurrentModificationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4810,19 +4810,19 @@ func (s ConcurrentModificationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConcurrentModificationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConcurrentModificationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Another operation is in progress on the resource that conflicts with the
 // current operation.
 type ConflictingOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4839,7 +4839,7 @@ func (s ConflictingOperationException) GoString() string {
 
 func newErrorConflictingOperationException(v protocol.ResponseMetadata) error {
 	return &ConflictingOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4867,12 +4867,12 @@ func (s ConflictingOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ConflictingOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ConflictingOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type CreateCommentInput struct {
@@ -5588,7 +5588,7 @@ func (s *CreateUserOutput) SetUser(v *User) *CreateUserOutput {
 // resource.
 type CustomMetadataLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5605,7 +5605,7 @@ func (s CustomMetadataLimitExceededException) GoString() string {
 
 func newErrorCustomMetadataLimitExceededException(v protocol.ResponseMetadata) error {
 	return &CustomMetadataLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5633,12 +5633,12 @@ func (s CustomMetadataLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s CustomMetadataLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s CustomMetadataLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeactivateUserInput struct {
@@ -5712,7 +5712,7 @@ func (s DeactivateUserOutput) GoString() string {
 // The last user in the organization is being deactivated.
 type DeactivatingLastSystemUserException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -5729,7 +5729,7 @@ func (s DeactivatingLastSystemUserException) GoString() string {
 
 func newErrorDeactivatingLastSystemUserException(v protocol.ResponseMetadata) error {
 	return &DeactivatingLastSystemUserException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5757,12 +5757,12 @@ func (s DeactivatingLastSystemUserException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DeactivatingLastSystemUserException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DeactivatingLastSystemUserException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DeleteCommentInput struct {
@@ -7632,7 +7632,7 @@ func (s *DescribeUsersOutput) SetUsers(v []*User) *DescribeUsersOutput {
 // tries to create or delete a comment on that document.
 type DocumentLockedForCommentsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7649,7 +7649,7 @@ func (s DocumentLockedForCommentsException) GoString() string {
 
 func newErrorDocumentLockedForCommentsException(v protocol.ResponseMetadata) error {
 	return &DocumentLockedForCommentsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7677,12 +7677,12 @@ func (s DocumentLockedForCommentsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DocumentLockedForCommentsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DocumentLockedForCommentsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the document.
@@ -7908,7 +7908,7 @@ func (s *DocumentVersionMetadata) SetThumbnail(v map[string]*string) *DocumentVe
 // version upload calls for a document that has been checked out from Web client.
 type DraftUploadOutOfSyncException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7925,7 +7925,7 @@ func (s DraftUploadOutOfSyncException) GoString() string {
 
 func newErrorDraftUploadOutOfSyncException(v protocol.ResponseMetadata) error {
 	return &DraftUploadOutOfSyncException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7953,18 +7953,18 @@ func (s DraftUploadOutOfSyncException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DraftUploadOutOfSyncException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DraftUploadOutOfSyncException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource already exists.
 type EntityAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7981,7 +7981,7 @@ func (s EntityAlreadyExistsException) GoString() string {
 
 func newErrorEntityAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &EntityAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8009,18 +8009,18 @@ func (s EntityAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EntityAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EntityAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource does not exist.
 type EntityNotExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	EntityIds []*string `type:"list"`
 
@@ -8039,7 +8039,7 @@ func (s EntityNotExistsException) GoString() string {
 
 func newErrorEntityNotExistsException(v protocol.ResponseMetadata) error {
 	return &EntityNotExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8067,12 +8067,12 @@ func (s EntityNotExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EntityNotExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EntityNotExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The AWS Directory Service cannot reach an on-premises instance. Or a dependency
@@ -8080,7 +8080,7 @@ func (s EntityNotExistsException) RequestID() string {
 // Directory.
 type FailedDependencyException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8097,7 +8097,7 @@ func (s FailedDependencyException) GoString() string {
 
 func newErrorFailedDependencyException(v protocol.ResponseMetadata) error {
 	return &FailedDependencyException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8125,12 +8125,12 @@ func (s FailedDependencyException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s FailedDependencyException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s FailedDependencyException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a folder.
@@ -9016,7 +9016,7 @@ func (s *GroupMetadata) SetName(v string) *GroupMetadata {
 // The user is undergoing transfer of ownership.
 type IllegalUserStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9033,7 +9033,7 @@ func (s IllegalUserStateException) GoString() string {
 
 func newErrorIllegalUserStateException(v protocol.ResponseMetadata) error {
 	return &IllegalUserStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9061,12 +9061,12 @@ func (s IllegalUserStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s IllegalUserStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s IllegalUserStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type InitiateDocumentVersionUploadInput struct {
@@ -9221,7 +9221,7 @@ func (s *InitiateDocumentVersionUploadOutput) SetUploadMetadata(v *UploadMetadat
 // The pagination marker or limit fields are not valid.
 type InvalidArgumentException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9238,7 +9238,7 @@ func (s InvalidArgumentException) GoString() string {
 
 func newErrorInvalidArgumentException(v protocol.ResponseMetadata) error {
 	return &InvalidArgumentException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9266,18 +9266,18 @@ func (s InvalidArgumentException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidArgumentException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidArgumentException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested operation is not allowed on the specified comment object.
 type InvalidCommentOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9294,7 +9294,7 @@ func (s InvalidCommentOperationException) GoString() string {
 
 func newErrorInvalidCommentOperationException(v protocol.ResponseMetadata) error {
 	return &InvalidCommentOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9322,18 +9322,18 @@ func (s InvalidCommentOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidCommentOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidCommentOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation is invalid.
 type InvalidOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9350,7 +9350,7 @@ func (s InvalidOperationException) GoString() string {
 
 func newErrorInvalidOperationException(v protocol.ResponseMetadata) error {
 	return &InvalidOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9378,18 +9378,18 @@ func (s InvalidOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The password is invalid.
 type InvalidPasswordException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9406,7 +9406,7 @@ func (s InvalidPasswordException) GoString() string {
 
 func newErrorInvalidPasswordException(v protocol.ResponseMetadata) error {
 	return &InvalidPasswordException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9434,18 +9434,18 @@ func (s InvalidPasswordException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPasswordException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPasswordException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The maximum of 100,000 folders under the parent folder has been exceeded.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9462,7 +9462,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9490,12 +9490,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Set of options which defines notification preferences of given action.
@@ -9642,7 +9642,7 @@ func (s *Principal) SetType(v string) *Principal {
 // The specified document version is not in the INITIALIZED state.
 type ProhibitedStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9659,7 +9659,7 @@ func (s ProhibitedStateException) GoString() string {
 
 func newErrorProhibitedStateException(v protocol.ResponseMetadata) error {
 	return &ProhibitedStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9687,12 +9687,12 @@ func (s ProhibitedStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ProhibitedStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ProhibitedStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RemoveAllResourcePermissionsInput struct {
@@ -9861,7 +9861,7 @@ func (s RemoveResourcePermissionOutput) GoString() string {
 // reduce the size of the response.
 type RequestedEntityTooLargeException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9878,7 +9878,7 @@ func (s RequestedEntityTooLargeException) GoString() string {
 
 func newErrorRequestedEntityTooLargeException(v protocol.ResponseMetadata) error {
 	return &RequestedEntityTooLargeException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9906,18 +9906,18 @@ func (s RequestedEntityTooLargeException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RequestedEntityTooLargeException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RequestedEntityTooLargeException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource is already checked out.
 type ResourceAlreadyCheckedOutException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9934,7 +9934,7 @@ func (s ResourceAlreadyCheckedOutException) GoString() string {
 
 func newErrorResourceAlreadyCheckedOutException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyCheckedOutException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9962,12 +9962,12 @@ func (s ResourceAlreadyCheckedOutException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyCheckedOutException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyCheckedOutException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the metadata of a resource.
@@ -10109,7 +10109,7 @@ func (s *ResourcePathComponent) SetName(v string) *ResourcePathComponent {
 // One or more of the dependencies is unavailable.
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10126,7 +10126,7 @@ func (s ServiceUnavailableException) GoString() string {
 
 func newErrorServiceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ServiceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10154,12 +10154,12 @@ func (s ServiceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ServiceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ServiceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the recipient type and ID, if available.
@@ -10304,7 +10304,7 @@ func (s *ShareResult) SetStatusMessage(v string) *ShareResult {
 // The storage limit has been exceeded.
 type StorageLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10321,7 +10321,7 @@ func (s StorageLimitExceededException) GoString() string {
 
 func newErrorStorageLimitExceededException(v protocol.ResponseMetadata) error {
 	return &StorageLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10349,18 +10349,18 @@ func (s StorageLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StorageLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StorageLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The storage limit will be exceeded.
 type StorageLimitWillExceedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10377,7 +10377,7 @@ func (s StorageLimitWillExceedException) GoString() string {
 
 func newErrorStorageLimitWillExceedException(v protocol.ResponseMetadata) error {
 	return &StorageLimitWillExceedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10405,12 +10405,12 @@ func (s StorageLimitWillExceedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s StorageLimitWillExceedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s StorageLimitWillExceedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the storage for a user.
@@ -10491,7 +10491,7 @@ func (s *Subscription) SetSubscriptionId(v string) *Subscription {
 // The limit has been reached on the number of labels for the specified resource.
 type TooManyLabelsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10508,7 +10508,7 @@ func (s TooManyLabelsException) GoString() string {
 
 func newErrorTooManyLabelsException(v protocol.ResponseMetadata) error {
 	return &TooManyLabelsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10536,19 +10536,19 @@ func (s TooManyLabelsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyLabelsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyLabelsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You've reached the limit on the number of subscriptions for the WorkDocs
 // instance.
 type TooManySubscriptionsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10565,7 +10565,7 @@ func (s TooManySubscriptionsException) GoString() string {
 
 func newErrorTooManySubscriptionsException(v protocol.ResponseMetadata) error {
 	return &TooManySubscriptionsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10593,18 +10593,18 @@ func (s TooManySubscriptionsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManySubscriptionsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManySubscriptionsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The operation is not permitted.
 type UnauthorizedOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10621,7 +10621,7 @@ func (s UnauthorizedOperationException) GoString() string {
 
 func newErrorUnauthorizedOperationException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10649,18 +10649,18 @@ func (s UnauthorizedOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The caller does not have access to perform the action on the resource.
 type UnauthorizedResourceAccessException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10677,7 +10677,7 @@ func (s UnauthorizedResourceAccessException) GoString() string {
 
 func newErrorUnauthorizedResourceAccessException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedResourceAccessException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -10705,12 +10705,12 @@ func (s UnauthorizedResourceAccessException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedResourceAccessException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedResourceAccessException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateDocumentInput struct {

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -4764,8 +4764,8 @@ func (s *CommentMetadata) SetRecipientId(v string) *CommentMetadata {
 
 // The resource hierarchy is changing.
 type ConcurrentModificationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4821,8 +4821,8 @@ func (s ConcurrentModificationException) RequestID() string {
 // Another operation is in progress on the resource that conflicts with the
 // current operation.
 type ConflictingOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5587,8 +5587,8 @@ func (s *CreateUserOutput) SetUser(v *User) *CreateUserOutput {
 // The limit has been reached on the number of custom properties for the specified
 // resource.
 type CustomMetadataLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5711,8 +5711,8 @@ func (s DeactivateUserOutput) GoString() string {
 
 // The last user in the organization is being deactivated.
 type DeactivatingLastSystemUserException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7631,8 +7631,8 @@ func (s *DescribeUsersOutput) SetUsers(v []*User) *DescribeUsersOutput {
 // This exception is thrown when the document is locked for comments and user
 // tries to create or delete a comment on that document.
 type DocumentLockedForCommentsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7907,8 +7907,8 @@ func (s *DocumentVersionMetadata) SetThumbnail(v map[string]*string) *DocumentVe
 // This exception is thrown when a valid checkout ID is not presented on document
 // version upload calls for a document that has been checked out from Web client.
 type DraftUploadOutOfSyncException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7963,8 +7963,8 @@ func (s DraftUploadOutOfSyncException) RequestID() string {
 
 // The resource already exists.
 type EntityAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8019,8 +8019,8 @@ func (s EntityAlreadyExistsException) RequestID() string {
 
 // The resource does not exist.
 type EntityNotExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	EntityIds []*string `type:"list"`
 
@@ -8079,8 +8079,8 @@ func (s EntityNotExistsException) RequestID() string {
 // under the control of the organization is failing, such as a connected Active
 // Directory.
 type FailedDependencyException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9015,8 +9015,8 @@ func (s *GroupMetadata) SetName(v string) *GroupMetadata {
 
 // The user is undergoing transfer of ownership.
 type IllegalUserStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9220,8 +9220,8 @@ func (s *InitiateDocumentVersionUploadOutput) SetUploadMetadata(v *UploadMetadat
 
 // The pagination marker or limit fields are not valid.
 type InvalidArgumentException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9276,8 +9276,8 @@ func (s InvalidArgumentException) RequestID() string {
 
 // The requested operation is not allowed on the specified comment object.
 type InvalidCommentOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9332,8 +9332,8 @@ func (s InvalidCommentOperationException) RequestID() string {
 
 // The operation is invalid.
 type InvalidOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9388,8 +9388,8 @@ func (s InvalidOperationException) RequestID() string {
 
 // The password is invalid.
 type InvalidPasswordException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9444,8 +9444,8 @@ func (s InvalidPasswordException) RequestID() string {
 
 // The maximum of 100,000 folders under the parent folder has been exceeded.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9641,8 +9641,8 @@ func (s *Principal) SetType(v string) *Principal {
 
 // The specified document version is not in the INITIALIZED state.
 type ProhibitedStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9860,8 +9860,8 @@ func (s RemoveResourcePermissionOutput) GoString() string {
 // The response is too large to return. The request must include a filter to
 // reduce the size of the response.
 type RequestedEntityTooLargeException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9916,8 +9916,8 @@ func (s RequestedEntityTooLargeException) RequestID() string {
 
 // The resource is already checked out.
 type ResourceAlreadyCheckedOutException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10108,8 +10108,8 @@ func (s *ResourcePathComponent) SetName(v string) *ResourcePathComponent {
 
 // One or more of the dependencies is unavailable.
 type ServiceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10303,8 +10303,8 @@ func (s *ShareResult) SetStatusMessage(v string) *ShareResult {
 
 // The storage limit has been exceeded.
 type StorageLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10359,8 +10359,8 @@ func (s StorageLimitExceededException) RequestID() string {
 
 // The storage limit will be exceeded.
 type StorageLimitWillExceedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10490,8 +10490,8 @@ func (s *Subscription) SetSubscriptionId(v string) *Subscription {
 
 // The limit has been reached on the number of labels for the specified resource.
 type TooManyLabelsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10547,8 +10547,8 @@ func (s TooManyLabelsException) RequestID() string {
 // You've reached the limit on the number of subscriptions for the WorkDocs
 // instance.
 type TooManySubscriptionsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -10603,8 +10603,8 @@ func (s TooManySubscriptionsException) RequestID() string {
 
 // The operation is not permitted.
 type UnauthorizedOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -10659,8 +10659,8 @@ func (s UnauthorizedOperationException) RequestID() string {
 
 // The caller does not have access to perform the action on the resource.
 type UnauthorizedResourceAccessException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/worklink/api.go
+++ b/service/worklink/api.go
@@ -4647,8 +4647,8 @@ func (s *FleetSummary) SetLastUpdatedTime(v time.Time) *FleetSummary {
 
 // The service is temporarily unavailable.
 type InternalServerErrorException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4703,8 +4703,8 @@ func (s InternalServerErrorException) RequestID() string {
 
 // The request is not valid.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5237,8 +5237,8 @@ func (s *ListWebsiteCertificateAuthoritiesOutput) SetWebsiteCertificateAuthoriti
 
 // The resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5293,8 +5293,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The requested resource was not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5565,8 +5565,8 @@ func (s SignOutUserOutput) GoString() string {
 
 // The number of requests exceeds the limit.
 type TooManyRequestsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5621,8 +5621,8 @@ func (s TooManyRequestsException) RequestID() string {
 
 // You are not authorized to perform this action.
 type UnauthorizedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/worklink/api.go
+++ b/service/worklink/api.go
@@ -4648,7 +4648,7 @@ func (s *FleetSummary) SetLastUpdatedTime(v time.Time) *FleetSummary {
 // The service is temporarily unavailable.
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4665,7 +4665,7 @@ func (s InternalServerErrorException) GoString() string {
 
 func newErrorInternalServerErrorException(v protocol.ResponseMetadata) error {
 	return &InternalServerErrorException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4693,18 +4693,18 @@ func (s InternalServerErrorException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InternalServerErrorException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InternalServerErrorException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request is not valid.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4721,7 +4721,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4749,12 +4749,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListDevicesInput struct {
@@ -5238,7 +5238,7 @@ func (s *ListWebsiteCertificateAuthoritiesOutput) SetWebsiteCertificateAuthoriti
 // The resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5255,7 +5255,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5283,18 +5283,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The requested resource was not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5311,7 +5311,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5339,12 +5339,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RestoreDomainAccessInput struct {
@@ -5566,7 +5566,7 @@ func (s SignOutUserOutput) GoString() string {
 // The number of requests exceeds the limit.
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5583,7 +5583,7 @@ func (s TooManyRequestsException) GoString() string {
 
 func newErrorTooManyRequestsException(v protocol.ResponseMetadata) error {
 	return &TooManyRequestsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5611,18 +5611,18 @@ func (s TooManyRequestsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyRequestsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyRequestsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You are not authorized to perform this action.
 type UnauthorizedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5639,7 +5639,7 @@ func (s UnauthorizedException) GoString() string {
 
 func newErrorUnauthorizedException(v protocol.ResponseMetadata) error {
 	return &UnauthorizedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5667,12 +5667,12 @@ func (s UnauthorizedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnauthorizedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnauthorizedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateAuditStreamConfigurationInput struct {

--- a/service/workmail/api.go
+++ b/service/workmail/api.go
@@ -6133,7 +6133,7 @@ func (s *DescribeUserOutput) SetUserRole(v string) *DescribeUserOutput {
 // The directory service doesn't recognize the credentials supplied by WorkMail.
 type DirectoryServiceAuthenticationFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6150,7 +6150,7 @@ func (s DirectoryServiceAuthenticationFailedException) GoString() string {
 
 func newErrorDirectoryServiceAuthenticationFailedException(v protocol.ResponseMetadata) error {
 	return &DirectoryServiceAuthenticationFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6178,18 +6178,18 @@ func (s DirectoryServiceAuthenticationFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryServiceAuthenticationFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryServiceAuthenticationFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The directory on which you are trying to perform operations isn't available.
 type DirectoryUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6206,7 +6206,7 @@ func (s DirectoryUnavailableException) GoString() string {
 
 func newErrorDirectoryUnavailableException(v protocol.ResponseMetadata) error {
 	return &DirectoryUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6234,12 +6234,12 @@ func (s DirectoryUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s DirectoryUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s DirectoryUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type DisassociateDelegateFromResourceInput struct {
@@ -6416,7 +6416,7 @@ func (s DisassociateMemberFromGroupOutput) GoString() string {
 // user, group, or resource.
 type EmailAddressInUseException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6433,7 +6433,7 @@ func (s EmailAddressInUseException) GoString() string {
 
 func newErrorEmailAddressInUseException(v protocol.ResponseMetadata) error {
 	return &EmailAddressInUseException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6461,18 +6461,18 @@ func (s EmailAddressInUseException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EmailAddressInUseException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EmailAddressInUseException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The user, group, or resource that you're trying to register is already registered.
 type EntityAlreadyRegisteredException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6489,7 +6489,7 @@ func (s EntityAlreadyRegisteredException) GoString() string {
 
 func newErrorEntityAlreadyRegisteredException(v protocol.ResponseMetadata) error {
 	return &EntityAlreadyRegisteredException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6517,19 +6517,19 @@ func (s EntityAlreadyRegisteredException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EntityAlreadyRegisteredException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EntityAlreadyRegisteredException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The identifier supplied for the user, group, or resource does not exist in
 // your organization.
 type EntityNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6546,7 +6546,7 @@ func (s EntityNotFoundException) GoString() string {
 
 func newErrorEntityNotFoundException(v protocol.ResponseMetadata) error {
 	return &EntityNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6574,19 +6574,19 @@ func (s EntityNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EntityNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EntityNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You are performing an operation on a user, group, or resource that isn't
 // in the expected state, such as trying to delete an active user.
 type EntityStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6603,7 +6603,7 @@ func (s EntityStateException) GoString() string {
 
 func newErrorEntityStateException(v protocol.ResponseMetadata) error {
 	return &EntityStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6631,12 +6631,12 @@ func (s EntityStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s EntityStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s EntityStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type GetAccessControlEffectInput struct {
@@ -6923,7 +6923,7 @@ func (s *Group) SetState(v string) *Group {
 // can do so on its behalf.
 type InvalidConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6940,7 +6940,7 @@ func (s InvalidConfigurationException) GoString() string {
 
 func newErrorInvalidConfigurationException(v protocol.ResponseMetadata) error {
 	return &InvalidConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6968,18 +6968,18 @@ func (s InvalidConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // One or more of the input parameters don't match the service's restrictions.
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6996,7 +6996,7 @@ func (s InvalidParameterException) GoString() string {
 
 func newErrorInvalidParameterException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7024,19 +7024,19 @@ func (s InvalidParameterException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The supplied password doesn't match the minimum security constraints, such
 // as length or use of special characters.
 type InvalidPasswordException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7053,7 +7053,7 @@ func (s InvalidPasswordException) GoString() string {
 
 func newErrorInvalidPasswordException(v protocol.ResponseMetadata) error {
 	return &InvalidPasswordException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7081,18 +7081,18 @@ func (s InvalidPasswordException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidPasswordException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidPasswordException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The request exceeds the limit of the resource.
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7109,7 +7109,7 @@ func (s LimitExceededException) GoString() string {
 
 func newErrorLimitExceededException(v protocol.ResponseMetadata) error {
 	return &LimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7137,12 +7137,12 @@ func (s LimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s LimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s LimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ListAccessControlRulesInput struct {
@@ -8100,7 +8100,7 @@ func (s *ListUsersOutput) SetUsers(v []*User) *ListUsersOutput {
 // must be defined in the organization.
 type MailDomainNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8117,7 +8117,7 @@ func (s MailDomainNotFoundException) GoString() string {
 
 func newErrorMailDomainNotFoundException(v protocol.ResponseMetadata) error {
 	return &MailDomainNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8145,19 +8145,19 @@ func (s MailDomainNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MailDomainNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MailDomainNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // After a domain has been added to the organization, it must be verified. The
 // domain is not yet verified.
 type MailDomainStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8174,7 +8174,7 @@ func (s MailDomainStateException) GoString() string {
 
 func newErrorMailDomainStateException(v protocol.ResponseMetadata) error {
 	return &MailDomainStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8202,12 +8202,12 @@ func (s MailDomainStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s MailDomainStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s MailDomainStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The representation of a user or group.
@@ -8282,7 +8282,7 @@ func (s *Member) SetType(v string) *Member {
 // The user, group, or resource name isn't unique in Amazon WorkMail.
 type NameAvailabilityException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8299,7 +8299,7 @@ func (s NameAvailabilityException) GoString() string {
 
 func newErrorNameAvailabilityException(v protocol.ResponseMetadata) error {
 	return &NameAvailabilityException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8327,19 +8327,19 @@ func (s NameAvailabilityException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s NameAvailabilityException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s NameAvailabilityException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // An operation received a valid organization identifier that either doesn't
 // belong or exist in the system.
 type OrganizationNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8356,7 +8356,7 @@ func (s OrganizationNotFoundException) GoString() string {
 
 func newErrorOrganizationNotFoundException(v protocol.ResponseMetadata) error {
 	return &OrganizationNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8384,19 +8384,19 @@ func (s OrganizationNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The organization must have a valid state (Active or Synchronizing) to perform
 // certain operations on the organization or its members.
 type OrganizationStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8413,7 +8413,7 @@ func (s OrganizationStateException) GoString() string {
 
 func newErrorOrganizationStateException(v protocol.ResponseMetadata) error {
 	return &OrganizationStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8441,12 +8441,12 @@ func (s OrganizationStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OrganizationStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OrganizationStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The representation of an organization.
@@ -8907,7 +8907,7 @@ func (s RegisterToWorkMailOutput) GoString() string {
 // This user, group, or resource name is not allowed in Amazon WorkMail.
 type ReservedNameException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8924,7 +8924,7 @@ func (s ReservedNameException) GoString() string {
 
 func newErrorReservedNameException(v protocol.ResponseMetadata) error {
 	return &ReservedNameException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8952,12 +8952,12 @@ func (s ReservedNameException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ReservedNameException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ReservedNameException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type ResetPasswordInput struct {
@@ -9125,7 +9125,7 @@ func (s *Resource) SetType(v string) *Resource {
 // The resource cannot be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9142,7 +9142,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9170,12 +9170,12 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a tag applied to a resource.
@@ -9316,7 +9316,7 @@ func (s TagResourceOutput) GoString() string {
 // The resource can have up to 50 user-applied tags.
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9333,7 +9333,7 @@ func (s TooManyTagsException) GoString() string {
 
 func newErrorTooManyTagsException(v protocol.ResponseMetadata) error {
 	return &TooManyTagsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9361,18 +9361,18 @@ func (s TooManyTagsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s TooManyTagsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s TooManyTagsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // You can't perform a write operation against a read-only directory.
 type UnsupportedOperationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9389,7 +9389,7 @@ func (s UnsupportedOperationException) GoString() string {
 
 func newErrorUnsupportedOperationException(v protocol.ResponseMetadata) error {
 	return &UnsupportedOperationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9417,12 +9417,12 @@ func (s UnsupportedOperationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedOperationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedOperationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UntagResourceInput struct {

--- a/service/workmail/api.go
+++ b/service/workmail/api.go
@@ -6132,8 +6132,8 @@ func (s *DescribeUserOutput) SetUserRole(v string) *DescribeUserOutput {
 
 // The directory service doesn't recognize the credentials supplied by WorkMail.
 type DirectoryServiceAuthenticationFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6188,8 +6188,8 @@ func (s DirectoryServiceAuthenticationFailedException) RequestID() string {
 
 // The directory on which you are trying to perform operations isn't available.
 type DirectoryUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6415,8 +6415,8 @@ func (s DisassociateMemberFromGroupOutput) GoString() string {
 // The email address that you're trying to assign is already created for a different
 // user, group, or resource.
 type EmailAddressInUseException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6471,8 +6471,8 @@ func (s EmailAddressInUseException) RequestID() string {
 
 // The user, group, or resource that you're trying to register is already registered.
 type EntityAlreadyRegisteredException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6528,8 +6528,8 @@ func (s EntityAlreadyRegisteredException) RequestID() string {
 // The identifier supplied for the user, group, or resource does not exist in
 // your organization.
 type EntityNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6585,8 +6585,8 @@ func (s EntityNotFoundException) RequestID() string {
 // You are performing an operation on a user, group, or resource that isn't
 // in the expected state, such as trying to delete an active user.
 type EntityStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6922,8 +6922,8 @@ func (s *Group) SetState(v string) *Group {
 // to auto-respond to requests or have at least one delegate associated that
 // can do so on its behalf.
 type InvalidConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -6978,8 +6978,8 @@ func (s InvalidConfigurationException) RequestID() string {
 
 // One or more of the input parameters don't match the service's restrictions.
 type InvalidParameterException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7035,8 +7035,8 @@ func (s InvalidParameterException) RequestID() string {
 // The supplied password doesn't match the minimum security constraints, such
 // as length or use of special characters.
 type InvalidPasswordException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -7091,8 +7091,8 @@ func (s InvalidPasswordException) RequestID() string {
 
 // The request exceeds the limit of the resource.
 type LimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8099,8 +8099,8 @@ func (s *ListUsersOutput) SetUsers(v []*User) *ListUsersOutput {
 // For an email or alias to be created in Amazon WorkMail, the included domain
 // must be defined in the organization.
 type MailDomainNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8156,8 +8156,8 @@ func (s MailDomainNotFoundException) RequestID() string {
 // After a domain has been added to the organization, it must be verified. The
 // domain is not yet verified.
 type MailDomainStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8281,8 +8281,8 @@ func (s *Member) SetType(v string) *Member {
 
 // The user, group, or resource name isn't unique in Amazon WorkMail.
 type NameAvailabilityException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8338,8 +8338,8 @@ func (s NameAvailabilityException) RequestID() string {
 // An operation received a valid organization identifier that either doesn't
 // belong or exist in the system.
 type OrganizationNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8395,8 +8395,8 @@ func (s OrganizationNotFoundException) RequestID() string {
 // The organization must have a valid state (Active or Synchronizing) to perform
 // certain operations on the organization or its members.
 type OrganizationStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -8906,8 +8906,8 @@ func (s RegisterToWorkMailOutput) GoString() string {
 
 // This user, group, or resource name is not allowed in Amazon WorkMail.
 type ReservedNameException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9124,8 +9124,8 @@ func (s *Resource) SetType(v string) *Resource {
 
 // The resource cannot be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9315,8 +9315,8 @@ func (s TagResourceOutput) GoString() string {
 
 // The resource can have up to 50 user-applied tags.
 type TooManyTagsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -9371,8 +9371,8 @@ func (s TooManyTagsException) RequestID() string {
 
 // You can't perform a write operation against a read-only directory.
 type UnsupportedOperationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }

--- a/service/workmailmessageflow/api.go
+++ b/service/workmailmessageflow/api.go
@@ -160,7 +160,7 @@ func (s *GetRawMessageContentOutput) SetMessageContent(v io.ReadCloser) *GetRawM
 // The requested email message is not found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -177,7 +177,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -205,10 +205,10 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }

--- a/service/workmailmessageflow/api.go
+++ b/service/workmailmessageflow/api.go
@@ -159,8 +159,8 @@ func (s *GetRawMessageContentOutput) SetMessageContent(v io.ReadCloser) *GetRawM
 
 // The requested email message is not found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -3797,7 +3797,7 @@ func (c *WorkSpaces) UpdateRulesOfIpGroupWithContext(ctx aws.Context, input *Upd
 // The user is not authorized to access a resource.
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -3814,7 +3814,7 @@ func (s AccessDeniedException) GoString() string {
 
 func newErrorAccessDeniedException(v protocol.ResponseMetadata) error {
 	return &AccessDeniedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -3842,12 +3842,12 @@ func (s AccessDeniedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s AccessDeniedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s AccessDeniedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes a modification to the configuration of Bring Your Own License (BYOL)
@@ -6056,7 +6056,7 @@ func (s *ImportWorkspaceImageOutput) SetImageId(v string) *ImportWorkspaceImageO
 // One or more parameter values are not valid.
 type InvalidParameterValuesException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6074,7 +6074,7 @@ func (s InvalidParameterValuesException) GoString() string {
 
 func newErrorInvalidParameterValuesException(v protocol.ResponseMetadata) error {
 	return &InvalidParameterValuesException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6102,18 +6102,18 @@ func (s InvalidParameterValuesException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidParameterValuesException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidParameterValuesException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The state of the resource is not valid for this operation.
 type InvalidResourceStateException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6130,7 +6130,7 @@ func (s InvalidResourceStateException) GoString() string {
 
 func newErrorInvalidResourceStateException(v protocol.ResponseMetadata) error {
 	return &InvalidResourceStateException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -6158,12 +6158,12 @@ func (s InvalidResourceStateException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidResourceStateException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidResourceStateException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes an IP access control group.
@@ -6959,7 +6959,7 @@ func (s *OperatingSystem) SetType(v string) *OperatingSystem {
 // in a moment.
 type OperationInProgressException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6976,7 +6976,7 @@ func (s OperationInProgressException) GoString() string {
 
 func newErrorOperationInProgressException(v protocol.ResponseMetadata) error {
 	return &OperationInProgressException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7004,18 +7004,18 @@ func (s OperationInProgressException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationInProgressException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationInProgressException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // This operation is not supported.
 type OperationNotSupportedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7032,7 +7032,7 @@ func (s OperationNotSupportedException) GoString() string {
 
 func newErrorOperationNotSupportedException(v protocol.ResponseMetadata) error {
 	return &OperationNotSupportedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7060,12 +7060,12 @@ func (s OperationNotSupportedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s OperationNotSupportedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s OperationNotSupportedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Describes the information used to reboot a WorkSpace.
@@ -7428,7 +7428,7 @@ func (s RegisterWorkspaceDirectoryOutput) GoString() string {
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7445,7 +7445,7 @@ func (s ResourceAlreadyExistsException) GoString() string {
 
 func newErrorResourceAlreadyExistsException(v protocol.ResponseMetadata) error {
 	return &ResourceAlreadyExistsException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7473,18 +7473,18 @@ func (s ResourceAlreadyExistsException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAlreadyExistsException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAlreadyExistsException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource is associated with a directory.
 type ResourceAssociatedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7501,7 +7501,7 @@ func (s ResourceAssociatedException) GoString() string {
 
 func newErrorResourceAssociatedException(v protocol.ResponseMetadata) error {
 	return &ResourceAssociatedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7529,18 +7529,18 @@ func (s ResourceAssociatedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceAssociatedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceAssociatedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource could not be created.
 type ResourceCreationFailedException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7557,7 +7557,7 @@ func (s ResourceCreationFailedException) GoString() string {
 
 func newErrorResourceCreationFailedException(v protocol.ResponseMetadata) error {
 	return &ResourceCreationFailedException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7585,18 +7585,18 @@ func (s ResourceCreationFailedException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceCreationFailedException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceCreationFailedException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // Your resource limits have been exceeded.
 type ResourceLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7614,7 +7614,7 @@ func (s ResourceLimitExceededException) GoString() string {
 
 func newErrorResourceLimitExceededException(v protocol.ResponseMetadata) error {
 	return &ResourceLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7642,18 +7642,18 @@ func (s ResourceLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The resource could not be found.
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The resource could not be found.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7674,7 +7674,7 @@ func (s ResourceNotFoundException) GoString() string {
 
 func newErrorResourceNotFoundException(v protocol.ResponseMetadata) error {
 	return &ResourceNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7702,18 +7702,18 @@ func (s ResourceNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The specified resource is not available.
 type ResourceUnavailableException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	// The exception error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7734,7 +7734,7 @@ func (s ResourceUnavailableException) GoString() string {
 
 func newErrorResourceUnavailableException(v protocol.ResponseMetadata) error {
 	return &ResourceUnavailableException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -7762,12 +7762,12 @@ func (s ResourceUnavailableException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ResourceUnavailableException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ResourceUnavailableException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type RestoreWorkspaceInput struct {
@@ -8346,7 +8346,7 @@ func (s *TerminateWorkspacesOutput) SetFailedRequests(v []*FailedWorkspaceChange
 // (https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html).
 type UnsupportedNetworkConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8363,7 +8363,7 @@ func (s UnsupportedNetworkConfigurationException) GoString() string {
 
 func newErrorUnsupportedNetworkConfigurationException(v protocol.ResponseMetadata) error {
 	return &UnsupportedNetworkConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8391,12 +8391,12 @@ func (s UnsupportedNetworkConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedNetworkConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedNetworkConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // The configuration of this WorkSpace is not supported for this operation.
@@ -8404,7 +8404,7 @@ func (s UnsupportedNetworkConfigurationException) RequestID() string {
 // WorkSpaces (https://docs.aws.amazon.com/workspaces/latest/adminguide/required-service-components.html).
 type UnsupportedWorkspaceConfigurationException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8421,7 +8421,7 @@ func (s UnsupportedWorkspaceConfigurationException) GoString() string {
 
 func newErrorUnsupportedWorkspaceConfigurationException(v protocol.ResponseMetadata) error {
 	return &UnsupportedWorkspaceConfigurationException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -8449,12 +8449,12 @@ func (s UnsupportedWorkspaceConfigurationException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s UnsupportedWorkspaceConfigurationException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s UnsupportedWorkspaceConfigurationException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type UpdateRulesOfIpGroupInput struct {
@@ -9460,7 +9460,7 @@ func (s *WorkspaceRequest) SetWorkspaceProperties(v *WorkspaceProperties) *Works
 // the workspaces_DefaultRole Role (https://docs.aws.amazon.com/workspaces/latest/adminguide/workspaces-access-control.html#create-default-role).
 type WorkspacesDefaultRoleNotFoundException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9477,7 +9477,7 @@ func (s WorkspacesDefaultRoleNotFoundException) GoString() string {
 
 func newErrorWorkspacesDefaultRoleNotFoundException(v protocol.ResponseMetadata) error {
 	return &WorkspacesDefaultRoleNotFoundException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -9505,12 +9505,12 @@ func (s WorkspacesDefaultRoleNotFoundException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s WorkspacesDefaultRoleNotFoundException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s WorkspacesDefaultRoleNotFoundException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 const (

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -3796,8 +3796,8 @@ func (c *WorkSpaces) UpdateRulesOfIpGroupWithContext(ctx aws.Context, input *Upd
 
 // The user is not authorized to access a resource.
 type AccessDeniedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6055,8 +6055,8 @@ func (s *ImportWorkspaceImageOutput) SetImageId(v string) *ImportWorkspaceImageO
 
 // One or more parameter values are not valid.
 type InvalidParameterValuesException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -6112,8 +6112,8 @@ func (s InvalidParameterValuesException) RequestID() string {
 
 // The state of the resource is not valid for this operation.
 type InvalidResourceStateException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -6958,8 +6958,8 @@ func (s *OperatingSystem) SetType(v string) *OperatingSystem {
 // The properties of this WorkSpace are currently being modified. Try again
 // in a moment.
 type OperationInProgressException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7014,8 +7014,8 @@ func (s OperationInProgressException) RequestID() string {
 
 // This operation is not supported.
 type OperationNotSupportedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7427,8 +7427,8 @@ func (s RegisterWorkspaceDirectoryOutput) GoString() string {
 
 // The specified resource already exists.
 type ResourceAlreadyExistsException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7483,8 +7483,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 
 // The resource is associated with a directory.
 type ResourceAssociatedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7539,8 +7539,8 @@ func (s ResourceAssociatedException) RequestID() string {
 
 // The resource could not be created.
 type ResourceCreationFailedException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -7595,8 +7595,8 @@ func (s ResourceCreationFailedException) RequestID() string {
 
 // Your resource limits have been exceeded.
 type ResourceLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7652,8 +7652,8 @@ func (s ResourceLimitExceededException) RequestID() string {
 
 // The resource could not be found.
 type ResourceNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The resource could not be found.
 	Message_ *string `locationName:"message" type:"string"`
@@ -7712,8 +7712,8 @@ func (s ResourceNotFoundException) RequestID() string {
 
 // The specified resource is not available.
 type ResourceUnavailableException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	// The exception error message.
 	Message_ *string `locationName:"message" type:"string"`
@@ -8345,8 +8345,8 @@ func (s *TerminateWorkspacesOutput) SetFailedRequests(v []*FailedWorkspaceChange
 // network IP range. For more information, see Configure a VPC for Amazon WorkSpaces
 // (https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html).
 type UnsupportedNetworkConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -8403,8 +8403,8 @@ func (s UnsupportedNetworkConfigurationException) RequestID() string {
 // For more information, see Required Configuration and Service Components for
 // WorkSpaces (https://docs.aws.amazon.com/workspaces/latest/adminguide/required-service-components.html).
 type UnsupportedWorkspaceConfigurationException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }
@@ -9459,8 +9459,8 @@ func (s *WorkspaceRequest) SetWorkspaceProperties(v *WorkspaceProperties) *Works
 // role before you can register a directory. For more information, see Creating
 // the workspaces_DefaultRole Role (https://docs.aws.amazon.com/workspaces/latest/adminguide/workspaces-access-control.html#create-default-role).
 type WorkspacesDefaultRoleNotFoundException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"message" type:"string"`
 }

--- a/service/xray/api.go
+++ b/service/xray/api.go
@@ -4355,7 +4355,7 @@ func (s *InstanceIdDetail) SetId(v string) *InstanceIdDetail {
 // The request is missing required parameters or has invalid parameters.
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4372,7 +4372,7 @@ func (s InvalidRequestException) GoString() string {
 
 func newErrorInvalidRequestException(v protocol.ResponseMetadata) error {
 	return &InvalidRequestException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4400,12 +4400,12 @@ func (s InvalidRequestException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s InvalidRequestException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s InvalidRequestException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 type PutEncryptionConfigInput struct {
@@ -4835,7 +4835,7 @@ func (s *RootCauseException) SetName(v string) *RootCauseException {
 // You have reached the maximum number of sampling rules.
 type RuleLimitExceededException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4852,7 +4852,7 @@ func (s RuleLimitExceededException) GoString() string {
 
 func newErrorRuleLimitExceededException(v protocol.ResponseMetadata) error {
 	return &RuleLimitExceededException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -4880,12 +4880,12 @@ func (s RuleLimitExceededException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s RuleLimitExceededException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s RuleLimitExceededException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A sampling rule that services use to decide whether to instrument a request.
@@ -5919,7 +5919,7 @@ func (s *TelemetryRecord) SetTimestamp(v time.Time) *TelemetryRecord {
 // The request exceeds the maximum number of requests per second.
 type ThrottledException struct {
 	_            struct{} `type:"structure"`
-	respMetadata protocol.ResponseMetadata
+	RespMetadata protocol.ResponseMetadata
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5936,7 +5936,7 @@ func (s ThrottledException) GoString() string {
 
 func newErrorThrottledException(v protocol.ResponseMetadata) error {
 	return &ThrottledException{
-		respMetadata: v,
+		RespMetadata: v,
 	}
 }
 
@@ -5964,12 +5964,12 @@ func (s ThrottledException) Error() string {
 
 // Status code returns the HTTP status code for the request's response error.
 func (s ThrottledException) StatusCode() int {
-	return s.respMetadata.StatusCode
+	return s.RespMetadata.StatusCode
 }
 
 // RequestID returns the service's response RequestID for request.
 func (s ThrottledException) RequestID() string {
-	return s.respMetadata.RequestID
+	return s.RespMetadata.RequestID
 }
 
 // A list of TimeSeriesStatistic structures.

--- a/service/xray/api.go
+++ b/service/xray/api.go
@@ -4354,8 +4354,8 @@ func (s *InstanceIdDetail) SetId(v string) *InstanceIdDetail {
 
 // The request is missing required parameters or has invalid parameters.
 type InvalidRequestException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -4834,8 +4834,8 @@ func (s *RootCauseException) SetName(v string) *RootCauseException {
 
 // You have reached the maximum number of sampling rules.
 type RuleLimitExceededException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }
@@ -5918,8 +5918,8 @@ func (s *TelemetryRecord) SetTimestamp(v time.Time) *TelemetryRecord {
 
 // The request exceeds the maximum number of requests per second.
 type ThrottledException struct {
-	_            struct{} `type:"structure"`
-	RespMetadata protocol.ResponseMetadata
+	_            struct{}                  `type:"structure"`
+	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
 
 	Message_ *string `locationName:"Message" type:"string"`
 }


### PR DESCRIPTION
Exports to the RespMetadata type on generated service API errors.