### PR TITLE
service/s3/s3manager: Add Context to S3 URL presigning

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -625,6 +625,7 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker, cleanup func()) (*UploadO
 		Key:    u.in.Key,
 	})
 	getReq.Config.Credentials = credentials.AnonymousCredentials
+	getReq.SetContext(u.ctx)
 	uploadLocation, _, _ := getReq.PresignRequest(1)
 
 	return &UploadOutput{


### PR DESCRIPTION
Fixes an issue uncovered while doing some testing with X-Ray SDK and the S3 Upload Manager. This ensures that we set the context when generating a presign URL after finishing an upload.