### PR TITLE
Add PolicyArns to stscreds.AssumeRoleProvider

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
-* `aws/credentials`: `PolicyArns` can now be passed in to `stscreds.AssumeRoleProvider` in the same way as `sts.AssumeRoleInput`.
+* `aws/credentials`: `PolicyArns` can now be passed in to `stscreds.AssumeRoleProvider` and `stscreds.WebIdentityRoleProvider` in the same way as `sts.AssumeRoleInput`.
 
 ### SDK Bugs

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
-* `aws/credentials`: `PolicyArns` can now be passed in to `stscreds.AssumeRoleProvider` and `stscreds.WebIdentityRoleProvider` in the same way as `sts.AssumeRoleInput`.
+* `aws/credentials/stscreds`: Add support for policy ARNs ([#3249](https://github.com/aws/aws-sdk-go/pull/3249))
+  * Adds support for passing AWS policy ARNs to the `AssumeRoleProvider` and `WebIdentityRoleProvider` credential providers. This allows you provide policy ARNs when assuming the role that will further limit the permissions of the credentials returned.
 
 ### SDK Bugs

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/credentials`: `PolicyArns` can now be passed in to `stscreds.AssumeRoleProvider` in the same way as `sts.AssumeRoleInput`.
 
 ### SDK Bugs

--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -169,6 +169,29 @@ type AssumeRoleProvider struct {
 	// size.
 	Policy *string
 
+	// The ARNs of IAM managed policies you want to use as managed session policies.
+	// The policies must exist in the same account as the role.
+	//
+	// This parameter is optional. You can provide up to 10 managed policy ARNs.
+	// However, the plain text that you use for both inline and managed session
+	// policies can't exceed 2,048 characters.
+	//
+	// An AWS conversion compresses the passed session policies and session tags
+	// into a packed binary format that has a separate limit. Your request can fail
+	// for this limit even if your plain text meets the other requirements. The
+	// PackedPolicySize response element indicates by percentage how close the policies
+	// and tags for your request are to the upper size limit.
+	//
+	// Passing policies to this operation returns new temporary credentials. The
+	// resulting session's permissions are the intersection of the role's identity-based
+	// policy and the session policies. You can use the role's temporary credentials
+	// in subsequent AWS API calls to access resources in the account that owns
+	// the role. You cannot use session policies to grant more permissions than
+	// those allowed by the identity-based policy of the role that is being assumed.
+	// For more information, see Session Policies (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session)
+	// in the IAM User Guide.
+	PolicyArns []*sts.PolicyDescriptorType
+
 	// The identification number of the MFA device that is associated with the user
 	// who is making the AssumeRole call. Specify this value if the trust policy
 	// of the role being assumed includes a condition that requires MFA authentication.
@@ -291,6 +314,7 @@ func (p *AssumeRoleProvider) RetrieveWithContext(ctx credentials.Context) (crede
 		RoleSessionName:   aws.String(p.RoleSessionName),
 		ExternalId:        p.ExternalID,
 		Tags:              p.Tags,
+		PolicyArns:        p.PolicyArns,
 		TransitiveTagKeys: p.TransitiveTagKeys,
 	}
 	if p.Policy != nil {

--- a/aws/credentials/stscreds/web_identity_provider.go
+++ b/aws/credentials/stscreds/web_identity_provider.go
@@ -32,6 +32,7 @@ var now = time.Now
 // an OIDC token.
 type WebIdentityRoleProvider struct {
 	credentials.Expiry
+	PolicyArns []*sts.PolicyDescriptorType
 
 	client       stsiface.STSAPI
 	ExpiryWindow time.Duration
@@ -84,6 +85,7 @@ func (p *WebIdentityRoleProvider) RetrieveWithContext(ctx credentials.Context) (
 		sessionName = strconv.FormatInt(now().UnixNano(), 10)
 	}
 	req, resp := p.client.AssumeRoleWithWebIdentityRequest(&sts.AssumeRoleWithWebIdentityInput{
+		PolicyArns:       p.PolicyArns,
 		RoleArn:          &p.roleARN,
 		RoleSessionName:  &sessionName,
 		WebIdentityToken: aws.String(string(b)),


### PR DESCRIPTION
To support passing `PolicyArns` to `stscreds.AssumeRoleProvider` in the same manner as `sts.AssumeRole`.

Resolves #3233