### PR TITLE
aws/credentials/stscreds: Added TokenFetcher

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/credentials/stscreds`: Add support for custom web identity TokenFetcher ([#3256](https://github.com/aws/aws-sdk-go/pull/3256))
+  * Adds new constructor, `NewWebIdentityRoleProviderWithToken` for `WebIdentityRoleProvider` which takes a `TokenFetcher`. Implement `TokenFetcher` to provide custom sources for web identity tokens. The `TokenFetcher` must be concurrency safe. `TokenFetcher` may return unique value each time it is called.
 
 ### SDK Bugs


### PR DESCRIPTION
This change makes it possible to fetch a token from an arbitrary source, rather than the file system (Ex: Fetch from an HTTP service)

```go
type FetchTokenFromMoon struct {}
func (v FetchTokenFromMoon) FetchToken(ctx credentials.Context) ([]byte, error) {
	return /* do something cool */
}
```