### PR TITLE
service/s3/s3crypto: Add missing return in encryption client

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,5 @@
   * Adds examples demonstrating how you can create and delete repositories with the SDK.
 
 ### SDK Bugs
+* `service/s3/s3crypto`: Add missing return in encryption client ([#3258](https://github.com/aws/aws-sdk-go/pull/3258))
+  * Fixes a missing return in the encryption client that was causing a nil dereference panic.

--- a/service/s3/s3crypto/encryption_client.go
+++ b/service/s3/s3crypto/encryption_client.go
@@ -103,6 +103,7 @@ func (c *EncryptionClient) PutObjectRequest(input *s3.PutObjectInput) (*request.
 		}
 		if err != nil {
 			r.Error = err
+			return
 		}
 
 		md5 := newMD5Reader(input.Body)


### PR DESCRIPTION
This was causing a nil pointer dereference runtime error instead of returning the error.

I was tearing my hair out trying to understand my SIGSEGV error, and in the end it turned out to be a silly `MissingRegion` problem.