### PR TITLE
`private`: Adds support for `httpChecksumRequired` trait 

### DIFF
--- a/aws/types.go
+++ b/aws/types.go
@@ -239,3 +239,26 @@ func (es errors) Error() string {
 
 	return strings.Join(parts, "\n")
 }
+
+// CopySeekableBody copies the seekable body to an io.Writer
+func CopySeekableBody(dst io.Writer, src io.ReadSeeker) (int64, error) {
+	curPos, err := src.Seek(0, sdkio.SeekCurrent)
+	if err != nil {
+		return 0, err
+	}
+
+	// hash the body.  seek back to the first position after reading to reset
+	// the body for transmission.  copy errors may be assumed to be from the
+	// body.
+	n, err := io.Copy(dst, src)
+	if err != nil {
+		return n, err
+	}
+
+	_, err = src.Seek(curPos, sdkio.SeekStart)
+	if err != nil {
+		return n, err
+	}
+
+	return n, nil
+}

--- a/aws/types.go
+++ b/aws/types.go
@@ -247,14 +247,14 @@ func CopySeekableBody(dst io.Writer, src io.ReadSeeker) (int64, error) {
 		return 0, err
 	}
 
-	// hash the body.  seek back to the first position after reading to reset
-	// the body for transmission.  copy errors may be assumed to be from the
-	// body.
+	// copy errors may be assumed to be from the body.
 	n, err := io.Copy(dst, src)
 	if err != nil {
 		return n, err
 	}
 
+	// seek back to the first position after reading to reset
+	// the body for transmission.
 	_, err = src.Seek(curPos, sdkio.SeekStart)
 	if err != nil {
 		return n, err

--- a/private/checksum/content_md5.go
+++ b/private/checksum/content_md5.go
@@ -1,22 +1,20 @@
-package util
+package checksum
 
 import (
 	"crypto/md5"
 	"encoding/base64"
 	"fmt"
-	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/internal/sdkio"
 )
 
 const contentMD5Header = "Content-Md5"
 
-// ContentMD5 computes and sets the HTTP Content-MD5 header for requests that
+// AddBodyContentMD5Handler computes and sets the HTTP Content-MD5 header for requests that
 // require it.
-func ContentMD5(r *request.Request) {
+func AddBodyContentMD5Handler(r *request.Request) {
 	// if Content-MD5 header is already present, return
 	if v := r.HTTPRequest.Header.Get(contentMD5Header); len(v) != 0 {
 		return
@@ -44,7 +42,7 @@ func ContentMD5(r *request.Request) {
 
 	h := md5.New()
 
-	if _, err := CopySeekableBody(h, r.Body); err != nil {
+	if _, err := aws.CopySeekableBody(h, r.Body); err != nil {
 		r.Error = awserr.New("ContentMD5", "failed to compute body MD5", err)
 		return
 	}
@@ -52,27 +50,4 @@ func ContentMD5(r *request.Request) {
 	// encode the md5 checksum in base64 and set the request header.
 	v := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	r.HTTPRequest.Header.Set(contentMD5Header, v)
-}
-
-// CopySeekableBody copies the seekable body to an io.Writer
-func CopySeekableBody(dst io.Writer, src io.ReadSeeker) (int64, error) {
-	curPos, err := src.Seek(0, sdkio.SeekCurrent)
-	if err != nil {
-		return 0, err
-	}
-
-	// hash the body.  seek back to the first position after reading to reset
-	// the body for transmission.  copy errors may be assumed to be from the
-	// body.
-	n, err := io.Copy(dst, src)
-	if err != nil {
-		return n, err
-	}
-
-	_, err = src.Seek(curPos, sdkio.SeekStart)
-	if err != nil {
-		return n, err
-	}
-
-	return n, nil
 }

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -313,10 +313,10 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}Request(` +
 	{{- end }}
 
 	{{- if .IsHttpChecksumRequired }}
-		{{- $_ := .API.AddSDKImport "private/util" }}
+		{{- $_ := .API.AddSDKImport "private/checksum" }}
 		req.Handlers.Build.PushBackNamed(request.NamedHandler{
 			Name: "contentMd5Handler",
-			Fn: util.ContentMD5,
+			Fn: checksum.AddBodyContentMD5Handler,
 		})
 	{{- end }}
 	return

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -34,6 +34,7 @@ type Operation struct {
 	IsEndpointDiscoveryOp bool               `json:"endpointoperation"`
 	EndpointDiscovery     *EndpointDiscovery `json:"endpointdiscovery"`
 	Endpoint              *EndpointTrait     `json:"endpoint"`
+	IsMD5HeaderRequired   bool               `json:"httpContentMd5"`
 }
 
 // EndpointTrait provides the structure of the modeled endpoint trait, and its
@@ -309,6 +310,14 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}Request(` +
 
 	{{- range $_, $handler := $.CustomBuildHandlers }}
 		req.Handlers.Build.PushBackNamed({{ $handler }})
+	{{- end }}
+
+	{{- if .IsMD5HeaderRequired }}
+		{{- $_ := .API.AddSDKImport "private/util" }}
+		req.Handlers.Build.PushBackNamed(request.NamedHandler{
+			Name: "contentMd5Handler",
+			Fn: util.ContentMD5,
+		})
 	{{- end }}
 	return
 }

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -31,10 +31,10 @@ type Operation struct {
 
 	EventStreamAPI *EventStreamAPI
 
-	IsEndpointDiscoveryOp bool               `json:"endpointoperation"`
-	EndpointDiscovery     *EndpointDiscovery `json:"endpointdiscovery"`
-	Endpoint              *EndpointTrait     `json:"endpoint"`
-	IsMD5HeaderRequired   bool               `json:"httpContentMd5"`
+	IsEndpointDiscoveryOp  bool               `json:"endpointoperation"`
+	EndpointDiscovery      *EndpointDiscovery `json:"endpointdiscovery"`
+	Endpoint               *EndpointTrait     `json:"endpoint"`
+	IsHttpChecksumRequired bool               `json:"httpChecksumRequired"`
 }
 
 // EndpointTrait provides the structure of the modeled endpoint trait, and its
@@ -312,7 +312,7 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}Request(` +
 		req.Handlers.Build.PushBackNamed({{ $handler }})
 	{{- end }}
 
-	{{- if .IsMD5HeaderRequired }}
+	{{- if .IsHttpChecksumRequired }}
 		{{- $_ := .API.AddSDKImport "private/util" }}
 		req.Handlers.Build.PushBackNamed(request.NamedHandler{
 			Name: "contentMd5Handler",

--- a/private/util/content_md5.go
+++ b/private/util/content_md5.go
@@ -1,0 +1,78 @@
+package util
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/sdkio"
+)
+
+const contentMD5Header = "Content-Md5"
+
+// ContentMD5 computes and sets the HTTP Content-MD5 header for requests that
+// require it.
+func ContentMD5(r *request.Request) {
+	// if Content-MD5 header is already present, return
+	if v := r.HTTPRequest.Header.Get(contentMD5Header); len(v) != 0 {
+		return
+	}
+
+	// if S3DisableContentMD5Validation flag is set, return
+	if aws.BoolValue(r.Config.S3DisableContentMD5Validation) {
+		return
+	}
+
+	// if request is presigned, return
+	if r.IsPresigned() {
+		return
+	}
+
+	// if body is not seekable, return
+	if !aws.IsReaderSeekable(r.Body) {
+		if r.Config.Logger != nil {
+			r.Config.Logger.Log(fmt.Sprintf(
+				"Unable to compute Content-MD5 for unseekable body, S3.%s",
+				r.Operation.Name))
+		}
+		return
+	}
+
+	h := md5.New()
+
+	if _, err := CopySeekableBody(h, r.Body); err != nil {
+		r.Error = awserr.New("ContentMD5", "failed to compute body MD5", err)
+		return
+	}
+
+	// encode the md5 checksum in base64 and set the request header.
+	v := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	r.HTTPRequest.Header.Set(contentMD5Header, v)
+}
+
+// CopySeekableBody copies the seekable body to an io.Writer
+func CopySeekableBody(dst io.Writer, src io.ReadSeeker) (int64, error) {
+	curPos, err := src.Seek(0, sdkio.SeekCurrent)
+	if err != nil {
+		return 0, err
+	}
+
+	// hash the body.  seek back to the first position after reading to reset
+	// the body for transmission.  copy errors may be assumed to be from the
+	// body.
+	n, err := io.Copy(dst, src)
+	if err != nil {
+		return n, err
+	}
+
+	_, err = src.Seek(curPos, sdkio.SeekStart)
+	if err != nil {
+		return n, err
+	}
+
+	return n, nil
+}

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi"
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
+	"github.com/aws/aws-sdk-go/private/util"
 	"github.com/aws/aws-sdk-go/service/s3/internal/arn"
 )
 
@@ -2085,6 +2086,10 @@ func (c *S3) DeleteObjectsRequest(input *DeleteObjectsInput) (req *request.Reque
 
 	output = &DeleteObjectsOutput{}
 	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -6403,6 +6408,10 @@ func (c *S3) PutBucketAclRequest(input *PutBucketAclInput) (req *request.Request
 	output = &PutBucketAclOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -6682,6 +6691,10 @@ func (c *S3) PutBucketCorsRequest(input *PutBucketCorsInput) (req *request.Reque
 	output = &PutBucketCorsOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -6799,6 +6812,10 @@ func (c *S3) PutBucketEncryptionRequest(input *PutBucketEncryptionInput) (req *r
 	output = &PutBucketEncryptionOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -7023,6 +7040,10 @@ func (c *S3) PutBucketLifecycleRequest(input *PutBucketLifecycleInput) (req *req
 	output = &PutBucketLifecycleOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -7150,6 +7171,10 @@ func (c *S3) PutBucketLifecycleConfigurationRequest(input *PutBucketLifecycleCon
 	output = &PutBucketLifecycleConfigurationOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -7287,6 +7312,10 @@ func (c *S3) PutBucketLoggingRequest(input *PutBucketLoggingInput) (req *request
 	output = &PutBucketLoggingOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -7514,6 +7543,10 @@ func (c *S3) PutBucketNotificationRequest(input *PutBucketNotificationInput) (re
 	output = &PutBucketNotificationOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -7716,6 +7749,10 @@ func (c *S3) PutBucketPolicyRequest(input *PutBucketPolicyInput) (req *request.R
 	output = &PutBucketPolicyOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -7812,6 +7849,10 @@ func (c *S3) PutBucketReplicationRequest(input *PutBucketReplicationInput) (req 
 	output = &PutBucketReplicationOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -7936,6 +7977,10 @@ func (c *S3) PutBucketRequestPaymentRequest(input *PutBucketRequestPaymentInput)
 	output = &PutBucketRequestPaymentOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -8021,6 +8066,10 @@ func (c *S3) PutBucketTaggingRequest(input *PutBucketTaggingInput) (req *request
 	output = &PutBucketTaggingOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -8137,6 +8186,10 @@ func (c *S3) PutBucketVersioningRequest(input *PutBucketVersioningInput) (req *r
 	output = &PutBucketVersioningOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -8245,6 +8298,10 @@ func (c *S3) PutBucketWebsiteRequest(input *PutBucketWebsiteInput) (req *request
 	output = &PutBucketWebsiteOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -8521,6 +8578,10 @@ func (c *S3) PutObjectAclRequest(input *PutObjectAclInput) (req *request.Request
 
 	output = &PutObjectAclOutput{}
 	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -8681,6 +8742,10 @@ func (c *S3) PutObjectLegalHoldRequest(input *PutObjectLegalHoldInput) (req *req
 
 	output = &PutObjectLegalHoldOutput{}
 	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -8759,6 +8824,10 @@ func (c *S3) PutObjectLockConfigurationRequest(input *PutObjectLockConfiguration
 
 	output = &PutObjectLockConfigurationOutput{}
 	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -8842,6 +8911,10 @@ func (c *S3) PutObjectRetentionRequest(input *PutObjectRetentionInput) (req *req
 
 	output = &PutObjectRetentionOutput{}
 	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -8920,6 +8993,10 @@ func (c *S3) PutObjectTaggingRequest(input *PutObjectTaggingInput) (req *request
 
 	output = &PutObjectTaggingOutput{}
 	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 
@@ -9032,6 +9109,10 @@ func (c *S3) PutPublicAccessBlockRequest(input *PutPublicAccessBlockInput) (req 
 	output = &PutPublicAccessBlockOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "contentMd5Handler",
+		Fn:   util.ContentMD5,
+	})
 	return
 }
 

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -14,12 +14,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/checksum"
 	"github.com/aws/aws-sdk-go/private/protocol"
 	"github.com/aws/aws-sdk-go/private/protocol/eventstream"
 	"github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi"
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
-	"github.com/aws/aws-sdk-go/private/util"
 	"github.com/aws/aws-sdk-go/service/s3/internal/arn"
 )
 
@@ -2088,7 +2088,7 @@ func (c *S3) DeleteObjectsRequest(input *DeleteObjectsInput) (req *request.Reque
 	req = c.newRequest(op, input, output)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -6410,7 +6410,7 @@ func (c *S3) PutBucketAclRequest(input *PutBucketAclInput) (req *request.Request
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -6693,7 +6693,7 @@ func (c *S3) PutBucketCorsRequest(input *PutBucketCorsInput) (req *request.Reque
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -6814,7 +6814,7 @@ func (c *S3) PutBucketEncryptionRequest(input *PutBucketEncryptionInput) (req *r
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -7042,7 +7042,7 @@ func (c *S3) PutBucketLifecycleRequest(input *PutBucketLifecycleInput) (req *req
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -7173,7 +7173,7 @@ func (c *S3) PutBucketLifecycleConfigurationRequest(input *PutBucketLifecycleCon
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -7314,7 +7314,7 @@ func (c *S3) PutBucketLoggingRequest(input *PutBucketLoggingInput) (req *request
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -7545,7 +7545,7 @@ func (c *S3) PutBucketNotificationRequest(input *PutBucketNotificationInput) (re
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -7751,7 +7751,7 @@ func (c *S3) PutBucketPolicyRequest(input *PutBucketPolicyInput) (req *request.R
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -7851,7 +7851,7 @@ func (c *S3) PutBucketReplicationRequest(input *PutBucketReplicationInput) (req 
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -7979,7 +7979,7 @@ func (c *S3) PutBucketRequestPaymentRequest(input *PutBucketRequestPaymentInput)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -8068,7 +8068,7 @@ func (c *S3) PutBucketTaggingRequest(input *PutBucketTaggingInput) (req *request
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -8188,7 +8188,7 @@ func (c *S3) PutBucketVersioningRequest(input *PutBucketVersioningInput) (req *r
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -8300,7 +8300,7 @@ func (c *S3) PutBucketWebsiteRequest(input *PutBucketWebsiteInput) (req *request
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -8580,7 +8580,7 @@ func (c *S3) PutObjectAclRequest(input *PutObjectAclInput) (req *request.Request
 	req = c.newRequest(op, input, output)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -8744,7 +8744,7 @@ func (c *S3) PutObjectLegalHoldRequest(input *PutObjectLegalHoldInput) (req *req
 	req = c.newRequest(op, input, output)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -8826,7 +8826,7 @@ func (c *S3) PutObjectLockConfigurationRequest(input *PutObjectLockConfiguration
 	req = c.newRequest(op, input, output)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -8913,7 +8913,7 @@ func (c *S3) PutObjectRetentionRequest(input *PutObjectRetentionInput) (req *req
 	req = c.newRequest(op, input, output)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -8995,7 +8995,7 @@ func (c *S3) PutObjectTaggingRequest(input *PutObjectTaggingInput) (req *request
 	req = c.newRequest(op, input, output)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }
@@ -9111,7 +9111,7 @@ func (c *S3) PutPublicAccessBlockRequest(input *PutPublicAccessBlockInput) (req 
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	req.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "contentMd5Handler",
-		Fn:   util.ContentMD5,
+		Fn:   checksum.AddBodyContentMD5Handler,
 	})
 	return
 }

--- a/service/s3/body_hash.go
+++ b/service/s3/body_hash.go
@@ -10,8 +10,6 @@ import (
 	"hash"
 	"io"
 
-	"github.com/aws/aws-sdk-go/private/util"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -67,7 +65,7 @@ func computeBodyHashes(r *request.Request) {
 		dst = io.MultiWriter(hashers...)
 	}
 
-	if _, err := util.CopySeekableBody(dst, r.Body); err != nil {
+	if _, err := aws.CopySeekableBody(dst, r.Body); err != nil {
 		r.Error = awserr.New("BodyHashError", "failed to compute body hashes", err)
 		return
 	}

--- a/service/s3/body_hash.go
+++ b/service/s3/body_hash.go
@@ -10,10 +10,11 @@ import (
 	"hash"
 	"io"
 
+	"github.com/aws/aws-sdk-go/private/util"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/internal/sdkio"
 )
 
 const (
@@ -24,30 +25,6 @@ const (
 
 	appendMD5TxEncoding = "append-md5"
 )
-
-// contentMD5 computes and sets the HTTP Content-MD5 header for requests that
-// require it.
-func contentMD5(r *request.Request) {
-	h := md5.New()
-
-	if !aws.IsReaderSeekable(r.Body) {
-		if r.Config.Logger != nil {
-			r.Config.Logger.Log(fmt.Sprintf(
-				"Unable to compute Content-MD5 for unseekable body, S3.%s",
-				r.Operation.Name))
-		}
-		return
-	}
-
-	if _, err := copySeekableBody(h, r.Body); err != nil {
-		r.Error = awserr.New("ContentMD5", "failed to compute body MD5", err)
-		return
-	}
-
-	// encode the md5 checksum in base64 and set the request header.
-	v := base64.StdEncoding.EncodeToString(h.Sum(nil))
-	r.HTTPRequest.Header.Set(contentMD5Header, v)
-}
 
 // computeBodyHashes will add Content MD5 and Content Sha256 hashes to the
 // request. If the body is not seekable or S3DisableContentMD5Validation set
@@ -90,7 +67,7 @@ func computeBodyHashes(r *request.Request) {
 		dst = io.MultiWriter(hashers...)
 	}
 
-	if _, err := copySeekableBody(dst, r.Body); err != nil {
+	if _, err := util.CopySeekableBody(dst, r.Body); err != nil {
 		r.Error = awserr.New("BodyHashError", "failed to compute body hashes", err)
 		return
 	}
@@ -118,28 +95,6 @@ const (
 	md5Base64EncLen = (md5.Size + 2) / 3 * 4 // base64.StdEncoding.EncodedLen
 	sha256HexEncLen = sha256.Size * 2        // hex.EncodedLen
 )
-
-func copySeekableBody(dst io.Writer, src io.ReadSeeker) (int64, error) {
-	curPos, err := src.Seek(0, sdkio.SeekCurrent)
-	if err != nil {
-		return 0, err
-	}
-
-	// hash the body.  seek back to the first position after reading to reset
-	// the body for transmission.  copy errors may be assumed to be from the
-	// body.
-	n, err := io.Copy(dst, src)
-	if err != nil {
-		return n, err
-	}
-
-	_, err = src.Seek(curPos, sdkio.SeekStart)
-	if err != nil {
-		return n, err
-	}
-
-	return n, nil
-}
 
 // Adds the x-amz-te: append_md5 header to the request. This requests the service
 // responds with a trailing MD5 checksum.

--- a/service/s3/content_md5_test.go
+++ b/service/s3/content_md5_test.go
@@ -1,0 +1,331 @@
+package s3_test
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+	"io/ioutil"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func assertMD5(t *testing.T, req *request.Request) {
+	err := req.Build()
+	if err != nil {
+		t.Errorf("expected no error, but received %v", err)
+	}
+
+	b, _ := ioutil.ReadAll(req.HTTPRequest.Body)
+	out := md5.Sum(b)
+	if len(b) == 0 {
+		t.Error("expected non-empty value")
+	}
+	if a := req.HTTPRequest.Header.Get("Content-MD5"); len(a) == 0 {
+		t.Fatal("Expected Content-MD5 header to be present in the operation request, was not")
+	} else if e := base64.StdEncoding.EncodeToString(out[:]); e != a {
+		t.Errorf("expected %s, but received %s", e, a)
+	}
+}
+
+func TestMD5InPutBucketCors(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketCorsRequest(&s3.PutBucketCorsInput{
+		Bucket: aws.String("bucketname"),
+		CORSConfiguration: &s3.CORSConfiguration{
+			CORSRules: []*s3.CORSRule{
+				{
+					AllowedMethods: []*string{aws.String("GET")},
+					AllowedOrigins: []*string{aws.String("*")},
+				},
+			},
+		},
+	})
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketLifecycle(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketLifecycleRequest(&s3.PutBucketLifecycleInput{
+		Bucket: aws.String("bucketname"),
+		LifecycleConfiguration: &s3.LifecycleConfiguration{
+			Rules: []*s3.Rule{
+				{
+					ID:     aws.String("ID"),
+					Prefix: aws.String("Prefix"),
+					Status: aws.String("Enabled"),
+				},
+			},
+		},
+	})
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketPolicy(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketPolicyRequest(&s3.PutBucketPolicyInput{
+		Bucket: aws.String("bucketname"),
+		Policy: aws.String("{}"),
+	})
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketTagging(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketTaggingRequest(&s3.PutBucketTaggingInput{
+		Bucket: aws.String("bucketname"),
+		Tagging: &s3.Tagging{
+			TagSet: []*s3.Tag{
+				{Key: aws.String("KEY"), Value: aws.String("VALUE")},
+			},
+		},
+	})
+	assertMD5(t, req)
+}
+
+func TestMD5InDeleteObjects(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.DeleteObjectsRequest(&s3.DeleteObjectsInput{
+		Bucket: aws.String("bucketname"),
+		Delete: &s3.Delete{
+			Objects: []*s3.ObjectIdentifier{
+				{Key: aws.String("key")},
+			},
+		},
+	})
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketLifecycleConfiguration(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketLifecycleConfigurationRequest(&s3.PutBucketLifecycleConfigurationInput{
+		Bucket: aws.String("bucketname"),
+		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
+			Rules: []*s3.LifecycleRule{
+				{Prefix: aws.String("prefix"), Status: aws.String(s3.ExpirationStatusEnabled)},
+			},
+		},
+	})
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketReplication(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketReplicationRequest(&s3.PutBucketReplicationInput{
+		Bucket: aws.String("bucketname"),
+		ReplicationConfiguration: &s3.ReplicationConfiguration{
+			Role: aws.String("Role"),
+			Rules: []*s3.ReplicationRule{
+				{
+					Destination: &s3.Destination{
+						Bucket: aws.String("mock bucket"),
+					},
+					Status: aws.String(s3.ReplicationRuleStatusDisabled),
+				},
+			},
+		},
+		Token: aws.String("token"),
+	})
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketAcl(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketAclRequest(&s3.PutBucketAclInput{
+		Bucket: aws.String("bucketname"),
+		AccessControlPolicy: &s3.AccessControlPolicy{
+			Grants: []*s3.Grant{{
+				Grantee: &s3.Grantee{
+					ID:   aws.String("mock id"),
+					Type: aws.String("type"),
+				},
+				Permission: aws.String(s3.PermissionFullControl),
+			}},
+			Owner: &s3.Owner{
+				DisplayName: aws.String("mock name"),
+			},
+		},
+	})
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketEncryption(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketEncryptionRequest(&s3.PutBucketEncryptionInput{
+		Bucket: aws.String("bucketname"),
+		ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
+			Rules: []*s3.ServerSideEncryptionRule{
+				{
+					ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
+						KMSMasterKeyID: aws.String("mock KMS master key id"),
+						SSEAlgorithm:   aws.String("mock SSE algorithm"),
+					},
+				},
+			},
+		},
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketLogging(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketLoggingRequest(&s3.PutBucketLoggingInput{
+		Bucket: aws.String("bucket name"),
+		BucketLoggingStatus: &s3.BucketLoggingStatus{LoggingEnabled: &s3.LoggingEnabled{
+			TargetBucket: aws.String("target bucket"),
+			TargetPrefix: aws.String("target prefix"),
+		}},
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketNotification(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketNotificationRequest(&s3.PutBucketNotificationInput{
+		Bucket: aws.String("bucket name"),
+		NotificationConfiguration: &s3.NotificationConfigurationDeprecated{
+			TopicConfiguration: &s3.TopicConfigurationDeprecated{
+				Id: aws.String("id"),
+			},
+		},
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketRequestPayment(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketRequestPaymentRequest(&s3.PutBucketRequestPaymentInput{
+		Bucket: aws.String("bucketname"),
+		RequestPaymentConfiguration: &s3.RequestPaymentConfiguration{
+			Payer: aws.String("payer"),
+		},
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketVersioning(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketVersioningRequest(&s3.PutBucketVersioningInput{
+		Bucket: aws.String("bucketname"),
+		VersioningConfiguration: &s3.VersioningConfiguration{
+			MFADelete: aws.String(s3.MFADeleteDisabled),
+			Status:    aws.String(s3.BucketVersioningStatusSuspended),
+		},
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutBucketWebsite(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutBucketWebsiteRequest(&s3.PutBucketWebsiteInput{
+		Bucket: aws.String("bucket name"),
+		WebsiteConfiguration: &s3.WebsiteConfiguration{
+			ErrorDocument: &s3.ErrorDocument{
+				Key: aws.String("error"),
+			},
+		},
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutObjectLegalHold(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutObjectLegalHoldRequest(&s3.PutObjectLegalHoldInput{
+		Bucket: aws.String("bucketname"),
+		Key:    aws.String("key"),
+		LegalHold: &s3.ObjectLockLegalHold{
+			Status: aws.String(s3.ObjectLockLegalHoldStatusOff),
+		},
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutObjectRetention(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutObjectRetentionRequest(&s3.PutObjectRetentionInput{
+		Bucket:                    aws.String("bucket name"),
+		BypassGovernanceRetention: nil,
+		Key:                       aws.String("key"),
+		RequestPayer:              nil,
+		Retention: &s3.ObjectLockRetention{
+			Mode: aws.String("mode"),
+		},
+		VersionId: nil,
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutObjectLockConfiguration(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutObjectLockConfigurationRequest(&s3.PutObjectLockConfigurationInput{
+		Bucket: aws.String("bucket name"),
+		ObjectLockConfiguration: &s3.ObjectLockConfiguration{
+			ObjectLockEnabled: aws.String(s3.ObjectLockEnabledEnabled),
+		},
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutObjectAcl(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutObjectAclRequest(&s3.PutObjectAclInput{
+		AccessControlPolicy: &s3.AccessControlPolicy{
+			Grants: []*s3.Grant{{
+				Grantee: &s3.Grantee{
+					ID:   aws.String("mock id"),
+					Type: aws.String("type"),
+				},
+				Permission: aws.String(s3.PermissionFullControl),
+			}},
+			Owner: &s3.Owner{
+				DisplayName: aws.String("mock name"),
+			},
+		},
+		Bucket: aws.String("bucket name"),
+		Key:    aws.String("key"),
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutObjectTagging(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutObjectTaggingRequest(&s3.PutObjectTaggingInput{
+		Bucket: aws.String("bucket name"),
+		Key:    aws.String("key"),
+		Tagging: &s3.Tagging{TagSet: []*s3.Tag{
+			{
+				Key:   aws.String("key"),
+				Value: aws.String("value"),
+			},
+		}},
+	})
+
+	assertMD5(t, req)
+}
+
+func TestMD5InPutPublicAccessBlock(t *testing.T) {
+	svc := s3.New(unit.Session)
+	req, _ := svc.PutPublicAccessBlockRequest(&s3.PutPublicAccessBlockInput{
+		Bucket: aws.String("bucket name"),
+		PublicAccessBlockConfiguration: &s3.PublicAccessBlockConfiguration{
+			BlockPublicAcls:       aws.Bool(true),
+			BlockPublicPolicy:     aws.Bool(true),
+			IgnorePublicAcls:      aws.Bool(true),
+			RestrictPublicBuckets: aws.Bool(true),
+		},
+	})
+
+	assertMD5(t, req)
+}

--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -33,12 +33,6 @@ func defaultInitRequestFn(r *request.Request) {
 	platformRequestHandlers(r)
 
 	switch r.Operation.Name {
-	case opPutBucketCors, opPutBucketLifecycle, opPutBucketPolicy,
-		opPutBucketTagging, opDeleteObjects, opPutBucketLifecycleConfiguration,
-		opPutObjectLegalHold, opPutObjectRetention, opPutObjectLockConfiguration,
-		opPutBucketReplication:
-		// These S3 operations require Content-MD5 to be set
-		r.Handlers.Build.PushBack(contentMD5)
 	case opGetBucketLocation:
 		// GetBucketLocation has custom parsing logic
 		r.Handlers.Unmarshal.PushFront(buildGetBucketLocation)

--- a/service/s3/customizations_test.go
+++ b/service/s3/customizations_test.go
@@ -1,116 +1,15 @@
 package s3_test
 
 import (
-	"crypto/md5"
-	"encoding/base64"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
-
-func assertMD5(t *testing.T, req *request.Request) {
-	err := req.Build()
-	if err != nil {
-		t.Errorf("expected no error, but received %v", err)
-	}
-
-	b, _ := ioutil.ReadAll(req.HTTPRequest.Body)
-	out := md5.Sum(b)
-	if len(b) == 0 {
-		t.Error("expected non-empty value")
-	}
-	if e, a := base64.StdEncoding.EncodeToString(out[:]), req.HTTPRequest.Header.Get("Content-MD5"); e != a {
-		t.Errorf("expected %s, but received %s", e, a)
-	}
-}
-
-func TestMD5InPutBucketCors(t *testing.T) {
-	svc := s3.New(unit.Session)
-	req, _ := svc.PutBucketCorsRequest(&s3.PutBucketCorsInput{
-		Bucket: aws.String("bucketname"),
-		CORSConfiguration: &s3.CORSConfiguration{
-			CORSRules: []*s3.CORSRule{
-				{
-					AllowedMethods: []*string{aws.String("GET")},
-					AllowedOrigins: []*string{aws.String("*")},
-				},
-			},
-		},
-	})
-	assertMD5(t, req)
-}
-
-func TestMD5InPutBucketLifecycle(t *testing.T) {
-	svc := s3.New(unit.Session)
-	req, _ := svc.PutBucketLifecycleRequest(&s3.PutBucketLifecycleInput{
-		Bucket: aws.String("bucketname"),
-		LifecycleConfiguration: &s3.LifecycleConfiguration{
-			Rules: []*s3.Rule{
-				{
-					ID:     aws.String("ID"),
-					Prefix: aws.String("Prefix"),
-					Status: aws.String("Enabled"),
-				},
-			},
-		},
-	})
-	assertMD5(t, req)
-}
-
-func TestMD5InPutBucketPolicy(t *testing.T) {
-	svc := s3.New(unit.Session)
-	req, _ := svc.PutBucketPolicyRequest(&s3.PutBucketPolicyInput{
-		Bucket: aws.String("bucketname"),
-		Policy: aws.String("{}"),
-	})
-	assertMD5(t, req)
-}
-
-func TestMD5InPutBucketTagging(t *testing.T) {
-	svc := s3.New(unit.Session)
-	req, _ := svc.PutBucketTaggingRequest(&s3.PutBucketTaggingInput{
-		Bucket: aws.String("bucketname"),
-		Tagging: &s3.Tagging{
-			TagSet: []*s3.Tag{
-				{Key: aws.String("KEY"), Value: aws.String("VALUE")},
-			},
-		},
-	})
-	assertMD5(t, req)
-}
-
-func TestMD5InDeleteObjects(t *testing.T) {
-	svc := s3.New(unit.Session)
-	req, _ := svc.DeleteObjectsRequest(&s3.DeleteObjectsInput{
-		Bucket: aws.String("bucketname"),
-		Delete: &s3.Delete{
-			Objects: []*s3.ObjectIdentifier{
-				{Key: aws.String("key")},
-			},
-		},
-	})
-	assertMD5(t, req)
-}
-
-func TestMD5InPutBucketLifecycleConfiguration(t *testing.T) {
-	svc := s3.New(unit.Session)
-	req, _ := svc.PutBucketLifecycleConfigurationRequest(&s3.PutBucketLifecycleConfigurationInput{
-		Bucket: aws.String("bucketname"),
-		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
-			Rules: []*s3.LifecycleRule{
-				{Prefix: aws.String("prefix"), Status: aws.String(s3.ExpirationStatusEnabled)},
-			},
-		},
-	})
-	assertMD5(t, req)
-}
 
 const (
 	metaKeyPrefix = `X-Amz-Meta-`


### PR DESCRIPTION
### This PR contains `s3 model` changes that should NOT be merged. 

* Adds support for `httpChecksumRequired` trait
* Adds expected model changes for testing
* Moves `contentMd5` handler func from `s3` to `private/utils`
* Removes customizations for specific operations requiring `Content-MD5` header
* Adds and modifies existing tests for service operations decorated by the trait.
