### PR TITLE
Add missing enum value for TGW peering attachment state

### DIFF
--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -112269,6 +112269,9 @@ const (
 	// TransitGatewayAttachmentStateInitiating is a TransitGatewayAttachmentState enum value
 	TransitGatewayAttachmentStateInitiating = "initiating"
 
+	// TransitGatewayAttachmentStateInitiatingRequest is a TransitGatewayAttachmentState enum value
+	TransitGatewayAttachmentStateInitiatingRequest = "initiatingRequest"
+
 	// TransitGatewayAttachmentStatePendingAcceptance is a TransitGatewayAttachmentState enum value
 	TransitGatewayAttachmentStatePendingAcceptance = "pendingAcceptance"
 


### PR DESCRIPTION
This PR includes a missing enum state for a Transit Gateway Peering Attachment.

The specific state for this resource is given by AWS as `initiatingRequest`, not `initiating` - as it is with a Transit Gateway Attachment.

Fixes bug #3284 
