### PR TITLE
signer/v4: Add SignString method

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/signer/v4`: Add SignString method ([#3287](https://github.com/aws/aws-sdk-go/pull/3287))
+  * Adds a new method to the AWS v4 signer allowing you to sign arbitrary string. The SignString method returns the signature for the string.
 
 ### SDK Bugs

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -318,7 +318,7 @@ func (v4 Signer) Presign(r *http.Request, body io.ReadSeeker, service, region st
 // It may be used to create signatures of "Browser-Based Upload using HTTP POST"
 // policy documents to be used in the browser. In which case, make sure to
 // base64 encode the policy document using base64.StdEncoding before creating
-// it's signature.
+// it's signature. See https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
 func (v4 Signer) SignString(awsContext aws.Context, stringToSign string, service, region string, exp time.Duration, signTime time.Time) (string, error) {
 	ctx := &signingCtx{
 		Time:                   signTime,

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -320,11 +320,6 @@ func (v4 Signer) Presign(r *http.Request, body io.ReadSeeker, service, region st
 // base64 encode the policy document using base64.StdEncoding before creating
 // it's signature.
 func (v4 Signer) SignString(awsContext aws.Context, stringToSign string, service, region string, exp time.Duration, signTime time.Time) (string, error) {
-	currentTimeFn := v4.currentTimeFn
-	if currentTimeFn == nil {
-		currentTimeFn = time.Now
-	}
-
 	ctx := &signingCtx{
 		Time:                   signTime,
 		ExpireTime:             exp,

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -315,9 +315,10 @@ func (v4 Signer) Presign(r *http.Request, body io.ReadSeeker, service, region st
 // signing process described in the documentation:
 // https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
 //
-// It may be used to create signatures for "Browser-Based Upload using HTTP POST"
-// policy documents to be used in the browser. Make sure to Base64 encode the
-// policy document using base64.StdEncoding before create it's signature.
+// It may be used to create signatures of "Browser-Based Upload using HTTP POST"
+// policy documents to be used in the browser. In which case, make sure to
+// base64 encode the policy document using base64.StdEncoding before creating
+// it's signature.
 func (v4 Signer) SignString(awsContext aws.Context, stringToSign string, service, region string, exp time.Duration, signTime time.Time) (string, error) {
 	currentTimeFn := v4.currentTimeFn
 	if currentTimeFn == nil {

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -325,8 +325,6 @@ func (v4 Signer) SignString(awsContext aws.Context, stringToSign string, service
 		ExpireTime:             exp,
 		ServiceName:            service,
 		Region:                 region,
-		DisableURIPathEscaping: v4.DisableURIPathEscaping,
-		unsignedPayload:        v4.UnsignedPayload,
 	}
 
 	var err error

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -645,6 +645,23 @@ func TestBuildCanonicalRequest(t *testing.T) {
 	}
 }
 
+func TestSignString_ReplaceRequestBody(t *testing.T) {
+	creds := credentials.NewStaticCredentials("AKID", "SECRET", "SESSION")
+
+	s := NewSigner(creds)
+
+	var stringToSign = "mypolicy"
+
+	signature, err := s.SignString(aws.BackgroundContext(), stringToSign, "s3", "us-east-1", time.Hour, time.Now())
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if len(signature) < 1 {
+		t.Errorf("expect signature to have value but it didn't")
+	}
+}
+
 func TestSignWithBody_ReplaceRequestBody(t *testing.T) {
 	creds := credentials.NewStaticCredentials("AKID", "SECRET", "SESSION")
 	req, seekerBody := buildRequest("dynamodb", "us-east-1", "{}")


### PR DESCRIPTION
SignString creates a signature of provided string according to AWS v4 signing process described in the documentation: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html

It may be used to create signatures for "Browser-Based Upload using HTTP POST" policy documents to be used in the browser. Make sure to Base64 encode the policy document using base64.StdEncoding before create it's signature.

Partial fix for: https://github.com/aws/aws-sdk-go/issues/666