### PR TITLE
`service/s3`: fix behavior for 200 OK responses with no body

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,4 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/s3`: Fix S3 client behavior wrt 200 OK response with empty payload

--- a/service/s3/s3manager/upload_internal_test.go
+++ b/service/s3/s3manager/upload_internal_test.go
@@ -22,6 +22,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/internal/s3testing"
 )
 
+const respBody = `<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadOutput>
+   <Location>mockValue</Location>
+   <Bucket>mockValue</Bucket>
+   <Key>mockValue</Key>
+   <ETag>mockValue</ETag>
+</CompleteMultipartUploadOutput>`
+
 type testReader struct {
 	br *bytes.Reader
 	m  sync.Mutex
@@ -83,7 +91,7 @@ func TestUploadByteSlicePool(t *testing.T) {
 
 				r.HTTPResponse = &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte(respBody))),
 				}
 
 				switch data := r.Data.(type) {
@@ -187,7 +195,7 @@ func TestUploadByteSlicePool_Failures(t *testing.T) {
 
 						r.HTTPResponse = &http.Response{
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+							Body:       ioutil.NopCloser(bytes.NewReader([]byte(respBody))),
 						}
 
 						switch data := r.Data.(type) {
@@ -255,7 +263,7 @@ func TestUploadByteSlicePoolConcurrentMultiPartSize(t *testing.T) {
 
 		r.HTTPResponse = &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(respBody))),
 		}
 
 		switch data := r.Data.(type) {

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -33,6 +33,14 @@ import (
 
 var emptyList = []string{}
 
+const respMsg = `<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadOutput>
+   <Location>mockValue</Location>
+   <Bucket>mockValue</Bucket>
+   <Key>mockValue</Key>
+   <ETag>mockValue</ETag>
+</CompleteMultipartUploadOutput>`
+
 func val(i interface{}, s string) interface{} {
 	v, err := awsutil.ValuesAtPath(i, s)
 	if err != nil || len(v) == 0 {
@@ -79,7 +87,7 @@ func loggingSvc(ignoreOps []string) (*s3.S3, *[]string, *[]interface{}) {
 
 		r.HTTPResponse = &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(respMsg))),
 		}
 
 		switch data := r.Data.(type) {
@@ -935,7 +943,7 @@ func TestSSE(t *testing.T) {
 		defer mutex.Unlock()
 		r.HTTPResponse = &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(respMsg))),
 		}
 		switch data := r.Data.(type) {
 		case *s3.CreateMultipartUploadOutput:
@@ -1190,7 +1198,7 @@ func TestUploadBufferStrategy(t *testing.T) {
 
 				r.HTTPResponse = &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte(respMsg))),
 				}
 
 				switch data := r.Data.(type) {

--- a/service/s3/statusok_error.go
+++ b/service/s3/statusok_error.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -24,17 +25,18 @@ func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
 	r.HTTPResponse.Body = ioutil.NopCloser(body)
 	defer body.Seek(0, sdkio.SeekStart)
 
-	if body.Len() == 0 {
-		// If there is no body don't attempt to parse the body.
-		return
-	}
-
 	unmarshalError(r)
 	if err, ok := r.Error.(awserr.Error); ok && err != nil {
-		if err.Code() == request.ErrCodeSerialization {
+		if err.Code() == request.ErrCodeSerialization &&
+			err.OrigErr() != io.EOF {
 			r.Error = nil
 			return
 		}
-		r.HTTPResponse.StatusCode = http.StatusServiceUnavailable
+		// if empty payload
+		if err.OrigErr() == io.EOF {
+			r.HTTPResponse.StatusCode = http.StatusInternalServerError
+		} else {
+			r.HTTPResponse.StatusCode = http.StatusServiceUnavailable
+		}
 	}
 }

--- a/service/s3/statusok_error_test.go
+++ b/service/s3/statusok_error_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package s3_test
 
 import (

--- a/service/s3/statusok_error_test.go
+++ b/service/s3/statusok_error_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +20,7 @@ import (
 )
 
 const errMsg = `<Error><Code>ErrorCode</Code><Message>message body</Message><RequestId>requestID</RequestId><HostId>hostID=</HostId></Error>`
+const xmlPreambleMsg = `<?xml version="1.0" encoding="UTF-8"?>`
 
 var lastModifiedTime = time.Date(2009, 11, 23, 0, 0, 0, 0, time.UTC)
 
@@ -183,4 +186,157 @@ func newCopyTestSvc(errMsg string) *s3.S3 {
 		})
 
 	return svc
+}
+
+func TestStatusOKPayloadHandling(t *testing.T) {
+	cases := map[string]struct {
+		Header   http.Header
+		Payloads [][]byte
+		OpCall   func(*s3.S3) error
+		Err      string
+	}{
+		"200 error": {
+			Header: http.Header{
+				"Content-Length": []string{strconv.Itoa(len(errMsg))},
+			},
+			Payloads: [][]byte{[]byte(errMsg)},
+			OpCall: func(c *s3.S3) error {
+				_, err := c.CopyObject(&s3.CopyObjectInput{
+					Bucket:     aws.String("bucketname"),
+					CopySource: aws.String("bucketname/doesnotexist.txt"),
+					Key:        aws.String("destination.txt"),
+				})
+				return err
+			},
+			Err: "ErrorCode: message body",
+		},
+		"200 error partial response": {
+			Header: http.Header{
+				"Content-Length": []string{strconv.Itoa(len(errMsg))},
+			},
+			Payloads: [][]byte{
+				[]byte(errMsg[:20]),
+			},
+			OpCall: func(c *s3.S3) error {
+				_, err := c.CopyObject(&s3.CopyObjectInput{
+					Bucket:     aws.String("bucketname"),
+					CopySource: aws.String("bucketname/doesnotexist.txt"),
+					Key:        aws.String("destination.txt"),
+				})
+				return err
+			},
+			Err: "unexpected EOF",
+		},
+		"200 error multipart": {
+			Header: http.Header{
+				"Transfer-Encoding": []string{"chunked"},
+			},
+			Payloads: [][]byte{
+				[]byte(errMsg[:20]),
+				[]byte(errMsg[20:]),
+			},
+			OpCall: func(c *s3.S3) error {
+				_, err := c.CopyObject(&s3.CopyObjectInput{
+					Bucket:     aws.String("bucketname"),
+					CopySource: aws.String("bucketname/doesnotexist.txt"),
+					Key:        aws.String("destination.txt"),
+				})
+				return err
+			},
+			Err: "ErrorCode: message body",
+		},
+		"200 error multipart partial response": {
+			Header: http.Header{
+				"Transfer-Encoding": []string{"chunked"},
+			},
+			Payloads: [][]byte{
+				[]byte(errMsg[:20]),
+			},
+			OpCall: func(c *s3.S3) error {
+				_, err := c.CopyObject(&s3.CopyObjectInput{
+					Bucket:     aws.String("bucketname"),
+					CopySource: aws.String("bucketname/doesnotexist.txt"),
+					Key:        aws.String("destination.txt"),
+				})
+				return err
+			},
+			Err: "XML syntax error",
+		},
+		"200 error multipart no payload": {
+			Header: http.Header{
+				"Transfer-Encoding": []string{"chunked"},
+			},
+			Payloads: [][]byte{},
+			OpCall: func(c *s3.S3) error {
+				_, err := c.CopyObject(&s3.CopyObjectInput{
+					Bucket:     aws.String("bucketname"),
+					CopySource: aws.String("bucketname/doesnotexist.txt"),
+					Key:        aws.String("destination.txt"),
+				})
+				return err
+			},
+			Err: "empty response payload",
+		},
+		"response with only xml preamble": {
+			Header: http.Header{
+				"Transfer-Encoding": []string{"chunked"},
+			},
+			Payloads: [][]byte{
+				[]byte(xmlPreambleMsg),
+			},
+			OpCall: func(c *s3.S3) error {
+				_, err := c.CopyObject(&s3.CopyObjectInput{
+					Bucket:     aws.String("bucketname"),
+					CopySource: aws.String("bucketname/doesnotexist.txt"),
+					Key:        aws.String("destination.txt"),
+				})
+				return err
+			},
+			Err: "empty response payload",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ww := w.(interface {
+					http.ResponseWriter
+					http.Flusher
+				})
+
+				for k, vs := range c.Header {
+					for _, v := range vs {
+						ww.Header().Add(k, v)
+					}
+				}
+				ww.WriteHeader(http.StatusOK)
+				ww.Flush()
+
+				for _, p := range c.Payloads {
+					ww.Write(p)
+					ww.Flush()
+				}
+			}))
+			defer srv.Close()
+
+			client := s3.New(unit.Session, &aws.Config{
+				Endpoint:               &srv.URL,
+				DisableSSL:             aws.Bool(true),
+				DisableParamValidation: aws.Bool(true),
+				S3ForcePathStyle:       aws.Bool(true),
+			})
+
+			err := c.OpCall(client)
+			if len(c.Err) != 0 {
+				if err == nil {
+					t.Fatalf("expect error, got none")
+				}
+				if e, a := c.Err, err.Error(); !strings.Contains(a, e) {
+					t.Fatalf("expect %v error in, %v", e, a)
+				}
+			} else if err != nil {
+				t.Fatalf("expect no error, got %v", err)
+			}
+		})
+	}
 }

--- a/service/s3/unmarshal_error.go
+++ b/service/s3/unmarshal_error.go
@@ -96,10 +96,10 @@ type RequestFailure interface {
 }
 
 // s3unmarshalXMLError is s3 specific xml error unmarshaler
-// for 200 response payloads.
+// for 200 OK errors and response payloads.
 // This function differs from the xmlUtil.UnmarshalXMLError
-// func as it does not ignore the EOF error and passes it up.
-// Related to bug fix for `s3 200 response with empty payload`
+// func. It does not ignore the EOF error and passes it up.
+// Related to bug fix for `s3 200 OK response with empty payload`
 func s3unmarshalXMLError(v interface{}, stream io.Reader) error {
 	var errBuf bytes.Buffer
 	body := io.TeeReader(stream, &errBuf)

--- a/service/s3/unmarshal_error.go
+++ b/service/s3/unmarshal_error.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -45,17 +46,24 @@ func unmarshalError(r *request.Request) {
 
 	// Attempt to parse error from body if it is known
 	var errResp xmlErrorResponse
-	err := xmlutil.UnmarshalXMLError(&errResp, r.HTTPResponse.Body)
-	if err == io.EOF {
-		// Only capture the error if an unmarshal error occurs that is not EOF,
-		// because S3 might send an error without a error message which causes
-		// the XML unmarshal to fail with EOF.
-		err = nil
+	var err error
+	if r.HTTPResponse.StatusCode >= 200 && r.HTTPResponse.StatusCode < 300 {
+		err = s3unmarshalXMLError(&errResp, r.HTTPResponse.Body)
+	} else {
+		err = xmlutil.UnmarshalXMLError(&errResp, r.HTTPResponse.Body)
 	}
+
 	if err != nil {
+		var errorMsg string
+		if err == io.EOF {
+			errorMsg = "empty response payload"
+		} else {
+			errorMsg = "failed to unmarshal error message"
+		}
+
 		r.Error = awserr.NewRequestFailure(
 			awserr.New(request.ErrCodeSerialization,
-				"failed to unmarshal error message", err),
+				errorMsg, err),
 			r.HTTPResponse.StatusCode,
 			r.RequestID,
 		)
@@ -85,4 +93,22 @@ type RequestFailure interface {
 
 	// Host ID is the S3 Host ID needed for debug, and contacting support
 	HostID() string
+}
+
+// s3unmarshalXMLError is s3 specific xml error unmarshaler
+// for 200 response payloads.
+// This function differs from the xmlUtil.UnmarshalXMLError
+// func as it does not ignore the EOF error and passes it up.
+// Related to bug fix for `s3 200 response with empty payload`
+func s3unmarshalXMLError(v interface{}, stream io.Reader) error {
+	var errBuf bytes.Buffer
+	body := io.TeeReader(stream, &errBuf)
+
+	err := xml.NewDecoder(body).Decode(v)
+	if err != nil && err != io.EOF {
+		return awserr.NewUnmarshalError(err,
+			"failed to unmarshal error message", errBuf.Bytes())
+	}
+
+	return err
 }


### PR DESCRIPTION
### Bug 
* In case of an internal error/ terminated connection, S3 operations supporting 200 errors i.e. CopyObject, UploadPartCopy, CompleteMultiPartUpload may return empty payload or payload with only xml Preamble. This is currently ignored by the SDK, and SDK returns 200 success with no response payload as a result. 

### Expected behavior
* S3 will always send a response payload in case of 200 error supporting operations. If not, client should handle internal errors/ terminated connections as retryable errors.

Rev 1
---
* Updates the S3 unmarshal xml error logic to handle empty or xml preamble only reponse payloads for operations support 200 response errors. 
* Adds and updates existing tests that use CopyObject, uploadPartCopy, or CompleteMultiPartUpload.