### PR TITLE
service/dynamodb/dynamodbattribute: Decode AttributeValue types as defined

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,4 +3,4 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-* `service/dynamodb/dynamodbattribute`:  Simplified decode logic to decode the AttributeValue as is [#]()
+* `service/dynamodb/dynamodbattribute`:  Simplified decode logic to decode AttributeValue as it is defined ([#3308](https://github.com/aws/aws-sdk-go/pull/3308))

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,4 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/dynamodb/dynamodbattribute`:  Simplified decode logic to decode the AttributeValue as is [#]()

--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -174,23 +174,23 @@ func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 	}
 
 	switch {
-	case len(av.B) != 0 || (av.B != nil && d.EnableEmptyCollections):
+	case av.B != nil:
 		return d.decodeBinary(av.B, v)
 	case av.BOOL != nil:
 		return d.decodeBool(av.BOOL, v)
-	case len(av.BS) != 0 || (av.BS != nil && d.EnableEmptyCollections):
+	case av.BS != nil:
 		return d.decodeBinarySet(av.BS, v)
-	case len(av.L) != 0 || (av.L != nil && d.EnableEmptyCollections):
+	case av.L != nil:
 		return d.decodeList(av.L, v)
-	case len(av.M) != 0 || (av.M != nil && d.EnableEmptyCollections):
+	case av.M != nil:
 		return d.decodeMap(av.M, v)
 	case av.N != nil:
 		return d.decodeNumber(av.N, v, fieldTag)
-	case len(av.NS) != 0 || (av.NS != nil && d.EnableEmptyCollections):
+	case av.NS != nil:
 		return d.decodeNumberSet(av.NS, v)
 	case av.S != nil: // DynamoDB does not allow for empty strings, so we do not consider the length or EnableEmptyCollections flag here
 		return d.decodeString(av.S, v, fieldTag)
-	case len(av.SS) != 0 || (av.SS != nil && d.EnableEmptyCollections):
+	case av.SS != nil:
 		return d.decodeStringSet(av.SS, v)
 	}
 

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -170,6 +170,49 @@ func TestUnmarshal(t *testing.T) {
 				Type:  reflect.TypeOf(uint8(0)),
 			},
 		},
+		// -------
+		// Empty Values
+		// -------
+		{
+			in:       &dynamodb.AttributeValue{B: []byte{}},
+			actual:   &[]byte{},
+			expected: []byte{},
+		},
+		{
+			in:       &dynamodb.AttributeValue{BS: [][]byte{}},
+			actual:   &[][]byte{},
+			expected: [][]byte{},
+		},
+		{
+			in:       &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{}},
+			actual:   &[]interface{}{},
+			expected: []interface{}{},
+		},
+		{
+			in:       &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{}},
+			actual:   &map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			in:     &dynamodb.AttributeValue{N: aws.String("")},
+			actual: new(int),
+			err:    fmt.Errorf("invalid syntax"),
+		},
+		{
+			in:       &dynamodb.AttributeValue{NS: []*string{}},
+			actual:   &[]*string{},
+			expected: []*string{},
+		},
+		{
+			in:       &dynamodb.AttributeValue{S: aws.String("")},
+			actual:   new(string),
+			expected: "",
+		},
+		{
+			in:       &dynamodb.AttributeValue{SS: []*string{}},
+			actual:   &[]*string{},
+			expected: []*string{},
+		},
 	}
 
 	for i, c := range cases {

--- a/service/dynamodb/dynamodbattribute/shared_test.go
+++ b/service/dynamodb/dynamodbattribute/shared_test.go
@@ -2,6 +2,7 @@ package dynamodbattribute
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -383,7 +384,7 @@ func assertConvertTest(t *testing.T, i int, actual, expected interface{}, err, e
 	i++
 	if expectedErr != nil {
 		if err != nil {
-			if e, a := expectedErr, err; !reflect.DeepEqual(e, a) {
+			if e, a := expectedErr, err; !strings.Contains(a.Error(), e.Error()) {
 				t.Errorf("case %d expect %v, got %v", i, e, a)
 			}
 		} else {


### PR DESCRIPTION
Simplifies the logic in `dynamodbattribute` to decode AttributeValue as it is defined.