### PR TITLE
service/s3/s3crypto: Add missing return on error

### DIFF
--- a/service/s3/s3crypto/encryption_client.go
+++ b/service/s3/s3crypto/encryption_client.go
@@ -103,6 +103,7 @@ func (c *EncryptionClient) PutObjectRequest(input *s3.PutObjectInput) (*request.
 		}
 		if err != nil {
 			r.Error = err
+			return
 		}
 
 		md5 := newMD5Reader(input.Body)


### PR DESCRIPTION
A missing return statement would allow an error
condition to fall through and trigger a panic.

