### PR TITLE
timeout_read: fix goroutine leak

### DIFF
--- a/aws/request/timeout_read_closer.go
+++ b/aws/request/timeout_read_closer.go
@@ -42,6 +42,11 @@ func (r *timeoutReadCloser) Read(b []byte) (int, error) {
 	case data := <-c:
 		return data.n, data.err
 	case <-timer.C:
+		// c needs to have a reader since the goroutine
+		// needs to send to it. 
+		go func() { 
+			<-c	// drop the data/error	
+		}()
 		return 0, timeoutErr
 	}
 }


### PR DESCRIPTION
Fix a goroutine leak in timeout_read. 
A simple demonstration: https://play.golang.com/p/-M1ae21XDw5

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
