### PR TITLE
 codegen: Add failsafe handling for unknown stream messages

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,5 +5,8 @@
   * Updates the documentation for GetBucketRegion's behavior with regard to default configuration for path style addressing. Provides examples how to override this behavior.
   * Updates the GetBucketRegion utility to not require a region hint when the session or client was configured with a custom endpoint URL.
   * Related to [#3115](https://github.com/aws/aws-sdk-go/issues/3115)
+* `service/s3`: Add failsafe handling for unknown stream messages
+  * Adds failsafe handling for receiving unknown stream messages from an API. A `<streamName>UnknownEvent` type will encapsulate the unknown message received from the API. Where `<streamName>` is the name of the API's stream, (e.g. S3's `SelectObjectContentEventStreamUnknownEvent`).
 
 ### SDK Bugs
+

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -101,6 +101,8 @@ func (c *RESTJSONService) EmptyStreamWithContext(ctx aws.Context, input *EmptySt
 	return out, req.Send()
 }
 
+var _ awserr.Error
+
 // EmptyStreamEventStream provides the event stream handling for the EmptyStream.
 type EmptyStreamEventStream struct {
 
@@ -161,6 +163,7 @@ func (es *EmptyStreamEventStream) waitStreamPartClose() {
 //
 // These events are:
 //
+//     * EmptyEventStreamUnknownEvent
 func (es *EmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
 	return es.Reader.Events()
 }
@@ -306,6 +309,8 @@ func (c *RESTJSONService) GetEventStreamWithContext(ctx aws.Context, input *GetE
 	return out, req.Send()
 }
 
+var _ awserr.Error
+
 // GetEventStreamEventStream provides the event stream handling for the GetEventStream.
 type GetEventStreamEventStream struct {
 
@@ -373,6 +378,7 @@ func (es *GetEventStreamEventStream) waitStreamPartClose() {
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
 //     * PayloadOnlyStringEvent
+//     * EventStreamUnknownEvent
 func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 	return es.Reader.Events()
 }
@@ -541,6 +547,8 @@ func (s *EmptyEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *EmptyEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	return msg, err
@@ -564,6 +572,7 @@ type EmptyEventStreamEvent interface {
 //
 // These events are:
 //
+//     * EmptyEventStreamUnknownEvent
 type EmptyEventStreamReader interface {
 	// Returns a channel of events as they are read from the event stream.
 	Events() <-chan EmptyEventStreamEvent
@@ -638,6 +647,9 @@ func (r *readEmptyEventStream) readEventStream() {
 				return
 			default:
 			}
+			if _, ok := err.(*eventstreamapi.UnknownMessageTypeError); ok {
+				continue
+			}
 			r.err.SetError(err)
 			return
 		}
@@ -657,12 +669,37 @@ type unmarshalerForEmptyEventStreamEvent struct {
 func (u unmarshalerForEmptyEventStreamEvent) UnmarshalerForEventName(eventType string) (eventstreamapi.Unmarshaler, error) {
 	switch eventType {
 	default:
-		return nil, awserr.New(
-			request.ErrCodeSerialization,
-			fmt.Sprintf("unknown event type name, %s, for EmptyEventStream", eventType),
-			nil,
-		)
+		return &EmptyEventStreamUnknownEvent{Type: eventType}, nil
 	}
+}
+
+// EmptyEventStreamUnknownEvent provides a failsafe event for the
+// EmptyEventStream group of events when an unknown event is received.
+type EmptyEventStreamUnknownEvent struct {
+	Type    string
+	Message eventstream.Message
+}
+
+// The EmptyEventStreamUnknownEvent is and event in the EmptyEventStream
+// group of events.
+func (s *EmptyEventStreamUnknownEvent) eventEmptyEventStream() {}
+
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
+func (e *EmptyEventStreamUnknownEvent) MarshalEvent(pm protocol.PayloadMarshaler) (
+	msg eventstream.Message, err error,
+) {
+	return e.Message.Clone(), nil
+}
+
+// UnmarshalEvent unmarshals the EventStream Message into the EmptyEventStream value.
+// This method is only used internally within the SDK's EventStream handling.
+func (e *EmptyEventStreamUnknownEvent) UnmarshalEvent(
+	payloadUnmarshaler protocol.PayloadUnmarshaler,
+	msg eventstream.Message,
+) error {
+	e.Message = msg.Clone()
+	return nil
 }
 
 type EmptyStreamInput struct {
@@ -732,6 +769,7 @@ type EventStreamEvent interface {
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
 //     * PayloadOnlyStringEvent
+//     * EventStreamUnknownEvent
 type EventStreamReader interface {
 	// Returns a channel of events as they are read from the event stream.
 	Events() <-chan EventStreamEvent
@@ -806,6 +844,9 @@ func (r *readEventStream) readEventStream() {
 				return
 			default:
 			}
+			if _, ok := err.(*eventstreamapi.UnknownMessageTypeError); ok {
+				continue
+			}
 			r.err.SetError(err)
 			return
 		}
@@ -843,12 +884,37 @@ func (u unmarshalerForEventStreamEvent) UnmarshalerForEventName(eventType string
 	case "Exception2":
 		return newErrorExceptionEvent2(u.metadata).(eventstreamapi.Unmarshaler), nil
 	default:
-		return nil, awserr.New(
-			request.ErrCodeSerialization,
-			fmt.Sprintf("unknown event type name, %s, for EventStream", eventType),
-			nil,
-		)
+		return &EventStreamUnknownEvent{Type: eventType}, nil
 	}
+}
+
+// EventStreamUnknownEvent provides a failsafe event for the
+// EventStream group of events when an unknown event is received.
+type EventStreamUnknownEvent struct {
+	Type    string
+	Message eventstream.Message
+}
+
+// The EventStreamUnknownEvent is and event in the EventStream
+// group of events.
+func (s *EventStreamUnknownEvent) eventEventStream() {}
+
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
+func (e *EventStreamUnknownEvent) MarshalEvent(pm protocol.PayloadMarshaler) (
+	msg eventstream.Message, err error,
+) {
+	return e.Message.Clone(), nil
+}
+
+// UnmarshalEvent unmarshals the EventStream Message into the EventStream value.
+// This method is only used internally within the SDK's EventStream handling.
+func (e *EventStreamUnknownEvent) UnmarshalEvent(
+	payloadUnmarshaler protocol.PayloadUnmarshaler,
+	msg eventstream.Message,
+) error {
+	e.Message = msg.Clone()
+	return nil
 }
 
 type ExceptionEvent struct {
@@ -887,6 +953,8 @@ func (s *ExceptionEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *ExceptionEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.ExceptionMessageType))
 	var buf bytes.Buffer
@@ -969,6 +1037,8 @@ func (s *ExceptionEvent2) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *ExceptionEvent2) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.ExceptionMessageType))
 	var buf bytes.Buffer
@@ -1080,6 +1150,8 @@ func (s *ExplicitPayloadEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *ExplicitPayloadEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Headers.Set("LongVal", eventstream.Int64Value(*s.LongVal))
@@ -1277,6 +1349,8 @@ func (s *HeaderOnlyEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *HeaderOnlyEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Headers.Set("BlobVal", eventstream.BytesValue(s.BlobVal))
@@ -1350,6 +1424,8 @@ func (s *ImplicitPayloadEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *ImplicitPayloadEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Headers.Set("ByteVal", eventstream.Int8Value(int8(*s.ByteVal)))
@@ -1456,6 +1532,8 @@ func (s *PayloadOnlyBlobEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *PayloadOnlyBlobEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Headers.Set(":content-type", eventstream.StringValue("application/octet-stream"))
@@ -1502,6 +1580,8 @@ func (s *PayloadOnlyEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *PayloadOnlyEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	var buf bytes.Buffer
@@ -1547,6 +1627,8 @@ func (s *PayloadOnlyStringEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *PayloadOnlyStringEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Payload = []byte(aws.StringValue(s.StringPayload))

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -103,6 +103,8 @@ func (c *RPCService) EmptyStreamWithContext(ctx aws.Context, input *EmptyStreamI
 	return out, req.Send()
 }
 
+var _ awserr.Error
+
 // EmptyStreamEventStream provides the event stream handling for the EmptyStream.
 type EmptyStreamEventStream struct {
 
@@ -176,6 +178,7 @@ func (e eventTypeForEmptyStreamEventStreamOutputEvent) UnmarshalerForEventName(e
 //
 // These events are:
 //
+//     * EmptyEventStreamUnknownEvent
 func (es *EmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
 	return es.Reader.Events()
 }
@@ -351,6 +354,8 @@ func (c *RPCService) GetEventStreamWithContext(ctx aws.Context, input *GetEventS
 	return out, req.Send()
 }
 
+var _ awserr.Error
+
 // GetEventStreamEventStream provides the event stream handling for the GetEventStream.
 type GetEventStreamEventStream struct {
 
@@ -431,6 +436,7 @@ func (e eventTypeForGetEventStreamEventStreamOutputEvent) UnmarshalerForEventNam
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
 //     * PayloadOnlyStringEvent
+//     * EventStreamUnknownEvent
 func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 	return es.Reader.Events()
 }
@@ -627,6 +633,8 @@ func (s *EmptyEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *EmptyEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	return msg, err
@@ -650,6 +658,7 @@ type EmptyEventStreamEvent interface {
 //
 // These events are:
 //
+//     * EmptyEventStreamUnknownEvent
 type EmptyEventStreamReader interface {
 	// Returns a channel of events as they are read from the event stream.
 	Events() <-chan EmptyEventStreamEvent
@@ -724,6 +733,9 @@ func (r *readEmptyEventStream) readEventStream() {
 				return
 			default:
 			}
+			if _, ok := err.(*eventstreamapi.UnknownMessageTypeError); ok {
+				continue
+			}
 			r.err.SetError(err)
 			return
 		}
@@ -743,12 +755,37 @@ type unmarshalerForEmptyEventStreamEvent struct {
 func (u unmarshalerForEmptyEventStreamEvent) UnmarshalerForEventName(eventType string) (eventstreamapi.Unmarshaler, error) {
 	switch eventType {
 	default:
-		return nil, awserr.New(
-			request.ErrCodeSerialization,
-			fmt.Sprintf("unknown event type name, %s, for EmptyEventStream", eventType),
-			nil,
-		)
+		return &EmptyEventStreamUnknownEvent{Type: eventType}, nil
 	}
+}
+
+// EmptyEventStreamUnknownEvent provides a failsafe event for the
+// EmptyEventStream group of events when an unknown event is received.
+type EmptyEventStreamUnknownEvent struct {
+	Type    string
+	Message eventstream.Message
+}
+
+// The EmptyEventStreamUnknownEvent is and event in the EmptyEventStream
+// group of events.
+func (s *EmptyEventStreamUnknownEvent) eventEmptyEventStream() {}
+
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
+func (e *EmptyEventStreamUnknownEvent) MarshalEvent(pm protocol.PayloadMarshaler) (
+	msg eventstream.Message, err error,
+) {
+	return e.Message.Clone(), nil
+}
+
+// UnmarshalEvent unmarshals the EventStream Message into the EmptyEventStream value.
+// This method is only used internally within the SDK's EventStream handling.
+func (e *EmptyEventStreamUnknownEvent) UnmarshalEvent(
+	payloadUnmarshaler protocol.PayloadUnmarshaler,
+	msg eventstream.Message,
+) error {
+	e.Message = msg.Clone()
+	return nil
 }
 
 type EmptyStreamInput struct {
@@ -803,6 +840,8 @@ func (s *EmptyStreamOutput) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *EmptyStreamOutput) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	var buf bytes.Buffer
@@ -845,6 +884,7 @@ type EventStreamEvent interface {
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
 //     * PayloadOnlyStringEvent
+//     * EventStreamUnknownEvent
 type EventStreamReader interface {
 	// Returns a channel of events as they are read from the event stream.
 	Events() <-chan EventStreamEvent
@@ -919,6 +959,9 @@ func (r *readEventStream) readEventStream() {
 				return
 			default:
 			}
+			if _, ok := err.(*eventstreamapi.UnknownMessageTypeError); ok {
+				continue
+			}
 			r.err.SetError(err)
 			return
 		}
@@ -956,12 +999,37 @@ func (u unmarshalerForEventStreamEvent) UnmarshalerForEventName(eventType string
 	case "Exception2":
 		return newErrorExceptionEvent2(u.metadata).(eventstreamapi.Unmarshaler), nil
 	default:
-		return nil, awserr.New(
-			request.ErrCodeSerialization,
-			fmt.Sprintf("unknown event type name, %s, for EventStream", eventType),
-			nil,
-		)
+		return &EventStreamUnknownEvent{Type: eventType}, nil
 	}
+}
+
+// EventStreamUnknownEvent provides a failsafe event for the
+// EventStream group of events when an unknown event is received.
+type EventStreamUnknownEvent struct {
+	Type    string
+	Message eventstream.Message
+}
+
+// The EventStreamUnknownEvent is and event in the EventStream
+// group of events.
+func (s *EventStreamUnknownEvent) eventEventStream() {}
+
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
+func (e *EventStreamUnknownEvent) MarshalEvent(pm protocol.PayloadMarshaler) (
+	msg eventstream.Message, err error,
+) {
+	return e.Message.Clone(), nil
+}
+
+// UnmarshalEvent unmarshals the EventStream Message into the EventStream value.
+// This method is only used internally within the SDK's EventStream handling.
+func (e *EventStreamUnknownEvent) UnmarshalEvent(
+	payloadUnmarshaler protocol.PayloadUnmarshaler,
+	msg eventstream.Message,
+) error {
+	e.Message = msg.Clone()
+	return nil
 }
 
 type ExceptionEvent struct {
@@ -1000,6 +1068,8 @@ func (s *ExceptionEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *ExceptionEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.ExceptionMessageType))
 	var buf bytes.Buffer
@@ -1082,6 +1152,8 @@ func (s *ExceptionEvent2) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *ExceptionEvent2) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.ExceptionMessageType))
 	var buf bytes.Buffer
@@ -1193,6 +1265,8 @@ func (s *ExplicitPayloadEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *ExplicitPayloadEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Headers.Set("LongVal", eventstream.Int64Value(*s.LongVal))
@@ -1281,6 +1355,8 @@ func (s *GetEventStreamOutput) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *GetEventStreamOutput) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	var buf bytes.Buffer
@@ -1417,6 +1493,8 @@ func (s *HeaderOnlyEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *HeaderOnlyEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Headers.Set("BlobVal", eventstream.BytesValue(s.BlobVal))
@@ -1490,6 +1568,8 @@ func (s *ImplicitPayloadEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *ImplicitPayloadEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Headers.Set("ByteVal", eventstream.Int8Value(int8(*s.ByteVal)))
@@ -1596,6 +1676,8 @@ func (s *PayloadOnlyBlobEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *PayloadOnlyBlobEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Headers.Set(":content-type", eventstream.StringValue("application/octet-stream"))
@@ -1642,6 +1724,8 @@ func (s *PayloadOnlyEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *PayloadOnlyEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	var buf bytes.Buffer
@@ -1687,6 +1771,8 @@ func (s *PayloadOnlyStringEvent) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *PayloadOnlyStringEvent) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.EventMessageType))
 	msg.Payload = []byte(aws.StringValue(s.StringPayload))

--- a/private/model/api/codegentest/service/rpcservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/rpcservice/eventstream_test.go
@@ -100,6 +100,70 @@ func TestEmptyStream_ReadClose(t *testing.T) {
 	}
 }
 
+func TestEmptyStream_ReadUnknownEvent(t *testing.T) {
+	expectEvents, eventMsgs := mockEmptyStreamReadEvents()
+	eventOffset := 1
+
+	unknownEvent := eventstream.Message{
+		Headers: eventstream.Headers{
+			eventstreamtest.EventMessageTypeHeader,
+			{
+				Name:  eventstreamapi.EventTypeHeader,
+				Value: eventstream.StringValue("UnknownEventName"),
+			},
+		},
+		Payload: []byte("some unknown event"),
+	}
+
+	eventMsgs = append(eventMsgs[:eventOffset],
+		append([]eventstream.Message{unknownEvent}, eventMsgs[eventOffset:]...)...)
+
+	expectEvents = append(expectEvents[:eventOffset],
+		append([]EmptyEventStreamEvent{
+			&EmptyEventStreamUnknownEvent{
+				Type:    "UnknownEventName",
+				Message: unknownEvent,
+			},
+		},
+			expectEvents[eventOffset:]...)...)
+
+	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
+		eventstreamtest.ServeEventStream{
+			T:      t,
+			Events: eventMsgs,
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expect no error, %v", err)
+	}
+	defer cleanupFn()
+
+	svc := New(sess)
+	resp, err := svc.EmptyStream(nil)
+	if err != nil {
+		t.Fatalf("expect no error got, %v", err)
+	}
+	defer resp.GetStream().Close()
+	// Trim off response output type pseudo event so only event messages remain.
+	expectEvents = expectEvents[1:]
+
+	var i int
+	for event := range resp.GetStream().Events() {
+		if event == nil {
+			t.Errorf("%d, expect event, got nil", i)
+		}
+		if e, a := expectEvents[i], event; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d, expect %T %v, got %T %v", i, e, e, a, a)
+		}
+		i++
+	}
+
+	if err := resp.GetStream().Err(); err != nil {
+		t.Errorf("expect no error, %v", err)
+	}
+}
+
 func BenchmarkEmptyStream_Read(b *testing.B) {
 	_, eventMsgs := mockEmptyStreamReadEvents()
 	var buf bytes.Buffer
@@ -256,6 +320,70 @@ func TestGetEventStream_ReadClose(t *testing.T) {
 
 	resp.GetStream().Close()
 	<-resp.GetStream().Events()
+
+	if err := resp.GetStream().Err(); err != nil {
+		t.Errorf("expect no error, %v", err)
+	}
+}
+
+func TestGetEventStream_ReadUnknownEvent(t *testing.T) {
+	expectEvents, eventMsgs := mockGetEventStreamReadEvents()
+	eventOffset := 1
+
+	unknownEvent := eventstream.Message{
+		Headers: eventstream.Headers{
+			eventstreamtest.EventMessageTypeHeader,
+			{
+				Name:  eventstreamapi.EventTypeHeader,
+				Value: eventstream.StringValue("UnknownEventName"),
+			},
+		},
+		Payload: []byte("some unknown event"),
+	}
+
+	eventMsgs = append(eventMsgs[:eventOffset],
+		append([]eventstream.Message{unknownEvent}, eventMsgs[eventOffset:]...)...)
+
+	expectEvents = append(expectEvents[:eventOffset],
+		append([]EventStreamEvent{
+			&EventStreamUnknownEvent{
+				Type:    "UnknownEventName",
+				Message: unknownEvent,
+			},
+		},
+			expectEvents[eventOffset:]...)...)
+
+	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
+		eventstreamtest.ServeEventStream{
+			T:      t,
+			Events: eventMsgs,
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expect no error, %v", err)
+	}
+	defer cleanupFn()
+
+	svc := New(sess)
+	resp, err := svc.GetEventStream(nil)
+	if err != nil {
+		t.Fatalf("expect no error got, %v", err)
+	}
+	defer resp.GetStream().Close()
+	// Trim off response output type pseudo event so only event messages remain.
+	expectEvents = expectEvents[1:]
+
+	var i int
+	for event := range resp.GetStream().Events() {
+		if event == nil {
+			t.Errorf("%d, expect event, got nil", i)
+		}
+		if e, a := expectEvents[i], event; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d, expect %T %v, got %T %v", i, e, e, a, a)
+		}
+		i++
+	}
 
 	if err := resp.GetStream().Err(); err != nil {
 		t.Errorf("expect no error, %v", err)

--- a/private/model/api/eventstream.go
+++ b/private/model/api/eventstream.go
@@ -71,6 +71,10 @@ func (es *EventStream) StreamUnmarshalerForEventName() string {
 	return "unmarshalerFor" + es.Name + "Event"
 }
 
+func (es *EventStream) StreamUnknownEventName() string {
+	return es.Name + "UnknownEvent"
+}
+
 // Event is a single EventStream event that can be sent or received in an
 // EventStream.
 type Event struct {

--- a/private/model/api/eventstream_tmpl.go
+++ b/private/model/api/eventstream_tmpl.go
@@ -21,6 +21,10 @@ func renderEventStreamAPI(w io.Writer, op *Operation) error {
 	op.API.AddSDKImport("private/protocol/eventstream")
 	op.API.AddSDKImport("private/protocol/eventstream/eventstreamapi")
 
+	w.Write([]byte(`
+var _ awserr.Error
+`))
+
 	return eventStreamAPITmpl.Execute(w, op)
 }
 
@@ -254,6 +258,7 @@ func (es *{{ $esapi.Name }}) waitStreamPartClose() {
 	// {{ range $_, $event := $outputStream.Events }}
 	//     * {{ $event.Shape.ShapeName }}
 	{{- end }}
+    //     * {{ $outputStream.StreamUnknownEventName }}
 	func (es *{{ $esapi.Name }}) Events() <-chan {{ $outputStream.EventGroupName }} {
 		return es.Reader.Events()
 	}
@@ -584,6 +589,8 @@ func (s *{{ $.ShapeName }}) UnmarshalEvent(
 	return nil
 }
 
+// MarshalEvent marshals the type into an stream event value. This method
+// should only used internally within the SDK's EventStream handling.
 func (s *{{ $.ShapeName}}) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue({{ ShapeMessageType $ }}))
 

--- a/private/protocol/eventstream/eventstreamapi/reader.go
+++ b/private/protocol/eventstream/eventstreamapi/reader.go
@@ -69,8 +69,21 @@ func (r *EventReader) ReadEvent() (event interface{}, err error) {
 	case ErrorMessageType:
 		return nil, r.unmarshalErrorMessage(msg)
 	default:
-		return nil, fmt.Errorf("unknown eventstream message type, %v", typ)
+		return nil, &UnknownMessageTypeError{
+			Type: typ, Message: msg.Clone(),
+		}
 	}
+}
+
+// UnknownMessageTypeError provides an error when a message is received from
+// the stream, but the reader is unable to determine what kind of message it is.
+type UnknownMessageTypeError struct {
+	Type    string
+	Message eventstream.Message
+}
+
+func (e *UnknownMessageTypeError) Error() string {
+	return "unknown eventstream message type, " + e.Type
 }
 
 func (r *EventReader) unmarshalEventMessage(

--- a/private/protocol/eventstream/header.go
+++ b/private/protocol/eventstream/header.go
@@ -52,6 +52,15 @@ func (hs *Headers) Del(name string) {
 	}
 }
 
+// Clone returns a deep copy of the headers
+func (hs Headers) Clone() Headers {
+	o := make(Headers, 0, len(hs))
+	for _, h := range hs {
+		o.Set(h.Name, h.Value)
+	}
+	return o
+}
+
 func decodeHeaders(r io.Reader) (Headers, error) {
 	hs := Headers{}
 

--- a/private/protocol/eventstream/message.go
+++ b/private/protocol/eventstream/message.go
@@ -57,6 +57,20 @@ func (m *Message) rawMessage() (rawMessage, error) {
 	return raw, nil
 }
 
+// Clone returns a deep copy of the message.
+func (m Message) Clone() Message {
+	var payload []byte
+	if m.Payload != nil {
+		payload = make([]byte, len(m.Payload))
+		copy(payload, m.Payload)
+	}
+
+	return Message{
+		Headers: m.Headers.Clone(),
+		Payload: payload,
+	}
+}
+
 type messagePrelude struct {
 	Length     uint32
 	HeadersLen uint32

--- a/service/kinesis/eventstream_test.go
+++ b/service/kinesis/eventstream_test.go
@@ -110,6 +110,70 @@ func TestSubscribeToShard_ReadClose(t *testing.T) {
 	}
 }
 
+func TestSubscribeToShard_ReadUnknownEvent(t *testing.T) {
+	expectEvents, eventMsgs := mockSubscribeToShardReadEvents()
+	eventOffset := 1
+
+	unknownEvent := eventstream.Message{
+		Headers: eventstream.Headers{
+			eventstreamtest.EventMessageTypeHeader,
+			{
+				Name:  eventstreamapi.EventTypeHeader,
+				Value: eventstream.StringValue("UnknownEventName"),
+			},
+		},
+		Payload: []byte("some unknown event"),
+	}
+
+	eventMsgs = append(eventMsgs[:eventOffset],
+		append([]eventstream.Message{unknownEvent}, eventMsgs[eventOffset:]...)...)
+
+	expectEvents = append(expectEvents[:eventOffset],
+		append([]SubscribeToShardEventStreamEvent{
+			&SubscribeToShardEventStreamUnknownEvent{
+				Type:    "UnknownEventName",
+				Message: unknownEvent,
+			},
+		},
+			expectEvents[eventOffset:]...)...)
+
+	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
+		eventstreamtest.ServeEventStream{
+			T:      t,
+			Events: eventMsgs,
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expect no error, %v", err)
+	}
+	defer cleanupFn()
+
+	svc := New(sess)
+	resp, err := svc.SubscribeToShard(nil)
+	if err != nil {
+		t.Fatalf("expect no error got, %v", err)
+	}
+	defer resp.GetStream().Close()
+	// Trim off response output type pseudo event so only event messages remain.
+	expectEvents = expectEvents[1:]
+
+	var i int
+	for event := range resp.GetStream().Events() {
+		if event == nil {
+			t.Errorf("%d, expect event, got nil", i)
+		}
+		if e, a := expectEvents[i], event; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d, expect %T %v, got %T %v", i, e, e, a, a)
+		}
+		i++
+	}
+
+	if err := resp.GetStream().Err(); err != nil {
+		t.Errorf("expect no error, %v", err)
+	}
+}
+
 func BenchmarkSubscribeToShard_Read(b *testing.B) {
 	_, eventMsgs := mockSubscribeToShardReadEvents()
 	var buf bytes.Buffer

--- a/service/s3/eventstream_test.go
+++ b/service/s3/eventstream_test.go
@@ -108,6 +108,68 @@ func TestSelectObjectContent_ReadClose(t *testing.T) {
 	}
 }
 
+func TestSelectObjectContent_ReadUnknownEvent(t *testing.T) {
+	expectEvents, eventMsgs := mockSelectObjectContentReadEvents()
+	var eventOffset int
+
+	unknownEvent := eventstream.Message{
+		Headers: eventstream.Headers{
+			eventstreamtest.EventMessageTypeHeader,
+			{
+				Name:  eventstreamapi.EventTypeHeader,
+				Value: eventstream.StringValue("UnknownEventName"),
+			},
+		},
+		Payload: []byte("some unknown event"),
+	}
+
+	eventMsgs = append(eventMsgs[:eventOffset],
+		append([]eventstream.Message{unknownEvent}, eventMsgs[eventOffset:]...)...)
+
+	expectEvents = append(expectEvents[:eventOffset],
+		append([]SelectObjectContentEventStreamEvent{
+			&SelectObjectContentEventStreamUnknownEvent{
+				Type:    "UnknownEventName",
+				Message: unknownEvent,
+			},
+		},
+			expectEvents[eventOffset:]...)...)
+
+	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
+		eventstreamtest.ServeEventStream{
+			T:      t,
+			Events: eventMsgs,
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expect no error, %v", err)
+	}
+	defer cleanupFn()
+
+	svc := New(sess)
+	resp, err := svc.SelectObjectContent(nil)
+	if err != nil {
+		t.Fatalf("expect no error got, %v", err)
+	}
+	defer resp.GetStream().Close()
+
+	var i int
+	for event := range resp.GetStream().Events() {
+		if event == nil {
+			t.Errorf("%d, expect event, got nil", i)
+		}
+		if e, a := expectEvents[i], event; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d, expect %T %v, got %T %v", i, e, e, a, a)
+		}
+		i++
+	}
+
+	if err := resp.GetStream().Err(); err != nil {
+		t.Errorf("expect no error, %v", err)
+	}
+}
+
 func BenchmarkSelectObjectContent_Read(b *testing.B) {
 	_, eventMsgs := mockSelectObjectContentReadEvents()
 	var buf bytes.Buffer

--- a/service/transcribestreamingservice/eventstream_test.go
+++ b/service/transcribestreamingservice/eventstream_test.go
@@ -108,6 +108,68 @@ func TestStartStreamTranscription_ReadClose(t *testing.T) {
 	}
 }
 
+func TestStartStreamTranscription_ReadUnknownEvent(t *testing.T) {
+	expectEvents, eventMsgs := mockStartStreamTranscriptionReadEvents()
+	var eventOffset int
+
+	unknownEvent := eventstream.Message{
+		Headers: eventstream.Headers{
+			eventstreamtest.EventMessageTypeHeader,
+			{
+				Name:  eventstreamapi.EventTypeHeader,
+				Value: eventstream.StringValue("UnknownEventName"),
+			},
+		},
+		Payload: []byte("some unknown event"),
+	}
+
+	eventMsgs = append(eventMsgs[:eventOffset],
+		append([]eventstream.Message{unknownEvent}, eventMsgs[eventOffset:]...)...)
+
+	expectEvents = append(expectEvents[:eventOffset],
+		append([]TranscriptResultStreamEvent{
+			&TranscriptResultStreamUnknownEvent{
+				Type:    "UnknownEventName",
+				Message: unknownEvent,
+			},
+		},
+			expectEvents[eventOffset:]...)...)
+
+	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
+		eventstreamtest.ServeEventStream{
+			T:      t,
+			Events: eventMsgs,
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expect no error, %v", err)
+	}
+	defer cleanupFn()
+
+	svc := New(sess)
+	resp, err := svc.StartStreamTranscription(nil)
+	if err != nil {
+		t.Fatalf("expect no error got, %v", err)
+	}
+	defer resp.GetStream().Close()
+
+	var i int
+	for event := range resp.GetStream().Events() {
+		if event == nil {
+			t.Errorf("%d, expect event, got nil", i)
+		}
+		if e, a := expectEvents[i], event; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d, expect %T %v, got %T %v", i, e, e, a, a)
+		}
+		i++
+	}
+
+	if err := resp.GetStream().Err(); err != nil {
+		t.Errorf("expect no error, %v", err)
+	}
+}
+
 func BenchmarkStartStreamTranscription_Read(b *testing.B) {
 	_, eventMsgs := mockStartStreamTranscriptionReadEvents()
 	var buf bytes.Buffer


### PR DESCRIPTION
Adds failsafe handling for receiving unknown stream messages from an API. A `<streamName>UnknownEvent` type will encapsulate the unknown message received from the API. Where `<streamName>` is the name of the API's stream, (e.g. S3's `SelectObjectContentEventStreamUnknownEvent`).