### PR TITLE
aws/credentials: Update shared creds provider docs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/credentials`: Update documentation for shared credentials provider to specify the type of credentials it supports retrieving from shared credentials file.
+    * Related to [#3328](https://github.com/aws/aws-sdk-go/issues/3328)
 
 ### SDK Bugs

--- a/aws/credentials/shared_credentials_provider.go
+++ b/aws/credentials/shared_credentials_provider.go
@@ -17,8 +17,9 @@ var (
 	ErrSharedCredentialsHomeNotFound = awserr.New("UserHomeNotFound", "user home directory not found.", nil)
 )
 
-// A SharedCredentialsProvider retrieves credentials from the current user's home
-// directory, and keeps track if those credentials are expired.
+// A SharedCredentialsProvider retrieves access key pair (access key ID,
+// secret access key, and session token if present) credentials from the current
+// user's home directory, and keeps track if those credentials are expired.
 //
 // Profile ini file example: $HOME/.aws/credentials
 type SharedCredentialsProvider struct {


### PR DESCRIPTION
Fix #3328 

Update documentation for shared credentials provider to specify the type of credentials it supports retrieving from shared credentials file.