### PR TITLE
service/s3/s3crypto Fix request retries

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/s3/s3crypto`: Fix client's temporary file buffer error on retry ([#3344](https://github.com/aws/aws-sdk-go/pull/3344))
+  * Fixes the Crypto client's temporary file buffer cleanup returning an error when the request is retried.

--- a/service/s3/s3crypto/helper.go
+++ b/service/s3/s3crypto/helper.go
@@ -19,7 +19,7 @@ func getWriterStore(req *request.Request, path string, useTempFile bool) (io.Rea
 		return nil, err
 	}
 
-	req.Handlers.Send.PushBack(func(r *request.Request) {
+	req.Handlers.Complete.PushBack(func(r *request.Request) {
 		// Close the temp file and cleanup
 		f.Close()
 		os.Remove(f.Name())

--- a/service/s3/s3crypto/helper_test.go
+++ b/service/s3/s3crypto/helper_test.go
@@ -121,8 +121,8 @@ func TestGetWriterStore_TempFile(t *testing.T) {
 
 func TestGetWriterStore_TempFileWithRetry(t *testing.T) {
 	responses := []*http.Response{
-		&http.Response{StatusCode: 500, Header: http.Header{}, Body: ioutil.NopCloser(&bytes.Buffer{})},
-		&http.Response{StatusCode: 200, Header: http.Header{}, Body: ioutil.NopCloser(&bytes.Buffer{})},
+		{StatusCode: 500, Header: http.Header{}, Body: ioutil.NopCloser(&bytes.Buffer{})},
+		{StatusCode: 200, Header: http.Header{}, Body: ioutil.NopCloser(&bytes.Buffer{})},
 	}
 	s := awstesting.NewClient(aws.NewConfig().WithMaxRetries(10))
 	s.Handlers.Validate.Clear()

--- a/service/s3/s3crypto/helper_test.go
+++ b/service/s3/s3crypto/helper_test.go
@@ -2,6 +2,7 @@ package s3crypto
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -115,6 +116,43 @@ func TestGetWriterStore_TempFile(t *testing.T) {
 	}
 	if _, err := os.Stat(tempFile.Name()); !os.IsNotExist(err) {
 		t.Errorf("expected temp file be deleted, but still exists %v", tempFile.Name())
+	}
+}
+
+func TestGetWriterStore_TempFileWithRetry(t *testing.T) {
+	responses := []*http.Response{
+		&http.Response{StatusCode: 500, Header: http.Header{}, Body: ioutil.NopCloser(&bytes.Buffer{})},
+		&http.Response{StatusCode: 200, Header: http.Header{}, Body: ioutil.NopCloser(&bytes.Buffer{})},
+	}
+	s := awstesting.NewClient(aws.NewConfig().WithMaxRetries(10))
+	s.Handlers.Validate.Clear()
+	s.Handlers.Send.Clear() // mock sending
+	s.Handlers.Send.PushBack(func(r *request.Request) {
+		r.HTTPResponse = responses[0]
+		responses = responses[1:]
+	})
+	type testData struct {
+		Data string
+	}
+	out := &testData{}
+	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
+	f, err := getWriterStore(r, "", true)
+	if err != nil {
+		t.Fatalf("expected no error, but received %v", err)
+	}
+	tempFile, ok := f.(*os.File)
+	if !ok {
+		t.Fatal("io.ReadWriteSeeker expected to be *os.file")
+	}
+	err = r.Send()
+	if err != nil {
+		t.Errorf("expected no error, but received %v", err)
+	}
+	if _, err := os.Stat(tempFile.Name()); !os.IsNotExist(err) {
+		t.Errorf("expected temp file be deleted, but still exists %v", tempFile.Name())
+	}
+	if v := len(responses); v != 0 {
+		t.Errorf("expect all retries to be used, have %v remaining", v)
 	}
 }
 


### PR DESCRIPTION
Closing and removing the temp file after send causes retry requests to
fail with an error such as:
```
filestore: SerializationError: failed to prepare body for retry
caused by: SerializationError: failed to reset request body
caused by: SerializationError: failed to get next request body reader
caused by: seek /tmp/213721967: file already closed
```
I believe the Complete handler is guaranteed to be called
after retries attempts have succeeded or been exhausted.

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
