### PR TITLE
`internal/sync`: Remove unstable single flight tests

### DIFF
--- a/internal/sync/singleflight/singleflight_test.go
+++ b/internal/sync/singleflight/singleflight_test.go
@@ -41,6 +41,8 @@ func TestDoErr(t *testing.T) {
 }
 
 func TestDoDupSuppress(t *testing.T) {
+	t.Skip("unable test")
+
 	var g Group
 	var wg1, wg2 sync.WaitGroup
 	c := make(chan string, 1)
@@ -89,6 +91,8 @@ func TestDoDupSuppress(t *testing.T) {
 // Test that singleflight behaves correctly after Forget called.
 // See https://github.com/golang/go/issues/31420
 func TestForget(t *testing.T) {
+	t.Skip("unable test")
+
 	var g Group
 
 	var firstStarted, firstFinished sync.WaitGroup


### PR DESCRIPTION
Removes the unstable single flight tests, to prevent transient failures.