### PR TITLE
service/s3/s3crypto: Allow envelope unmarshal to accept JSON numbers for tag length.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `service/s3/s3crypto`: Allow envelope unmarshal to accept JSON numbers for tag length [(#3422)](https://github.com/aws/aws-sdk-go/pull/3422)
 
 ### SDK Bugs

--- a/service/s3/s3crypto/envelope.go
+++ b/service/s3/s3crypto/envelope.go
@@ -38,6 +38,7 @@ type Envelope struct {
 	UnencryptedContentLen string `json:"x-amz-unencrypted-content-length"`
 }
 
+// UnmarshalJSON unmarshalls the given JSON bytes into Envelope
 func (e *Envelope) UnmarshalJSON(bytes []byte) error {
 	type StrictEnvelope Envelope
 	type LaxEnvelope struct {

--- a/service/s3/s3crypto/envelope_test.go
+++ b/service/s3/s3crypto/envelope_test.go
@@ -1,0 +1,72 @@
+// +build go1.7
+
+package s3crypto
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestEnvelope_UnmarshalJSON(t *testing.T) {
+	cases := map[string]struct {
+		content  []byte
+		expected Envelope
+		actual   Envelope
+	}{
+		"standard": {
+			content: []byte(`{
+  "x-amz-iv": "iv",
+  "x-amz-key-v2": "key",
+  "x-amz-matdesc": "{\"aws:x-amz-cek-alg\":\"AES/GCM/NoPadding\"}",
+  "x-amz-wrap-alg": "kms+context",
+  "x-amz-cek-alg": "AES/GCM/NoPadding",
+  "x-amz-tag-len": "128",
+  "x-amz-unencrypted-content-length": "1024"
+}
+`),
+			expected: Envelope{
+				IV:                    "iv",
+				CipherKey:             "key",
+				MatDesc:               `{"aws:x-amz-cek-alg":"AES/GCM/NoPadding"}`,
+				WrapAlg:               "kms+context",
+				CEKAlg:                "AES/GCM/NoPadding",
+				TagLen:                "128",
+				UnencryptedContentLen: "1024",
+			},
+		},
+		"allow json number tags": {
+			content: []byte(`{
+  "x-amz-iv": "iv",
+  "x-amz-key-v2": "key",
+  "x-amz-matdesc": "{\"aws:x-amz-cek-alg\":\"AES/GCM/NoPadding\"}",
+  "x-amz-wrap-alg": "kms+context",
+  "x-amz-cek-alg": "AES/GCM/NoPadding",
+  "x-amz-tag-len": 128,
+  "x-amz-unencrypted-content-length": "1024"
+}
+`),
+			expected: Envelope{
+				IV:                    "iv",
+				CipherKey:             "key",
+				MatDesc:               `{"aws:x-amz-cek-alg":"AES/GCM/NoPadding"}`,
+				WrapAlg:               "kms+context",
+				CEKAlg:                "AES/GCM/NoPadding",
+				TagLen:                "128",
+				UnencryptedContentLen: "1024",
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := json.Unmarshal(tt.content, &tt.actual)
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+			if !reflect.DeepEqual(tt.expected, tt.actual) {
+				t.Errorf("expected %v, got %v", tt.expected, tt.actual)
+			}
+		})
+	}
+}

--- a/service/s3/s3crypto/envelope_test.go
+++ b/service/s3/s3crypto/envelope_test.go
@@ -35,7 +35,7 @@ func TestEnvelope_UnmarshalJSON(t *testing.T) {
 				UnencryptedContentLen: "1024",
 			},
 		},
-		"allow json number tags": {
+		"tag length as number": {
 			content: []byte(`{
   "x-amz-iv": "iv",
   "x-amz-key-v2": "key",
@@ -53,6 +53,45 @@ func TestEnvelope_UnmarshalJSON(t *testing.T) {
 				WrapAlg:               "kms+context",
 				CEKAlg:                "AES/GCM/NoPadding",
 				TagLen:                "128",
+				UnencryptedContentLen: "1024",
+			},
+		},
+		"null tag length": {
+			content: []byte(`{
+  "x-amz-iv": "iv",
+  "x-amz-key-v2": "key",
+  "x-amz-matdesc": "{\"aws:x-amz-cek-alg\":\"AES/GCM/NoPadding\"}",
+  "x-amz-wrap-alg": "kms+context",
+  "x-amz-cek-alg": "AES/GCM/NoPadding",
+  "x-amz-tag-len": null,
+  "x-amz-unencrypted-content-length": "1024"
+}
+`),
+			expected: Envelope{
+				IV:                    "iv",
+				CipherKey:             "key",
+				MatDesc:               `{"aws:x-amz-cek-alg":"AES/GCM/NoPadding"}`,
+				WrapAlg:               "kms+context",
+				CEKAlg:                "AES/GCM/NoPadding",
+				UnencryptedContentLen: "1024",
+			},
+		},
+		"no tag length": {
+			content: []byte(`{
+  "x-amz-iv": "iv",
+  "x-amz-key-v2": "key",
+  "x-amz-matdesc": "{\"aws:x-amz-cek-alg\":\"AES/GCM/NoPadding\"}",
+  "x-amz-wrap-alg": "kms+context",
+  "x-amz-cek-alg": "AES/GCM/NoPadding",
+  "x-amz-unencrypted-content-length": "1024"
+}
+`),
+			expected: Envelope{
+				IV:                    "iv",
+				CipherKey:             "key",
+				MatDesc:               `{"aws:x-amz-cek-alg":"AES/GCM/NoPadding"}`,
+				WrapAlg:               "kms+context",
+				CEKAlg:                "AES/GCM/NoPadding",
 				UnencryptedContentLen: "1024",
 			},
 		},


### PR DESCRIPTION
Allows the tag length envelope member to be valid JSON numbers.