### PR TITLE
clarify Endpoint behavior on empty strings

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -43,7 +43,7 @@ type Config struct {
 
 	// An optional endpoint URL (hostname only or fully qualified URI)
 	// that overrides the default generated endpoint for a client. Set this
-	// to `nil` to use the default generated endpoint.
+	// to `nil` or the value to `""` to use the default generated endpoint.
 	//
 	// Note: You must still provide a `Region` value when specifying an
 	// endpoint for a client.


### PR DESCRIPTION
The following PR changed the Endpoint behavior to include falling back to the default generated endpoint if an empty string is set. 
https://github.com/aws/aws-sdk-go/pull/3349

It's not very clear that this is the intended behavior when reading the docs. Adding this clarification promotes using the following code rather than have to conditionally check if it's set or not.
For example:
```go
type S3 struct {
	Endpoint string
	Region 	 string
}


// ideal behavior
sess, err := session.NewSession(&aws.Config{
	Endpoint: aws.String(s3Cfg.Endpoint),
	Region:   aws.String(s3Cfg.Region),
})


// required check given docs assumption
var endpoint *string
if s3Cfg.Endpoint != "" {
	endpoint = aws.String(s3Cfg.Endpoint)
}
sess, err := session.NewSession(&aws.Config{
	Endpoint: endpoint,
	Region:   aws.String(s3Cfg.Region),
})
```