### PR TITLE
service/s3/s3crypto: Allow content length JSON Number

### DIFF
--- a/service/s3/s3crypto/envelope.go
+++ b/service/s3/s3crypto/envelope.go
@@ -47,7 +47,8 @@ func (e *Envelope) UnmarshalJSON(value []byte) error {
 	type StrictEnvelope Envelope
 	type LaxEnvelope struct {
 		StrictEnvelope
-		TagLen json.RawMessage `json:"x-amz-tag-len"`
+		TagLen                json.RawMessage `json:"x-amz-tag-len"`
+		UnencryptedContentLen json.RawMessage `json:"x-amz-unencrypted-content-length"`
 	}
 
 	inner := LaxEnvelope{}
@@ -60,6 +61,11 @@ func (e *Envelope) UnmarshalJSON(value []byte) error {
 	e.TagLen, err = getJSONNumberAsString(inner.TagLen)
 	if err != nil {
 		return fmt.Errorf("failed to parse tag length: %v", err)
+	}
+
+	e.UnencryptedContentLen, err = getJSONNumberAsString(inner.UnencryptedContentLen)
+	if err != nil {
+		return fmt.Errorf("failed to parse unencrypted content length: %v", err)
 	}
 
 	return nil

--- a/service/s3/s3crypto/envelope_test.go
+++ b/service/s3/s3crypto/envelope_test.go
@@ -14,7 +14,7 @@ func TestEnvelope_UnmarshalJSON(t *testing.T) {
 		expected Envelope
 		actual   Envelope
 	}{
-		"standard": {
+		"string json numbers": {
 			content: []byte(`{
   "x-amz-iv": "iv",
   "x-amz-key-v2": "key",
@@ -35,7 +35,7 @@ func TestEnvelope_UnmarshalJSON(t *testing.T) {
 				UnencryptedContentLen: "1024",
 			},
 		},
-		"tag length as number": {
+		"integer json numbers": {
 			content: []byte(`{
   "x-amz-iv": "iv",
   "x-amz-key-v2": "key",
@@ -43,7 +43,7 @@ func TestEnvelope_UnmarshalJSON(t *testing.T) {
   "x-amz-wrap-alg": "kms+context",
   "x-amz-cek-alg": "AES/GCM/NoPadding",
   "x-amz-tag-len": 128,
-  "x-amz-unencrypted-content-length": "1024"
+  "x-amz-unencrypted-content-length": 1024
 }
 `),
 			expected: Envelope{
@@ -56,7 +56,7 @@ func TestEnvelope_UnmarshalJSON(t *testing.T) {
 				UnencryptedContentLen: "1024",
 			},
 		},
-		"null tag length": {
+		"null json numbers": {
 			content: []byte(`{
   "x-amz-iv": "iv",
   "x-amz-key-v2": "key",
@@ -64,35 +64,32 @@ func TestEnvelope_UnmarshalJSON(t *testing.T) {
   "x-amz-wrap-alg": "kms+context",
   "x-amz-cek-alg": "AES/GCM/NoPadding",
   "x-amz-tag-len": null,
-  "x-amz-unencrypted-content-length": "1024"
+  "x-amz-unencrypted-content-length": null
 }
 `),
 			expected: Envelope{
-				IV:                    "iv",
-				CipherKey:             "key",
-				MatDesc:               `{"aws:x-amz-cek-alg":"AES/GCM/NoPadding"}`,
-				WrapAlg:               "kms+context",
-				CEKAlg:                "AES/GCM/NoPadding",
-				UnencryptedContentLen: "1024",
+				IV:        "iv",
+				CipherKey: "key",
+				MatDesc:   `{"aws:x-amz-cek-alg":"AES/GCM/NoPadding"}`,
+				WrapAlg:   "kms+context",
+				CEKAlg:    "AES/GCM/NoPadding",
 			},
 		},
-		"no tag length": {
+		"no json numbers": {
 			content: []byte(`{
   "x-amz-iv": "iv",
   "x-amz-key-v2": "key",
   "x-amz-matdesc": "{\"aws:x-amz-cek-alg\":\"AES/GCM/NoPadding\"}",
   "x-amz-wrap-alg": "kms+context",
-  "x-amz-cek-alg": "AES/GCM/NoPadding",
-  "x-amz-unencrypted-content-length": "1024"
+  "x-amz-cek-alg": "AES/GCM/NoPadding"
 }
 `),
 			expected: Envelope{
-				IV:                    "iv",
-				CipherKey:             "key",
-				MatDesc:               `{"aws:x-amz-cek-alg":"AES/GCM/NoPadding"}`,
-				WrapAlg:               "kms+context",
-				CEKAlg:                "AES/GCM/NoPadding",
-				UnencryptedContentLen: "1024",
+				IV:        "iv",
+				CipherKey: "key",
+				MatDesc:   `{"aws:x-amz-cek-alg":"AES/GCM/NoPadding"}`,
+				WrapAlg:   "kms+context",
+				CEKAlg:    "AES/GCM/NoPadding",
 			},
 		},
 	}


### PR DESCRIPTION
Allow the envelope content length key to be a JSON Number.