### PR TITLE
service/dynamodb/dynamodbattribute: Fix typo in package docs.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `service/dynamodb/dynamodbattribute`: Fix typo in package docs ([#3446](https://github.com/aws/aws-sdk-go/pull/3446))
+  * Fixes typo in dynamodbattribute package docs.
 
 ### SDK Bugs

--- a/service/dynamodb/dynamodbattribute/doc.go
+++ b/service/dynamodb/dynamodbattribute/doc.go
@@ -88,7 +88,7 @@
 // the reliance on encoding.json. `json` struct tags are still supported. In
 // addition support for a new struct tag `dynamodbav` was added. Support for
 // the json.Marshaler and json.Unmarshaler interfaces have been removed and
-// replaced with have been replaced with dynamodbattribute.Marshaler and
+// replaced with dynamodbattribute.Marshaler and
 // dynamodbattribute.Unmarshaler interfaces.
 //
 // The Unmarshal functions are backwards compatible with data marshalled by


### PR DESCRIPTION
Fixes typo in `dynamodbattribute` package docs.