### PR TITLE
private/model/api: Generate enum shape functions to retrieve all values

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `codegen`: Add XXX_Values functions for getting slice of API enums by type.
+  * Fixes [#3441](https://github.com/aws/aws-sdk-go/issues/3441) by adding a new XXX_Values function for each API enum type that returns a slice of enum values, e.g `DomainStatus_Values`.
 
 ### SDK Bugs

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -862,6 +862,15 @@ const (
 
 	{{ end }}
 )
+
+// {{ $.ShapeName }}_Values returns all elements of the {{ $.ShapeName }} enum
+func {{ $.ShapeName }}_Values() []string {
+	return []string{
+		{{ range $index, $elem := $.Enum -}}
+		{{ index $.EnumConsts $index }},
+		{{ end }}
+	}
+}
 `))
 
 // GoCode returns the rendered Go code for the Shape.

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -863,6 +863,7 @@ const (
 	{{ end }}
 )
 
+{{/* Enum iterators use non-idomatic _Values suffix to avoid naming collisions with other generated types, and enum values */}}
 // {{ $.ShapeName }}_Values returns all elements of the {{ $.ShapeName }} enum
 func {{ $.ShapeName }}_Values() []string {
 	return []string{

--- a/private/protocol/ec2query/build_test.go
+++ b/private/protocol/ec2query/build_test.go
@@ -1797,6 +1797,14 @@ const (
 	EnumTypeBar = "bar"
 )
 
+// InputService10TestShapeEnumType_Values returns all elements of the InputService10TestShapeEnumType enum
+func InputService10TestShapeEnumType_Values() []string {
+	return []string{
+		EnumTypeFoo,
+		EnumTypeBar,
+	}
+}
+
 // InputService11ProtocolTest provides the API operation methods for making requests to
 // . See this package's package overview docs
 // for details on the service.

--- a/private/protocol/ec2query/unmarshal_test.go
+++ b/private/protocol/ec2query/unmarshal_test.go
@@ -1792,6 +1792,14 @@ const (
 	EC2EnumTypeBar = "bar"
 )
 
+// OutputService11TestShapeEC2EnumType_Values returns all elements of the OutputService11TestShapeEC2EnumType enum
+func OutputService11TestShapeEC2EnumType_Values() []string {
+	return []string{
+		EC2EnumTypeFoo,
+		EC2EnumTypeBar,
+	}
+}
+
 //
 // Tests begin here
 //

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -2023,6 +2023,14 @@ const (
 	EnumTypeBar = "bar"
 )
 
+// InputService8TestShapeEnumType_Values returns all elements of the InputService8TestShapeEnumType enum
+func InputService8TestShapeEnumType_Values() []string {
+	return []string{
+		EnumTypeFoo,
+		EnumTypeBar,
+	}
+}
+
 // InputService9ProtocolTest provides the API operation methods for making requests to
 // . See this package's package overview docs
 // for details on the service.

--- a/private/protocol/jsonrpc/unmarshal_test.go
+++ b/private/protocol/jsonrpc/unmarshal_test.go
@@ -1333,6 +1333,14 @@ const (
 	JSONEnumTypeBar = "bar"
 )
 
+// OutputService7TestShapeJSONEnumType_Values returns all elements of the OutputService7TestShapeJSONEnumType enum
+func OutputService7TestShapeJSONEnumType_Values() []string {
+	return []string{
+		JSONEnumTypeFoo,
+		JSONEnumTypeBar,
+	}
+}
+
 // OutputService8ProtocolTest provides the API operation methods for making requests to
 // . See this package's package overview docs
 // for details on the service.

--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -3476,6 +3476,14 @@ const (
 	EnumTypeBar = "bar"
 )
 
+// InputService15TestShapeEnumType_Values returns all elements of the InputService15TestShapeEnumType enum
+func InputService15TestShapeEnumType_Values() []string {
+	return []string{
+		EnumTypeFoo,
+		EnumTypeBar,
+	}
+}
+
 // InputService16ProtocolTest provides the API operation methods for making requests to
 // . See this package's package overview docs
 // for details on the service.

--- a/private/protocol/query/unmarshal_test.go
+++ b/private/protocol/query/unmarshal_test.go
@@ -2746,6 +2746,14 @@ const (
 	EC2EnumTypeBar = "bar"
 )
 
+// OutputService17TestShapeEC2EnumType_Values returns all elements of the OutputService17TestShapeEC2EnumType enum
+func OutputService17TestShapeEC2EnumType_Values() []string {
+	return []string{
+		EC2EnumTypeFoo,
+		EC2EnumTypeBar,
+	}
+}
+
 //
 // Tests begin here
 //

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -4998,6 +4998,16 @@ const (
 	EnumType1 = "1"
 )
 
+// InputService22TestShapeEnumType_Values returns all elements of the InputService22TestShapeEnumType enum
+func InputService22TestShapeEnumType_Values() []string {
+	return []string{
+		EnumTypeFoo,
+		EnumTypeBar,
+		EnumType0,
+		EnumType1,
+	}
+}
+
 // InputService23ProtocolTest provides the API operation methods for making requests to
 // . See this package's package overview docs
 // for details on the service.

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -2588,6 +2588,16 @@ const (
 	RESTJSONEnumType1 = "1"
 )
 
+// OutputService14TestShapeRESTJSONEnumType_Values returns all elements of the OutputService14TestShapeRESTJSONEnumType enum
+func OutputService14TestShapeRESTJSONEnumType_Values() []string {
+	return []string{
+		RESTJSONEnumTypeFoo,
+		RESTJSONEnumTypeBar,
+		RESTJSONEnumType0,
+		RESTJSONEnumType1,
+	}
+}
+
 //
 // Tests begin here
 //

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -5606,6 +5606,16 @@ const (
 	EnumType1 = "1"
 )
 
+// InputService25TestShapeEnumType_Values returns all elements of the InputService25TestShapeEnumType enum
+func InputService25TestShapeEnumType_Values() []string {
+	return []string{
+		EnumTypeFoo,
+		EnumTypeBar,
+		EnumType0,
+		EnumType1,
+	}
+}
+
 // InputService26ProtocolTest provides the API operation methods for making requests to
 // . See this package's package overview docs
 // for details on the service.

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -2682,6 +2682,16 @@ const (
 	RESTJSONEnumType1 = "1"
 )
 
+// OutputService14TestShapeRESTJSONEnumType_Values returns all elements of the OutputService14TestShapeRESTJSONEnumType enum
+func OutputService14TestShapeRESTJSONEnumType_Values() []string {
+	return []string{
+		RESTJSONEnumTypeFoo,
+		RESTJSONEnumTypeBar,
+		RESTJSONEnumType0,
+		RESTJSONEnumType1,
+	}
+}
+
 // OutputService15ProtocolTest provides the API operation methods for making requests to
 // . See this package's package overview docs
 // for details on the service.
@@ -2873,6 +2883,15 @@ const (
 	// ItemTypeType3 is a OutputService15TestShapeItemType enum value
 	ItemTypeType3 = "Type3"
 )
+
+// OutputService15TestShapeItemType_Values returns all elements of the OutputService15TestShapeItemType enum
+func OutputService15TestShapeItemType_Values() []string {
+	return []string{
+		ItemTypeType1,
+		ItemTypeType2,
+		ItemTypeType3,
+	}
+}
 
 //
 // Tests begin here

--- a/service/accessanalyzer/api.go
+++ b/service/accessanalyzer/api.go
@@ -4878,6 +4878,16 @@ const (
 	AnalyzerStatusFailed = "FAILED"
 )
 
+// AnalyzerStatus_Values returns all elements of the AnalyzerStatus enum
+func AnalyzerStatus_Values() []string {
+	return []string{
+		AnalyzerStatusActive,
+		AnalyzerStatusCreating,
+		AnalyzerStatusDisabled,
+		AnalyzerStatusFailed,
+	}
+}
+
 const (
 	// FindingSourceTypeBucketAcl is a FindingSourceType enum value
 	FindingSourceTypeBucketAcl = "BUCKET_ACL"
@@ -4888,6 +4898,15 @@ const (
 	// FindingSourceTypeS3AccessPoint is a FindingSourceType enum value
 	FindingSourceTypeS3AccessPoint = "S3_ACCESS_POINT"
 )
+
+// FindingSourceType_Values returns all elements of the FindingSourceType enum
+func FindingSourceType_Values() []string {
+	return []string{
+		FindingSourceTypeBucketAcl,
+		FindingSourceTypePolicy,
+		FindingSourceTypeS3AccessPoint,
+	}
+}
 
 const (
 	// FindingStatusActive is a FindingStatus enum value
@@ -4900,6 +4919,15 @@ const (
 	FindingStatusResolved = "RESOLVED"
 )
 
+// FindingStatus_Values returns all elements of the FindingStatus enum
+func FindingStatus_Values() []string {
+	return []string{
+		FindingStatusActive,
+		FindingStatusArchived,
+		FindingStatusResolved,
+	}
+}
+
 const (
 	// FindingStatusUpdateActive is a FindingStatusUpdate enum value
 	FindingStatusUpdateActive = "ACTIVE"
@@ -4908,6 +4936,14 @@ const (
 	FindingStatusUpdateArchived = "ARCHIVED"
 )
 
+// FindingStatusUpdate_Values returns all elements of the FindingStatusUpdate enum
+func FindingStatusUpdate_Values() []string {
+	return []string{
+		FindingStatusUpdateActive,
+		FindingStatusUpdateArchived,
+	}
+}
+
 const (
 	// OrderByAsc is a OrderBy enum value
 	OrderByAsc = "ASC"
@@ -4915,6 +4951,14 @@ const (
 	// OrderByDesc is a OrderBy enum value
 	OrderByDesc = "DESC"
 )
+
+// OrderBy_Values returns all elements of the OrderBy enum
+func OrderBy_Values() []string {
+	return []string{
+		OrderByAsc,
+		OrderByDesc,
+	}
+}
 
 const (
 	// ReasonCodeAwsServiceAccessDisabled is a ReasonCode enum value
@@ -4929,6 +4973,16 @@ const (
 	// ReasonCodeServiceLinkedRoleCreationFailed is a ReasonCode enum value
 	ReasonCodeServiceLinkedRoleCreationFailed = "SERVICE_LINKED_ROLE_CREATION_FAILED"
 )
+
+// ReasonCode_Values returns all elements of the ReasonCode enum
+func ReasonCode_Values() []string {
+	return []string{
+		ReasonCodeAwsServiceAccessDisabled,
+		ReasonCodeDelegatedAdministratorDeregistered,
+		ReasonCodeOrganizationDeleted,
+		ReasonCodeServiceLinkedRoleCreationFailed,
+	}
+}
 
 const (
 	// ResourceTypeAwsIamRole is a ResourceType enum value
@@ -4950,6 +5004,18 @@ const (
 	ResourceTypeAwsSqsQueue = "AWS::SQS::Queue"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeAwsIamRole,
+		ResourceTypeAwsKmsKey,
+		ResourceTypeAwsLambdaFunction,
+		ResourceTypeAwsLambdaLayerVersion,
+		ResourceTypeAwsS3Bucket,
+		ResourceTypeAwsSqsQueue,
+	}
+}
+
 const (
 	// TypeAccount is a Type enum value
 	TypeAccount = "ACCOUNT"
@@ -4957,6 +5023,14 @@ const (
 	// TypeOrganization is a Type enum value
 	TypeOrganization = "ORGANIZATION"
 )
+
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypeAccount,
+		TypeOrganization,
+	}
+}
 
 const (
 	// ValidationExceptionReasonCannotParse is a ValidationExceptionReason enum value
@@ -4971,3 +5045,13 @@ const (
 	// ValidationExceptionReasonUnknownOperation is a ValidationExceptionReason enum value
 	ValidationExceptionReasonUnknownOperation = "unknownOperation"
 )
+
+// ValidationExceptionReason_Values returns all elements of the ValidationExceptionReason enum
+func ValidationExceptionReason_Values() []string {
+	return []string{
+		ValidationExceptionReasonCannotParse,
+		ValidationExceptionReasonFieldValidationFailed,
+		ValidationExceptionReasonOther,
+		ValidationExceptionReasonUnknownOperation,
+	}
+}

--- a/service/acm/api.go
+++ b/service/acm/api.go
@@ -4142,6 +4142,19 @@ const (
 	CertificateStatusFailed = "FAILED"
 )
 
+// CertificateStatus_Values returns all elements of the CertificateStatus enum
+func CertificateStatus_Values() []string {
+	return []string{
+		CertificateStatusPendingValidation,
+		CertificateStatusIssued,
+		CertificateStatusInactive,
+		CertificateStatusExpired,
+		CertificateStatusValidationTimedOut,
+		CertificateStatusRevoked,
+		CertificateStatusFailed,
+	}
+}
+
 const (
 	// CertificateTransparencyLoggingPreferenceEnabled is a CertificateTransparencyLoggingPreference enum value
 	CertificateTransparencyLoggingPreferenceEnabled = "ENABLED"
@@ -4149,6 +4162,14 @@ const (
 	// CertificateTransparencyLoggingPreferenceDisabled is a CertificateTransparencyLoggingPreference enum value
 	CertificateTransparencyLoggingPreferenceDisabled = "DISABLED"
 )
+
+// CertificateTransparencyLoggingPreference_Values returns all elements of the CertificateTransparencyLoggingPreference enum
+func CertificateTransparencyLoggingPreference_Values() []string {
+	return []string{
+		CertificateTransparencyLoggingPreferenceEnabled,
+		CertificateTransparencyLoggingPreferenceDisabled,
+	}
+}
 
 const (
 	// CertificateTypeImported is a CertificateType enum value
@@ -4161,6 +4182,15 @@ const (
 	CertificateTypePrivate = "PRIVATE"
 )
 
+// CertificateType_Values returns all elements of the CertificateType enum
+func CertificateType_Values() []string {
+	return []string{
+		CertificateTypeImported,
+		CertificateTypeAmazonIssued,
+		CertificateTypePrivate,
+	}
+}
+
 const (
 	// DomainStatusPendingValidation is a DomainStatus enum value
 	DomainStatusPendingValidation = "PENDING_VALIDATION"
@@ -4171,6 +4201,15 @@ const (
 	// DomainStatusFailed is a DomainStatus enum value
 	DomainStatusFailed = "FAILED"
 )
+
+// DomainStatus_Values returns all elements of the DomainStatus enum
+func DomainStatus_Values() []string {
+	return []string{
+		DomainStatusPendingValidation,
+		DomainStatusSuccess,
+		DomainStatusFailed,
+	}
+}
 
 const (
 	// ExtendedKeyUsageNameTlsWebServerAuthentication is a ExtendedKeyUsageName enum value
@@ -4209,6 +4248,24 @@ const (
 	// ExtendedKeyUsageNameCustom is a ExtendedKeyUsageName enum value
 	ExtendedKeyUsageNameCustom = "CUSTOM"
 )
+
+// ExtendedKeyUsageName_Values returns all elements of the ExtendedKeyUsageName enum
+func ExtendedKeyUsageName_Values() []string {
+	return []string{
+		ExtendedKeyUsageNameTlsWebServerAuthentication,
+		ExtendedKeyUsageNameTlsWebClientAuthentication,
+		ExtendedKeyUsageNameCodeSigning,
+		ExtendedKeyUsageNameEmailProtection,
+		ExtendedKeyUsageNameTimeStamping,
+		ExtendedKeyUsageNameOcspSigning,
+		ExtendedKeyUsageNameIpsecEndSystem,
+		ExtendedKeyUsageNameIpsecTunnel,
+		ExtendedKeyUsageNameIpsecUser,
+		ExtendedKeyUsageNameAny,
+		ExtendedKeyUsageNameNone,
+		ExtendedKeyUsageNameCustom,
+	}
+}
 
 const (
 	// FailureReasonNoAvailableContacts is a FailureReason enum value
@@ -4260,6 +4317,28 @@ const (
 	FailureReasonOther = "OTHER"
 )
 
+// FailureReason_Values returns all elements of the FailureReason enum
+func FailureReason_Values() []string {
+	return []string{
+		FailureReasonNoAvailableContacts,
+		FailureReasonAdditionalVerificationRequired,
+		FailureReasonDomainNotAllowed,
+		FailureReasonInvalidPublicDomain,
+		FailureReasonDomainValidationDenied,
+		FailureReasonCaaError,
+		FailureReasonPcaLimitExceeded,
+		FailureReasonPcaInvalidArn,
+		FailureReasonPcaInvalidState,
+		FailureReasonPcaRequestFailed,
+		FailureReasonPcaNameConstraintsValidation,
+		FailureReasonPcaResourceNotFound,
+		FailureReasonPcaInvalidArgs,
+		FailureReasonPcaInvalidDuration,
+		FailureReasonPcaAccessDenied,
+		FailureReasonOther,
+	}
+}
+
 const (
 	// KeyAlgorithmRsa2048 is a KeyAlgorithm enum value
 	KeyAlgorithmRsa2048 = "RSA_2048"
@@ -4279,6 +4358,18 @@ const (
 	// KeyAlgorithmEcSecp521r1 is a KeyAlgorithm enum value
 	KeyAlgorithmEcSecp521r1 = "EC_secp521r1"
 )
+
+// KeyAlgorithm_Values returns all elements of the KeyAlgorithm enum
+func KeyAlgorithm_Values() []string {
+	return []string{
+		KeyAlgorithmRsa2048,
+		KeyAlgorithmRsa1024,
+		KeyAlgorithmRsa4096,
+		KeyAlgorithmEcPrime256v1,
+		KeyAlgorithmEcSecp384r1,
+		KeyAlgorithmEcSecp521r1,
+	}
+}
 
 const (
 	// KeyUsageNameDigitalSignature is a KeyUsageName enum value
@@ -4315,10 +4406,34 @@ const (
 	KeyUsageNameCustom = "CUSTOM"
 )
 
+// KeyUsageName_Values returns all elements of the KeyUsageName enum
+func KeyUsageName_Values() []string {
+	return []string{
+		KeyUsageNameDigitalSignature,
+		KeyUsageNameNonRepudiation,
+		KeyUsageNameKeyEncipherment,
+		KeyUsageNameDataEncipherment,
+		KeyUsageNameKeyAgreement,
+		KeyUsageNameCertificateSigning,
+		KeyUsageNameCrlSigning,
+		KeyUsageNameEncipherOnly,
+		KeyUsageNameDecipherOnly,
+		KeyUsageNameAny,
+		KeyUsageNameCustom,
+	}
+}
+
 const (
 	// RecordTypeCname is a RecordType enum value
 	RecordTypeCname = "CNAME"
 )
+
+// RecordType_Values returns all elements of the RecordType enum
+func RecordType_Values() []string {
+	return []string{
+		RecordTypeCname,
+	}
+}
 
 const (
 	// RenewalEligibilityEligible is a RenewalEligibility enum value
@@ -4327,6 +4442,14 @@ const (
 	// RenewalEligibilityIneligible is a RenewalEligibility enum value
 	RenewalEligibilityIneligible = "INELIGIBLE"
 )
+
+// RenewalEligibility_Values returns all elements of the RenewalEligibility enum
+func RenewalEligibility_Values() []string {
+	return []string{
+		RenewalEligibilityEligible,
+		RenewalEligibilityIneligible,
+	}
+}
 
 const (
 	// RenewalStatusPendingAutoRenewal is a RenewalStatus enum value
@@ -4341,6 +4464,16 @@ const (
 	// RenewalStatusFailed is a RenewalStatus enum value
 	RenewalStatusFailed = "FAILED"
 )
+
+// RenewalStatus_Values returns all elements of the RenewalStatus enum
+func RenewalStatus_Values() []string {
+	return []string{
+		RenewalStatusPendingAutoRenewal,
+		RenewalStatusPendingValidation,
+		RenewalStatusSuccess,
+		RenewalStatusFailed,
+	}
+}
 
 const (
 	// RevocationReasonUnspecified is a RevocationReason enum value
@@ -4374,6 +4507,22 @@ const (
 	RevocationReasonAACompromise = "A_A_COMPROMISE"
 )
 
+// RevocationReason_Values returns all elements of the RevocationReason enum
+func RevocationReason_Values() []string {
+	return []string{
+		RevocationReasonUnspecified,
+		RevocationReasonKeyCompromise,
+		RevocationReasonCaCompromise,
+		RevocationReasonAffiliationChanged,
+		RevocationReasonSuperceded,
+		RevocationReasonCessationOfOperation,
+		RevocationReasonCertificateHold,
+		RevocationReasonRemoveFromCrl,
+		RevocationReasonPrivilegeWithdrawn,
+		RevocationReasonAACompromise,
+	}
+}
+
 const (
 	// ValidationMethodEmail is a ValidationMethod enum value
 	ValidationMethodEmail = "EMAIL"
@@ -4381,3 +4530,11 @@ const (
 	// ValidationMethodDns is a ValidationMethod enum value
 	ValidationMethodDns = "DNS"
 )
+
+// ValidationMethod_Values returns all elements of the ValidationMethod enum
+func ValidationMethod_Values() []string {
+	return []string{
+		ValidationMethodEmail,
+		ValidationMethodDns,
+	}
+}

--- a/service/acmpca/api.go
+++ b/service/acmpca/api.go
@@ -5882,6 +5882,15 @@ const (
 	ActionTypeListPermissions = "ListPermissions"
 )
 
+// ActionType_Values returns all elements of the ActionType enum
+func ActionType_Values() []string {
+	return []string{
+		ActionTypeIssueCertificate,
+		ActionTypeGetCertificate,
+		ActionTypeListPermissions,
+	}
+}
+
 const (
 	// AuditReportResponseFormatJson is a AuditReportResponseFormat enum value
 	AuditReportResponseFormatJson = "JSON"
@@ -5889,6 +5898,14 @@ const (
 	// AuditReportResponseFormatCsv is a AuditReportResponseFormat enum value
 	AuditReportResponseFormatCsv = "CSV"
 )
+
+// AuditReportResponseFormat_Values returns all elements of the AuditReportResponseFormat enum
+func AuditReportResponseFormat_Values() []string {
+	return []string{
+		AuditReportResponseFormatJson,
+		AuditReportResponseFormatCsv,
+	}
+}
 
 const (
 	// AuditReportStatusCreating is a AuditReportStatus enum value
@@ -5900,6 +5917,15 @@ const (
 	// AuditReportStatusFailed is a AuditReportStatus enum value
 	AuditReportStatusFailed = "FAILED"
 )
+
+// AuditReportStatus_Values returns all elements of the AuditReportStatus enum
+func AuditReportStatus_Values() []string {
+	return []string{
+		AuditReportStatusCreating,
+		AuditReportStatusSuccess,
+		AuditReportStatusFailed,
+	}
+}
 
 const (
 	// CertificateAuthorityStatusCreating is a CertificateAuthorityStatus enum value
@@ -5924,6 +5950,19 @@ const (
 	CertificateAuthorityStatusFailed = "FAILED"
 )
 
+// CertificateAuthorityStatus_Values returns all elements of the CertificateAuthorityStatus enum
+func CertificateAuthorityStatus_Values() []string {
+	return []string{
+		CertificateAuthorityStatusCreating,
+		CertificateAuthorityStatusPendingCertificate,
+		CertificateAuthorityStatusActive,
+		CertificateAuthorityStatusDeleted,
+		CertificateAuthorityStatusDisabled,
+		CertificateAuthorityStatusExpired,
+		CertificateAuthorityStatusFailed,
+	}
+}
+
 const (
 	// CertificateAuthorityTypeRoot is a CertificateAuthorityType enum value
 	CertificateAuthorityTypeRoot = "ROOT"
@@ -5931,6 +5970,14 @@ const (
 	// CertificateAuthorityTypeSubordinate is a CertificateAuthorityType enum value
 	CertificateAuthorityTypeSubordinate = "SUBORDINATE"
 )
+
+// CertificateAuthorityType_Values returns all elements of the CertificateAuthorityType enum
+func CertificateAuthorityType_Values() []string {
+	return []string{
+		CertificateAuthorityTypeRoot,
+		CertificateAuthorityTypeSubordinate,
+	}
+}
 
 const (
 	// FailureReasonRequestTimedOut is a FailureReason enum value
@@ -5942,6 +5989,15 @@ const (
 	// FailureReasonOther is a FailureReason enum value
 	FailureReasonOther = "OTHER"
 )
+
+// FailureReason_Values returns all elements of the FailureReason enum
+func FailureReason_Values() []string {
+	return []string{
+		FailureReasonRequestTimedOut,
+		FailureReasonUnsupportedAlgorithm,
+		FailureReasonOther,
+	}
+}
 
 const (
 	// KeyAlgorithmRsa2048 is a KeyAlgorithm enum value
@@ -5956,6 +6012,16 @@ const (
 	// KeyAlgorithmEcSecp384r1 is a KeyAlgorithm enum value
 	KeyAlgorithmEcSecp384r1 = "EC_secp384r1"
 )
+
+// KeyAlgorithm_Values returns all elements of the KeyAlgorithm enum
+func KeyAlgorithm_Values() []string {
+	return []string{
+		KeyAlgorithmRsa2048,
+		KeyAlgorithmRsa4096,
+		KeyAlgorithmEcPrime256v1,
+		KeyAlgorithmEcSecp384r1,
+	}
+}
 
 const (
 	// RevocationReasonUnspecified is a RevocationReason enum value
@@ -5983,6 +6049,20 @@ const (
 	RevocationReasonAACompromise = "A_A_COMPROMISE"
 )
 
+// RevocationReason_Values returns all elements of the RevocationReason enum
+func RevocationReason_Values() []string {
+	return []string{
+		RevocationReasonUnspecified,
+		RevocationReasonKeyCompromise,
+		RevocationReasonCertificateAuthorityCompromise,
+		RevocationReasonAffiliationChanged,
+		RevocationReasonSuperseded,
+		RevocationReasonCessationOfOperation,
+		RevocationReasonPrivilegeWithdrawn,
+		RevocationReasonAACompromise,
+	}
+}
+
 const (
 	// SigningAlgorithmSha256withecdsa is a SigningAlgorithm enum value
 	SigningAlgorithmSha256withecdsa = "SHA256WITHECDSA"
@@ -6003,6 +6083,18 @@ const (
 	SigningAlgorithmSha512withrsa = "SHA512WITHRSA"
 )
 
+// SigningAlgorithm_Values returns all elements of the SigningAlgorithm enum
+func SigningAlgorithm_Values() []string {
+	return []string{
+		SigningAlgorithmSha256withecdsa,
+		SigningAlgorithmSha384withecdsa,
+		SigningAlgorithmSha512withecdsa,
+		SigningAlgorithmSha256withrsa,
+		SigningAlgorithmSha384withrsa,
+		SigningAlgorithmSha512withrsa,
+	}
+}
+
 const (
 	// ValidityPeriodTypeEndDate is a ValidityPeriodType enum value
 	ValidityPeriodTypeEndDate = "END_DATE"
@@ -6019,3 +6111,14 @@ const (
 	// ValidityPeriodTypeYears is a ValidityPeriodType enum value
 	ValidityPeriodTypeYears = "YEARS"
 )
+
+// ValidityPeriodType_Values returns all elements of the ValidityPeriodType enum
+func ValidityPeriodType_Values() []string {
+	return []string{
+		ValidityPeriodTypeEndDate,
+		ValidityPeriodTypeAbsolute,
+		ValidityPeriodTypeDays,
+		ValidityPeriodTypeMonths,
+		ValidityPeriodTypeYears,
+	}
+}

--- a/service/alexaforbusiness/api.go
+++ b/service/alexaforbusiness/api.go
@@ -20862,6 +20862,15 @@ const (
 	BusinessReportFailureCodeInternalFailure = "INTERNAL_FAILURE"
 )
 
+// BusinessReportFailureCode_Values returns all elements of the BusinessReportFailureCode enum
+func BusinessReportFailureCode_Values() []string {
+	return []string{
+		BusinessReportFailureCodeAccessDenied,
+		BusinessReportFailureCodeNoSuchBucket,
+		BusinessReportFailureCodeInternalFailure,
+	}
+}
+
 const (
 	// BusinessReportFormatCsv is a BusinessReportFormat enum value
 	BusinessReportFormatCsv = "CSV"
@@ -20869,6 +20878,14 @@ const (
 	// BusinessReportFormatCsvZip is a BusinessReportFormat enum value
 	BusinessReportFormatCsvZip = "CSV_ZIP"
 )
+
+// BusinessReportFormat_Values returns all elements of the BusinessReportFormat enum
+func BusinessReportFormat_Values() []string {
+	return []string{
+		BusinessReportFormatCsv,
+		BusinessReportFormatCsvZip,
+	}
+}
 
 const (
 	// BusinessReportIntervalOneDay is a BusinessReportInterval enum value
@@ -20881,6 +20898,15 @@ const (
 	BusinessReportIntervalThirtyDays = "THIRTY_DAYS"
 )
 
+// BusinessReportInterval_Values returns all elements of the BusinessReportInterval enum
+func BusinessReportInterval_Values() []string {
+	return []string{
+		BusinessReportIntervalOneDay,
+		BusinessReportIntervalOneWeek,
+		BusinessReportIntervalThirtyDays,
+	}
+}
+
 const (
 	// BusinessReportStatusRunning is a BusinessReportStatus enum value
 	BusinessReportStatusRunning = "RUNNING"
@@ -20892,6 +20918,15 @@ const (
 	BusinessReportStatusFailed = "FAILED"
 )
 
+// BusinessReportStatus_Values returns all elements of the BusinessReportStatus enum
+func BusinessReportStatus_Values() []string {
+	return []string{
+		BusinessReportStatusRunning,
+		BusinessReportStatusSucceeded,
+		BusinessReportStatusFailed,
+	}
+}
+
 const (
 	// CommsProtocolSip is a CommsProtocol enum value
 	CommsProtocolSip = "SIP"
@@ -20902,6 +20937,15 @@ const (
 	// CommsProtocolH323 is a CommsProtocol enum value
 	CommsProtocolH323 = "H323"
 )
+
+// CommsProtocol_Values returns all elements of the CommsProtocol enum
+func CommsProtocol_Values() []string {
+	return []string{
+		CommsProtocolSip,
+		CommsProtocolSips,
+		CommsProtocolH323,
+	}
+}
 
 const (
 	// ConferenceProviderTypeChime is a ConferenceProviderType enum value
@@ -20935,6 +20979,22 @@ const (
 	ConferenceProviderTypeCustom = "CUSTOM"
 )
 
+// ConferenceProviderType_Values returns all elements of the ConferenceProviderType enum
+func ConferenceProviderType_Values() []string {
+	return []string{
+		ConferenceProviderTypeChime,
+		ConferenceProviderTypeBluejeans,
+		ConferenceProviderTypeFuze,
+		ConferenceProviderTypeGoogleHangouts,
+		ConferenceProviderTypePolycom,
+		ConferenceProviderTypeRingcentral,
+		ConferenceProviderTypeSkypeForBusiness,
+		ConferenceProviderTypeWebex,
+		ConferenceProviderTypeZoom,
+		ConferenceProviderTypeCustom,
+	}
+}
+
 const (
 	// ConnectionStatusOnline is a ConnectionStatus enum value
 	ConnectionStatusOnline = "ONLINE"
@@ -20943,6 +21003,14 @@ const (
 	ConnectionStatusOffline = "OFFLINE"
 )
 
+// ConnectionStatus_Values returns all elements of the ConnectionStatus enum
+func ConnectionStatus_Values() []string {
+	return []string{
+		ConnectionStatusOnline,
+		ConnectionStatusOffline,
+	}
+}
+
 const (
 	// DeviceEventTypeConnectionStatus is a DeviceEventType enum value
 	DeviceEventTypeConnectionStatus = "CONNECTION_STATUS"
@@ -20950,6 +21018,14 @@ const (
 	// DeviceEventTypeDeviceStatus is a DeviceEventType enum value
 	DeviceEventTypeDeviceStatus = "DEVICE_STATUS"
 )
+
+// DeviceEventType_Values returns all elements of the DeviceEventType enum
+func DeviceEventType_Values() []string {
+	return []string{
+		DeviceEventTypeConnectionStatus,
+		DeviceEventTypeDeviceStatus,
+	}
+}
 
 const (
 	// DeviceStatusReady is a DeviceStatus enum value
@@ -20967,6 +21043,17 @@ const (
 	// DeviceStatusFailed is a DeviceStatus enum value
 	DeviceStatusFailed = "FAILED"
 )
+
+// DeviceStatus_Values returns all elements of the DeviceStatus enum
+func DeviceStatus_Values() []string {
+	return []string{
+		DeviceStatusReady,
+		DeviceStatusPending,
+		DeviceStatusWasOffline,
+		DeviceStatusDeregistered,
+		DeviceStatusFailed,
+	}
+}
 
 const (
 	// DeviceStatusDetailCodeDeviceSoftwareUpdateNeeded is a DeviceStatusDetailCode enum value
@@ -21021,10 +21108,40 @@ const (
 	DeviceStatusDetailCodeCertificateAuthorityAccessDenied = "CERTIFICATE_AUTHORITY_ACCESS_DENIED"
 )
 
+// DeviceStatusDetailCode_Values returns all elements of the DeviceStatusDetailCode enum
+func DeviceStatusDetailCode_Values() []string {
+	return []string{
+		DeviceStatusDetailCodeDeviceSoftwareUpdateNeeded,
+		DeviceStatusDetailCodeDeviceWasOffline,
+		DeviceStatusDetailCodeCredentialsAccessFailure,
+		DeviceStatusDetailCodeTlsVersionMismatch,
+		DeviceStatusDetailCodeAssociationRejection,
+		DeviceStatusDetailCodeAuthenticationFailure,
+		DeviceStatusDetailCodeDhcpFailure,
+		DeviceStatusDetailCodeInternetUnavailable,
+		DeviceStatusDetailCodeDnsFailure,
+		DeviceStatusDetailCodeUnknownFailure,
+		DeviceStatusDetailCodeCertificateIssuingLimitExceeded,
+		DeviceStatusDetailCodeInvalidCertificateAuthority,
+		DeviceStatusDetailCodeNetworkProfileNotFound,
+		DeviceStatusDetailCodeInvalidPasswordState,
+		DeviceStatusDetailCodePasswordNotFound,
+		DeviceStatusDetailCodePasswordManagerAccessDenied,
+		DeviceStatusDetailCodeCertificateAuthorityAccessDenied,
+	}
+}
+
 const (
 	// DeviceUsageTypeVoice is a DeviceUsageType enum value
 	DeviceUsageTypeVoice = "VOICE"
 )
+
+// DeviceUsageType_Values returns all elements of the DeviceUsageType enum
+func DeviceUsageType_Values() []string {
+	return []string{
+		DeviceUsageTypeVoice,
+	}
+}
 
 const (
 	// DistanceUnitMetric is a DistanceUnit enum value
@@ -21034,6 +21151,14 @@ const (
 	DistanceUnitImperial = "IMPERIAL"
 )
 
+// DistanceUnit_Values returns all elements of the DistanceUnit enum
+func DistanceUnit_Values() []string {
+	return []string{
+		DistanceUnitMetric,
+		DistanceUnitImperial,
+	}
+}
+
 const (
 	// EnablementTypeEnabled is a EnablementType enum value
 	EnablementTypeEnabled = "ENABLED"
@@ -21042,6 +21167,14 @@ const (
 	EnablementTypePending = "PENDING"
 )
 
+// EnablementType_Values returns all elements of the EnablementType enum
+func EnablementType_Values() []string {
+	return []string{
+		EnablementTypeEnabled,
+		EnablementTypePending,
+	}
+}
+
 const (
 	// EnablementTypeFilterEnabled is a EnablementTypeFilter enum value
 	EnablementTypeFilterEnabled = "ENABLED"
@@ -21049,6 +21182,14 @@ const (
 	// EnablementTypeFilterPending is a EnablementTypeFilter enum value
 	EnablementTypeFilterPending = "PENDING"
 )
+
+// EnablementTypeFilter_Values returns all elements of the EnablementTypeFilter enum
+func EnablementTypeFilter_Values() []string {
+	return []string{
+		EnablementTypeFilterEnabled,
+		EnablementTypeFilterPending,
+	}
+}
 
 const (
 	// EndOfMeetingReminderTypeAnnouncementTimeCheck is a EndOfMeetingReminderType enum value
@@ -21063,6 +21204,16 @@ const (
 	// EndOfMeetingReminderTypeKnock is a EndOfMeetingReminderType enum value
 	EndOfMeetingReminderTypeKnock = "KNOCK"
 )
+
+// EndOfMeetingReminderType_Values returns all elements of the EndOfMeetingReminderType enum
+func EndOfMeetingReminderType_Values() []string {
+	return []string{
+		EndOfMeetingReminderTypeAnnouncementTimeCheck,
+		EndOfMeetingReminderTypeAnnouncementVariableTimeLeft,
+		EndOfMeetingReminderTypeChime,
+		EndOfMeetingReminderTypeKnock,
+	}
+}
 
 const (
 	// EnrollmentStatusInitialized is a EnrollmentStatus enum value
@@ -21080,6 +21231,17 @@ const (
 	// EnrollmentStatusDeregistering is a EnrollmentStatus enum value
 	EnrollmentStatusDeregistering = "DEREGISTERING"
 )
+
+// EnrollmentStatus_Values returns all elements of the EnrollmentStatus enum
+func EnrollmentStatus_Values() []string {
+	return []string{
+		EnrollmentStatusInitialized,
+		EnrollmentStatusPending,
+		EnrollmentStatusRegistered,
+		EnrollmentStatusDisassociating,
+		EnrollmentStatusDeregistering,
+	}
+}
 
 const (
 	// FeatureBluetooth is a Feature enum value
@@ -21107,15 +21269,43 @@ const (
 	FeatureAll = "ALL"
 )
 
+// Feature_Values returns all elements of the Feature enum
+func Feature_Values() []string {
+	return []string{
+		FeatureBluetooth,
+		FeatureVolume,
+		FeatureNotifications,
+		FeatureLists,
+		FeatureSkills,
+		FeatureNetworkProfile,
+		FeatureSettings,
+		FeatureAll,
+	}
+}
+
 const (
 	// LocaleEnUs is a Locale enum value
 	LocaleEnUs = "en-US"
 )
 
+// Locale_Values returns all elements of the Locale enum
+func Locale_Values() []string {
+	return []string{
+		LocaleEnUs,
+	}
+}
+
 const (
 	// NetworkEapMethodEapTls is a NetworkEapMethod enum value
 	NetworkEapMethodEapTls = "EAP_TLS"
 )
+
+// NetworkEapMethod_Values returns all elements of the NetworkEapMethod enum
+func NetworkEapMethod_Values() []string {
+	return []string{
+		NetworkEapMethodEapTls,
+	}
+}
 
 const (
 	// NetworkSecurityTypeOpen is a NetworkSecurityType enum value
@@ -21134,6 +21324,17 @@ const (
 	NetworkSecurityTypeWpa2Enterprise = "WPA2_ENTERPRISE"
 )
 
+// NetworkSecurityType_Values returns all elements of the NetworkSecurityType enum
+func NetworkSecurityType_Values() []string {
+	return []string{
+		NetworkSecurityTypeOpen,
+		NetworkSecurityTypeWep,
+		NetworkSecurityTypeWpaPsk,
+		NetworkSecurityTypeWpa2Psk,
+		NetworkSecurityTypeWpa2Enterprise,
+	}
+}
+
 const (
 	// PhoneNumberTypeMobile is a PhoneNumberType enum value
 	PhoneNumberTypeMobile = "MOBILE"
@@ -21144,6 +21345,15 @@ const (
 	// PhoneNumberTypeHome is a PhoneNumberType enum value
 	PhoneNumberTypeHome = "HOME"
 )
+
+// PhoneNumberType_Values returns all elements of the PhoneNumberType enum
+func PhoneNumberType_Values() []string {
+	return []string{
+		PhoneNumberTypeMobile,
+		PhoneNumberTypeWork,
+		PhoneNumberTypeHome,
+	}
+}
 
 const (
 	// RequirePinYes is a RequirePin enum value
@@ -21156,10 +21366,26 @@ const (
 	RequirePinOptional = "OPTIONAL"
 )
 
+// RequirePin_Values returns all elements of the RequirePin enum
+func RequirePin_Values() []string {
+	return []string{
+		RequirePinYes,
+		RequirePinNo,
+		RequirePinOptional,
+	}
+}
+
 const (
 	// SipTypeWork is a SipType enum value
 	SipTypeWork = "WORK"
 )
+
+// SipType_Values returns all elements of the SipType enum
+func SipType_Values() []string {
+	return []string{
+		SipTypeWork,
+	}
+}
 
 const (
 	// SkillTypePublic is a SkillType enum value
@@ -21168,6 +21394,14 @@ const (
 	// SkillTypePrivate is a SkillType enum value
 	SkillTypePrivate = "PRIVATE"
 )
+
+// SkillType_Values returns all elements of the SkillType enum
+func SkillType_Values() []string {
+	return []string{
+		SkillTypePublic,
+		SkillTypePrivate,
+	}
+}
 
 const (
 	// SkillTypeFilterPublic is a SkillTypeFilter enum value
@@ -21180,6 +21414,15 @@ const (
 	SkillTypeFilterAll = "ALL"
 )
 
+// SkillTypeFilter_Values returns all elements of the SkillTypeFilter enum
+func SkillTypeFilter_Values() []string {
+	return []string{
+		SkillTypeFilterPublic,
+		SkillTypeFilterPrivate,
+		SkillTypeFilterAll,
+	}
+}
+
 const (
 	// SortValueAsc is a SortValue enum value
 	SortValueAsc = "ASC"
@@ -21188,6 +21431,14 @@ const (
 	SortValueDesc = "DESC"
 )
 
+// SortValue_Values returns all elements of the SortValue enum
+func SortValue_Values() []string {
+	return []string{
+		SortValueAsc,
+		SortValueDesc,
+	}
+}
+
 const (
 	// TemperatureUnitFahrenheit is a TemperatureUnit enum value
 	TemperatureUnitFahrenheit = "FAHRENHEIT"
@@ -21195,6 +21446,14 @@ const (
 	// TemperatureUnitCelsius is a TemperatureUnit enum value
 	TemperatureUnitCelsius = "CELSIUS"
 )
+
+// TemperatureUnit_Values returns all elements of the TemperatureUnit enum
+func TemperatureUnit_Values() []string {
+	return []string{
+		TemperatureUnitFahrenheit,
+		TemperatureUnitCelsius,
+	}
+}
 
 const (
 	// WakeWordAlexa is a WakeWord enum value
@@ -21209,3 +21468,13 @@ const (
 	// WakeWordComputer is a WakeWord enum value
 	WakeWordComputer = "COMPUTER"
 )
+
+// WakeWord_Values returns all elements of the WakeWord enum
+func WakeWord_Values() []string {
+	return []string{
+		WakeWordAlexa,
+		WakeWordAmazon,
+		WakeWordEcho,
+		WakeWordComputer,
+	}
+}

--- a/service/amplify/api.go
+++ b/service/amplify/api.go
@@ -9338,6 +9338,20 @@ const (
 	DomainStatusUpdating = "UPDATING"
 )
 
+// DomainStatus_Values returns all elements of the DomainStatus enum
+func DomainStatus_Values() []string {
+	return []string{
+		DomainStatusPendingVerification,
+		DomainStatusInProgress,
+		DomainStatusAvailable,
+		DomainStatusPendingDeployment,
+		DomainStatusFailed,
+		DomainStatusCreating,
+		DomainStatusRequestingCertificate,
+		DomainStatusUpdating,
+	}
+}
+
 const (
 	// JobStatusPending is a JobStatus enum value
 	JobStatusPending = "PENDING"
@@ -9361,6 +9375,19 @@ const (
 	JobStatusCancelled = "CANCELLED"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusPending,
+		JobStatusProvisioning,
+		JobStatusRunning,
+		JobStatusFailed,
+		JobStatusSucceed,
+		JobStatusCancelling,
+		JobStatusCancelled,
+	}
+}
+
 const (
 	// JobTypeRelease is a JobType enum value
 	JobTypeRelease = "RELEASE"
@@ -9375,10 +9402,27 @@ const (
 	JobTypeWebHook = "WEB_HOOK"
 )
 
+// JobType_Values returns all elements of the JobType enum
+func JobType_Values() []string {
+	return []string{
+		JobTypeRelease,
+		JobTypeRetry,
+		JobTypeManual,
+		JobTypeWebHook,
+	}
+}
+
 const (
 	// PlatformWeb is a Platform enum value
 	PlatformWeb = "WEB"
 )
+
+// Platform_Values returns all elements of the Platform enum
+func Platform_Values() []string {
+	return []string{
+		PlatformWeb,
+	}
+}
 
 const (
 	// StageProduction is a Stage enum value
@@ -9396,3 +9440,14 @@ const (
 	// StagePullRequest is a Stage enum value
 	StagePullRequest = "PULL_REQUEST"
 )
+
+// Stage_Values returns all elements of the Stage enum
+func Stage_Values() []string {
+	return []string{
+		StageProduction,
+		StageBeta,
+		StageDevelopment,
+		StageExperimental,
+		StagePullRequest,
+	}
+}

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -25456,10 +25456,25 @@ const (
 	ApiKeySourceTypeAuthorizer = "AUTHORIZER"
 )
 
+// ApiKeySourceType_Values returns all elements of the ApiKeySourceType enum
+func ApiKeySourceType_Values() []string {
+	return []string{
+		ApiKeySourceTypeHeader,
+		ApiKeySourceTypeAuthorizer,
+	}
+}
+
 const (
 	// ApiKeysFormatCsv is a ApiKeysFormat enum value
 	ApiKeysFormatCsv = "csv"
 )
+
+// ApiKeysFormat_Values returns all elements of the ApiKeysFormat enum
+func ApiKeysFormat_Values() []string {
+	return []string{
+		ApiKeysFormatCsv,
+	}
+}
 
 // The authorizer type. Valid values are TOKEN for a Lambda function using a
 // single authorization token submitted in a custom header, REQUEST for a Lambda
@@ -25475,6 +25490,15 @@ const (
 	// AuthorizerTypeCognitoUserPools is a AuthorizerType enum value
 	AuthorizerTypeCognitoUserPools = "COGNITO_USER_POOLS"
 )
+
+// AuthorizerType_Values returns all elements of the AuthorizerType enum
+func AuthorizerType_Values() []string {
+	return []string{
+		AuthorizerTypeToken,
+		AuthorizerTypeRequest,
+		AuthorizerTypeCognitoUserPools,
+	}
+}
 
 // Returns the size of the CacheCluster.
 const (
@@ -25503,6 +25527,20 @@ const (
 	CacheClusterSize237 = "237"
 )
 
+// CacheClusterSize_Values returns all elements of the CacheClusterSize enum
+func CacheClusterSize_Values() []string {
+	return []string{
+		CacheClusterSize05,
+		CacheClusterSize16,
+		CacheClusterSize61,
+		CacheClusterSize135,
+		CacheClusterSize284,
+		CacheClusterSize582,
+		CacheClusterSize118,
+		CacheClusterSize237,
+	}
+}
+
 // Returns the status of the CacheCluster.
 const (
 	// CacheClusterStatusCreateInProgress is a CacheClusterStatus enum value
@@ -25521,6 +25559,17 @@ const (
 	CacheClusterStatusFlushInProgress = "FLUSH_IN_PROGRESS"
 )
 
+// CacheClusterStatus_Values returns all elements of the CacheClusterStatus enum
+func CacheClusterStatus_Values() []string {
+	return []string{
+		CacheClusterStatusCreateInProgress,
+		CacheClusterStatusAvailable,
+		CacheClusterStatusDeleteInProgress,
+		CacheClusterStatusNotAvailable,
+		CacheClusterStatusFlushInProgress,
+	}
+}
+
 const (
 	// ConnectionTypeInternet is a ConnectionType enum value
 	ConnectionTypeInternet = "INTERNET"
@@ -25529,6 +25578,14 @@ const (
 	ConnectionTypeVpcLink = "VPC_LINK"
 )
 
+// ConnectionType_Values returns all elements of the ConnectionType enum
+func ConnectionType_Values() []string {
+	return []string{
+		ConnectionTypeInternet,
+		ConnectionTypeVpcLink,
+	}
+}
+
 const (
 	// ContentHandlingStrategyConvertToBinary is a ContentHandlingStrategy enum value
 	ContentHandlingStrategyConvertToBinary = "CONVERT_TO_BINARY"
@@ -25536,6 +25593,14 @@ const (
 	// ContentHandlingStrategyConvertToText is a ContentHandlingStrategy enum value
 	ContentHandlingStrategyConvertToText = "CONVERT_TO_TEXT"
 )
+
+// ContentHandlingStrategy_Values returns all elements of the ContentHandlingStrategy enum
+func ContentHandlingStrategy_Values() []string {
+	return []string{
+		ContentHandlingStrategyConvertToBinary,
+		ContentHandlingStrategyConvertToText,
+	}
+}
 
 const (
 	// DocumentationPartTypeApi is a DocumentationPartType enum value
@@ -25575,6 +25640,24 @@ const (
 	DocumentationPartTypeResponseBody = "RESPONSE_BODY"
 )
 
+// DocumentationPartType_Values returns all elements of the DocumentationPartType enum
+func DocumentationPartType_Values() []string {
+	return []string{
+		DocumentationPartTypeApi,
+		DocumentationPartTypeAuthorizer,
+		DocumentationPartTypeModel,
+		DocumentationPartTypeResource,
+		DocumentationPartTypeMethod,
+		DocumentationPartTypePathParameter,
+		DocumentationPartTypeQueryParameter,
+		DocumentationPartTypeRequestHeader,
+		DocumentationPartTypeRequestBody,
+		DocumentationPartTypeResponse,
+		DocumentationPartTypeResponseHeader,
+		DocumentationPartTypeResponseBody,
+	}
+}
+
 const (
 	// DomainNameStatusAvailable is a DomainNameStatus enum value
 	DomainNameStatusAvailable = "AVAILABLE"
@@ -25585,6 +25668,15 @@ const (
 	// DomainNameStatusPending is a DomainNameStatus enum value
 	DomainNameStatusPending = "PENDING"
 )
+
+// DomainNameStatus_Values returns all elements of the DomainNameStatus enum
+func DomainNameStatus_Values() []string {
+	return []string{
+		DomainNameStatusAvailable,
+		DomainNameStatusUpdating,
+		DomainNameStatusPending,
+	}
+}
 
 // The endpoint type. The valid values are EDGE for edge-optimized API setup,
 // most suitable for mobile applications; REGIONAL for regional API endpoint
@@ -25600,6 +25692,15 @@ const (
 	// EndpointTypePrivate is a EndpointType enum value
 	EndpointTypePrivate = "PRIVATE"
 )
+
+// EndpointType_Values returns all elements of the EndpointType enum
+func EndpointType_Values() []string {
+	return []string{
+		EndpointTypeRegional,
+		EndpointTypeEdge,
+		EndpointTypePrivate,
+	}
+}
 
 const (
 	// GatewayResponseTypeDefault4xx is a GatewayResponseType enum value
@@ -25663,6 +25764,32 @@ const (
 	GatewayResponseTypeQuotaExceeded = "QUOTA_EXCEEDED"
 )
 
+// GatewayResponseType_Values returns all elements of the GatewayResponseType enum
+func GatewayResponseType_Values() []string {
+	return []string{
+		GatewayResponseTypeDefault4xx,
+		GatewayResponseTypeDefault5xx,
+		GatewayResponseTypeResourceNotFound,
+		GatewayResponseTypeUnauthorized,
+		GatewayResponseTypeInvalidApiKey,
+		GatewayResponseTypeAccessDenied,
+		GatewayResponseTypeAuthorizerFailure,
+		GatewayResponseTypeAuthorizerConfigurationError,
+		GatewayResponseTypeInvalidSignature,
+		GatewayResponseTypeExpiredToken,
+		GatewayResponseTypeMissingAuthenticationToken,
+		GatewayResponseTypeIntegrationFailure,
+		GatewayResponseTypeIntegrationTimeout,
+		GatewayResponseTypeApiConfigurationError,
+		GatewayResponseTypeUnsupportedMediaType,
+		GatewayResponseTypeBadRequestParameters,
+		GatewayResponseTypeBadRequestBody,
+		GatewayResponseTypeRequestTooLarge,
+		GatewayResponseTypeThrottled,
+		GatewayResponseTypeQuotaExceeded,
+	}
+}
+
 // The integration type. The valid value is HTTP for integrating an API method
 // with an HTTP backend; AWS with any AWS service endpoints; MOCK for testing
 // without actually invoking the backend; HTTP_PROXY for integrating with the
@@ -25684,6 +25811,17 @@ const (
 	IntegrationTypeAwsProxy = "AWS_PROXY"
 )
 
+// IntegrationType_Values returns all elements of the IntegrationType enum
+func IntegrationType_Values() []string {
+	return []string{
+		IntegrationTypeHttp,
+		IntegrationTypeAws,
+		IntegrationTypeMock,
+		IntegrationTypeHttpProxy,
+		IntegrationTypeAwsProxy,
+	}
+}
+
 const (
 	// LocationStatusTypeDocumented is a LocationStatusType enum value
 	LocationStatusTypeDocumented = "DOCUMENTED"
@@ -25691,6 +25829,14 @@ const (
 	// LocationStatusTypeUndocumented is a LocationStatusType enum value
 	LocationStatusTypeUndocumented = "UNDOCUMENTED"
 )
+
+// LocationStatusType_Values returns all elements of the LocationStatusType enum
+func LocationStatusType_Values() []string {
+	return []string{
+		LocationStatusTypeDocumented,
+		LocationStatusTypeUndocumented,
+	}
+}
 
 const (
 	// OpAdd is a Op enum value
@@ -25712,6 +25858,18 @@ const (
 	OpTest = "test"
 )
 
+// Op_Values returns all elements of the Op enum
+func Op_Values() []string {
+	return []string{
+		OpAdd,
+		OpRemove,
+		OpReplace,
+		OpMove,
+		OpCopy,
+		OpTest,
+	}
+}
+
 const (
 	// PutModeMerge is a PutMode enum value
 	PutModeMerge = "merge"
@@ -25719,6 +25877,14 @@ const (
 	// PutModeOverwrite is a PutMode enum value
 	PutModeOverwrite = "overwrite"
 )
+
+// PutMode_Values returns all elements of the PutMode enum
+func PutMode_Values() []string {
+	return []string{
+		PutModeMerge,
+		PutModeOverwrite,
+	}
+}
 
 const (
 	// QuotaPeriodTypeDay is a QuotaPeriodType enum value
@@ -25731,6 +25897,15 @@ const (
 	QuotaPeriodTypeMonth = "MONTH"
 )
 
+// QuotaPeriodType_Values returns all elements of the QuotaPeriodType enum
+func QuotaPeriodType_Values() []string {
+	return []string{
+		QuotaPeriodTypeDay,
+		QuotaPeriodTypeWeek,
+		QuotaPeriodTypeMonth,
+	}
+}
+
 const (
 	// SecurityPolicyTls10 is a SecurityPolicy enum value
 	SecurityPolicyTls10 = "TLS_1_0"
@@ -25738,6 +25913,14 @@ const (
 	// SecurityPolicyTls12 is a SecurityPolicy enum value
 	SecurityPolicyTls12 = "TLS_1_2"
 )
+
+// SecurityPolicy_Values returns all elements of the SecurityPolicy enum
+func SecurityPolicy_Values() []string {
+	return []string{
+		SecurityPolicyTls10,
+		SecurityPolicyTls12,
+	}
+}
 
 const (
 	// UnauthorizedCacheControlHeaderStrategyFailWith403 is a UnauthorizedCacheControlHeaderStrategy enum value
@@ -25749,6 +25932,15 @@ const (
 	// UnauthorizedCacheControlHeaderStrategySucceedWithoutResponseHeader is a UnauthorizedCacheControlHeaderStrategy enum value
 	UnauthorizedCacheControlHeaderStrategySucceedWithoutResponseHeader = "SUCCEED_WITHOUT_RESPONSE_HEADER"
 )
+
+// UnauthorizedCacheControlHeaderStrategy_Values returns all elements of the UnauthorizedCacheControlHeaderStrategy enum
+func UnauthorizedCacheControlHeaderStrategy_Values() []string {
+	return []string{
+		UnauthorizedCacheControlHeaderStrategyFailWith403,
+		UnauthorizedCacheControlHeaderStrategySucceedWithResponseHeader,
+		UnauthorizedCacheControlHeaderStrategySucceedWithoutResponseHeader,
+	}
+}
 
 const (
 	// VpcLinkStatusAvailable is a VpcLinkStatus enum value
@@ -25763,3 +25955,13 @@ const (
 	// VpcLinkStatusFailed is a VpcLinkStatus enum value
 	VpcLinkStatusFailed = "FAILED"
 )
+
+// VpcLinkStatus_Values returns all elements of the VpcLinkStatus enum
+func VpcLinkStatus_Values() []string {
+	return []string{
+		VpcLinkStatusAvailable,
+		VpcLinkStatusPending,
+		VpcLinkStatusDeleting,
+		VpcLinkStatusFailed,
+	}
+}

--- a/service/apigatewayv2/api.go
+++ b/service/apigatewayv2/api.go
@@ -18128,6 +18128,16 @@ const (
 	AuthorizationTypeJwt = "JWT"
 )
 
+// AuthorizationType_Values returns all elements of the AuthorizationType enum
+func AuthorizationType_Values() []string {
+	return []string{
+		AuthorizationTypeNone,
+		AuthorizationTypeAwsIam,
+		AuthorizationTypeCustom,
+		AuthorizationTypeJwt,
+	}
+}
+
 // The authorizer type. For WebSocket APIs, specify REQUEST for a Lambda function
 // using incoming request parameters. For HTTP APIs, specify JWT to use JSON
 // Web Tokens.
@@ -18139,6 +18149,14 @@ const (
 	AuthorizerTypeJwt = "JWT"
 )
 
+// AuthorizerType_Values returns all elements of the AuthorizerType enum
+func AuthorizerType_Values() []string {
+	return []string{
+		AuthorizerTypeRequest,
+		AuthorizerTypeJwt,
+	}
+}
+
 // Represents a connection type.
 const (
 	// ConnectionTypeInternet is a ConnectionType enum value
@@ -18147,6 +18165,14 @@ const (
 	// ConnectionTypeVpcLink is a ConnectionType enum value
 	ConnectionTypeVpcLink = "VPC_LINK"
 )
+
+// ConnectionType_Values returns all elements of the ConnectionType enum
+func ConnectionType_Values() []string {
+	return []string{
+		ConnectionTypeInternet,
+		ConnectionTypeVpcLink,
+	}
+}
 
 // Specifies how to handle response payload content type conversions. Supported
 // only for WebSocket APIs.
@@ -18157,6 +18183,14 @@ const (
 	// ContentHandlingStrategyConvertToText is a ContentHandlingStrategy enum value
 	ContentHandlingStrategyConvertToText = "CONVERT_TO_TEXT"
 )
+
+// ContentHandlingStrategy_Values returns all elements of the ContentHandlingStrategy enum
+func ContentHandlingStrategy_Values() []string {
+	return []string{
+		ContentHandlingStrategyConvertToBinary,
+		ContentHandlingStrategyConvertToText,
+	}
+}
 
 // Represents a deployment status.
 const (
@@ -18170,6 +18204,15 @@ const (
 	DeploymentStatusDeployed = "DEPLOYED"
 )
 
+// DeploymentStatus_Values returns all elements of the DeploymentStatus enum
+func DeploymentStatus_Values() []string {
+	return []string{
+		DeploymentStatusPending,
+		DeploymentStatusFailed,
+		DeploymentStatusDeployed,
+	}
+}
+
 // The status of the domain name migration. The valid values are AVAILABLE and
 // UPDATING. If the status is UPDATING, the domain cannot be modified further
 // until the existing operation is complete. If it is AVAILABLE, the domain
@@ -18182,6 +18225,14 @@ const (
 	DomainNameStatusUpdating = "UPDATING"
 )
 
+// DomainNameStatus_Values returns all elements of the DomainNameStatus enum
+func DomainNameStatus_Values() []string {
+	return []string{
+		DomainNameStatusAvailable,
+		DomainNameStatusUpdating,
+	}
+}
+
 // Represents an endpoint type.
 const (
 	// EndpointTypeRegional is a EndpointType enum value
@@ -18190,6 +18241,14 @@ const (
 	// EndpointTypeEdge is a EndpointType enum value
 	EndpointTypeEdge = "EDGE"
 )
+
+// EndpointType_Values returns all elements of the EndpointType enum
+func EndpointType_Values() []string {
+	return []string{
+		EndpointTypeRegional,
+		EndpointTypeEdge,
+	}
+}
 
 // Represents an API method integration type.
 const (
@@ -18209,6 +18268,17 @@ const (
 	IntegrationTypeAwsProxy = "AWS_PROXY"
 )
 
+// IntegrationType_Values returns all elements of the IntegrationType enum
+func IntegrationType_Values() []string {
+	return []string{
+		IntegrationTypeAws,
+		IntegrationTypeHttp,
+		IntegrationTypeMock,
+		IntegrationTypeHttpProxy,
+		IntegrationTypeAwsProxy,
+	}
+}
+
 // The logging level.
 const (
 	// LoggingLevelError is a LoggingLevel enum value
@@ -18220,6 +18290,15 @@ const (
 	// LoggingLevelOff is a LoggingLevel enum value
 	LoggingLevelOff = "OFF"
 )
+
+// LoggingLevel_Values returns all elements of the LoggingLevel enum
+func LoggingLevel_Values() []string {
+	return []string{
+		LoggingLevelError,
+		LoggingLevelInfo,
+		LoggingLevelOff,
+	}
+}
 
 // Represents passthrough behavior for an integration response. Supported only
 // for WebSocket APIs.
@@ -18234,6 +18313,15 @@ const (
 	PassthroughBehaviorWhenNoTemplates = "WHEN_NO_TEMPLATES"
 )
 
+// PassthroughBehavior_Values returns all elements of the PassthroughBehavior enum
+func PassthroughBehavior_Values() []string {
+	return []string{
+		PassthroughBehaviorWhenNoMatch,
+		PassthroughBehaviorNever,
+		PassthroughBehaviorWhenNoTemplates,
+	}
+}
+
 // Represents a protocol type.
 const (
 	// ProtocolTypeWebsocket is a ProtocolType enum value
@@ -18242,6 +18330,14 @@ const (
 	// ProtocolTypeHttp is a ProtocolType enum value
 	ProtocolTypeHttp = "HTTP"
 )
+
+// ProtocolType_Values returns all elements of the ProtocolType enum
+func ProtocolType_Values() []string {
+	return []string{
+		ProtocolTypeWebsocket,
+		ProtocolTypeHttp,
+	}
+}
 
 // The Transport Layer Security (TLS) version of the security policy for this
 // domain name. The valid values are TLS_1_0 and TLS_1_2.
@@ -18252,6 +18348,14 @@ const (
 	// SecurityPolicyTls12 is a SecurityPolicy enum value
 	SecurityPolicyTls12 = "TLS_1_2"
 )
+
+// SecurityPolicy_Values returns all elements of the SecurityPolicy enum
+func SecurityPolicy_Values() []string {
+	return []string{
+		SecurityPolicyTls10,
+		SecurityPolicyTls12,
+	}
+}
 
 // The status of the VPC link.
 const (
@@ -18271,8 +18375,26 @@ const (
 	VpcLinkStatusInactive = "INACTIVE"
 )
 
+// VpcLinkStatus_Values returns all elements of the VpcLinkStatus enum
+func VpcLinkStatus_Values() []string {
+	return []string{
+		VpcLinkStatusPending,
+		VpcLinkStatusAvailable,
+		VpcLinkStatusDeleting,
+		VpcLinkStatusFailed,
+		VpcLinkStatusInactive,
+	}
+}
+
 // The version of the VPC link.
 const (
 	// VpcLinkVersionV2 is a VpcLinkVersion enum value
 	VpcLinkVersionV2 = "V2"
 )
+
+// VpcLinkVersion_Values returns all elements of the VpcLinkVersion enum
+func VpcLinkVersion_Values() []string {
+	return []string{
+		VpcLinkVersionV2,
+	}
+}

--- a/service/appconfig/api.go
+++ b/service/appconfig/api.go
@@ -8570,6 +8570,13 @@ const (
 	BytesMeasureKilobytes = "KILOBYTES"
 )
 
+// BytesMeasure_Values returns all elements of the BytesMeasure enum
+func BytesMeasure_Values() []string {
+	return []string{
+		BytesMeasureKilobytes,
+	}
+}
+
 const (
 	// DeploymentEventTypePercentageUpdated is a DeploymentEventType enum value
 	DeploymentEventTypePercentageUpdated = "PERCENTAGE_UPDATED"
@@ -8589,6 +8596,18 @@ const (
 	// DeploymentEventTypeDeploymentCompleted is a DeploymentEventType enum value
 	DeploymentEventTypeDeploymentCompleted = "DEPLOYMENT_COMPLETED"
 )
+
+// DeploymentEventType_Values returns all elements of the DeploymentEventType enum
+func DeploymentEventType_Values() []string {
+	return []string{
+		DeploymentEventTypePercentageUpdated,
+		DeploymentEventTypeRollbackStarted,
+		DeploymentEventTypeRollbackCompleted,
+		DeploymentEventTypeBakeTimeStarted,
+		DeploymentEventTypeDeploymentStarted,
+		DeploymentEventTypeDeploymentCompleted,
+	}
+}
 
 const (
 	// DeploymentStateBaking is a DeploymentState enum value
@@ -8610,6 +8629,18 @@ const (
 	DeploymentStateRolledBack = "ROLLED_BACK"
 )
 
+// DeploymentState_Values returns all elements of the DeploymentState enum
+func DeploymentState_Values() []string {
+	return []string{
+		DeploymentStateBaking,
+		DeploymentStateValidating,
+		DeploymentStateDeploying,
+		DeploymentStateComplete,
+		DeploymentStateRollingBack,
+		DeploymentStateRolledBack,
+	}
+}
+
 const (
 	// EnvironmentStateReadyForDeployment is a EnvironmentState enum value
 	EnvironmentStateReadyForDeployment = "READY_FOR_DEPLOYMENT"
@@ -8624,6 +8655,16 @@ const (
 	EnvironmentStateRolledBack = "ROLLED_BACK"
 )
 
+// EnvironmentState_Values returns all elements of the EnvironmentState enum
+func EnvironmentState_Values() []string {
+	return []string{
+		EnvironmentStateReadyForDeployment,
+		EnvironmentStateDeploying,
+		EnvironmentStateRollingBack,
+		EnvironmentStateRolledBack,
+	}
+}
+
 const (
 	// GrowthTypeLinear is a GrowthType enum value
 	GrowthTypeLinear = "LINEAR"
@@ -8632,6 +8673,14 @@ const (
 	GrowthTypeExponential = "EXPONENTIAL"
 )
 
+// GrowthType_Values returns all elements of the GrowthType enum
+func GrowthType_Values() []string {
+	return []string{
+		GrowthTypeLinear,
+		GrowthTypeExponential,
+	}
+}
+
 const (
 	// ReplicateToNone is a ReplicateTo enum value
 	ReplicateToNone = "NONE"
@@ -8639,6 +8688,14 @@ const (
 	// ReplicateToSsmDocument is a ReplicateTo enum value
 	ReplicateToSsmDocument = "SSM_DOCUMENT"
 )
+
+// ReplicateTo_Values returns all elements of the ReplicateTo enum
+func ReplicateTo_Values() []string {
+	return []string{
+		ReplicateToNone,
+		ReplicateToSsmDocument,
+	}
+}
 
 const (
 	// TriggeredByUser is a TriggeredBy enum value
@@ -8654,6 +8711,16 @@ const (
 	TriggeredByInternalError = "INTERNAL_ERROR"
 )
 
+// TriggeredBy_Values returns all elements of the TriggeredBy enum
+func TriggeredBy_Values() []string {
+	return []string{
+		TriggeredByUser,
+		TriggeredByAppconfig,
+		TriggeredByCloudwatchAlarm,
+		TriggeredByInternalError,
+	}
+}
+
 const (
 	// ValidatorTypeJsonSchema is a ValidatorType enum value
 	ValidatorTypeJsonSchema = "JSON_SCHEMA"
@@ -8661,3 +8728,11 @@ const (
 	// ValidatorTypeLambda is a ValidatorType enum value
 	ValidatorTypeLambda = "LAMBDA"
 )
+
+// ValidatorType_Values returns all elements of the ValidatorType enum
+func ValidatorType_Values() []string {
+	return []string{
+		ValidatorTypeJsonSchema,
+		ValidatorTypeLambda,
+	}
+}

--- a/service/applicationautoscaling/api.go
+++ b/service/applicationautoscaling/api.go
@@ -5508,6 +5508,15 @@ const (
 	AdjustmentTypeExactCapacity = "ExactCapacity"
 )
 
+// AdjustmentType_Values returns all elements of the AdjustmentType enum
+func AdjustmentType_Values() []string {
+	return []string{
+		AdjustmentTypeChangeInCapacity,
+		AdjustmentTypePercentChangeInCapacity,
+		AdjustmentTypeExactCapacity,
+	}
+}
+
 const (
 	// MetricAggregationTypeAverage is a MetricAggregationType enum value
 	MetricAggregationTypeAverage = "Average"
@@ -5518,6 +5527,15 @@ const (
 	// MetricAggregationTypeMaximum is a MetricAggregationType enum value
 	MetricAggregationTypeMaximum = "Maximum"
 )
+
+// MetricAggregationType_Values returns all elements of the MetricAggregationType enum
+func MetricAggregationType_Values() []string {
+	return []string{
+		MetricAggregationTypeAverage,
+		MetricAggregationTypeMinimum,
+		MetricAggregationTypeMaximum,
+	}
+}
 
 const (
 	// MetricStatisticAverage is a MetricStatistic enum value
@@ -5535,6 +5553,17 @@ const (
 	// MetricStatisticSum is a MetricStatistic enum value
 	MetricStatisticSum = "Sum"
 )
+
+// MetricStatistic_Values returns all elements of the MetricStatistic enum
+func MetricStatistic_Values() []string {
+	return []string{
+		MetricStatisticAverage,
+		MetricStatisticMinimum,
+		MetricStatisticMaximum,
+		MetricStatisticSampleCount,
+		MetricStatisticSum,
+	}
+}
 
 const (
 	// MetricTypeDynamoDbreadCapacityUtilization is a MetricType enum value
@@ -5586,6 +5615,28 @@ const (
 	MetricTypeCassandraWriteCapacityUtilization = "CassandraWriteCapacityUtilization"
 )
 
+// MetricType_Values returns all elements of the MetricType enum
+func MetricType_Values() []string {
+	return []string{
+		MetricTypeDynamoDbreadCapacityUtilization,
+		MetricTypeDynamoDbwriteCapacityUtilization,
+		MetricTypeAlbrequestCountPerTarget,
+		MetricTypeRdsreaderAverageCpuutilization,
+		MetricTypeRdsreaderAverageDatabaseConnections,
+		MetricTypeEc2spotFleetRequestAverageCpuutilization,
+		MetricTypeEc2spotFleetRequestAverageNetworkIn,
+		MetricTypeEc2spotFleetRequestAverageNetworkOut,
+		MetricTypeSageMakerVariantInvocationsPerInstance,
+		MetricTypeEcsserviceAverageCpuutilization,
+		MetricTypeEcsserviceAverageMemoryUtilization,
+		MetricTypeAppStreamAverageCapacityUtilization,
+		MetricTypeComprehendInferenceUtilization,
+		MetricTypeLambdaProvisionedConcurrencyUtilization,
+		MetricTypeCassandraReadCapacityUtilization,
+		MetricTypeCassandraWriteCapacityUtilization,
+	}
+}
+
 const (
 	// PolicyTypeStepScaling is a PolicyType enum value
 	PolicyTypeStepScaling = "StepScaling"
@@ -5593,6 +5644,14 @@ const (
 	// PolicyTypeTargetTrackingScaling is a PolicyType enum value
 	PolicyTypeTargetTrackingScaling = "TargetTrackingScaling"
 )
+
+// PolicyType_Values returns all elements of the PolicyType enum
+func PolicyType_Values() []string {
+	return []string{
+		PolicyTypeStepScaling,
+		PolicyTypeTargetTrackingScaling,
+	}
+}
 
 const (
 	// ScalableDimensionEcsServiceDesiredCount is a ScalableDimension enum value
@@ -5641,6 +5700,27 @@ const (
 	ScalableDimensionCassandraTableWriteCapacityUnits = "cassandra:table:WriteCapacityUnits"
 )
 
+// ScalableDimension_Values returns all elements of the ScalableDimension enum
+func ScalableDimension_Values() []string {
+	return []string{
+		ScalableDimensionEcsServiceDesiredCount,
+		ScalableDimensionEc2SpotFleetRequestTargetCapacity,
+		ScalableDimensionElasticmapreduceInstancegroupInstanceCount,
+		ScalableDimensionAppstreamFleetDesiredCapacity,
+		ScalableDimensionDynamodbTableReadCapacityUnits,
+		ScalableDimensionDynamodbTableWriteCapacityUnits,
+		ScalableDimensionDynamodbIndexReadCapacityUnits,
+		ScalableDimensionDynamodbIndexWriteCapacityUnits,
+		ScalableDimensionRdsClusterReadReplicaCount,
+		ScalableDimensionSagemakerVariantDesiredInstanceCount,
+		ScalableDimensionCustomResourceResourceTypeProperty,
+		ScalableDimensionComprehendDocumentClassifierEndpointDesiredInferenceUnits,
+		ScalableDimensionLambdaFunctionProvisionedConcurrency,
+		ScalableDimensionCassandraTableReadCapacityUnits,
+		ScalableDimensionCassandraTableWriteCapacityUnits,
+	}
+}
+
 const (
 	// ScalingActivityStatusCodePending is a ScalingActivityStatusCode enum value
 	ScalingActivityStatusCodePending = "Pending"
@@ -5660,6 +5740,18 @@ const (
 	// ScalingActivityStatusCodeFailed is a ScalingActivityStatusCode enum value
 	ScalingActivityStatusCodeFailed = "Failed"
 )
+
+// ScalingActivityStatusCode_Values returns all elements of the ScalingActivityStatusCode enum
+func ScalingActivityStatusCode_Values() []string {
+	return []string{
+		ScalingActivityStatusCodePending,
+		ScalingActivityStatusCodeInProgress,
+		ScalingActivityStatusCodeSuccessful,
+		ScalingActivityStatusCodeOverridden,
+		ScalingActivityStatusCodeUnfulfilled,
+		ScalingActivityStatusCodeFailed,
+	}
+}
 
 const (
 	// ServiceNamespaceEcs is a ServiceNamespace enum value
@@ -5695,3 +5787,20 @@ const (
 	// ServiceNamespaceCassandra is a ServiceNamespace enum value
 	ServiceNamespaceCassandra = "cassandra"
 )
+
+// ServiceNamespace_Values returns all elements of the ServiceNamespace enum
+func ServiceNamespace_Values() []string {
+	return []string{
+		ServiceNamespaceEcs,
+		ServiceNamespaceElasticmapreduce,
+		ServiceNamespaceEc2,
+		ServiceNamespaceAppstream,
+		ServiceNamespaceDynamodb,
+		ServiceNamespaceRds,
+		ServiceNamespaceSagemaker,
+		ServiceNamespaceCustomResource,
+		ServiceNamespaceComprehend,
+		ServiceNamespaceLambda,
+		ServiceNamespaceCassandra,
+	}
+}

--- a/service/applicationdiscoveryservice/api.go
+++ b/service/applicationdiscoveryservice/api.go
@@ -6546,6 +6546,18 @@ const (
 	AgentStatusShutdown = "SHUTDOWN"
 )
 
+// AgentStatus_Values returns all elements of the AgentStatus enum
+func AgentStatus_Values() []string {
+	return []string{
+		AgentStatusHealthy,
+		AgentStatusUnhealthy,
+		AgentStatusRunning,
+		AgentStatusUnknown,
+		AgentStatusBlacklisted,
+		AgentStatusShutdown,
+	}
+}
+
 const (
 	// BatchDeleteImportDataErrorCodeNotFound is a BatchDeleteImportDataErrorCode enum value
 	BatchDeleteImportDataErrorCodeNotFound = "NOT_FOUND"
@@ -6556,6 +6568,15 @@ const (
 	// BatchDeleteImportDataErrorCodeOverLimit is a BatchDeleteImportDataErrorCode enum value
 	BatchDeleteImportDataErrorCodeOverLimit = "OVER_LIMIT"
 )
+
+// BatchDeleteImportDataErrorCode_Values returns all elements of the BatchDeleteImportDataErrorCode enum
+func BatchDeleteImportDataErrorCode_Values() []string {
+	return []string{
+		BatchDeleteImportDataErrorCodeNotFound,
+		BatchDeleteImportDataErrorCodeInternalServerError,
+		BatchDeleteImportDataErrorCodeOverLimit,
+	}
+}
 
 const (
 	// ConfigurationItemTypeServer is a ConfigurationItemType enum value
@@ -6570,6 +6591,16 @@ const (
 	// ConfigurationItemTypeApplication is a ConfigurationItemType enum value
 	ConfigurationItemTypeApplication = "APPLICATION"
 )
+
+// ConfigurationItemType_Values returns all elements of the ConfigurationItemType enum
+func ConfigurationItemType_Values() []string {
+	return []string{
+		ConfigurationItemTypeServer,
+		ConfigurationItemTypeProcess,
+		ConfigurationItemTypeConnection,
+		ConfigurationItemTypeApplication,
+	}
+}
 
 const (
 	// ContinuousExportStatusStartInProgress is a ContinuousExportStatus enum value
@@ -6594,10 +6625,30 @@ const (
 	ContinuousExportStatusInactive = "INACTIVE"
 )
 
+// ContinuousExportStatus_Values returns all elements of the ContinuousExportStatus enum
+func ContinuousExportStatus_Values() []string {
+	return []string{
+		ContinuousExportStatusStartInProgress,
+		ContinuousExportStatusStartFailed,
+		ContinuousExportStatusActive,
+		ContinuousExportStatusError,
+		ContinuousExportStatusStopInProgress,
+		ContinuousExportStatusStopFailed,
+		ContinuousExportStatusInactive,
+	}
+}
+
 const (
 	// DataSourceAgent is a DataSource enum value
 	DataSourceAgent = "AGENT"
 )
+
+// DataSource_Values returns all elements of the DataSource enum
+func DataSource_Values() []string {
+	return []string{
+		DataSourceAgent,
+	}
+}
 
 const (
 	// ExportDataFormatCsv is a ExportDataFormat enum value
@@ -6606,6 +6657,14 @@ const (
 	// ExportDataFormatGraphml is a ExportDataFormat enum value
 	ExportDataFormatGraphml = "GRAPHML"
 )
+
+// ExportDataFormat_Values returns all elements of the ExportDataFormat enum
+func ExportDataFormat_Values() []string {
+	return []string{
+		ExportDataFormatCsv,
+		ExportDataFormatGraphml,
+	}
+}
 
 const (
 	// ExportStatusFailed is a ExportStatus enum value
@@ -6617,6 +6676,15 @@ const (
 	// ExportStatusInProgress is a ExportStatus enum value
 	ExportStatusInProgress = "IN_PROGRESS"
 )
+
+// ExportStatus_Values returns all elements of the ExportStatus enum
+func ExportStatus_Values() []string {
+	return []string{
+		ExportStatusFailed,
+		ExportStatusSucceeded,
+		ExportStatusInProgress,
+	}
+}
 
 const (
 	// ImportStatusImportInProgress is a ImportStatus enum value
@@ -6653,6 +6721,23 @@ const (
 	ImportStatusInternalError = "INTERNAL_ERROR"
 )
 
+// ImportStatus_Values returns all elements of the ImportStatus enum
+func ImportStatus_Values() []string {
+	return []string{
+		ImportStatusImportInProgress,
+		ImportStatusImportComplete,
+		ImportStatusImportCompleteWithErrors,
+		ImportStatusImportFailed,
+		ImportStatusImportFailedServerLimitExceeded,
+		ImportStatusImportFailedRecordLimitExceeded,
+		ImportStatusDeleteInProgress,
+		ImportStatusDeleteComplete,
+		ImportStatusDeleteFailed,
+		ImportStatusDeleteFailedLimitExceeded,
+		ImportStatusInternalError,
+	}
+}
+
 const (
 	// ImportTaskFilterNameImportTaskId is a ImportTaskFilterName enum value
 	ImportTaskFilterNameImportTaskId = "IMPORT_TASK_ID"
@@ -6664,6 +6749,15 @@ const (
 	ImportTaskFilterNameName = "NAME"
 )
 
+// ImportTaskFilterName_Values returns all elements of the ImportTaskFilterName enum
+func ImportTaskFilterName_Values() []string {
+	return []string{
+		ImportTaskFilterNameImportTaskId,
+		ImportTaskFilterNameStatus,
+		ImportTaskFilterNameName,
+	}
+}
+
 const (
 	// OrderStringAsc is a OrderString enum value
 	OrderStringAsc = "ASC"
@@ -6671,3 +6765,11 @@ const (
 	// OrderStringDesc is a OrderString enum value
 	OrderStringDesc = "DESC"
 )
+
+// OrderString_Values returns all elements of the OrderString enum
+func OrderString_Values() []string {
+	return []string{
+		OrderStringAsc,
+		OrderStringDesc,
+	}
+}

--- a/service/applicationinsights/api.go
+++ b/service/applicationinsights/api.go
@@ -6393,6 +6393,15 @@ const (
 	CloudWatchEventSourceHealth = "HEALTH"
 )
 
+// CloudWatchEventSource_Values returns all elements of the CloudWatchEventSource enum
+func CloudWatchEventSource_Values() []string {
+	return []string{
+		CloudWatchEventSourceEc2,
+		CloudWatchEventSourceCodeDeploy,
+		CloudWatchEventSourceHealth,
+	}
+}
+
 const (
 	// ConfigurationEventResourceTypeCloudwatchAlarm is a ConfigurationEventResourceType enum value
 	ConfigurationEventResourceTypeCloudwatchAlarm = "CLOUDWATCH_ALARM"
@@ -6403,6 +6412,15 @@ const (
 	// ConfigurationEventResourceTypeSsmAssociation is a ConfigurationEventResourceType enum value
 	ConfigurationEventResourceTypeSsmAssociation = "SSM_ASSOCIATION"
 )
+
+// ConfigurationEventResourceType_Values returns all elements of the ConfigurationEventResourceType enum
+func ConfigurationEventResourceType_Values() []string {
+	return []string{
+		ConfigurationEventResourceTypeCloudwatchAlarm,
+		ConfigurationEventResourceTypeCloudformation,
+		ConfigurationEventResourceTypeSsmAssociation,
+	}
+}
 
 const (
 	// ConfigurationEventStatusInfo is a ConfigurationEventStatus enum value
@@ -6415,10 +6433,26 @@ const (
 	ConfigurationEventStatusError = "ERROR"
 )
 
+// ConfigurationEventStatus_Values returns all elements of the ConfigurationEventStatus enum
+func ConfigurationEventStatus_Values() []string {
+	return []string{
+		ConfigurationEventStatusInfo,
+		ConfigurationEventStatusWarn,
+		ConfigurationEventStatusError,
+	}
+}
+
 const (
 	// FeedbackKeyInsightsFeedback is a FeedbackKey enum value
 	FeedbackKeyInsightsFeedback = "INSIGHTS_FEEDBACK"
 )
+
+// FeedbackKey_Values returns all elements of the FeedbackKey enum
+func FeedbackKey_Values() []string {
+	return []string{
+		FeedbackKeyInsightsFeedback,
+	}
+}
 
 const (
 	// FeedbackValueNotSpecified is a FeedbackValue enum value
@@ -6431,6 +6465,15 @@ const (
 	FeedbackValueNotUseful = "NOT_USEFUL"
 )
 
+// FeedbackValue_Values returns all elements of the FeedbackValue enum
+func FeedbackValue_Values() []string {
+	return []string{
+		FeedbackValueNotSpecified,
+		FeedbackValueUseful,
+		FeedbackValueNotUseful,
+	}
+}
+
 const (
 	// LogFilterError is a LogFilter enum value
 	LogFilterError = "ERROR"
@@ -6441,6 +6484,15 @@ const (
 	// LogFilterInfo is a LogFilter enum value
 	LogFilterInfo = "INFO"
 )
+
+// LogFilter_Values returns all elements of the LogFilter enum
+func LogFilter_Values() []string {
+	return []string{
+		LogFilterError,
+		LogFilterWarn,
+		LogFilterInfo,
+	}
+}
 
 const (
 	// SeverityLevelLow is a SeverityLevel enum value
@@ -6453,6 +6505,15 @@ const (
 	SeverityLevelHigh = "High"
 )
 
+// SeverityLevel_Values returns all elements of the SeverityLevel enum
+func SeverityLevel_Values() []string {
+	return []string{
+		SeverityLevelLow,
+		SeverityLevelMedium,
+		SeverityLevelHigh,
+	}
+}
+
 const (
 	// StatusIgnore is a Status enum value
 	StatusIgnore = "IGNORE"
@@ -6463,6 +6524,15 @@ const (
 	// StatusPending is a Status enum value
 	StatusPending = "PENDING"
 )
+
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusIgnore,
+		StatusResolved,
+		StatusPending,
+	}
+}
 
 const (
 	// TierDefault is a Tier enum value
@@ -6480,3 +6550,14 @@ const (
 	// TierSqlServer is a Tier enum value
 	TierSqlServer = "SQL_SERVER"
 )
+
+// Tier_Values returns all elements of the Tier enum
+func Tier_Values() []string {
+	return []string{
+		TierDefault,
+		TierDotNetCore,
+		TierDotNetWorker,
+		TierDotNetWeb,
+		TierSqlServer,
+	}
+}

--- a/service/appmesh/api.go
+++ b/service/appmesh/api.go
@@ -14725,6 +14725,14 @@ const (
 	DurationUnitS = "s"
 )
 
+// DurationUnit_Values returns all elements of the DurationUnit enum
+func DurationUnit_Values() []string {
+	return []string{
+		DurationUnitMs,
+		DurationUnitS,
+	}
+}
+
 const (
 	// EgressFilterTypeAllowAll is a EgressFilterType enum value
 	EgressFilterTypeAllowAll = "ALLOW_ALL"
@@ -14732,6 +14740,14 @@ const (
 	// EgressFilterTypeDropAll is a EgressFilterType enum value
 	EgressFilterTypeDropAll = "DROP_ALL"
 )
+
+// EgressFilterType_Values returns all elements of the EgressFilterType enum
+func EgressFilterType_Values() []string {
+	return []string{
+		EgressFilterTypeAllowAll,
+		EgressFilterTypeDropAll,
+	}
+}
 
 const (
 	// GatewayRouteStatusCodeActive is a GatewayRouteStatusCode enum value
@@ -14743,6 +14759,15 @@ const (
 	// GatewayRouteStatusCodeInactive is a GatewayRouteStatusCode enum value
 	GatewayRouteStatusCodeInactive = "INACTIVE"
 )
+
+// GatewayRouteStatusCode_Values returns all elements of the GatewayRouteStatusCode enum
+func GatewayRouteStatusCode_Values() []string {
+	return []string{
+		GatewayRouteStatusCodeActive,
+		GatewayRouteStatusCodeDeleted,
+		GatewayRouteStatusCodeInactive,
+	}
+}
 
 const (
 	// GrpcRetryPolicyEventCancelled is a GrpcRetryPolicyEvent enum value
@@ -14760,6 +14785,17 @@ const (
 	// GrpcRetryPolicyEventUnavailable is a GrpcRetryPolicyEvent enum value
 	GrpcRetryPolicyEventUnavailable = "unavailable"
 )
+
+// GrpcRetryPolicyEvent_Values returns all elements of the GrpcRetryPolicyEvent enum
+func GrpcRetryPolicyEvent_Values() []string {
+	return []string{
+		GrpcRetryPolicyEventCancelled,
+		GrpcRetryPolicyEventDeadlineExceeded,
+		GrpcRetryPolicyEventInternal,
+		GrpcRetryPolicyEventResourceExhausted,
+		GrpcRetryPolicyEventUnavailable,
+	}
+}
 
 const (
 	// HttpMethodConnect is a HttpMethod enum value
@@ -14790,6 +14826,21 @@ const (
 	HttpMethodTrace = "TRACE"
 )
 
+// HttpMethod_Values returns all elements of the HttpMethod enum
+func HttpMethod_Values() []string {
+	return []string{
+		HttpMethodConnect,
+		HttpMethodDelete,
+		HttpMethodGet,
+		HttpMethodHead,
+		HttpMethodOptions,
+		HttpMethodPatch,
+		HttpMethodPost,
+		HttpMethodPut,
+		HttpMethodTrace,
+	}
+}
+
 const (
 	// HttpSchemeHttp is a HttpScheme enum value
 	HttpSchemeHttp = "http"
@@ -14797,6 +14848,14 @@ const (
 	// HttpSchemeHttps is a HttpScheme enum value
 	HttpSchemeHttps = "https"
 )
+
+// HttpScheme_Values returns all elements of the HttpScheme enum
+func HttpScheme_Values() []string {
+	return []string{
+		HttpSchemeHttp,
+		HttpSchemeHttps,
+	}
+}
 
 const (
 	// ListenerTlsModeDisabled is a ListenerTlsMode enum value
@@ -14809,6 +14868,15 @@ const (
 	ListenerTlsModeStrict = "STRICT"
 )
 
+// ListenerTlsMode_Values returns all elements of the ListenerTlsMode enum
+func ListenerTlsMode_Values() []string {
+	return []string{
+		ListenerTlsModeDisabled,
+		ListenerTlsModePermissive,
+		ListenerTlsModeStrict,
+	}
+}
+
 const (
 	// MeshStatusCodeActive is a MeshStatusCode enum value
 	MeshStatusCodeActive = "ACTIVE"
@@ -14819,6 +14887,15 @@ const (
 	// MeshStatusCodeInactive is a MeshStatusCode enum value
 	MeshStatusCodeInactive = "INACTIVE"
 )
+
+// MeshStatusCode_Values returns all elements of the MeshStatusCode enum
+func MeshStatusCode_Values() []string {
+	return []string{
+		MeshStatusCodeActive,
+		MeshStatusCodeDeleted,
+		MeshStatusCodeInactive,
+	}
+}
 
 const (
 	// PortProtocolGrpc is a PortProtocol enum value
@@ -14834,6 +14911,16 @@ const (
 	PortProtocolTcp = "tcp"
 )
 
+// PortProtocol_Values returns all elements of the PortProtocol enum
+func PortProtocol_Values() []string {
+	return []string{
+		PortProtocolGrpc,
+		PortProtocolHttp,
+		PortProtocolHttp2,
+		PortProtocolTcp,
+	}
+}
+
 const (
 	// RouteStatusCodeActive is a RouteStatusCode enum value
 	RouteStatusCodeActive = "ACTIVE"
@@ -14845,10 +14932,26 @@ const (
 	RouteStatusCodeInactive = "INACTIVE"
 )
 
+// RouteStatusCode_Values returns all elements of the RouteStatusCode enum
+func RouteStatusCode_Values() []string {
+	return []string{
+		RouteStatusCodeActive,
+		RouteStatusCodeDeleted,
+		RouteStatusCodeInactive,
+	}
+}
+
 const (
 	// TcpRetryPolicyEventConnectionError is a TcpRetryPolicyEvent enum value
 	TcpRetryPolicyEventConnectionError = "connection-error"
 )
+
+// TcpRetryPolicyEvent_Values returns all elements of the TcpRetryPolicyEvent enum
+func TcpRetryPolicyEvent_Values() []string {
+	return []string{
+		TcpRetryPolicyEventConnectionError,
+	}
+}
 
 const (
 	// VirtualGatewayListenerTlsModeDisabled is a VirtualGatewayListenerTlsMode enum value
@@ -14861,6 +14964,15 @@ const (
 	VirtualGatewayListenerTlsModeStrict = "STRICT"
 )
 
+// VirtualGatewayListenerTlsMode_Values returns all elements of the VirtualGatewayListenerTlsMode enum
+func VirtualGatewayListenerTlsMode_Values() []string {
+	return []string{
+		VirtualGatewayListenerTlsModeDisabled,
+		VirtualGatewayListenerTlsModePermissive,
+		VirtualGatewayListenerTlsModeStrict,
+	}
+}
+
 const (
 	// VirtualGatewayPortProtocolGrpc is a VirtualGatewayPortProtocol enum value
 	VirtualGatewayPortProtocolGrpc = "grpc"
@@ -14871,6 +14983,15 @@ const (
 	// VirtualGatewayPortProtocolHttp2 is a VirtualGatewayPortProtocol enum value
 	VirtualGatewayPortProtocolHttp2 = "http2"
 )
+
+// VirtualGatewayPortProtocol_Values returns all elements of the VirtualGatewayPortProtocol enum
+func VirtualGatewayPortProtocol_Values() []string {
+	return []string{
+		VirtualGatewayPortProtocolGrpc,
+		VirtualGatewayPortProtocolHttp,
+		VirtualGatewayPortProtocolHttp2,
+	}
+}
 
 const (
 	// VirtualGatewayStatusCodeActive is a VirtualGatewayStatusCode enum value
@@ -14883,6 +15004,15 @@ const (
 	VirtualGatewayStatusCodeInactive = "INACTIVE"
 )
 
+// VirtualGatewayStatusCode_Values returns all elements of the VirtualGatewayStatusCode enum
+func VirtualGatewayStatusCode_Values() []string {
+	return []string{
+		VirtualGatewayStatusCodeActive,
+		VirtualGatewayStatusCodeDeleted,
+		VirtualGatewayStatusCodeInactive,
+	}
+}
+
 const (
 	// VirtualNodeStatusCodeActive is a VirtualNodeStatusCode enum value
 	VirtualNodeStatusCodeActive = "ACTIVE"
@@ -14893,6 +15023,15 @@ const (
 	// VirtualNodeStatusCodeInactive is a VirtualNodeStatusCode enum value
 	VirtualNodeStatusCodeInactive = "INACTIVE"
 )
+
+// VirtualNodeStatusCode_Values returns all elements of the VirtualNodeStatusCode enum
+func VirtualNodeStatusCode_Values() []string {
+	return []string{
+		VirtualNodeStatusCodeActive,
+		VirtualNodeStatusCodeDeleted,
+		VirtualNodeStatusCodeInactive,
+	}
+}
 
 const (
 	// VirtualRouterStatusCodeActive is a VirtualRouterStatusCode enum value
@@ -14905,6 +15044,15 @@ const (
 	VirtualRouterStatusCodeInactive = "INACTIVE"
 )
 
+// VirtualRouterStatusCode_Values returns all elements of the VirtualRouterStatusCode enum
+func VirtualRouterStatusCode_Values() []string {
+	return []string{
+		VirtualRouterStatusCodeActive,
+		VirtualRouterStatusCodeDeleted,
+		VirtualRouterStatusCodeInactive,
+	}
+}
+
 const (
 	// VirtualServiceStatusCodeActive is a VirtualServiceStatusCode enum value
 	VirtualServiceStatusCodeActive = "ACTIVE"
@@ -14915,3 +15063,12 @@ const (
 	// VirtualServiceStatusCodeInactive is a VirtualServiceStatusCode enum value
 	VirtualServiceStatusCodeInactive = "INACTIVE"
 )
+
+// VirtualServiceStatusCode_Values returns all elements of the VirtualServiceStatusCode enum
+func VirtualServiceStatusCode_Values() []string {
+	return []string{
+		VirtualServiceStatusCodeActive,
+		VirtualServiceStatusCodeDeleted,
+		VirtualServiceStatusCodeInactive,
+	}
+}

--- a/service/appstream/api.go
+++ b/service/appstream/api.go
@@ -11664,6 +11664,13 @@ const (
 	AccessEndpointTypeStreaming = "STREAMING"
 )
 
+// AccessEndpointType_Values returns all elements of the AccessEndpointType enum
+func AccessEndpointType_Values() []string {
+	return []string{
+		AccessEndpointTypeStreaming,
+	}
+}
+
 const (
 	// ActionClipboardCopyFromLocalDevice is a Action enum value
 	ActionClipboardCopyFromLocalDevice = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
@@ -11681,6 +11688,17 @@ const (
 	ActionPrintingToLocalDevice = "PRINTING_TO_LOCAL_DEVICE"
 )
 
+// Action_Values returns all elements of the Action enum
+func Action_Values() []string {
+	return []string{
+		ActionClipboardCopyFromLocalDevice,
+		ActionClipboardCopyToLocalDevice,
+		ActionFileUpload,
+		ActionFileDownload,
+		ActionPrintingToLocalDevice,
+	}
+}
+
 const (
 	// AuthenticationTypeApi is a AuthenticationType enum value
 	AuthenticationTypeApi = "API"
@@ -11691,6 +11709,15 @@ const (
 	// AuthenticationTypeUserpool is a AuthenticationType enum value
 	AuthenticationTypeUserpool = "USERPOOL"
 )
+
+// AuthenticationType_Values returns all elements of the AuthenticationType enum
+func AuthenticationType_Values() []string {
+	return []string{
+		AuthenticationTypeApi,
+		AuthenticationTypeSaml,
+		AuthenticationTypeUserpool,
+	}
+}
 
 // The fleet attribute.
 const (
@@ -11706,6 +11733,16 @@ const (
 	// FleetAttributeIamRoleArn is a FleetAttribute enum value
 	FleetAttributeIamRoleArn = "IAM_ROLE_ARN"
 )
+
+// FleetAttribute_Values returns all elements of the FleetAttribute enum
+func FleetAttribute_Values() []string {
+	return []string{
+		FleetAttributeVpcConfiguration,
+		FleetAttributeVpcConfigurationSecurityGroupIds,
+		FleetAttributeDomainJoinInfo,
+		FleetAttributeIamRoleArn,
+	}
+}
 
 const (
 	// FleetErrorCodeIamServiceRoleMissingEniDescribeAction is a FleetErrorCode enum value
@@ -11793,6 +11830,40 @@ const (
 	FleetErrorCodeDomainJoinInternalServiceError = "DOMAIN_JOIN_INTERNAL_SERVICE_ERROR"
 )
 
+// FleetErrorCode_Values returns all elements of the FleetErrorCode enum
+func FleetErrorCode_Values() []string {
+	return []string{
+		FleetErrorCodeIamServiceRoleMissingEniDescribeAction,
+		FleetErrorCodeIamServiceRoleMissingEniCreateAction,
+		FleetErrorCodeIamServiceRoleMissingEniDeleteAction,
+		FleetErrorCodeNetworkInterfaceLimitExceeded,
+		FleetErrorCodeInternalServiceError,
+		FleetErrorCodeIamServiceRoleIsMissing,
+		FleetErrorCodeMachineRoleIsMissing,
+		FleetErrorCodeStsDisabledInRegion,
+		FleetErrorCodeSubnetHasInsufficientIpAddresses,
+		FleetErrorCodeIamServiceRoleMissingDescribeSubnetAction,
+		FleetErrorCodeSubnetNotFound,
+		FleetErrorCodeImageNotFound,
+		FleetErrorCodeInvalidSubnetConfiguration,
+		FleetErrorCodeSecurityGroupsNotFound,
+		FleetErrorCodeIgwNotAttached,
+		FleetErrorCodeIamServiceRoleMissingDescribeSecurityGroupsAction,
+		FleetErrorCodeDomainJoinErrorFileNotFound,
+		FleetErrorCodeDomainJoinErrorAccessDenied,
+		FleetErrorCodeDomainJoinErrorLogonFailure,
+		FleetErrorCodeDomainJoinErrorInvalidParameter,
+		FleetErrorCodeDomainJoinErrorMoreData,
+		FleetErrorCodeDomainJoinErrorNoSuchDomain,
+		FleetErrorCodeDomainJoinErrorNotSupported,
+		FleetErrorCodeDomainJoinNerrInvalidWorkgroupName,
+		FleetErrorCodeDomainJoinNerrWorkstationNotStarted,
+		FleetErrorCodeDomainJoinErrorDsMachineAccountQuotaExceeded,
+		FleetErrorCodeDomainJoinNerrPasswordExpired,
+		FleetErrorCodeDomainJoinInternalServiceError,
+	}
+}
+
 const (
 	// FleetStateStarting is a FleetState enum value
 	FleetStateStarting = "STARTING"
@@ -11807,6 +11878,16 @@ const (
 	FleetStateStopped = "STOPPED"
 )
 
+// FleetState_Values returns all elements of the FleetState enum
+func FleetState_Values() []string {
+	return []string{
+		FleetStateStarting,
+		FleetStateRunning,
+		FleetStateStopping,
+		FleetStateStopped,
+	}
+}
+
 const (
 	// FleetTypeAlwaysOn is a FleetType enum value
 	FleetTypeAlwaysOn = "ALWAYS_ON"
@@ -11814,6 +11895,14 @@ const (
 	// FleetTypeOnDemand is a FleetType enum value
 	FleetTypeOnDemand = "ON_DEMAND"
 )
+
+// FleetType_Values returns all elements of the FleetType enum
+func FleetType_Values() []string {
+	return []string{
+		FleetTypeAlwaysOn,
+		FleetTypeOnDemand,
+	}
+}
 
 const (
 	// ImageBuilderStatePending is a ImageBuilderState enum value
@@ -11844,6 +11933,21 @@ const (
 	ImageBuilderStateFailed = "FAILED"
 )
 
+// ImageBuilderState_Values returns all elements of the ImageBuilderState enum
+func ImageBuilderState_Values() []string {
+	return []string{
+		ImageBuilderStatePending,
+		ImageBuilderStateUpdatingAgent,
+		ImageBuilderStateRunning,
+		ImageBuilderStateStopping,
+		ImageBuilderStateStopped,
+		ImageBuilderStateRebooting,
+		ImageBuilderStateSnapshotting,
+		ImageBuilderStateDeleting,
+		ImageBuilderStateFailed,
+	}
+}
+
 const (
 	// ImageBuilderStateChangeReasonCodeInternalError is a ImageBuilderStateChangeReasonCode enum value
 	ImageBuilderStateChangeReasonCodeInternalError = "INTERNAL_ERROR"
@@ -11851,6 +11955,14 @@ const (
 	// ImageBuilderStateChangeReasonCodeImageUnavailable is a ImageBuilderStateChangeReasonCode enum value
 	ImageBuilderStateChangeReasonCodeImageUnavailable = "IMAGE_UNAVAILABLE"
 )
+
+// ImageBuilderStateChangeReasonCode_Values returns all elements of the ImageBuilderStateChangeReasonCode enum
+func ImageBuilderStateChangeReasonCode_Values() []string {
+	return []string{
+		ImageBuilderStateChangeReasonCodeInternalError,
+		ImageBuilderStateChangeReasonCodeImageUnavailable,
+	}
+}
 
 const (
 	// ImageStatePending is a ImageState enum value
@@ -11869,6 +11981,17 @@ const (
 	ImageStateDeleting = "DELETING"
 )
 
+// ImageState_Values returns all elements of the ImageState enum
+func ImageState_Values() []string {
+	return []string{
+		ImageStatePending,
+		ImageStateAvailable,
+		ImageStateFailed,
+		ImageStateCopying,
+		ImageStateDeleting,
+	}
+}
+
 const (
 	// ImageStateChangeReasonCodeInternalError is a ImageStateChangeReasonCode enum value
 	ImageStateChangeReasonCodeInternalError = "INTERNAL_ERROR"
@@ -11880,6 +12003,15 @@ const (
 	ImageStateChangeReasonCodeImageCopyFailure = "IMAGE_COPY_FAILURE"
 )
 
+// ImageStateChangeReasonCode_Values returns all elements of the ImageStateChangeReasonCode enum
+func ImageStateChangeReasonCode_Values() []string {
+	return []string{
+		ImageStateChangeReasonCodeInternalError,
+		ImageStateChangeReasonCodeImageBuilderNotAvailable,
+		ImageStateChangeReasonCodeImageCopyFailure,
+	}
+}
+
 const (
 	// MessageActionSuppress is a MessageAction enum value
 	MessageActionSuppress = "SUPPRESS"
@@ -11888,6 +12020,14 @@ const (
 	MessageActionResend = "RESEND"
 )
 
+// MessageAction_Values returns all elements of the MessageAction enum
+func MessageAction_Values() []string {
+	return []string{
+		MessageActionSuppress,
+		MessageActionResend,
+	}
+}
+
 const (
 	// PermissionEnabled is a Permission enum value
 	PermissionEnabled = "ENABLED"
@@ -11895,6 +12035,14 @@ const (
 	// PermissionDisabled is a Permission enum value
 	PermissionDisabled = "DISABLED"
 )
+
+// Permission_Values returns all elements of the Permission enum
+func Permission_Values() []string {
+	return []string{
+		PermissionEnabled,
+		PermissionDisabled,
+	}
+}
 
 const (
 	// PlatformTypeWindows is a PlatformType enum value
@@ -11907,6 +12055,15 @@ const (
 	PlatformTypeWindowsServer2019 = "WINDOWS_SERVER_2019"
 )
 
+// PlatformType_Values returns all elements of the PlatformType enum
+func PlatformType_Values() []string {
+	return []string{
+		PlatformTypeWindows,
+		PlatformTypeWindowsServer2016,
+		PlatformTypeWindowsServer2019,
+	}
+}
+
 const (
 	// SessionConnectionStateConnected is a SessionConnectionState enum value
 	SessionConnectionStateConnected = "CONNECTED"
@@ -11914,6 +12071,14 @@ const (
 	// SessionConnectionStateNotConnected is a SessionConnectionState enum value
 	SessionConnectionStateNotConnected = "NOT_CONNECTED"
 )
+
+// SessionConnectionState_Values returns all elements of the SessionConnectionState enum
+func SessionConnectionState_Values() []string {
+	return []string{
+		SessionConnectionStateConnected,
+		SessionConnectionStateNotConnected,
+	}
+}
 
 // Possible values for the state of a streaming session.
 const (
@@ -11926,6 +12091,15 @@ const (
 	// SessionStateExpired is a SessionState enum value
 	SessionStateExpired = "EXPIRED"
 )
+
+// SessionState_Values returns all elements of the SessionState enum
+func SessionState_Values() []string {
+	return []string{
+		SessionStateActive,
+		SessionStatePending,
+		SessionStateExpired,
+	}
+}
 
 const (
 	// StackAttributeStorageConnectors is a StackAttribute enum value
@@ -11962,6 +12136,23 @@ const (
 	StackAttributeAccessEndpoints = "ACCESS_ENDPOINTS"
 )
 
+// StackAttribute_Values returns all elements of the StackAttribute enum
+func StackAttribute_Values() []string {
+	return []string{
+		StackAttributeStorageConnectors,
+		StackAttributeStorageConnectorHomefolders,
+		StackAttributeStorageConnectorGoogleDrive,
+		StackAttributeStorageConnectorOneDrive,
+		StackAttributeRedirectUrl,
+		StackAttributeFeedbackUrl,
+		StackAttributeThemeName,
+		StackAttributeUserSettings,
+		StackAttributeEmbedHostDomains,
+		StackAttributeIamRoleArn,
+		StackAttributeAccessEndpoints,
+	}
+}
+
 const (
 	// StackErrorCodeStorageConnectorError is a StackErrorCode enum value
 	StackErrorCodeStorageConnectorError = "STORAGE_CONNECTOR_ERROR"
@@ -11969,6 +12160,14 @@ const (
 	// StackErrorCodeInternalServiceError is a StackErrorCode enum value
 	StackErrorCodeInternalServiceError = "INTERNAL_SERVICE_ERROR"
 )
+
+// StackErrorCode_Values returns all elements of the StackErrorCode enum
+func StackErrorCode_Values() []string {
+	return []string{
+		StackErrorCodeStorageConnectorError,
+		StackErrorCodeInternalServiceError,
+	}
+}
 
 // The type of storage connector.
 const (
@@ -11982,6 +12181,15 @@ const (
 	StorageConnectorTypeOneDrive = "ONE_DRIVE"
 )
 
+// StorageConnectorType_Values returns all elements of the StorageConnectorType enum
+func StorageConnectorType_Values() []string {
+	return []string{
+		StorageConnectorTypeHomefolders,
+		StorageConnectorTypeGoogleDrive,
+		StorageConnectorTypeOneDrive,
+	}
+}
+
 const (
 	// UsageReportExecutionErrorCodeResourceNotFound is a UsageReportExecutionErrorCode enum value
 	UsageReportExecutionErrorCodeResourceNotFound = "RESOURCE_NOT_FOUND"
@@ -11993,10 +12201,26 @@ const (
 	UsageReportExecutionErrorCodeInternalServiceError = "INTERNAL_SERVICE_ERROR"
 )
 
+// UsageReportExecutionErrorCode_Values returns all elements of the UsageReportExecutionErrorCode enum
+func UsageReportExecutionErrorCode_Values() []string {
+	return []string{
+		UsageReportExecutionErrorCodeResourceNotFound,
+		UsageReportExecutionErrorCodeAccessDenied,
+		UsageReportExecutionErrorCodeInternalServiceError,
+	}
+}
+
 const (
 	// UsageReportScheduleDaily is a UsageReportSchedule enum value
 	UsageReportScheduleDaily = "DAILY"
 )
+
+// UsageReportSchedule_Values returns all elements of the UsageReportSchedule enum
+func UsageReportSchedule_Values() []string {
+	return []string{
+		UsageReportScheduleDaily,
+	}
+}
 
 const (
 	// UserStackAssociationErrorCodeStackNotFound is a UserStackAssociationErrorCode enum value
@@ -12009,6 +12233,15 @@ const (
 	UserStackAssociationErrorCodeInternalError = "INTERNAL_ERROR"
 )
 
+// UserStackAssociationErrorCode_Values returns all elements of the UserStackAssociationErrorCode enum
+func UserStackAssociationErrorCode_Values() []string {
+	return []string{
+		UserStackAssociationErrorCodeStackNotFound,
+		UserStackAssociationErrorCodeUserNameNotFound,
+		UserStackAssociationErrorCodeInternalError,
+	}
+}
+
 const (
 	// VisibilityTypePublic is a VisibilityType enum value
 	VisibilityTypePublic = "PUBLIC"
@@ -12019,3 +12252,12 @@ const (
 	// VisibilityTypeShared is a VisibilityType enum value
 	VisibilityTypeShared = "SHARED"
 )
+
+// VisibilityType_Values returns all elements of the VisibilityType enum
+func VisibilityType_Values() []string {
+	return []string{
+		VisibilityTypePublic,
+		VisibilityTypePrivate,
+		VisibilityTypeShared,
+	}
+}

--- a/service/appsync/api.go
+++ b/service/appsync/api.go
@@ -10340,6 +10340,17 @@ const (
 	ApiCacheStatusFailed = "FAILED"
 )
 
+// ApiCacheStatus_Values returns all elements of the ApiCacheStatus enum
+func ApiCacheStatus_Values() []string {
+	return []string{
+		ApiCacheStatusAvailable,
+		ApiCacheStatusCreating,
+		ApiCacheStatusDeleting,
+		ApiCacheStatusModifying,
+		ApiCacheStatusFailed,
+	}
+}
+
 const (
 	// ApiCacheTypeT2Small is a ApiCacheType enum value
 	ApiCacheTypeT2Small = "T2_SMALL"
@@ -10387,6 +10398,27 @@ const (
 	ApiCacheTypeLarge12x = "LARGE_12X"
 )
 
+// ApiCacheType_Values returns all elements of the ApiCacheType enum
+func ApiCacheType_Values() []string {
+	return []string{
+		ApiCacheTypeT2Small,
+		ApiCacheTypeT2Medium,
+		ApiCacheTypeR4Large,
+		ApiCacheTypeR4Xlarge,
+		ApiCacheTypeR42xlarge,
+		ApiCacheTypeR44xlarge,
+		ApiCacheTypeR48xlarge,
+		ApiCacheTypeSmall,
+		ApiCacheTypeMedium,
+		ApiCacheTypeLarge,
+		ApiCacheTypeXlarge,
+		ApiCacheTypeLarge2x,
+		ApiCacheTypeLarge4x,
+		ApiCacheTypeLarge8x,
+		ApiCacheTypeLarge12x,
+	}
+}
+
 const (
 	// ApiCachingBehaviorFullRequestCaching is a ApiCachingBehavior enum value
 	ApiCachingBehaviorFullRequestCaching = "FULL_REQUEST_CACHING"
@@ -10394,6 +10426,14 @@ const (
 	// ApiCachingBehaviorPerResolverCaching is a ApiCachingBehavior enum value
 	ApiCachingBehaviorPerResolverCaching = "PER_RESOLVER_CACHING"
 )
+
+// ApiCachingBehavior_Values returns all elements of the ApiCachingBehavior enum
+func ApiCachingBehavior_Values() []string {
+	return []string{
+		ApiCachingBehaviorFullRequestCaching,
+		ApiCachingBehaviorPerResolverCaching,
+	}
+}
 
 const (
 	// AuthenticationTypeApiKey is a AuthenticationType enum value
@@ -10409,10 +10449,27 @@ const (
 	AuthenticationTypeOpenidConnect = "OPENID_CONNECT"
 )
 
+// AuthenticationType_Values returns all elements of the AuthenticationType enum
+func AuthenticationType_Values() []string {
+	return []string{
+		AuthenticationTypeApiKey,
+		AuthenticationTypeAwsIam,
+		AuthenticationTypeAmazonCognitoUserPools,
+		AuthenticationTypeOpenidConnect,
+	}
+}
+
 const (
 	// AuthorizationTypeAwsIam is a AuthorizationType enum value
 	AuthorizationTypeAwsIam = "AWS_IAM"
 )
+
+// AuthorizationType_Values returns all elements of the AuthorizationType enum
+func AuthorizationType_Values() []string {
+	return []string{
+		AuthorizationTypeAwsIam,
+	}
+}
 
 const (
 	// ConflictDetectionTypeVersion is a ConflictDetectionType enum value
@@ -10421,6 +10478,14 @@ const (
 	// ConflictDetectionTypeNone is a ConflictDetectionType enum value
 	ConflictDetectionTypeNone = "NONE"
 )
+
+// ConflictDetectionType_Values returns all elements of the ConflictDetectionType enum
+func ConflictDetectionType_Values() []string {
+	return []string{
+		ConflictDetectionTypeVersion,
+		ConflictDetectionTypeNone,
+	}
+}
 
 const (
 	// ConflictHandlerTypeOptimisticConcurrency is a ConflictHandlerType enum value
@@ -10435,6 +10500,16 @@ const (
 	// ConflictHandlerTypeNone is a ConflictHandlerType enum value
 	ConflictHandlerTypeNone = "NONE"
 )
+
+// ConflictHandlerType_Values returns all elements of the ConflictHandlerType enum
+func ConflictHandlerType_Values() []string {
+	return []string{
+		ConflictHandlerTypeOptimisticConcurrency,
+		ConflictHandlerTypeLambda,
+		ConflictHandlerTypeAutomerge,
+		ConflictHandlerTypeNone,
+	}
+}
 
 const (
 	// DataSourceTypeAwsLambda is a DataSourceType enum value
@@ -10456,6 +10531,18 @@ const (
 	DataSourceTypeRelationalDatabase = "RELATIONAL_DATABASE"
 )
 
+// DataSourceType_Values returns all elements of the DataSourceType enum
+func DataSourceType_Values() []string {
+	return []string{
+		DataSourceTypeAwsLambda,
+		DataSourceTypeAmazonDynamodb,
+		DataSourceTypeAmazonElasticsearch,
+		DataSourceTypeNone,
+		DataSourceTypeHttp,
+		DataSourceTypeRelationalDatabase,
+	}
+}
+
 const (
 	// DefaultActionAllow is a DefaultAction enum value
 	DefaultActionAllow = "ALLOW"
@@ -10463,6 +10550,14 @@ const (
 	// DefaultActionDeny is a DefaultAction enum value
 	DefaultActionDeny = "DENY"
 )
+
+// DefaultAction_Values returns all elements of the DefaultAction enum
+func DefaultAction_Values() []string {
+	return []string{
+		DefaultActionAllow,
+		DefaultActionDeny,
+	}
+}
 
 const (
 	// FieldLogLevelNone is a FieldLogLevel enum value
@@ -10475,6 +10570,15 @@ const (
 	FieldLogLevelAll = "ALL"
 )
 
+// FieldLogLevel_Values returns all elements of the FieldLogLevel enum
+func FieldLogLevel_Values() []string {
+	return []string{
+		FieldLogLevelNone,
+		FieldLogLevelError,
+		FieldLogLevelAll,
+	}
+}
+
 const (
 	// OutputTypeSdl is a OutputType enum value
 	OutputTypeSdl = "SDL"
@@ -10483,10 +10587,25 @@ const (
 	OutputTypeJson = "JSON"
 )
 
+// OutputType_Values returns all elements of the OutputType enum
+func OutputType_Values() []string {
+	return []string{
+		OutputTypeSdl,
+		OutputTypeJson,
+	}
+}
+
 const (
 	// RelationalDatabaseSourceTypeRdsHttpEndpoint is a RelationalDatabaseSourceType enum value
 	RelationalDatabaseSourceTypeRdsHttpEndpoint = "RDS_HTTP_ENDPOINT"
 )
+
+// RelationalDatabaseSourceType_Values returns all elements of the RelationalDatabaseSourceType enum
+func RelationalDatabaseSourceType_Values() []string {
+	return []string{
+		RelationalDatabaseSourceTypeRdsHttpEndpoint,
+	}
+}
 
 const (
 	// ResolverKindUnit is a ResolverKind enum value
@@ -10495,6 +10614,14 @@ const (
 	// ResolverKindPipeline is a ResolverKind enum value
 	ResolverKindPipeline = "PIPELINE"
 )
+
+// ResolverKind_Values returns all elements of the ResolverKind enum
+func ResolverKind_Values() []string {
+	return []string{
+		ResolverKindUnit,
+		ResolverKindPipeline,
+	}
+}
 
 const (
 	// SchemaStatusProcessing is a SchemaStatus enum value
@@ -10516,6 +10643,18 @@ const (
 	SchemaStatusNotApplicable = "NOT_APPLICABLE"
 )
 
+// SchemaStatus_Values returns all elements of the SchemaStatus enum
+func SchemaStatus_Values() []string {
+	return []string{
+		SchemaStatusProcessing,
+		SchemaStatusActive,
+		SchemaStatusDeleting,
+		SchemaStatusFailed,
+		SchemaStatusSuccess,
+		SchemaStatusNotApplicable,
+	}
+}
+
 const (
 	// TypeDefinitionFormatSdl is a TypeDefinitionFormat enum value
 	TypeDefinitionFormatSdl = "SDL"
@@ -10523,3 +10662,11 @@ const (
 	// TypeDefinitionFormatJson is a TypeDefinitionFormat enum value
 	TypeDefinitionFormatJson = "JSON"
 )
+
+// TypeDefinitionFormat_Values returns all elements of the TypeDefinitionFormat enum
+func TypeDefinitionFormat_Values() []string {
+	return []string{
+		TypeDefinitionFormatSdl,
+		TypeDefinitionFormatJson,
+	}
+}

--- a/service/athena/api.go
+++ b/service/athena/api.go
@@ -7206,6 +7206,15 @@ const (
 	ColumnNullableUnknown = "UNKNOWN"
 )
 
+// ColumnNullable_Values returns all elements of the ColumnNullable enum
+func ColumnNullable_Values() []string {
+	return []string{
+		ColumnNullableNotNull,
+		ColumnNullableNullable,
+		ColumnNullableUnknown,
+	}
+}
+
 const (
 	// DataCatalogTypeLambda is a DataCatalogType enum value
 	DataCatalogTypeLambda = "LAMBDA"
@@ -7217,6 +7226,15 @@ const (
 	DataCatalogTypeHive = "HIVE"
 )
 
+// DataCatalogType_Values returns all elements of the DataCatalogType enum
+func DataCatalogType_Values() []string {
+	return []string{
+		DataCatalogTypeLambda,
+		DataCatalogTypeGlue,
+		DataCatalogTypeHive,
+	}
+}
+
 const (
 	// EncryptionOptionSseS3 is a EncryptionOption enum value
 	EncryptionOptionSseS3 = "SSE_S3"
@@ -7227,6 +7245,15 @@ const (
 	// EncryptionOptionCseKms is a EncryptionOption enum value
 	EncryptionOptionCseKms = "CSE_KMS"
 )
+
+// EncryptionOption_Values returns all elements of the EncryptionOption enum
+func EncryptionOption_Values() []string {
+	return []string{
+		EncryptionOptionSseS3,
+		EncryptionOptionSseKms,
+		EncryptionOptionCseKms,
+	}
+}
 
 const (
 	// QueryExecutionStateQueued is a QueryExecutionState enum value
@@ -7245,6 +7272,17 @@ const (
 	QueryExecutionStateCancelled = "CANCELLED"
 )
 
+// QueryExecutionState_Values returns all elements of the QueryExecutionState enum
+func QueryExecutionState_Values() []string {
+	return []string{
+		QueryExecutionStateQueued,
+		QueryExecutionStateRunning,
+		QueryExecutionStateSucceeded,
+		QueryExecutionStateFailed,
+		QueryExecutionStateCancelled,
+	}
+}
+
 const (
 	// StatementTypeDdl is a StatementType enum value
 	StatementTypeDdl = "DDL"
@@ -7256,12 +7294,28 @@ const (
 	StatementTypeUtility = "UTILITY"
 )
 
+// StatementType_Values returns all elements of the StatementType enum
+func StatementType_Values() []string {
+	return []string{
+		StatementTypeDdl,
+		StatementTypeDml,
+		StatementTypeUtility,
+	}
+}
+
 // The reason for the query throttling, for example, when it exceeds the concurrent
 // query limit.
 const (
 	// ThrottleReasonConcurrentQueryLimitExceeded is a ThrottleReason enum value
 	ThrottleReasonConcurrentQueryLimitExceeded = "CONCURRENT_QUERY_LIMIT_EXCEEDED"
 )
+
+// ThrottleReason_Values returns all elements of the ThrottleReason enum
+func ThrottleReason_Values() []string {
+	return []string{
+		ThrottleReasonConcurrentQueryLimitExceeded,
+	}
+}
 
 const (
 	// WorkGroupStateEnabled is a WorkGroupState enum value
@@ -7270,3 +7324,11 @@ const (
 	// WorkGroupStateDisabled is a WorkGroupState enum value
 	WorkGroupStateDisabled = "DISABLED"
 )
+
+// WorkGroupState_Values returns all elements of the WorkGroupState enum
+func WorkGroupState_Values() []string {
+	return []string{
+		WorkGroupStateEnabled,
+		WorkGroupStateDisabled,
+	}
+}

--- a/service/augmentedairuntime/api.go
+++ b/service/augmentedairuntime/api.go
@@ -1533,6 +1533,14 @@ const (
 	ContentClassifierFreeOfAdultContent = "FreeOfAdultContent"
 )
 
+// ContentClassifier_Values returns all elements of the ContentClassifier enum
+func ContentClassifier_Values() []string {
+	return []string{
+		ContentClassifierFreeOfPersonallyIdentifiableInformation,
+		ContentClassifierFreeOfAdultContent,
+	}
+}
+
 const (
 	// HumanLoopStatusInProgress is a HumanLoopStatus enum value
 	HumanLoopStatusInProgress = "InProgress"
@@ -1550,6 +1558,17 @@ const (
 	HumanLoopStatusStopping = "Stopping"
 )
 
+// HumanLoopStatus_Values returns all elements of the HumanLoopStatus enum
+func HumanLoopStatus_Values() []string {
+	return []string{
+		HumanLoopStatusInProgress,
+		HumanLoopStatusFailed,
+		HumanLoopStatusCompleted,
+		HumanLoopStatusStopped,
+		HumanLoopStatusStopping,
+	}
+}
+
 const (
 	// SortOrderAscending is a SortOrder enum value
 	SortOrderAscending = "Ascending"
@@ -1557,3 +1576,11 @@ const (
 	// SortOrderDescending is a SortOrder enum value
 	SortOrderDescending = "Descending"
 )
+
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderAscending,
+		SortOrderDescending,
+	}
+}

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -14854,6 +14854,14 @@ const (
 	InstanceMetadataEndpointStateEnabled = "enabled"
 )
 
+// InstanceMetadataEndpointState_Values returns all elements of the InstanceMetadataEndpointState enum
+func InstanceMetadataEndpointState_Values() []string {
+	return []string{
+		InstanceMetadataEndpointStateDisabled,
+		InstanceMetadataEndpointStateEnabled,
+	}
+}
+
 const (
 	// InstanceMetadataHttpTokensStateOptional is a InstanceMetadataHttpTokensState enum value
 	InstanceMetadataHttpTokensStateOptional = "optional"
@@ -14861,6 +14869,14 @@ const (
 	// InstanceMetadataHttpTokensStateRequired is a InstanceMetadataHttpTokensState enum value
 	InstanceMetadataHttpTokensStateRequired = "required"
 )
+
+// InstanceMetadataHttpTokensState_Values returns all elements of the InstanceMetadataHttpTokensState enum
+func InstanceMetadataHttpTokensState_Values() []string {
+	return []string{
+		InstanceMetadataHttpTokensStateOptional,
+		InstanceMetadataHttpTokensStateRequired,
+	}
+}
 
 const (
 	// InstanceRefreshStatusPending is a InstanceRefreshStatus enum value
@@ -14881,6 +14897,18 @@ const (
 	// InstanceRefreshStatusCancelled is a InstanceRefreshStatus enum value
 	InstanceRefreshStatusCancelled = "Cancelled"
 )
+
+// InstanceRefreshStatus_Values returns all elements of the InstanceRefreshStatus enum
+func InstanceRefreshStatus_Values() []string {
+	return []string{
+		InstanceRefreshStatusPending,
+		InstanceRefreshStatusInProgress,
+		InstanceRefreshStatusSuccessful,
+		InstanceRefreshStatusFailed,
+		InstanceRefreshStatusCancelling,
+		InstanceRefreshStatusCancelled,
+	}
+}
 
 const (
 	// LifecycleStatePending is a LifecycleState enum value
@@ -14923,6 +14951,25 @@ const (
 	LifecycleStateStandby = "Standby"
 )
 
+// LifecycleState_Values returns all elements of the LifecycleState enum
+func LifecycleState_Values() []string {
+	return []string{
+		LifecycleStatePending,
+		LifecycleStatePendingWait,
+		LifecycleStatePendingProceed,
+		LifecycleStateQuarantined,
+		LifecycleStateInService,
+		LifecycleStateTerminating,
+		LifecycleStateTerminatingWait,
+		LifecycleStateTerminatingProceed,
+		LifecycleStateTerminated,
+		LifecycleStateDetaching,
+		LifecycleStateDetached,
+		LifecycleStateEnteringStandby,
+		LifecycleStateStandby,
+	}
+}
+
 const (
 	// MetricStatisticAverage is a MetricStatistic enum value
 	MetricStatisticAverage = "Average"
@@ -14940,6 +14987,17 @@ const (
 	MetricStatisticSum = "Sum"
 )
 
+// MetricStatistic_Values returns all elements of the MetricStatistic enum
+func MetricStatistic_Values() []string {
+	return []string{
+		MetricStatisticAverage,
+		MetricStatisticMinimum,
+		MetricStatisticMaximum,
+		MetricStatisticSampleCount,
+		MetricStatisticSum,
+	}
+}
+
 const (
 	// MetricTypeAsgaverageCpuutilization is a MetricType enum value
 	MetricTypeAsgaverageCpuutilization = "ASGAverageCPUUtilization"
@@ -14954,10 +15012,27 @@ const (
 	MetricTypeAlbrequestCountPerTarget = "ALBRequestCountPerTarget"
 )
 
+// MetricType_Values returns all elements of the MetricType enum
+func MetricType_Values() []string {
+	return []string{
+		MetricTypeAsgaverageCpuutilization,
+		MetricTypeAsgaverageNetworkIn,
+		MetricTypeAsgaverageNetworkOut,
+		MetricTypeAlbrequestCountPerTarget,
+	}
+}
+
 const (
 	// RefreshStrategyRolling is a RefreshStrategy enum value
 	RefreshStrategyRolling = "Rolling"
 )
+
+// RefreshStrategy_Values returns all elements of the RefreshStrategy enum
+func RefreshStrategy_Values() []string {
+	return []string{
+		RefreshStrategyRolling,
+	}
+}
 
 const (
 	// ScalingActivityStatusCodePendingSpotBidPlacement is a ScalingActivityStatusCode enum value
@@ -14996,3 +15071,21 @@ const (
 	// ScalingActivityStatusCodeCancelled is a ScalingActivityStatusCode enum value
 	ScalingActivityStatusCodeCancelled = "Cancelled"
 )
+
+// ScalingActivityStatusCode_Values returns all elements of the ScalingActivityStatusCode enum
+func ScalingActivityStatusCode_Values() []string {
+	return []string{
+		ScalingActivityStatusCodePendingSpotBidPlacement,
+		ScalingActivityStatusCodeWaitingForSpotInstanceRequestId,
+		ScalingActivityStatusCodeWaitingForSpotInstanceId,
+		ScalingActivityStatusCodeWaitingForInstanceId,
+		ScalingActivityStatusCodePreInService,
+		ScalingActivityStatusCodeInProgress,
+		ScalingActivityStatusCodeWaitingForElbconnectionDraining,
+		ScalingActivityStatusCodeMidLifecycleAction,
+		ScalingActivityStatusCodeWaitingForInstanceWarmup,
+		ScalingActivityStatusCodeSuccessful,
+		ScalingActivityStatusCodeFailed,
+		ScalingActivityStatusCodeCancelled,
+	}
+}

--- a/service/autoscalingplans/api.go
+++ b/service/autoscalingplans/api.go
@@ -2946,6 +2946,16 @@ const (
 	ForecastDataTypeScheduledActionMaxCapacity = "ScheduledActionMaxCapacity"
 )
 
+// ForecastDataType_Values returns all elements of the ForecastDataType enum
+func ForecastDataType_Values() []string {
+	return []string{
+		ForecastDataTypeCapacityForecast,
+		ForecastDataTypeLoadForecast,
+		ForecastDataTypeScheduledActionMinCapacity,
+		ForecastDataTypeScheduledActionMaxCapacity,
+	}
+}
+
 const (
 	// LoadMetricTypeAsgtotalCpuutilization is a LoadMetricType enum value
 	LoadMetricTypeAsgtotalCpuutilization = "ASGTotalCPUUtilization"
@@ -2959,6 +2969,16 @@ const (
 	// LoadMetricTypeAlbtargetGroupRequestCount is a LoadMetricType enum value
 	LoadMetricTypeAlbtargetGroupRequestCount = "ALBTargetGroupRequestCount"
 )
+
+// LoadMetricType_Values returns all elements of the LoadMetricType enum
+func LoadMetricType_Values() []string {
+	return []string{
+		LoadMetricTypeAsgtotalCpuutilization,
+		LoadMetricTypeAsgtotalNetworkIn,
+		LoadMetricTypeAsgtotalNetworkOut,
+		LoadMetricTypeAlbtargetGroupRequestCount,
+	}
+}
 
 const (
 	// MetricStatisticAverage is a MetricStatistic enum value
@@ -2977,10 +2997,28 @@ const (
 	MetricStatisticSum = "Sum"
 )
 
+// MetricStatistic_Values returns all elements of the MetricStatistic enum
+func MetricStatistic_Values() []string {
+	return []string{
+		MetricStatisticAverage,
+		MetricStatisticMinimum,
+		MetricStatisticMaximum,
+		MetricStatisticSampleCount,
+		MetricStatisticSum,
+	}
+}
+
 const (
 	// PolicyTypeTargetTrackingScaling is a PolicyType enum value
 	PolicyTypeTargetTrackingScaling = "TargetTrackingScaling"
 )
+
+// PolicyType_Values returns all elements of the PolicyType enum
+func PolicyType_Values() []string {
+	return []string{
+		PolicyTypeTargetTrackingScaling,
+	}
+}
 
 const (
 	// PredictiveScalingMaxCapacityBehaviorSetForecastCapacityToMaxCapacity is a PredictiveScalingMaxCapacityBehavior enum value
@@ -2993,6 +3031,15 @@ const (
 	PredictiveScalingMaxCapacityBehaviorSetMaxCapacityAboveForecastCapacity = "SetMaxCapacityAboveForecastCapacity"
 )
 
+// PredictiveScalingMaxCapacityBehavior_Values returns all elements of the PredictiveScalingMaxCapacityBehavior enum
+func PredictiveScalingMaxCapacityBehavior_Values() []string {
+	return []string{
+		PredictiveScalingMaxCapacityBehaviorSetForecastCapacityToMaxCapacity,
+		PredictiveScalingMaxCapacityBehaviorSetMaxCapacityToForecastCapacity,
+		PredictiveScalingMaxCapacityBehaviorSetMaxCapacityAboveForecastCapacity,
+	}
+}
+
 const (
 	// PredictiveScalingModeForecastAndScale is a PredictiveScalingMode enum value
 	PredictiveScalingModeForecastAndScale = "ForecastAndScale"
@@ -3000,6 +3047,14 @@ const (
 	// PredictiveScalingModeForecastOnly is a PredictiveScalingMode enum value
 	PredictiveScalingModeForecastOnly = "ForecastOnly"
 )
+
+// PredictiveScalingMode_Values returns all elements of the PredictiveScalingMode enum
+func PredictiveScalingMode_Values() []string {
+	return []string{
+		PredictiveScalingModeForecastAndScale,
+		PredictiveScalingModeForecastOnly,
+	}
+}
 
 const (
 	// ScalableDimensionAutoscalingAutoScalingGroupDesiredCapacity is a ScalableDimension enum value
@@ -3026,6 +3081,20 @@ const (
 	// ScalableDimensionDynamodbIndexWriteCapacityUnits is a ScalableDimension enum value
 	ScalableDimensionDynamodbIndexWriteCapacityUnits = "dynamodb:index:WriteCapacityUnits"
 )
+
+// ScalableDimension_Values returns all elements of the ScalableDimension enum
+func ScalableDimension_Values() []string {
+	return []string{
+		ScalableDimensionAutoscalingAutoScalingGroupDesiredCapacity,
+		ScalableDimensionEcsServiceDesiredCount,
+		ScalableDimensionEc2SpotFleetRequestTargetCapacity,
+		ScalableDimensionRdsClusterReadReplicaCount,
+		ScalableDimensionDynamodbTableReadCapacityUnits,
+		ScalableDimensionDynamodbTableWriteCapacityUnits,
+		ScalableDimensionDynamodbIndexReadCapacityUnits,
+		ScalableDimensionDynamodbIndexWriteCapacityUnits,
+	}
+}
 
 const (
 	// ScalingMetricTypeAsgaverageCpuutilization is a ScalingMetricType enum value
@@ -3068,6 +3137,25 @@ const (
 	ScalingMetricTypeEc2spotFleetRequestAverageNetworkOut = "EC2SpotFleetRequestAverageNetworkOut"
 )
 
+// ScalingMetricType_Values returns all elements of the ScalingMetricType enum
+func ScalingMetricType_Values() []string {
+	return []string{
+		ScalingMetricTypeAsgaverageCpuutilization,
+		ScalingMetricTypeAsgaverageNetworkIn,
+		ScalingMetricTypeAsgaverageNetworkOut,
+		ScalingMetricTypeDynamoDbreadCapacityUtilization,
+		ScalingMetricTypeDynamoDbwriteCapacityUtilization,
+		ScalingMetricTypeEcsserviceAverageCpuutilization,
+		ScalingMetricTypeEcsserviceAverageMemoryUtilization,
+		ScalingMetricTypeAlbrequestCountPerTarget,
+		ScalingMetricTypeRdsreaderAverageCpuutilization,
+		ScalingMetricTypeRdsreaderAverageDatabaseConnections,
+		ScalingMetricTypeEc2spotFleetRequestAverageCpuutilization,
+		ScalingMetricTypeEc2spotFleetRequestAverageNetworkIn,
+		ScalingMetricTypeEc2spotFleetRequestAverageNetworkOut,
+	}
+}
+
 const (
 	// ScalingPlanStatusCodeActive is a ScalingPlanStatusCode enum value
 	ScalingPlanStatusCodeActive = "Active"
@@ -3094,6 +3182,20 @@ const (
 	ScalingPlanStatusCodeUpdateFailed = "UpdateFailed"
 )
 
+// ScalingPlanStatusCode_Values returns all elements of the ScalingPlanStatusCode enum
+func ScalingPlanStatusCode_Values() []string {
+	return []string{
+		ScalingPlanStatusCodeActive,
+		ScalingPlanStatusCodeActiveWithProblems,
+		ScalingPlanStatusCodeCreationInProgress,
+		ScalingPlanStatusCodeCreationFailed,
+		ScalingPlanStatusCodeDeletionInProgress,
+		ScalingPlanStatusCodeDeletionFailed,
+		ScalingPlanStatusCodeUpdateInProgress,
+		ScalingPlanStatusCodeUpdateFailed,
+	}
+}
+
 const (
 	// ScalingPolicyUpdateBehaviorKeepExternalPolicies is a ScalingPolicyUpdateBehavior enum value
 	ScalingPolicyUpdateBehaviorKeepExternalPolicies = "KeepExternalPolicies"
@@ -3101,6 +3203,14 @@ const (
 	// ScalingPolicyUpdateBehaviorReplaceExternalPolicies is a ScalingPolicyUpdateBehavior enum value
 	ScalingPolicyUpdateBehaviorReplaceExternalPolicies = "ReplaceExternalPolicies"
 )
+
+// ScalingPolicyUpdateBehavior_Values returns all elements of the ScalingPolicyUpdateBehavior enum
+func ScalingPolicyUpdateBehavior_Values() []string {
+	return []string{
+		ScalingPolicyUpdateBehaviorKeepExternalPolicies,
+		ScalingPolicyUpdateBehaviorReplaceExternalPolicies,
+	}
+}
 
 const (
 	// ScalingStatusCodeInactive is a ScalingStatusCode enum value
@@ -3112,6 +3222,15 @@ const (
 	// ScalingStatusCodeActive is a ScalingStatusCode enum value
 	ScalingStatusCodeActive = "Active"
 )
+
+// ScalingStatusCode_Values returns all elements of the ScalingStatusCode enum
+func ScalingStatusCode_Values() []string {
+	return []string{
+		ScalingStatusCodeInactive,
+		ScalingStatusCodePartiallyActive,
+		ScalingStatusCodeActive,
+	}
+}
 
 const (
 	// ServiceNamespaceAutoscaling is a ServiceNamespace enum value
@@ -3129,3 +3248,14 @@ const (
 	// ServiceNamespaceDynamodb is a ServiceNamespace enum value
 	ServiceNamespaceDynamodb = "dynamodb"
 )
+
+// ServiceNamespace_Values returns all elements of the ServiceNamespace enum
+func ServiceNamespace_Values() []string {
+	return []string{
+		ServiceNamespaceAutoscaling,
+		ServiceNamespaceEcs,
+		ServiceNamespaceEc2,
+		ServiceNamespaceRds,
+		ServiceNamespaceDynamodb,
+	}
+}

--- a/service/backup/api.go
+++ b/service/backup/api.go
@@ -12469,6 +12469,13 @@ const (
 	ConditionTypeStringequals = "STRINGEQUALS"
 )
 
+// ConditionType_Values returns all elements of the ConditionType enum
+func ConditionType_Values() []string {
+	return []string{
+		ConditionTypeStringequals,
+	}
+}
+
 const (
 	// CopyJobStateCreated is a CopyJobState enum value
 	CopyJobStateCreated = "CREATED"
@@ -12482,6 +12489,16 @@ const (
 	// CopyJobStateFailed is a CopyJobState enum value
 	CopyJobStateFailed = "FAILED"
 )
+
+// CopyJobState_Values returns all elements of the CopyJobState enum
+func CopyJobState_Values() []string {
+	return []string{
+		CopyJobStateCreated,
+		CopyJobStateRunning,
+		CopyJobStateCompleted,
+		CopyJobStateFailed,
+	}
+}
 
 const (
 	// JobStateCreated is a JobState enum value
@@ -12509,6 +12526,20 @@ const (
 	JobStateExpired = "EXPIRED"
 )
 
+// JobState_Values returns all elements of the JobState enum
+func JobState_Values() []string {
+	return []string{
+		JobStateCreated,
+		JobStatePending,
+		JobStateRunning,
+		JobStateAborting,
+		JobStateAborted,
+		JobStateCompleted,
+		JobStateFailed,
+		JobStateExpired,
+	}
+}
+
 const (
 	// RecoveryPointStatusCompleted is a RecoveryPointStatus enum value
 	RecoveryPointStatusCompleted = "COMPLETED"
@@ -12522,6 +12553,16 @@ const (
 	// RecoveryPointStatusExpired is a RecoveryPointStatus enum value
 	RecoveryPointStatusExpired = "EXPIRED"
 )
+
+// RecoveryPointStatus_Values returns all elements of the RecoveryPointStatus enum
+func RecoveryPointStatus_Values() []string {
+	return []string{
+		RecoveryPointStatusCompleted,
+		RecoveryPointStatusPartial,
+		RecoveryPointStatusDeleting,
+		RecoveryPointStatusExpired,
+	}
+}
 
 const (
 	// RestoreJobStatusPending is a RestoreJobStatus enum value
@@ -12540,6 +12581,17 @@ const (
 	RestoreJobStatusFailed = "FAILED"
 )
 
+// RestoreJobStatus_Values returns all elements of the RestoreJobStatus enum
+func RestoreJobStatus_Values() []string {
+	return []string{
+		RestoreJobStatusPending,
+		RestoreJobStatusRunning,
+		RestoreJobStatusCompleted,
+		RestoreJobStatusAborted,
+		RestoreJobStatusFailed,
+	}
+}
+
 const (
 	// StorageClassWarm is a StorageClass enum value
 	StorageClassWarm = "WARM"
@@ -12550,6 +12602,15 @@ const (
 	// StorageClassDeleted is a StorageClass enum value
 	StorageClassDeleted = "DELETED"
 )
+
+// StorageClass_Values returns all elements of the StorageClass enum
+func StorageClass_Values() []string {
+	return []string{
+		StorageClassWarm,
+		StorageClassCold,
+		StorageClassDeleted,
+	}
+}
 
 const (
 	// VaultEventBackupJobStarted is a VaultEvent enum value
@@ -12597,3 +12658,24 @@ const (
 	// VaultEventBackupPlanModified is a VaultEvent enum value
 	VaultEventBackupPlanModified = "BACKUP_PLAN_MODIFIED"
 )
+
+// VaultEvent_Values returns all elements of the VaultEvent enum
+func VaultEvent_Values() []string {
+	return []string{
+		VaultEventBackupJobStarted,
+		VaultEventBackupJobCompleted,
+		VaultEventBackupJobSuccessful,
+		VaultEventBackupJobFailed,
+		VaultEventBackupJobExpired,
+		VaultEventRestoreJobStarted,
+		VaultEventRestoreJobCompleted,
+		VaultEventRestoreJobSuccessful,
+		VaultEventRestoreJobFailed,
+		VaultEventCopyJobStarted,
+		VaultEventCopyJobSuccessful,
+		VaultEventCopyJobFailed,
+		VaultEventRecoveryPointModified,
+		VaultEventBackupPlanCreated,
+		VaultEventBackupPlanModified,
+	}
+}

--- a/service/batch/api.go
+++ b/service/batch/api.go
@@ -6180,6 +6180,14 @@ const (
 	ArrayJobDependencySequential = "SEQUENTIAL"
 )
 
+// ArrayJobDependency_Values returns all elements of the ArrayJobDependency enum
+func ArrayJobDependency_Values() []string {
+	return []string{
+		ArrayJobDependencyNToN,
+		ArrayJobDependencySequential,
+	}
+}
+
 const (
 	// CEStateEnabled is a CEState enum value
 	CEStateEnabled = "ENABLED"
@@ -6187,6 +6195,14 @@ const (
 	// CEStateDisabled is a CEState enum value
 	CEStateDisabled = "DISABLED"
 )
+
+// CEState_Values returns all elements of the CEState enum
+func CEState_Values() []string {
+	return []string{
+		CEStateEnabled,
+		CEStateDisabled,
+	}
+}
 
 const (
 	// CEStatusCreating is a CEStatus enum value
@@ -6208,6 +6224,18 @@ const (
 	CEStatusInvalid = "INVALID"
 )
 
+// CEStatus_Values returns all elements of the CEStatus enum
+func CEStatus_Values() []string {
+	return []string{
+		CEStatusCreating,
+		CEStatusUpdating,
+		CEStatusDeleting,
+		CEStatusDeleted,
+		CEStatusValid,
+		CEStatusInvalid,
+	}
+}
+
 const (
 	// CETypeManaged is a CEType enum value
 	CETypeManaged = "MANAGED"
@@ -6215,6 +6243,14 @@ const (
 	// CETypeUnmanaged is a CEType enum value
 	CETypeUnmanaged = "UNMANAGED"
 )
+
+// CEType_Values returns all elements of the CEType enum
+func CEType_Values() []string {
+	return []string{
+		CETypeManaged,
+		CETypeUnmanaged,
+	}
+}
 
 const (
 	// CRAllocationStrategyBestFit is a CRAllocationStrategy enum value
@@ -6227,6 +6263,15 @@ const (
 	CRAllocationStrategySpotCapacityOptimized = "SPOT_CAPACITY_OPTIMIZED"
 )
 
+// CRAllocationStrategy_Values returns all elements of the CRAllocationStrategy enum
+func CRAllocationStrategy_Values() []string {
+	return []string{
+		CRAllocationStrategyBestFit,
+		CRAllocationStrategyBestFitProgressive,
+		CRAllocationStrategySpotCapacityOptimized,
+	}
+}
+
 const (
 	// CRTypeEc2 is a CRType enum value
 	CRTypeEc2 = "EC2"
@@ -6234,6 +6279,14 @@ const (
 	// CRTypeSpot is a CRType enum value
 	CRTypeSpot = "SPOT"
 )
+
+// CRType_Values returns all elements of the CRType enum
+func CRType_Values() []string {
+	return []string{
+		CRTypeEc2,
+		CRTypeSpot,
+	}
+}
 
 const (
 	// DeviceCgroupPermissionRead is a DeviceCgroupPermission enum value
@@ -6246,6 +6299,15 @@ const (
 	DeviceCgroupPermissionMknod = "MKNOD"
 )
 
+// DeviceCgroupPermission_Values returns all elements of the DeviceCgroupPermission enum
+func DeviceCgroupPermission_Values() []string {
+	return []string{
+		DeviceCgroupPermissionRead,
+		DeviceCgroupPermissionWrite,
+		DeviceCgroupPermissionMknod,
+	}
+}
+
 const (
 	// JQStateEnabled is a JQState enum value
 	JQStateEnabled = "ENABLED"
@@ -6253,6 +6315,14 @@ const (
 	// JQStateDisabled is a JQState enum value
 	JQStateDisabled = "DISABLED"
 )
+
+// JQState_Values returns all elements of the JQState enum
+func JQState_Values() []string {
+	return []string{
+		JQStateEnabled,
+		JQStateDisabled,
+	}
+}
 
 const (
 	// JQStatusCreating is a JQStatus enum value
@@ -6274,6 +6344,18 @@ const (
 	JQStatusInvalid = "INVALID"
 )
 
+// JQStatus_Values returns all elements of the JQStatus enum
+func JQStatus_Values() []string {
+	return []string{
+		JQStatusCreating,
+		JQStatusUpdating,
+		JQStatusDeleting,
+		JQStatusDeleted,
+		JQStatusValid,
+		JQStatusInvalid,
+	}
+}
+
 const (
 	// JobDefinitionTypeContainer is a JobDefinitionType enum value
 	JobDefinitionTypeContainer = "container"
@@ -6281,6 +6363,14 @@ const (
 	// JobDefinitionTypeMultinode is a JobDefinitionType enum value
 	JobDefinitionTypeMultinode = "multinode"
 )
+
+// JobDefinitionType_Values returns all elements of the JobDefinitionType enum
+func JobDefinitionType_Values() []string {
+	return []string{
+		JobDefinitionTypeContainer,
+		JobDefinitionTypeMultinode,
+	}
+}
 
 const (
 	// JobStatusSubmitted is a JobStatus enum value
@@ -6305,7 +6395,27 @@ const (
 	JobStatusFailed = "FAILED"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusSubmitted,
+		JobStatusPending,
+		JobStatusRunnable,
+		JobStatusStarting,
+		JobStatusRunning,
+		JobStatusSucceeded,
+		JobStatusFailed,
+	}
+}
+
 const (
 	// ResourceTypeGpu is a ResourceType enum value
 	ResourceTypeGpu = "GPU"
 )
+
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeGpu,
+	}
+}

--- a/service/budgets/api.go
+++ b/service/budgets/api.go
@@ -4210,6 +4210,18 @@ const (
 	BudgetTypeSavingsPlansCoverage = "SAVINGS_PLANS_COVERAGE"
 )
 
+// BudgetType_Values returns all elements of the BudgetType enum
+func BudgetType_Values() []string {
+	return []string{
+		BudgetTypeUsage,
+		BudgetTypeCost,
+		BudgetTypeRiUtilization,
+		BudgetTypeRiCoverage,
+		BudgetTypeSavingsPlansUtilization,
+		BudgetTypeSavingsPlansCoverage,
+	}
+}
+
 // The comparison operator of a notification. Currently the service supports
 // the following operators:
 //
@@ -4225,6 +4237,15 @@ const (
 	ComparisonOperatorEqualTo = "EQUAL_TO"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorGreaterThan,
+		ComparisonOperatorLessThan,
+		ComparisonOperatorEqualTo,
+	}
+}
+
 const (
 	// NotificationStateOk is a NotificationState enum value
 	NotificationStateOk = "OK"
@@ -4232,6 +4253,14 @@ const (
 	// NotificationStateAlarm is a NotificationState enum value
 	NotificationStateAlarm = "ALARM"
 )
+
+// NotificationState_Values returns all elements of the NotificationState enum
+func NotificationState_Values() []string {
+	return []string{
+		NotificationStateOk,
+		NotificationStateAlarm,
+	}
+}
 
 // The type of a notification. It must be ACTUAL or FORECASTED.
 const (
@@ -4242,6 +4271,14 @@ const (
 	NotificationTypeForecasted = "FORECASTED"
 )
 
+// NotificationType_Values returns all elements of the NotificationType enum
+func NotificationType_Values() []string {
+	return []string{
+		NotificationTypeActual,
+		NotificationTypeForecasted,
+	}
+}
+
 // The subscription type of the subscriber. It can be SMS or EMAIL.
 const (
 	// SubscriptionTypeSns is a SubscriptionType enum value
@@ -4251,6 +4288,14 @@ const (
 	SubscriptionTypeEmail = "EMAIL"
 )
 
+// SubscriptionType_Values returns all elements of the SubscriptionType enum
+func SubscriptionType_Values() []string {
+	return []string{
+		SubscriptionTypeSns,
+		SubscriptionTypeEmail,
+	}
+}
+
 // The type of threshold for a notification. It can be PERCENTAGE or ABSOLUTE_VALUE.
 const (
 	// ThresholdTypePercentage is a ThresholdType enum value
@@ -4259,6 +4304,14 @@ const (
 	// ThresholdTypeAbsoluteValue is a ThresholdType enum value
 	ThresholdTypeAbsoluteValue = "ABSOLUTE_VALUE"
 )
+
+// ThresholdType_Values returns all elements of the ThresholdType enum
+func ThresholdType_Values() []string {
+	return []string{
+		ThresholdTypePercentage,
+		ThresholdTypeAbsoluteValue,
+	}
+}
 
 // The time unit of the budget, such as MONTHLY or QUARTERLY.
 const (
@@ -4274,3 +4327,13 @@ const (
 	// TimeUnitAnnually is a TimeUnit enum value
 	TimeUnitAnnually = "ANNUALLY"
 )
+
+// TimeUnit_Values returns all elements of the TimeUnit enum
+func TimeUnit_Values() []string {
+	return []string{
+		TimeUnitDaily,
+		TimeUnitMonthly,
+		TimeUnitQuarterly,
+		TimeUnitAnnually,
+	}
+}

--- a/service/chime/api.go
+++ b/service/chime/api.go
@@ -25977,10 +25977,27 @@ const (
 	AccountTypeEnterpriseOidc = "EnterpriseOIDC"
 )
 
+// AccountType_Values returns all elements of the AccountType enum
+func AccountType_Values() []string {
+	return []string{
+		AccountTypeTeam,
+		AccountTypeEnterpriseDirectory,
+		AccountTypeEnterpriseLwa,
+		AccountTypeEnterpriseOidc,
+	}
+}
+
 const (
 	// BotTypeChatBot is a BotType enum value
 	BotTypeChatBot = "ChatBot"
 )
+
+// BotType_Values returns all elements of the BotType enum
+func BotType_Values() []string {
+	return []string{
+		BotTypeChatBot,
+	}
+}
 
 const (
 	// CallingNameStatusUnassigned is a CallingNameStatus enum value
@@ -25996,6 +26013,16 @@ const (
 	CallingNameStatusUpdateFailed = "UpdateFailed"
 )
 
+// CallingNameStatus_Values returns all elements of the CallingNameStatus enum
+func CallingNameStatus_Values() []string {
+	return []string{
+		CallingNameStatusUnassigned,
+		CallingNameStatusUpdateInProgress,
+		CallingNameStatusUpdateSucceeded,
+		CallingNameStatusUpdateFailed,
+	}
+}
+
 const (
 	// CapabilityVoice is a Capability enum value
 	CapabilityVoice = "Voice"
@@ -26003,6 +26030,14 @@ const (
 	// CapabilitySms is a Capability enum value
 	CapabilitySms = "SMS"
 )
+
+// Capability_Values returns all elements of the Capability enum
+func Capability_Values() []string {
+	return []string{
+		CapabilityVoice,
+		CapabilitySms,
+	}
+}
 
 const (
 	// EmailStatusNotSent is a EmailStatus enum value
@@ -26014,6 +26049,15 @@ const (
 	// EmailStatusFailed is a EmailStatus enum value
 	EmailStatusFailed = "Failed"
 )
+
+// EmailStatus_Values returns all elements of the EmailStatus enum
+func EmailStatus_Values() []string {
+	return []string{
+		EmailStatusNotSent,
+		EmailStatusSent,
+		EmailStatusFailed,
+	}
+}
 
 const (
 	// ErrorCodeBadRequest is a ErrorCode enum value
@@ -26062,6 +26106,27 @@ const (
 	ErrorCodePhoneNumberAssociationsExist = "PhoneNumberAssociationsExist"
 )
 
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeBadRequest,
+		ErrorCodeConflict,
+		ErrorCodeForbidden,
+		ErrorCodeNotFound,
+		ErrorCodePreconditionFailed,
+		ErrorCodeResourceLimitExceeded,
+		ErrorCodeServiceFailure,
+		ErrorCodeAccessDenied,
+		ErrorCodeServiceUnavailable,
+		ErrorCodeThrottled,
+		ErrorCodeThrottling,
+		ErrorCodeUnauthorized,
+		ErrorCodeUnprocessable,
+		ErrorCodeVoiceConnectorGroupAssociationsExist,
+		ErrorCodePhoneNumberAssociationsExist,
+	}
+}
+
 const (
 	// GeoMatchLevelCountry is a GeoMatchLevel enum value
 	GeoMatchLevelCountry = "Country"
@@ -26069,6 +26134,14 @@ const (
 	// GeoMatchLevelAreaCode is a GeoMatchLevel enum value
 	GeoMatchLevelAreaCode = "AreaCode"
 )
+
+// GeoMatchLevel_Values returns all elements of the GeoMatchLevel enum
+func GeoMatchLevel_Values() []string {
+	return []string{
+		GeoMatchLevelCountry,
+		GeoMatchLevelAreaCode,
+	}
+}
 
 const (
 	// InviteStatusPending is a InviteStatus enum value
@@ -26080,6 +26153,15 @@ const (
 	// InviteStatusFailed is a InviteStatus enum value
 	InviteStatusFailed = "Failed"
 )
+
+// InviteStatus_Values returns all elements of the InviteStatus enum
+func InviteStatus_Values() []string {
+	return []string{
+		InviteStatusPending,
+		InviteStatusAccepted,
+		InviteStatusFailed,
+	}
+}
 
 const (
 	// LicenseBasic is a License enum value
@@ -26095,6 +26177,16 @@ const (
 	LicenseProTrial = "ProTrial"
 )
 
+// License_Values returns all elements of the License enum
+func License_Values() []string {
+	return []string{
+		LicenseBasic,
+		LicensePlus,
+		LicensePro,
+		LicenseProTrial,
+	}
+}
+
 const (
 	// MemberTypeUser is a MemberType enum value
 	MemberTypeUser = "User"
@@ -26105,6 +26197,15 @@ const (
 	// MemberTypeWebhook is a MemberType enum value
 	MemberTypeWebhook = "Webhook"
 )
+
+// MemberType_Values returns all elements of the MemberType enum
+func MemberType_Values() []string {
+	return []string{
+		MemberTypeUser,
+		MemberTypeBot,
+		MemberTypeWebhook,
+	}
+}
 
 const (
 	// NotificationTargetEventBridge is a NotificationTarget enum value
@@ -26117,6 +26218,15 @@ const (
 	NotificationTargetSqs = "SQS"
 )
 
+// NotificationTarget_Values returns all elements of the NotificationTarget enum
+func NotificationTarget_Values() []string {
+	return []string{
+		NotificationTargetEventBridge,
+		NotificationTargetSns,
+		NotificationTargetSqs,
+	}
+}
+
 const (
 	// NumberSelectionBehaviorPreferSticky is a NumberSelectionBehavior enum value
 	NumberSelectionBehaviorPreferSticky = "PreferSticky"
@@ -26124,6 +26234,14 @@ const (
 	// NumberSelectionBehaviorAvoidSticky is a NumberSelectionBehavior enum value
 	NumberSelectionBehaviorAvoidSticky = "AvoidSticky"
 )
+
+// NumberSelectionBehavior_Values returns all elements of the NumberSelectionBehavior enum
+func NumberSelectionBehavior_Values() []string {
+	return []string{
+		NumberSelectionBehaviorPreferSticky,
+		NumberSelectionBehaviorAvoidSticky,
+	}
+}
 
 const (
 	// OrderedPhoneNumberStatusProcessing is a OrderedPhoneNumberStatus enum value
@@ -26136,6 +26254,15 @@ const (
 	OrderedPhoneNumberStatusFailed = "Failed"
 )
 
+// OrderedPhoneNumberStatus_Values returns all elements of the OrderedPhoneNumberStatus enum
+func OrderedPhoneNumberStatus_Values() []string {
+	return []string{
+		OrderedPhoneNumberStatusProcessing,
+		OrderedPhoneNumberStatusAcquired,
+		OrderedPhoneNumberStatusFailed,
+	}
+}
+
 const (
 	// OriginationRouteProtocolTcp is a OriginationRouteProtocol enum value
 	OriginationRouteProtocolTcp = "TCP"
@@ -26143,6 +26270,14 @@ const (
 	// OriginationRouteProtocolUdp is a OriginationRouteProtocol enum value
 	OriginationRouteProtocolUdp = "UDP"
 )
+
+// OriginationRouteProtocol_Values returns all elements of the OriginationRouteProtocol enum
+func OriginationRouteProtocol_Values() []string {
+	return []string{
+		OriginationRouteProtocolTcp,
+		OriginationRouteProtocolUdp,
+	}
+}
 
 const (
 	// PhoneNumberAssociationNameAccountId is a PhoneNumberAssociationName enum value
@@ -26158,6 +26293,16 @@ const (
 	PhoneNumberAssociationNameVoiceConnectorGroupId = "VoiceConnectorGroupId"
 )
 
+// PhoneNumberAssociationName_Values returns all elements of the PhoneNumberAssociationName enum
+func PhoneNumberAssociationName_Values() []string {
+	return []string{
+		PhoneNumberAssociationNameAccountId,
+		PhoneNumberAssociationNameUserId,
+		PhoneNumberAssociationNameVoiceConnectorId,
+		PhoneNumberAssociationNameVoiceConnectorGroupId,
+	}
+}
+
 const (
 	// PhoneNumberOrderStatusProcessing is a PhoneNumberOrderStatus enum value
 	PhoneNumberOrderStatusProcessing = "Processing"
@@ -26172,6 +26317,16 @@ const (
 	PhoneNumberOrderStatusPartial = "Partial"
 )
 
+// PhoneNumberOrderStatus_Values returns all elements of the PhoneNumberOrderStatus enum
+func PhoneNumberOrderStatus_Values() []string {
+	return []string{
+		PhoneNumberOrderStatusProcessing,
+		PhoneNumberOrderStatusSuccessful,
+		PhoneNumberOrderStatusFailed,
+		PhoneNumberOrderStatusPartial,
+	}
+}
+
 const (
 	// PhoneNumberProductTypeBusinessCalling is a PhoneNumberProductType enum value
 	PhoneNumberProductTypeBusinessCalling = "BusinessCalling"
@@ -26179,6 +26334,14 @@ const (
 	// PhoneNumberProductTypeVoiceConnector is a PhoneNumberProductType enum value
 	PhoneNumberProductTypeVoiceConnector = "VoiceConnector"
 )
+
+// PhoneNumberProductType_Values returns all elements of the PhoneNumberProductType enum
+func PhoneNumberProductType_Values() []string {
+	return []string{
+		PhoneNumberProductTypeBusinessCalling,
+		PhoneNumberProductTypeVoiceConnector,
+	}
+}
 
 const (
 	// PhoneNumberStatusAcquireInProgress is a PhoneNumberStatus enum value
@@ -26206,6 +26369,20 @@ const (
 	PhoneNumberStatusDeleteFailed = "DeleteFailed"
 )
 
+// PhoneNumberStatus_Values returns all elements of the PhoneNumberStatus enum
+func PhoneNumberStatus_Values() []string {
+	return []string{
+		PhoneNumberStatusAcquireInProgress,
+		PhoneNumberStatusAcquireFailed,
+		PhoneNumberStatusUnassigned,
+		PhoneNumberStatusAssigned,
+		PhoneNumberStatusReleaseInProgress,
+		PhoneNumberStatusDeleteInProgress,
+		PhoneNumberStatusReleaseFailed,
+		PhoneNumberStatusDeleteFailed,
+	}
+}
+
 const (
 	// PhoneNumberTypeLocal is a PhoneNumberType enum value
 	PhoneNumberTypeLocal = "Local"
@@ -26213,6 +26390,14 @@ const (
 	// PhoneNumberTypeTollFree is a PhoneNumberType enum value
 	PhoneNumberTypeTollFree = "TollFree"
 )
+
+// PhoneNumberType_Values returns all elements of the PhoneNumberType enum
+func PhoneNumberType_Values() []string {
+	return []string{
+		PhoneNumberTypeLocal,
+		PhoneNumberTypeTollFree,
+	}
+}
 
 const (
 	// ProxySessionStatusOpen is a ProxySessionStatus enum value
@@ -26225,6 +26410,15 @@ const (
 	ProxySessionStatusClosed = "Closed"
 )
 
+// ProxySessionStatus_Values returns all elements of the ProxySessionStatus enum
+func ProxySessionStatus_Values() []string {
+	return []string{
+		ProxySessionStatusOpen,
+		ProxySessionStatusInProgress,
+		ProxySessionStatusClosed,
+	}
+}
+
 const (
 	// RegistrationStatusUnregistered is a RegistrationStatus enum value
 	RegistrationStatusUnregistered = "Unregistered"
@@ -26236,6 +26430,15 @@ const (
 	RegistrationStatusSuspended = "Suspended"
 )
 
+// RegistrationStatus_Values returns all elements of the RegistrationStatus enum
+func RegistrationStatus_Values() []string {
+	return []string{
+		RegistrationStatusUnregistered,
+		RegistrationStatusRegistered,
+		RegistrationStatusSuspended,
+	}
+}
+
 const (
 	// RoomMembershipRoleAdministrator is a RoomMembershipRole enum value
 	RoomMembershipRoleAdministrator = "Administrator"
@@ -26243,6 +26446,14 @@ const (
 	// RoomMembershipRoleMember is a RoomMembershipRole enum value
 	RoomMembershipRoleMember = "Member"
 )
+
+// RoomMembershipRole_Values returns all elements of the RoomMembershipRole enum
+func RoomMembershipRole_Values() []string {
+	return []string{
+		RoomMembershipRoleAdministrator,
+		RoomMembershipRoleMember,
+	}
+}
 
 const (
 	// UserTypePrivateUser is a UserType enum value
@@ -26252,6 +26463,14 @@ const (
 	UserTypeSharedDevice = "SharedDevice"
 )
 
+// UserType_Values returns all elements of the UserType enum
+func UserType_Values() []string {
+	return []string{
+		UserTypePrivateUser,
+		UserTypeSharedDevice,
+	}
+}
+
 const (
 	// VoiceConnectorAwsRegionUsEast1 is a VoiceConnectorAwsRegion enum value
 	VoiceConnectorAwsRegionUsEast1 = "us-east-1"
@@ -26259,3 +26478,11 @@ const (
 	// VoiceConnectorAwsRegionUsWest2 is a VoiceConnectorAwsRegion enum value
 	VoiceConnectorAwsRegionUsWest2 = "us-west-2"
 )
+
+// VoiceConnectorAwsRegion_Values returns all elements of the VoiceConnectorAwsRegion enum
+func VoiceConnectorAwsRegion_Values() []string {
+	return []string{
+		VoiceConnectorAwsRegionUsEast1,
+		VoiceConnectorAwsRegionUsWest2,
+	}
+}

--- a/service/cloud9/api.go
+++ b/service/cloud9/api.go
@@ -3121,6 +3121,17 @@ const (
 	EnvironmentLifecycleStatusDeleteFailed = "DELETE_FAILED"
 )
 
+// EnvironmentLifecycleStatus_Values returns all elements of the EnvironmentLifecycleStatus enum
+func EnvironmentLifecycleStatus_Values() []string {
+	return []string{
+		EnvironmentLifecycleStatusCreating,
+		EnvironmentLifecycleStatusCreated,
+		EnvironmentLifecycleStatusCreateFailed,
+		EnvironmentLifecycleStatusDeleting,
+		EnvironmentLifecycleStatusDeleteFailed,
+	}
+}
+
 const (
 	// EnvironmentStatusError is a EnvironmentStatus enum value
 	EnvironmentStatusError = "error"
@@ -3144,6 +3155,19 @@ const (
 	EnvironmentStatusDeleting = "deleting"
 )
 
+// EnvironmentStatus_Values returns all elements of the EnvironmentStatus enum
+func EnvironmentStatus_Values() []string {
+	return []string{
+		EnvironmentStatusError,
+		EnvironmentStatusCreating,
+		EnvironmentStatusConnecting,
+		EnvironmentStatusReady,
+		EnvironmentStatusStopping,
+		EnvironmentStatusStopped,
+		EnvironmentStatusDeleting,
+	}
+}
+
 const (
 	// EnvironmentTypeSsh is a EnvironmentType enum value
 	EnvironmentTypeSsh = "ssh"
@@ -3152,6 +3176,14 @@ const (
 	EnvironmentTypeEc2 = "ec2"
 )
 
+// EnvironmentType_Values returns all elements of the EnvironmentType enum
+func EnvironmentType_Values() []string {
+	return []string{
+		EnvironmentTypeSsh,
+		EnvironmentTypeEc2,
+	}
+}
+
 const (
 	// MemberPermissionsReadWrite is a MemberPermissions enum value
 	MemberPermissionsReadWrite = "read-write"
@@ -3159,6 +3191,14 @@ const (
 	// MemberPermissionsReadOnly is a MemberPermissions enum value
 	MemberPermissionsReadOnly = "read-only"
 )
+
+// MemberPermissions_Values returns all elements of the MemberPermissions enum
+func MemberPermissions_Values() []string {
+	return []string{
+		MemberPermissionsReadWrite,
+		MemberPermissionsReadOnly,
+	}
+}
 
 const (
 	// PermissionsOwner is a Permissions enum value
@@ -3170,3 +3210,12 @@ const (
 	// PermissionsReadOnly is a Permissions enum value
 	PermissionsReadOnly = "read-only"
 )
+
+// Permissions_Values returns all elements of the Permissions enum
+func Permissions_Values() []string {
+	return []string{
+		PermissionsOwner,
+		PermissionsReadWrite,
+		PermissionsReadOnly,
+	}
+}

--- a/service/clouddirectory/api.go
+++ b/service/clouddirectory/api.go
@@ -22282,6 +22282,25 @@ const (
 	BatchReadExceptionTypeInternalServiceException = "InternalServiceException"
 )
 
+// BatchReadExceptionType_Values returns all elements of the BatchReadExceptionType enum
+func BatchReadExceptionType_Values() []string {
+	return []string{
+		BatchReadExceptionTypeValidationException,
+		BatchReadExceptionTypeInvalidArnException,
+		BatchReadExceptionTypeResourceNotFoundException,
+		BatchReadExceptionTypeInvalidNextTokenException,
+		BatchReadExceptionTypeAccessDeniedException,
+		BatchReadExceptionTypeNotNodeException,
+		BatchReadExceptionTypeFacetValidationException,
+		BatchReadExceptionTypeCannotListParentOfRootException,
+		BatchReadExceptionTypeNotIndexException,
+		BatchReadExceptionTypeNotPolicyException,
+		BatchReadExceptionTypeDirectoryNotEnabledException,
+		BatchReadExceptionTypeLimitExceededException,
+		BatchReadExceptionTypeInternalServiceException,
+	}
+}
+
 const (
 	// BatchWriteExceptionTypeInternalServiceException is a BatchWriteExceptionType enum value
 	BatchWriteExceptionTypeInternalServiceException = "InternalServiceException"
@@ -22338,6 +22357,30 @@ const (
 	BatchWriteExceptionTypeUnsupportedIndexTypeException = "UnsupportedIndexTypeException"
 )
 
+// BatchWriteExceptionType_Values returns all elements of the BatchWriteExceptionType enum
+func BatchWriteExceptionType_Values() []string {
+	return []string{
+		BatchWriteExceptionTypeInternalServiceException,
+		BatchWriteExceptionTypeValidationException,
+		BatchWriteExceptionTypeInvalidArnException,
+		BatchWriteExceptionTypeLinkNameAlreadyInUseException,
+		BatchWriteExceptionTypeStillContainsLinksException,
+		BatchWriteExceptionTypeFacetValidationException,
+		BatchWriteExceptionTypeObjectNotDetachedException,
+		BatchWriteExceptionTypeResourceNotFoundException,
+		BatchWriteExceptionTypeAccessDeniedException,
+		BatchWriteExceptionTypeInvalidAttachmentException,
+		BatchWriteExceptionTypeNotIndexException,
+		BatchWriteExceptionTypeNotNodeException,
+		BatchWriteExceptionTypeIndexedAttributeMissingException,
+		BatchWriteExceptionTypeObjectAlreadyDetachedException,
+		BatchWriteExceptionTypeNotPolicyException,
+		BatchWriteExceptionTypeDirectoryNotEnabledException,
+		BatchWriteExceptionTypeLimitExceededException,
+		BatchWriteExceptionTypeUnsupportedIndexTypeException,
+	}
+}
+
 const (
 	// ConsistencyLevelSerializable is a ConsistencyLevel enum value
 	ConsistencyLevelSerializable = "SERIALIZABLE"
@@ -22345,6 +22388,14 @@ const (
 	// ConsistencyLevelEventual is a ConsistencyLevel enum value
 	ConsistencyLevelEventual = "EVENTUAL"
 )
+
+// ConsistencyLevel_Values returns all elements of the ConsistencyLevel enum
+func ConsistencyLevel_Values() []string {
+	return []string{
+		ConsistencyLevelSerializable,
+		ConsistencyLevelEventual,
+	}
+}
 
 const (
 	// DirectoryStateEnabled is a DirectoryState enum value
@@ -22356,6 +22407,15 @@ const (
 	// DirectoryStateDeleted is a DirectoryState enum value
 	DirectoryStateDeleted = "DELETED"
 )
+
+// DirectoryState_Values returns all elements of the DirectoryState enum
+func DirectoryState_Values() []string {
+	return []string{
+		DirectoryStateEnabled,
+		DirectoryStateDisabled,
+		DirectoryStateDeleted,
+	}
+}
 
 const (
 	// FacetAttributeTypeString is a FacetAttributeType enum value
@@ -22377,6 +22437,18 @@ const (
 	FacetAttributeTypeVariant = "VARIANT"
 )
 
+// FacetAttributeType_Values returns all elements of the FacetAttributeType enum
+func FacetAttributeType_Values() []string {
+	return []string{
+		FacetAttributeTypeString,
+		FacetAttributeTypeBinary,
+		FacetAttributeTypeBoolean,
+		FacetAttributeTypeNumber,
+		FacetAttributeTypeDatetime,
+		FacetAttributeTypeVariant,
+	}
+}
+
 const (
 	// FacetStyleStatic is a FacetStyle enum value
 	FacetStyleStatic = "STATIC"
@@ -22384,6 +22456,14 @@ const (
 	// FacetStyleDynamic is a FacetStyle enum value
 	FacetStyleDynamic = "DYNAMIC"
 )
+
+// FacetStyle_Values returns all elements of the FacetStyle enum
+func FacetStyle_Values() []string {
+	return []string{
+		FacetStyleStatic,
+		FacetStyleDynamic,
+	}
+}
 
 const (
 	// ObjectTypeNode is a ObjectType enum value
@@ -22398,6 +22478,16 @@ const (
 	// ObjectTypeIndex is a ObjectType enum value
 	ObjectTypeIndex = "INDEX"
 )
+
+// ObjectType_Values returns all elements of the ObjectType enum
+func ObjectType_Values() []string {
+	return []string{
+		ObjectTypeNode,
+		ObjectTypeLeafNode,
+		ObjectTypePolicy,
+		ObjectTypeIndex,
+	}
+}
 
 const (
 	// RangeModeFirst is a RangeMode enum value
@@ -22416,6 +22506,17 @@ const (
 	RangeModeExclusive = "EXCLUSIVE"
 )
 
+// RangeMode_Values returns all elements of the RangeMode enum
+func RangeMode_Values() []string {
+	return []string{
+		RangeModeFirst,
+		RangeModeLast,
+		RangeModeLastBeforeMissingValues,
+		RangeModeInclusive,
+		RangeModeExclusive,
+	}
+}
+
 const (
 	// RequiredAttributeBehaviorRequiredAlways is a RequiredAttributeBehavior enum value
 	RequiredAttributeBehaviorRequiredAlways = "REQUIRED_ALWAYS"
@@ -22423,6 +22524,14 @@ const (
 	// RequiredAttributeBehaviorNotRequired is a RequiredAttributeBehavior enum value
 	RequiredAttributeBehaviorNotRequired = "NOT_REQUIRED"
 )
+
+// RequiredAttributeBehavior_Values returns all elements of the RequiredAttributeBehavior enum
+func RequiredAttributeBehavior_Values() []string {
+	return []string{
+		RequiredAttributeBehaviorRequiredAlways,
+		RequiredAttributeBehaviorNotRequired,
+	}
+}
 
 const (
 	// RuleTypeBinaryLength is a RuleType enum value
@@ -22438,6 +22547,16 @@ const (
 	RuleTypeStringLength = "STRING_LENGTH"
 )
 
+// RuleType_Values returns all elements of the RuleType enum
+func RuleType_Values() []string {
+	return []string{
+		RuleTypeBinaryLength,
+		RuleTypeNumberComparison,
+		RuleTypeStringFromSet,
+		RuleTypeStringLength,
+	}
+}
+
 const (
 	// UpdateActionTypeCreateOrUpdate is a UpdateActionType enum value
 	UpdateActionTypeCreateOrUpdate = "CREATE_OR_UPDATE"
@@ -22445,3 +22564,11 @@ const (
 	// UpdateActionTypeDelete is a UpdateActionType enum value
 	UpdateActionTypeDelete = "DELETE"
 )
+
+// UpdateActionType_Values returns all elements of the UpdateActionType enum
+func UpdateActionType_Values() []string {
+	return []string{
+		UpdateActionTypeCreateOrUpdate,
+		UpdateActionTypeDelete,
+	}
+}

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -17154,6 +17154,15 @@ const (
 	AccountGateStatusSkipped = "SKIPPED"
 )
 
+// AccountGateStatus_Values returns all elements of the AccountGateStatus enum
+func AccountGateStatus_Values() []string {
+	return []string{
+		AccountGateStatusSucceeded,
+		AccountGateStatusFailed,
+		AccountGateStatusSkipped,
+	}
+}
+
 const (
 	// CapabilityCapabilityIam is a Capability enum value
 	CapabilityCapabilityIam = "CAPABILITY_IAM"
@@ -17164,6 +17173,15 @@ const (
 	// CapabilityCapabilityAutoExpand is a Capability enum value
 	CapabilityCapabilityAutoExpand = "CAPABILITY_AUTO_EXPAND"
 )
+
+// Capability_Values returns all elements of the Capability enum
+func Capability_Values() []string {
+	return []string{
+		CapabilityCapabilityIam,
+		CapabilityCapabilityNamedIam,
+		CapabilityCapabilityAutoExpand,
+	}
+}
 
 const (
 	// ChangeActionAdd is a ChangeAction enum value
@@ -17178,6 +17196,16 @@ const (
 	// ChangeActionImport is a ChangeAction enum value
 	ChangeActionImport = "Import"
 )
+
+// ChangeAction_Values returns all elements of the ChangeAction enum
+func ChangeAction_Values() []string {
+	return []string{
+		ChangeActionAdd,
+		ChangeActionModify,
+		ChangeActionRemove,
+		ChangeActionImport,
+	}
+}
 
 const (
 	// ChangeSetStatusCreatePending is a ChangeSetStatus enum value
@@ -17196,6 +17224,17 @@ const (
 	ChangeSetStatusFailed = "FAILED"
 )
 
+// ChangeSetStatus_Values returns all elements of the ChangeSetStatus enum
+func ChangeSetStatus_Values() []string {
+	return []string{
+		ChangeSetStatusCreatePending,
+		ChangeSetStatusCreateInProgress,
+		ChangeSetStatusCreateComplete,
+		ChangeSetStatusDeleteComplete,
+		ChangeSetStatusFailed,
+	}
+}
+
 const (
 	// ChangeSetTypeCreate is a ChangeSetType enum value
 	ChangeSetTypeCreate = "CREATE"
@@ -17206,6 +17245,15 @@ const (
 	// ChangeSetTypeImport is a ChangeSetType enum value
 	ChangeSetTypeImport = "IMPORT"
 )
+
+// ChangeSetType_Values returns all elements of the ChangeSetType enum
+func ChangeSetType_Values() []string {
+	return []string{
+		ChangeSetTypeCreate,
+		ChangeSetTypeUpdate,
+		ChangeSetTypeImport,
+	}
+}
 
 const (
 	// ChangeSourceResourceReference is a ChangeSource enum value
@@ -17224,10 +17272,28 @@ const (
 	ChangeSourceAutomatic = "Automatic"
 )
 
+// ChangeSource_Values returns all elements of the ChangeSource enum
+func ChangeSource_Values() []string {
+	return []string{
+		ChangeSourceResourceReference,
+		ChangeSourceParameterReference,
+		ChangeSourceResourceAttribute,
+		ChangeSourceDirectModification,
+		ChangeSourceAutomatic,
+	}
+}
+
 const (
 	// ChangeTypeResource is a ChangeType enum value
 	ChangeTypeResource = "Resource"
 )
+
+// ChangeType_Values returns all elements of the ChangeType enum
+func ChangeType_Values() []string {
+	return []string{
+		ChangeTypeResource,
+	}
+}
 
 const (
 	// DeprecatedStatusLive is a DeprecatedStatus enum value
@@ -17236,6 +17302,14 @@ const (
 	// DeprecatedStatusDeprecated is a DeprecatedStatus enum value
 	DeprecatedStatusDeprecated = "DEPRECATED"
 )
+
+// DeprecatedStatus_Values returns all elements of the DeprecatedStatus enum
+func DeprecatedStatus_Values() []string {
+	return []string{
+		DeprecatedStatusLive,
+		DeprecatedStatusDeprecated,
+	}
+}
 
 const (
 	// DifferenceTypeAdd is a DifferenceType enum value
@@ -17248,6 +17322,15 @@ const (
 	DifferenceTypeNotEqual = "NOT_EQUAL"
 )
 
+// DifferenceType_Values returns all elements of the DifferenceType enum
+func DifferenceType_Values() []string {
+	return []string{
+		DifferenceTypeAdd,
+		DifferenceTypeRemove,
+		DifferenceTypeNotEqual,
+	}
+}
+
 const (
 	// EvaluationTypeStatic is a EvaluationType enum value
 	EvaluationTypeStatic = "Static"
@@ -17255,6 +17338,14 @@ const (
 	// EvaluationTypeDynamic is a EvaluationType enum value
 	EvaluationTypeDynamic = "Dynamic"
 )
+
+// EvaluationType_Values returns all elements of the EvaluationType enum
+func EvaluationType_Values() []string {
+	return []string{
+		EvaluationTypeStatic,
+		EvaluationTypeDynamic,
+	}
+}
 
 const (
 	// ExecutionStatusUnavailable is a ExecutionStatus enum value
@@ -17275,6 +17366,18 @@ const (
 	// ExecutionStatusObsolete is a ExecutionStatus enum value
 	ExecutionStatusObsolete = "OBSOLETE"
 )
+
+// ExecutionStatus_Values returns all elements of the ExecutionStatus enum
+func ExecutionStatus_Values() []string {
+	return []string{
+		ExecutionStatusUnavailable,
+		ExecutionStatusAvailable,
+		ExecutionStatusExecuteInProgress,
+		ExecutionStatusExecuteComplete,
+		ExecutionStatusExecuteFailed,
+		ExecutionStatusObsolete,
+	}
+}
 
 const (
 	// HandlerErrorCodeNotUpdatable is a HandlerErrorCode enum value
@@ -17320,6 +17423,26 @@ const (
 	HandlerErrorCodeInternalFailure = "InternalFailure"
 )
 
+// HandlerErrorCode_Values returns all elements of the HandlerErrorCode enum
+func HandlerErrorCode_Values() []string {
+	return []string{
+		HandlerErrorCodeNotUpdatable,
+		HandlerErrorCodeInvalidRequest,
+		HandlerErrorCodeAccessDenied,
+		HandlerErrorCodeInvalidCredentials,
+		HandlerErrorCodeAlreadyExists,
+		HandlerErrorCodeNotFound,
+		HandlerErrorCodeResourceConflict,
+		HandlerErrorCodeThrottling,
+		HandlerErrorCodeServiceLimitExceeded,
+		HandlerErrorCodeNotStabilized,
+		HandlerErrorCodeGeneralServiceException,
+		HandlerErrorCodeServiceInternalError,
+		HandlerErrorCodeNetworkFailure,
+		HandlerErrorCodeInternalFailure,
+	}
+}
+
 const (
 	// OnFailureDoNothing is a OnFailure enum value
 	OnFailureDoNothing = "DO_NOTHING"
@@ -17330,6 +17453,15 @@ const (
 	// OnFailureDelete is a OnFailure enum value
 	OnFailureDelete = "DELETE"
 )
+
+// OnFailure_Values returns all elements of the OnFailure enum
+func OnFailure_Values() []string {
+	return []string{
+		OnFailureDoNothing,
+		OnFailureRollback,
+		OnFailureDelete,
+	}
+}
 
 const (
 	// OperationStatusPending is a OperationStatus enum value
@@ -17345,6 +17477,16 @@ const (
 	OperationStatusFailed = "FAILED"
 )
 
+// OperationStatus_Values returns all elements of the OperationStatus enum
+func OperationStatus_Values() []string {
+	return []string{
+		OperationStatusPending,
+		OperationStatusInProgress,
+		OperationStatusSuccess,
+		OperationStatusFailed,
+	}
+}
+
 const (
 	// PermissionModelsServiceManaged is a PermissionModels enum value
 	PermissionModelsServiceManaged = "SERVICE_MANAGED"
@@ -17352,6 +17494,14 @@ const (
 	// PermissionModelsSelfManaged is a PermissionModels enum value
 	PermissionModelsSelfManaged = "SELF_MANAGED"
 )
+
+// PermissionModels_Values returns all elements of the PermissionModels enum
+func PermissionModels_Values() []string {
+	return []string{
+		PermissionModelsServiceManaged,
+		PermissionModelsSelfManaged,
+	}
+}
 
 const (
 	// ProvisioningTypeNonProvisionable is a ProvisioningType enum value
@@ -17364,6 +17514,15 @@ const (
 	ProvisioningTypeFullyMutable = "FULLY_MUTABLE"
 )
 
+// ProvisioningType_Values returns all elements of the ProvisioningType enum
+func ProvisioningType_Values() []string {
+	return []string{
+		ProvisioningTypeNonProvisionable,
+		ProvisioningTypeImmutable,
+		ProvisioningTypeFullyMutable,
+	}
+}
+
 const (
 	// RegistrationStatusComplete is a RegistrationStatus enum value
 	RegistrationStatusComplete = "COMPLETE"
@@ -17375,10 +17534,26 @@ const (
 	RegistrationStatusFailed = "FAILED"
 )
 
+// RegistrationStatus_Values returns all elements of the RegistrationStatus enum
+func RegistrationStatus_Values() []string {
+	return []string{
+		RegistrationStatusComplete,
+		RegistrationStatusInProgress,
+		RegistrationStatusFailed,
+	}
+}
+
 const (
 	// RegistryTypeResource is a RegistryType enum value
 	RegistryTypeResource = "RESOURCE"
 )
+
+// RegistryType_Values returns all elements of the RegistryType enum
+func RegistryType_Values() []string {
+	return []string{
+		RegistryTypeResource,
+	}
+}
 
 const (
 	// ReplacementTrue is a Replacement enum value
@@ -17391,6 +17566,15 @@ const (
 	ReplacementConditional = "Conditional"
 )
 
+// Replacement_Values returns all elements of the Replacement enum
+func Replacement_Values() []string {
+	return []string{
+		ReplacementTrue,
+		ReplacementFalse,
+		ReplacementConditional,
+	}
+}
+
 const (
 	// RequiresRecreationNever is a RequiresRecreation enum value
 	RequiresRecreationNever = "Never"
@@ -17401,6 +17585,15 @@ const (
 	// RequiresRecreationAlways is a RequiresRecreation enum value
 	RequiresRecreationAlways = "Always"
 )
+
+// RequiresRecreation_Values returns all elements of the RequiresRecreation enum
+func RequiresRecreation_Values() []string {
+	return []string{
+		RequiresRecreationNever,
+		RequiresRecreationConditionally,
+		RequiresRecreationAlways,
+	}
+}
 
 const (
 	// ResourceAttributeProperties is a ResourceAttribute enum value
@@ -17422,6 +17615,18 @@ const (
 	ResourceAttributeTags = "Tags"
 )
 
+// ResourceAttribute_Values returns all elements of the ResourceAttribute enum
+func ResourceAttribute_Values() []string {
+	return []string{
+		ResourceAttributeProperties,
+		ResourceAttributeMetadata,
+		ResourceAttributeCreationPolicy,
+		ResourceAttributeUpdatePolicy,
+		ResourceAttributeDeletionPolicy,
+		ResourceAttributeTags,
+	}
+}
+
 const (
 	// ResourceSignalStatusSuccess is a ResourceSignalStatus enum value
 	ResourceSignalStatusSuccess = "SUCCESS"
@@ -17429,6 +17634,14 @@ const (
 	// ResourceSignalStatusFailure is a ResourceSignalStatus enum value
 	ResourceSignalStatusFailure = "FAILURE"
 )
+
+// ResourceSignalStatus_Values returns all elements of the ResourceSignalStatus enum
+func ResourceSignalStatus_Values() []string {
+	return []string{
+		ResourceSignalStatusSuccess,
+		ResourceSignalStatusFailure,
+	}
+}
 
 const (
 	// ResourceStatusCreateInProgress is a ResourceStatus enum value
@@ -17480,6 +17693,28 @@ const (
 	ResourceStatusImportRollbackComplete = "IMPORT_ROLLBACK_COMPLETE"
 )
 
+// ResourceStatus_Values returns all elements of the ResourceStatus enum
+func ResourceStatus_Values() []string {
+	return []string{
+		ResourceStatusCreateInProgress,
+		ResourceStatusCreateFailed,
+		ResourceStatusCreateComplete,
+		ResourceStatusDeleteInProgress,
+		ResourceStatusDeleteFailed,
+		ResourceStatusDeleteComplete,
+		ResourceStatusDeleteSkipped,
+		ResourceStatusUpdateInProgress,
+		ResourceStatusUpdateFailed,
+		ResourceStatusUpdateComplete,
+		ResourceStatusImportFailed,
+		ResourceStatusImportComplete,
+		ResourceStatusImportInProgress,
+		ResourceStatusImportRollbackInProgress,
+		ResourceStatusImportRollbackFailed,
+		ResourceStatusImportRollbackComplete,
+	}
+}
+
 const (
 	// StackDriftDetectionStatusDetectionInProgress is a StackDriftDetectionStatus enum value
 	StackDriftDetectionStatusDetectionInProgress = "DETECTION_IN_PROGRESS"
@@ -17490,6 +17725,15 @@ const (
 	// StackDriftDetectionStatusDetectionComplete is a StackDriftDetectionStatus enum value
 	StackDriftDetectionStatusDetectionComplete = "DETECTION_COMPLETE"
 )
+
+// StackDriftDetectionStatus_Values returns all elements of the StackDriftDetectionStatus enum
+func StackDriftDetectionStatus_Values() []string {
+	return []string{
+		StackDriftDetectionStatusDetectionInProgress,
+		StackDriftDetectionStatusDetectionFailed,
+		StackDriftDetectionStatusDetectionComplete,
+	}
+}
 
 const (
 	// StackDriftStatusDrifted is a StackDriftStatus enum value
@@ -17504,6 +17748,16 @@ const (
 	// StackDriftStatusNotChecked is a StackDriftStatus enum value
 	StackDriftStatusNotChecked = "NOT_CHECKED"
 )
+
+// StackDriftStatus_Values returns all elements of the StackDriftStatus enum
+func StackDriftStatus_Values() []string {
+	return []string{
+		StackDriftStatusDrifted,
+		StackDriftStatusInSync,
+		StackDriftStatusUnknown,
+		StackDriftStatusNotChecked,
+	}
+}
 
 const (
 	// StackInstanceDetailedStatusPending is a StackInstanceDetailedStatus enum value
@@ -17525,10 +17779,29 @@ const (
 	StackInstanceDetailedStatusInoperable = "INOPERABLE"
 )
 
+// StackInstanceDetailedStatus_Values returns all elements of the StackInstanceDetailedStatus enum
+func StackInstanceDetailedStatus_Values() []string {
+	return []string{
+		StackInstanceDetailedStatusPending,
+		StackInstanceDetailedStatusRunning,
+		StackInstanceDetailedStatusSucceeded,
+		StackInstanceDetailedStatusFailed,
+		StackInstanceDetailedStatusCancelled,
+		StackInstanceDetailedStatusInoperable,
+	}
+}
+
 const (
 	// StackInstanceFilterNameDetailedStatus is a StackInstanceFilterName enum value
 	StackInstanceFilterNameDetailedStatus = "DETAILED_STATUS"
 )
+
+// StackInstanceFilterName_Values returns all elements of the StackInstanceFilterName enum
+func StackInstanceFilterName_Values() []string {
+	return []string{
+		StackInstanceFilterNameDetailedStatus,
+	}
+}
 
 const (
 	// StackInstanceStatusCurrent is a StackInstanceStatus enum value
@@ -17540,6 +17813,15 @@ const (
 	// StackInstanceStatusInoperable is a StackInstanceStatus enum value
 	StackInstanceStatusInoperable = "INOPERABLE"
 )
+
+// StackInstanceStatus_Values returns all elements of the StackInstanceStatus enum
+func StackInstanceStatus_Values() []string {
+	return []string{
+		StackInstanceStatusCurrent,
+		StackInstanceStatusOutdated,
+		StackInstanceStatusInoperable,
+	}
+}
 
 const (
 	// StackResourceDriftStatusInSync is a StackResourceDriftStatus enum value
@@ -17554,6 +17836,16 @@ const (
 	// StackResourceDriftStatusNotChecked is a StackResourceDriftStatus enum value
 	StackResourceDriftStatusNotChecked = "NOT_CHECKED"
 )
+
+// StackResourceDriftStatus_Values returns all elements of the StackResourceDriftStatus enum
+func StackResourceDriftStatus_Values() []string {
+	return []string{
+		StackResourceDriftStatusInSync,
+		StackResourceDriftStatusModified,
+		StackResourceDriftStatusDeleted,
+		StackResourceDriftStatusNotChecked,
+	}
+}
 
 const (
 	// StackSetDriftDetectionStatusCompleted is a StackSetDriftDetectionStatus enum value
@@ -17572,6 +17864,17 @@ const (
 	StackSetDriftDetectionStatusStopped = "STOPPED"
 )
 
+// StackSetDriftDetectionStatus_Values returns all elements of the StackSetDriftDetectionStatus enum
+func StackSetDriftDetectionStatus_Values() []string {
+	return []string{
+		StackSetDriftDetectionStatusCompleted,
+		StackSetDriftDetectionStatusFailed,
+		StackSetDriftDetectionStatusPartialSuccess,
+		StackSetDriftDetectionStatusInProgress,
+		StackSetDriftDetectionStatusStopped,
+	}
+}
+
 const (
 	// StackSetDriftStatusDrifted is a StackSetDriftStatus enum value
 	StackSetDriftStatusDrifted = "DRIFTED"
@@ -17582,6 +17885,15 @@ const (
 	// StackSetDriftStatusNotChecked is a StackSetDriftStatus enum value
 	StackSetDriftStatusNotChecked = "NOT_CHECKED"
 )
+
+// StackSetDriftStatus_Values returns all elements of the StackSetDriftStatus enum
+func StackSetDriftStatus_Values() []string {
+	return []string{
+		StackSetDriftStatusDrifted,
+		StackSetDriftStatusInSync,
+		StackSetDriftStatusNotChecked,
+	}
+}
 
 const (
 	// StackSetOperationActionCreate is a StackSetOperationAction enum value
@@ -17596,6 +17908,16 @@ const (
 	// StackSetOperationActionDetectDrift is a StackSetOperationAction enum value
 	StackSetOperationActionDetectDrift = "DETECT_DRIFT"
 )
+
+// StackSetOperationAction_Values returns all elements of the StackSetOperationAction enum
+func StackSetOperationAction_Values() []string {
+	return []string{
+		StackSetOperationActionCreate,
+		StackSetOperationActionUpdate,
+		StackSetOperationActionDelete,
+		StackSetOperationActionDetectDrift,
+	}
+}
 
 const (
 	// StackSetOperationResultStatusPending is a StackSetOperationResultStatus enum value
@@ -17613,6 +17935,17 @@ const (
 	// StackSetOperationResultStatusCancelled is a StackSetOperationResultStatus enum value
 	StackSetOperationResultStatusCancelled = "CANCELLED"
 )
+
+// StackSetOperationResultStatus_Values returns all elements of the StackSetOperationResultStatus enum
+func StackSetOperationResultStatus_Values() []string {
+	return []string{
+		StackSetOperationResultStatusPending,
+		StackSetOperationResultStatusRunning,
+		StackSetOperationResultStatusSucceeded,
+		StackSetOperationResultStatusFailed,
+		StackSetOperationResultStatusCancelled,
+	}
+}
 
 const (
 	// StackSetOperationStatusRunning is a StackSetOperationStatus enum value
@@ -17634,6 +17967,18 @@ const (
 	StackSetOperationStatusQueued = "QUEUED"
 )
 
+// StackSetOperationStatus_Values returns all elements of the StackSetOperationStatus enum
+func StackSetOperationStatus_Values() []string {
+	return []string{
+		StackSetOperationStatusRunning,
+		StackSetOperationStatusSucceeded,
+		StackSetOperationStatusFailed,
+		StackSetOperationStatusStopping,
+		StackSetOperationStatusStopped,
+		StackSetOperationStatusQueued,
+	}
+}
+
 const (
 	// StackSetStatusActive is a StackSetStatus enum value
 	StackSetStatusActive = "ACTIVE"
@@ -17641,6 +17986,14 @@ const (
 	// StackSetStatusDeleted is a StackSetStatus enum value
 	StackSetStatusDeleted = "DELETED"
 )
+
+// StackSetStatus_Values returns all elements of the StackSetStatus enum
+func StackSetStatus_Values() []string {
+	return []string{
+		StackSetStatusActive,
+		StackSetStatusDeleted,
+	}
+}
 
 const (
 	// StackStatusCreateInProgress is a StackStatus enum value
@@ -17710,6 +18063,34 @@ const (
 	StackStatusImportRollbackComplete = "IMPORT_ROLLBACK_COMPLETE"
 )
 
+// StackStatus_Values returns all elements of the StackStatus enum
+func StackStatus_Values() []string {
+	return []string{
+		StackStatusCreateInProgress,
+		StackStatusCreateFailed,
+		StackStatusCreateComplete,
+		StackStatusRollbackInProgress,
+		StackStatusRollbackFailed,
+		StackStatusRollbackComplete,
+		StackStatusDeleteInProgress,
+		StackStatusDeleteFailed,
+		StackStatusDeleteComplete,
+		StackStatusUpdateInProgress,
+		StackStatusUpdateCompleteCleanupInProgress,
+		StackStatusUpdateComplete,
+		StackStatusUpdateRollbackInProgress,
+		StackStatusUpdateRollbackFailed,
+		StackStatusUpdateRollbackCompleteCleanupInProgress,
+		StackStatusUpdateRollbackComplete,
+		StackStatusReviewInProgress,
+		StackStatusImportInProgress,
+		StackStatusImportComplete,
+		StackStatusImportRollbackInProgress,
+		StackStatusImportRollbackFailed,
+		StackStatusImportRollbackComplete,
+	}
+}
+
 const (
 	// TemplateStageOriginal is a TemplateStage enum value
 	TemplateStageOriginal = "Original"
@@ -17718,6 +18099,14 @@ const (
 	TemplateStageProcessed = "Processed"
 )
 
+// TemplateStage_Values returns all elements of the TemplateStage enum
+func TemplateStage_Values() []string {
+	return []string{
+		TemplateStageOriginal,
+		TemplateStageProcessed,
+	}
+}
+
 const (
 	// VisibilityPublic is a Visibility enum value
 	VisibilityPublic = "PUBLIC"
@@ -17725,3 +18114,11 @@ const (
 	// VisibilityPrivate is a Visibility enum value
 	VisibilityPrivate = "PRIVATE"
 )
+
+// Visibility_Values returns all elements of the Visibility enum
+func Visibility_Values() []string {
+	return []string{
+		VisibilityPublic,
+		VisibilityPrivate,
+	}
+}

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -19408,6 +19408,16 @@ const (
 	CachePolicyCookieBehaviorAll = "all"
 )
 
+// CachePolicyCookieBehavior_Values returns all elements of the CachePolicyCookieBehavior enum
+func CachePolicyCookieBehavior_Values() []string {
+	return []string{
+		CachePolicyCookieBehaviorNone,
+		CachePolicyCookieBehaviorWhitelist,
+		CachePolicyCookieBehaviorAllExcept,
+		CachePolicyCookieBehaviorAll,
+	}
+}
+
 const (
 	// CachePolicyHeaderBehaviorNone is a CachePolicyHeaderBehavior enum value
 	CachePolicyHeaderBehaviorNone = "none"
@@ -19415,6 +19425,14 @@ const (
 	// CachePolicyHeaderBehaviorWhitelist is a CachePolicyHeaderBehavior enum value
 	CachePolicyHeaderBehaviorWhitelist = "whitelist"
 )
+
+// CachePolicyHeaderBehavior_Values returns all elements of the CachePolicyHeaderBehavior enum
+func CachePolicyHeaderBehavior_Values() []string {
+	return []string{
+		CachePolicyHeaderBehaviorNone,
+		CachePolicyHeaderBehaviorWhitelist,
+	}
+}
 
 const (
 	// CachePolicyQueryStringBehaviorNone is a CachePolicyQueryStringBehavior enum value
@@ -19430,6 +19448,16 @@ const (
 	CachePolicyQueryStringBehaviorAll = "all"
 )
 
+// CachePolicyQueryStringBehavior_Values returns all elements of the CachePolicyQueryStringBehavior enum
+func CachePolicyQueryStringBehavior_Values() []string {
+	return []string{
+		CachePolicyQueryStringBehaviorNone,
+		CachePolicyQueryStringBehaviorWhitelist,
+		CachePolicyQueryStringBehaviorAllExcept,
+		CachePolicyQueryStringBehaviorAll,
+	}
+}
+
 const (
 	// CachePolicyTypeManaged is a CachePolicyType enum value
 	CachePolicyTypeManaged = "managed"
@@ -19437,6 +19465,14 @@ const (
 	// CachePolicyTypeCustom is a CachePolicyType enum value
 	CachePolicyTypeCustom = "custom"
 )
+
+// CachePolicyType_Values returns all elements of the CachePolicyType enum
+func CachePolicyType_Values() []string {
+	return []string{
+		CachePolicyTypeManaged,
+		CachePolicyTypeCustom,
+	}
+}
 
 const (
 	// CertificateSourceCloudfront is a CertificateSource enum value
@@ -19448,6 +19484,15 @@ const (
 	// CertificateSourceAcm is a CertificateSource enum value
 	CertificateSourceAcm = "acm"
 )
+
+// CertificateSource_Values returns all elements of the CertificateSource enum
+func CertificateSource_Values() []string {
+	return []string{
+		CertificateSourceCloudfront,
+		CertificateSourceIam,
+		CertificateSourceAcm,
+	}
+}
 
 const (
 	// EventTypeViewerRequest is a EventType enum value
@@ -19463,10 +19508,27 @@ const (
 	EventTypeOriginResponse = "origin-response"
 )
 
+// EventType_Values returns all elements of the EventType enum
+func EventType_Values() []string {
+	return []string{
+		EventTypeViewerRequest,
+		EventTypeViewerResponse,
+		EventTypeOriginRequest,
+		EventTypeOriginResponse,
+	}
+}
+
 const (
 	// FormatUrlencoded is a Format enum value
 	FormatUrlencoded = "URLEncoded"
 )
+
+// Format_Values returns all elements of the Format enum
+func Format_Values() []string {
+	return []string{
+		FormatUrlencoded,
+	}
+}
 
 const (
 	// GeoRestrictionTypeBlacklist is a GeoRestrictionType enum value
@@ -19479,6 +19541,15 @@ const (
 	GeoRestrictionTypeNone = "none"
 )
 
+// GeoRestrictionType_Values returns all elements of the GeoRestrictionType enum
+func GeoRestrictionType_Values() []string {
+	return []string{
+		GeoRestrictionTypeBlacklist,
+		GeoRestrictionTypeWhitelist,
+		GeoRestrictionTypeNone,
+	}
+}
+
 const (
 	// HttpVersionHttp11 is a HttpVersion enum value
 	HttpVersionHttp11 = "http1.1"
@@ -19486,6 +19557,14 @@ const (
 	// HttpVersionHttp2 is a HttpVersion enum value
 	HttpVersionHttp2 = "http2"
 )
+
+// HttpVersion_Values returns all elements of the HttpVersion enum
+func HttpVersion_Values() []string {
+	return []string{
+		HttpVersionHttp11,
+		HttpVersionHttp2,
+	}
+}
 
 const (
 	// ICPRecordalStatusApproved is a ICPRecordalStatus enum value
@@ -19498,6 +19577,15 @@ const (
 	ICPRecordalStatusPending = "PENDING"
 )
 
+// ICPRecordalStatus_Values returns all elements of the ICPRecordalStatus enum
+func ICPRecordalStatus_Values() []string {
+	return []string{
+		ICPRecordalStatusApproved,
+		ICPRecordalStatusSuspended,
+		ICPRecordalStatusPending,
+	}
+}
+
 const (
 	// ItemSelectionNone is a ItemSelection enum value
 	ItemSelectionNone = "none"
@@ -19508,6 +19596,15 @@ const (
 	// ItemSelectionAll is a ItemSelection enum value
 	ItemSelectionAll = "all"
 )
+
+// ItemSelection_Values returns all elements of the ItemSelection enum
+func ItemSelection_Values() []string {
+	return []string{
+		ItemSelectionNone,
+		ItemSelectionWhitelist,
+		ItemSelectionAll,
+	}
+}
 
 const (
 	// MethodGet is a Method enum value
@@ -19532,6 +19629,19 @@ const (
 	MethodDelete = "DELETE"
 )
 
+// Method_Values returns all elements of the Method enum
+func Method_Values() []string {
+	return []string{
+		MethodGet,
+		MethodHead,
+		MethodPost,
+		MethodPut,
+		MethodPatch,
+		MethodOptions,
+		MethodDelete,
+	}
+}
+
 const (
 	// MinimumProtocolVersionSslv3 is a MinimumProtocolVersion enum value
 	MinimumProtocolVersionSslv3 = "SSLv3"
@@ -19552,6 +19662,18 @@ const (
 	MinimumProtocolVersionTlsv122019 = "TLSv1.2_2019"
 )
 
+// MinimumProtocolVersion_Values returns all elements of the MinimumProtocolVersion enum
+func MinimumProtocolVersion_Values() []string {
+	return []string{
+		MinimumProtocolVersionSslv3,
+		MinimumProtocolVersionTlsv1,
+		MinimumProtocolVersionTlsv12016,
+		MinimumProtocolVersionTlsv112016,
+		MinimumProtocolVersionTlsv122018,
+		MinimumProtocolVersionTlsv122019,
+	}
+}
+
 const (
 	// OriginProtocolPolicyHttpOnly is a OriginProtocolPolicy enum value
 	OriginProtocolPolicyHttpOnly = "http-only"
@@ -19563,6 +19685,15 @@ const (
 	OriginProtocolPolicyHttpsOnly = "https-only"
 )
 
+// OriginProtocolPolicy_Values returns all elements of the OriginProtocolPolicy enum
+func OriginProtocolPolicy_Values() []string {
+	return []string{
+		OriginProtocolPolicyHttpOnly,
+		OriginProtocolPolicyMatchViewer,
+		OriginProtocolPolicyHttpsOnly,
+	}
+}
+
 const (
 	// OriginRequestPolicyCookieBehaviorNone is a OriginRequestPolicyCookieBehavior enum value
 	OriginRequestPolicyCookieBehaviorNone = "none"
@@ -19573,6 +19704,15 @@ const (
 	// OriginRequestPolicyCookieBehaviorAll is a OriginRequestPolicyCookieBehavior enum value
 	OriginRequestPolicyCookieBehaviorAll = "all"
 )
+
+// OriginRequestPolicyCookieBehavior_Values returns all elements of the OriginRequestPolicyCookieBehavior enum
+func OriginRequestPolicyCookieBehavior_Values() []string {
+	return []string{
+		OriginRequestPolicyCookieBehaviorNone,
+		OriginRequestPolicyCookieBehaviorWhitelist,
+		OriginRequestPolicyCookieBehaviorAll,
+	}
+}
 
 const (
 	// OriginRequestPolicyHeaderBehaviorNone is a OriginRequestPolicyHeaderBehavior enum value
@@ -19588,6 +19728,16 @@ const (
 	OriginRequestPolicyHeaderBehaviorAllViewerAndWhitelistCloudFront = "allViewerAndWhitelistCloudFront"
 )
 
+// OriginRequestPolicyHeaderBehavior_Values returns all elements of the OriginRequestPolicyHeaderBehavior enum
+func OriginRequestPolicyHeaderBehavior_Values() []string {
+	return []string{
+		OriginRequestPolicyHeaderBehaviorNone,
+		OriginRequestPolicyHeaderBehaviorWhitelist,
+		OriginRequestPolicyHeaderBehaviorAllViewer,
+		OriginRequestPolicyHeaderBehaviorAllViewerAndWhitelistCloudFront,
+	}
+}
+
 const (
 	// OriginRequestPolicyQueryStringBehaviorNone is a OriginRequestPolicyQueryStringBehavior enum value
 	OriginRequestPolicyQueryStringBehaviorNone = "none"
@@ -19599,6 +19749,15 @@ const (
 	OriginRequestPolicyQueryStringBehaviorAll = "all"
 )
 
+// OriginRequestPolicyQueryStringBehavior_Values returns all elements of the OriginRequestPolicyQueryStringBehavior enum
+func OriginRequestPolicyQueryStringBehavior_Values() []string {
+	return []string{
+		OriginRequestPolicyQueryStringBehaviorNone,
+		OriginRequestPolicyQueryStringBehaviorWhitelist,
+		OriginRequestPolicyQueryStringBehaviorAll,
+	}
+}
+
 const (
 	// OriginRequestPolicyTypeManaged is a OriginRequestPolicyType enum value
 	OriginRequestPolicyTypeManaged = "managed"
@@ -19606,6 +19765,14 @@ const (
 	// OriginRequestPolicyTypeCustom is a OriginRequestPolicyType enum value
 	OriginRequestPolicyTypeCustom = "custom"
 )
+
+// OriginRequestPolicyType_Values returns all elements of the OriginRequestPolicyType enum
+func OriginRequestPolicyType_Values() []string {
+	return []string{
+		OriginRequestPolicyTypeManaged,
+		OriginRequestPolicyTypeCustom,
+	}
+}
 
 const (
 	// PriceClassPriceClass100 is a PriceClass enum value
@@ -19618,6 +19785,15 @@ const (
 	PriceClassPriceClassAll = "PriceClass_All"
 )
 
+// PriceClass_Values returns all elements of the PriceClass enum
+func PriceClass_Values() []string {
+	return []string{
+		PriceClassPriceClass100,
+		PriceClassPriceClass200,
+		PriceClassPriceClassAll,
+	}
+}
+
 const (
 	// SSLSupportMethodSniOnly is a SSLSupportMethod enum value
 	SSLSupportMethodSniOnly = "sni-only"
@@ -19625,6 +19801,14 @@ const (
 	// SSLSupportMethodVip is a SSLSupportMethod enum value
 	SSLSupportMethodVip = "vip"
 )
+
+// SSLSupportMethod_Values returns all elements of the SSLSupportMethod enum
+func SSLSupportMethod_Values() []string {
+	return []string{
+		SSLSupportMethodSniOnly,
+		SSLSupportMethodVip,
+	}
+}
 
 const (
 	// SslProtocolSslv3 is a SslProtocol enum value
@@ -19640,6 +19824,16 @@ const (
 	SslProtocolTlsv12 = "TLSv1.2"
 )
 
+// SslProtocol_Values returns all elements of the SslProtocol enum
+func SslProtocol_Values() []string {
+	return []string{
+		SslProtocolSslv3,
+		SslProtocolTlsv1,
+		SslProtocolTlsv11,
+		SslProtocolTlsv12,
+	}
+}
+
 const (
 	// ViewerProtocolPolicyAllowAll is a ViewerProtocolPolicy enum value
 	ViewerProtocolPolicyAllowAll = "allow-all"
@@ -19650,3 +19844,12 @@ const (
 	// ViewerProtocolPolicyRedirectToHttps is a ViewerProtocolPolicy enum value
 	ViewerProtocolPolicyRedirectToHttps = "redirect-to-https"
 )
+
+// ViewerProtocolPolicy_Values returns all elements of the ViewerProtocolPolicy enum
+func ViewerProtocolPolicy_Values() []string {
+	return []string{
+		ViewerProtocolPolicyAllowAll,
+		ViewerProtocolPolicyHttpsOnly,
+		ViewerProtocolPolicyRedirectToHttps,
+	}
+}

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -3943,6 +3943,14 @@ const (
 	ClientVersion53 = "5.3"
 )
 
+// ClientVersion_Values returns all elements of the ClientVersion enum
+func ClientVersion_Values() []string {
+	return []string{
+		ClientVersion51,
+		ClientVersion53,
+	}
+}
+
 const (
 	// CloudHsmObjectStateReady is a CloudHsmObjectState enum value
 	CloudHsmObjectStateReady = "READY"
@@ -3953,6 +3961,15 @@ const (
 	// CloudHsmObjectStateDegraded is a CloudHsmObjectState enum value
 	CloudHsmObjectStateDegraded = "DEGRADED"
 )
+
+// CloudHsmObjectState_Values returns all elements of the CloudHsmObjectState enum
+func CloudHsmObjectState_Values() []string {
+	return []string{
+		CloudHsmObjectStateReady,
+		CloudHsmObjectStateUpdating,
+		CloudHsmObjectStateDegraded,
+	}
+}
 
 const (
 	// HsmStatusPending is a HsmStatus enum value
@@ -3977,6 +3994,19 @@ const (
 	HsmStatusDegraded = "DEGRADED"
 )
 
+// HsmStatus_Values returns all elements of the HsmStatus enum
+func HsmStatus_Values() []string {
+	return []string{
+		HsmStatusPending,
+		HsmStatusRunning,
+		HsmStatusUpdating,
+		HsmStatusSuspended,
+		HsmStatusTerminating,
+		HsmStatusTerminated,
+		HsmStatusDegraded,
+	}
+}
+
 // Specifies the type of subscription for the HSM.
 //
 //    * PRODUCTION - The HSM is being used in a production environment.
@@ -3986,3 +4016,10 @@ const (
 	// SubscriptionTypeProduction is a SubscriptionType enum value
 	SubscriptionTypeProduction = "PRODUCTION"
 )
+
+// SubscriptionType_Values returns all elements of the SubscriptionType enum
+func SubscriptionType_Values() []string {
+	return []string{
+		SubscriptionTypeProduction,
+	}
+}

--- a/service/cloudhsmv2/api.go
+++ b/service/cloudhsmv2/api.go
@@ -3476,6 +3476,13 @@ const (
 	BackupPolicyDefault = "DEFAULT"
 )
 
+// BackupPolicy_Values returns all elements of the BackupPolicy enum
+func BackupPolicy_Values() []string {
+	return []string{
+		BackupPolicyDefault,
+	}
+}
+
 const (
 	// BackupStateCreateInProgress is a BackupState enum value
 	BackupStateCreateInProgress = "CREATE_IN_PROGRESS"
@@ -3489,6 +3496,16 @@ const (
 	// BackupStatePendingDeletion is a BackupState enum value
 	BackupStatePendingDeletion = "PENDING_DELETION"
 )
+
+// BackupState_Values returns all elements of the BackupState enum
+func BackupState_Values() []string {
+	return []string{
+		BackupStateCreateInProgress,
+		BackupStateReady,
+		BackupStateDeleted,
+		BackupStatePendingDeletion,
+	}
+}
 
 const (
 	// ClusterStateCreateInProgress is a ClusterState enum value
@@ -3519,6 +3536,21 @@ const (
 	ClusterStateDegraded = "DEGRADED"
 )
 
+// ClusterState_Values returns all elements of the ClusterState enum
+func ClusterState_Values() []string {
+	return []string{
+		ClusterStateCreateInProgress,
+		ClusterStateUninitialized,
+		ClusterStateInitializeInProgress,
+		ClusterStateInitialized,
+		ClusterStateActive,
+		ClusterStateUpdateInProgress,
+		ClusterStateDeleteInProgress,
+		ClusterStateDeleted,
+		ClusterStateDegraded,
+	}
+}
+
 const (
 	// HsmStateCreateInProgress is a HsmState enum value
 	HsmStateCreateInProgress = "CREATE_IN_PROGRESS"
@@ -3535,3 +3567,14 @@ const (
 	// HsmStateDeleted is a HsmState enum value
 	HsmStateDeleted = "DELETED"
 )
+
+// HsmState_Values returns all elements of the HsmState enum
+func HsmState_Values() []string {
+	return []string{
+		HsmStateCreateInProgress,
+		HsmStateActive,
+		HsmStateDegraded,
+		HsmStateDeleteInProgress,
+		HsmStateDeleted,
+	}
+}

--- a/service/cloudsearch/api.go
+++ b/service/cloudsearch/api.go
@@ -6625,6 +6625,16 @@ const (
 	AlgorithmicStemmingFull = "full"
 )
 
+// AlgorithmicStemming_Values returns all elements of the AlgorithmicStemming enum
+func AlgorithmicStemming_Values() []string {
+	return []string{
+		AlgorithmicStemmingNone,
+		AlgorithmicStemmingMinimal,
+		AlgorithmicStemmingLight,
+		AlgorithmicStemmingFull,
+	}
+}
+
 // An IETF RFC 4646 (http://tools.ietf.org/html/rfc4646) language code or mul
 // for multiple languages.
 const (
@@ -6734,6 +6744,47 @@ const (
 	AnalysisSchemeLanguageZhHant = "zh-Hant"
 )
 
+// AnalysisSchemeLanguage_Values returns all elements of the AnalysisSchemeLanguage enum
+func AnalysisSchemeLanguage_Values() []string {
+	return []string{
+		AnalysisSchemeLanguageAr,
+		AnalysisSchemeLanguageBg,
+		AnalysisSchemeLanguageCa,
+		AnalysisSchemeLanguageCs,
+		AnalysisSchemeLanguageDa,
+		AnalysisSchemeLanguageDe,
+		AnalysisSchemeLanguageEl,
+		AnalysisSchemeLanguageEn,
+		AnalysisSchemeLanguageEs,
+		AnalysisSchemeLanguageEu,
+		AnalysisSchemeLanguageFa,
+		AnalysisSchemeLanguageFi,
+		AnalysisSchemeLanguageFr,
+		AnalysisSchemeLanguageGa,
+		AnalysisSchemeLanguageGl,
+		AnalysisSchemeLanguageHe,
+		AnalysisSchemeLanguageHi,
+		AnalysisSchemeLanguageHu,
+		AnalysisSchemeLanguageHy,
+		AnalysisSchemeLanguageId,
+		AnalysisSchemeLanguageIt,
+		AnalysisSchemeLanguageJa,
+		AnalysisSchemeLanguageKo,
+		AnalysisSchemeLanguageLv,
+		AnalysisSchemeLanguageMul,
+		AnalysisSchemeLanguageNl,
+		AnalysisSchemeLanguageNo,
+		AnalysisSchemeLanguagePt,
+		AnalysisSchemeLanguageRo,
+		AnalysisSchemeLanguageRu,
+		AnalysisSchemeLanguageSv,
+		AnalysisSchemeLanguageTh,
+		AnalysisSchemeLanguageTr,
+		AnalysisSchemeLanguageZhHans,
+		AnalysisSchemeLanguageZhHant,
+	}
+}
+
 // The type of field. The valid options for a field depend on the field type.
 // For more information about the supported field types, see Configuring Index
 // Fields (http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-index-fields.html)
@@ -6773,6 +6824,23 @@ const (
 	IndexFieldTypeDateArray = "date-array"
 )
 
+// IndexFieldType_Values returns all elements of the IndexFieldType enum
+func IndexFieldType_Values() []string {
+	return []string{
+		IndexFieldTypeInt,
+		IndexFieldTypeDouble,
+		IndexFieldTypeLiteral,
+		IndexFieldTypeText,
+		IndexFieldTypeDate,
+		IndexFieldTypeLatlon,
+		IndexFieldTypeIntArray,
+		IndexFieldTypeDoubleArray,
+		IndexFieldTypeLiteralArray,
+		IndexFieldTypeTextArray,
+		IndexFieldTypeDateArray,
+	}
+}
+
 // The state of processing a change to an option. One of:
 //
 //    * RequiresIndexDocuments: The option's latest value will not be deployed
@@ -6798,6 +6866,16 @@ const (
 	// OptionStateFailedToValidate is a OptionState enum value
 	OptionStateFailedToValidate = "FailedToValidate"
 )
+
+// OptionState_Values returns all elements of the OptionState enum
+func OptionState_Values() []string {
+	return []string{
+		OptionStateRequiresIndexDocuments,
+		OptionStateProcessing,
+		OptionStateActive,
+		OptionStateFailedToValidate,
+	}
+}
 
 // The instance type (such as search.m1.small) on which an index partition is
 // hosted.
@@ -6827,6 +6905,20 @@ const (
 	PartitionInstanceTypeSearchM32xlarge = "search.m3.2xlarge"
 )
 
+// PartitionInstanceType_Values returns all elements of the PartitionInstanceType enum
+func PartitionInstanceType_Values() []string {
+	return []string{
+		PartitionInstanceTypeSearchM1Small,
+		PartitionInstanceTypeSearchM1Large,
+		PartitionInstanceTypeSearchM2Xlarge,
+		PartitionInstanceTypeSearchM22xlarge,
+		PartitionInstanceTypeSearchM3Medium,
+		PartitionInstanceTypeSearchM3Large,
+		PartitionInstanceTypeSearchM3Xlarge,
+		PartitionInstanceTypeSearchM32xlarge,
+	}
+}
+
 const (
 	// SuggesterFuzzyMatchingNone is a SuggesterFuzzyMatching enum value
 	SuggesterFuzzyMatchingNone = "none"
@@ -6838,6 +6930,15 @@ const (
 	SuggesterFuzzyMatchingHigh = "high"
 )
 
+// SuggesterFuzzyMatching_Values returns all elements of the SuggesterFuzzyMatching enum
+func SuggesterFuzzyMatching_Values() []string {
+	return []string{
+		SuggesterFuzzyMatchingNone,
+		SuggesterFuzzyMatchingLow,
+		SuggesterFuzzyMatchingHigh,
+	}
+}
+
 // The minimum required TLS version.
 const (
 	// TLSSecurityPolicyPolicyMinTls10201907 is a TLSSecurityPolicy enum value
@@ -6846,3 +6947,11 @@ const (
 	// TLSSecurityPolicyPolicyMinTls12201907 is a TLSSecurityPolicy enum value
 	TLSSecurityPolicyPolicyMinTls12201907 = "Policy-Min-TLS-1-2-2019-07"
 )
+
+// TLSSecurityPolicy_Values returns all elements of the TLSSecurityPolicy enum
+func TLSSecurityPolicy_Values() []string {
+	return []string{
+		TLSSecurityPolicyPolicyMinTls10201907,
+		TLSSecurityPolicyPolicyMinTls12201907,
+	}
+}

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -1551,6 +1551,14 @@ const (
 	ContentTypeApplicationXml = "application/xml"
 )
 
+// ContentType_Values returns all elements of the ContentType enum
+func ContentType_Values() []string {
+	return []string{
+		ContentTypeApplicationJson,
+		ContentTypeApplicationXml,
+	}
+}
+
 const (
 	// QueryParserSimple is a QueryParser enum value
 	QueryParserSimple = "simple"
@@ -1564,3 +1572,13 @@ const (
 	// QueryParserDismax is a QueryParser enum value
 	QueryParserDismax = "dismax"
 )
+
+// QueryParser_Values returns all elements of the QueryParser enum
+func QueryParser_Values() []string {
+	return []string{
+		QueryParserSimple,
+		QueryParserStructured,
+		QueryParserLucene,
+		QueryParserDismax,
+	}
+}

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -7845,10 +7845,24 @@ const (
 	EventCategoryInsight = "insight"
 )
 
+// EventCategory_Values returns all elements of the EventCategory enum
+func EventCategory_Values() []string {
+	return []string{
+		EventCategoryInsight,
+	}
+}
+
 const (
 	// InsightTypeApiCallRateInsight is a InsightType enum value
 	InsightTypeApiCallRateInsight = "ApiCallRateInsight"
 )
+
+// InsightType_Values returns all elements of the InsightType enum
+func InsightType_Values() []string {
+	return []string{
+		InsightTypeApiCallRateInsight,
+	}
+}
 
 const (
 	// LookupAttributeKeyEventId is a LookupAttributeKey enum value
@@ -7876,6 +7890,20 @@ const (
 	LookupAttributeKeyAccessKeyId = "AccessKeyId"
 )
 
+// LookupAttributeKey_Values returns all elements of the LookupAttributeKey enum
+func LookupAttributeKey_Values() []string {
+	return []string{
+		LookupAttributeKeyEventId,
+		LookupAttributeKeyEventName,
+		LookupAttributeKeyReadOnly,
+		LookupAttributeKeyUsername,
+		LookupAttributeKeyResourceType,
+		LookupAttributeKeyResourceName,
+		LookupAttributeKeyEventSource,
+		LookupAttributeKeyAccessKeyId,
+	}
+}
+
 const (
 	// ReadWriteTypeReadOnly is a ReadWriteType enum value
 	ReadWriteTypeReadOnly = "ReadOnly"
@@ -7886,3 +7914,12 @@ const (
 	// ReadWriteTypeAll is a ReadWriteType enum value
 	ReadWriteTypeAll = "All"
 )
+
+// ReadWriteType_Values returns all elements of the ReadWriteType enum
+func ReadWriteType_Values() []string {
+	return []string{
+		ReadWriteTypeReadOnly,
+		ReadWriteTypeWriteOnly,
+		ReadWriteTypeAll,
+	}
+}

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -8908,6 +8908,14 @@ const (
 	AlarmTypeMetricAlarm = "MetricAlarm"
 )
 
+// AlarmType_Values returns all elements of the AlarmType enum
+func AlarmType_Values() []string {
+	return []string{
+		AlarmTypeCompositeAlarm,
+		AlarmTypeMetricAlarm,
+	}
+}
+
 const (
 	// AnomalyDetectorStateValuePendingTraining is a AnomalyDetectorStateValue enum value
 	AnomalyDetectorStateValuePendingTraining = "PENDING_TRAINING"
@@ -8918,6 +8926,15 @@ const (
 	// AnomalyDetectorStateValueTrained is a AnomalyDetectorStateValue enum value
 	AnomalyDetectorStateValueTrained = "TRAINED"
 )
+
+// AnomalyDetectorStateValue_Values returns all elements of the AnomalyDetectorStateValue enum
+func AnomalyDetectorStateValue_Values() []string {
+	return []string{
+		AnomalyDetectorStateValuePendingTraining,
+		AnomalyDetectorStateValueTrainedInsufficientData,
+		AnomalyDetectorStateValueTrained,
+	}
+}
 
 const (
 	// ComparisonOperatorGreaterThanOrEqualToThreshold is a ComparisonOperator enum value
@@ -8942,6 +8959,19 @@ const (
 	ComparisonOperatorGreaterThanUpperThreshold = "GreaterThanUpperThreshold"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorGreaterThanOrEqualToThreshold,
+		ComparisonOperatorGreaterThanThreshold,
+		ComparisonOperatorLessThanThreshold,
+		ComparisonOperatorLessThanOrEqualToThreshold,
+		ComparisonOperatorLessThanLowerOrGreaterThanUpperThreshold,
+		ComparisonOperatorLessThanLowerThreshold,
+		ComparisonOperatorGreaterThanUpperThreshold,
+	}
+}
+
 const (
 	// HistoryItemTypeConfigurationUpdate is a HistoryItemType enum value
 	HistoryItemTypeConfigurationUpdate = "ConfigurationUpdate"
@@ -8953,10 +8983,26 @@ const (
 	HistoryItemTypeAction = "Action"
 )
 
+// HistoryItemType_Values returns all elements of the HistoryItemType enum
+func HistoryItemType_Values() []string {
+	return []string{
+		HistoryItemTypeConfigurationUpdate,
+		HistoryItemTypeStateUpdate,
+		HistoryItemTypeAction,
+	}
+}
+
 const (
 	// RecentlyActivePt3h is a RecentlyActive enum value
 	RecentlyActivePt3h = "PT3H"
 )
+
+// RecentlyActive_Values returns all elements of the RecentlyActive enum
+func RecentlyActive_Values() []string {
+	return []string{
+		RecentlyActivePt3h,
+	}
+}
 
 const (
 	// ScanByTimestampDescending is a ScanBy enum value
@@ -8965,6 +9011,14 @@ const (
 	// ScanByTimestampAscending is a ScanBy enum value
 	ScanByTimestampAscending = "TimestampAscending"
 )
+
+// ScanBy_Values returns all elements of the ScanBy enum
+func ScanBy_Values() []string {
+	return []string{
+		ScanByTimestampDescending,
+		ScanByTimestampAscending,
+	}
+}
 
 const (
 	// StandardUnitSeconds is a StandardUnit enum value
@@ -9049,6 +9103,39 @@ const (
 	StandardUnitNone = "None"
 )
 
+// StandardUnit_Values returns all elements of the StandardUnit enum
+func StandardUnit_Values() []string {
+	return []string{
+		StandardUnitSeconds,
+		StandardUnitMicroseconds,
+		StandardUnitMilliseconds,
+		StandardUnitBytes,
+		StandardUnitKilobytes,
+		StandardUnitMegabytes,
+		StandardUnitGigabytes,
+		StandardUnitTerabytes,
+		StandardUnitBits,
+		StandardUnitKilobits,
+		StandardUnitMegabits,
+		StandardUnitGigabits,
+		StandardUnitTerabits,
+		StandardUnitPercent,
+		StandardUnitCount,
+		StandardUnitBytesSecond,
+		StandardUnitKilobytesSecond,
+		StandardUnitMegabytesSecond,
+		StandardUnitGigabytesSecond,
+		StandardUnitTerabytesSecond,
+		StandardUnitBitsSecond,
+		StandardUnitKilobitsSecond,
+		StandardUnitMegabitsSecond,
+		StandardUnitGigabitsSecond,
+		StandardUnitTerabitsSecond,
+		StandardUnitCountSecond,
+		StandardUnitNone,
+	}
+}
+
 const (
 	// StateValueOk is a StateValue enum value
 	StateValueOk = "OK"
@@ -9059,6 +9146,15 @@ const (
 	// StateValueInsufficientData is a StateValue enum value
 	StateValueInsufficientData = "INSUFFICIENT_DATA"
 )
+
+// StateValue_Values returns all elements of the StateValue enum
+func StateValue_Values() []string {
+	return []string{
+		StateValueOk,
+		StateValueAlarm,
+		StateValueInsufficientData,
+	}
+}
 
 const (
 	// StatisticSampleCount is a Statistic enum value
@@ -9077,6 +9173,17 @@ const (
 	StatisticMaximum = "Maximum"
 )
 
+// Statistic_Values returns all elements of the Statistic enum
+func Statistic_Values() []string {
+	return []string{
+		StatisticSampleCount,
+		StatisticAverage,
+		StatisticSum,
+		StatisticMinimum,
+		StatisticMaximum,
+	}
+}
+
 const (
 	// StatusCodeComplete is a StatusCode enum value
 	StatusCodeComplete = "Complete"
@@ -9087,3 +9194,12 @@ const (
 	// StatusCodePartialData is a StatusCode enum value
 	StatusCodePartialData = "PartialData"
 )
+
+// StatusCode_Values returns all elements of the StatusCode enum
+func StatusCode_Values() []string {
+	return []string{
+		StatusCodeComplete,
+		StatusCodeInternalError,
+		StatusCodePartialData,
+	}
+}

--- a/service/cloudwatchevents/api.go
+++ b/service/cloudwatchevents/api.go
@@ -8084,6 +8084,14 @@ const (
 	AssignPublicIpDisabled = "DISABLED"
 )
 
+// AssignPublicIp_Values returns all elements of the AssignPublicIp enum
+func AssignPublicIp_Values() []string {
+	return []string{
+		AssignPublicIpEnabled,
+		AssignPublicIpDisabled,
+	}
+}
+
 const (
 	// EventSourceStatePending is a EventSourceState enum value
 	EventSourceStatePending = "PENDING"
@@ -8095,6 +8103,15 @@ const (
 	EventSourceStateDeleted = "DELETED"
 )
 
+// EventSourceState_Values returns all elements of the EventSourceState enum
+func EventSourceState_Values() []string {
+	return []string{
+		EventSourceStatePending,
+		EventSourceStateActive,
+		EventSourceStateDeleted,
+	}
+}
+
 const (
 	// LaunchTypeEc2 is a LaunchType enum value
 	LaunchTypeEc2 = "EC2"
@@ -8103,6 +8120,14 @@ const (
 	LaunchTypeFargate = "FARGATE"
 )
 
+// LaunchType_Values returns all elements of the LaunchType enum
+func LaunchType_Values() []string {
+	return []string{
+		LaunchTypeEc2,
+		LaunchTypeFargate,
+	}
+}
+
 const (
 	// RuleStateEnabled is a RuleState enum value
 	RuleStateEnabled = "ENABLED"
@@ -8110,3 +8135,11 @@ const (
 	// RuleStateDisabled is a RuleState enum value
 	RuleStateDisabled = "DISABLED"
 )
+
+// RuleState_Values returns all elements of the RuleState enum
+func RuleState_Values() []string {
+	return []string{
+		RuleStateEnabled,
+		RuleStateDisabled,
+	}
+}

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -10023,6 +10023,14 @@ const (
 	DistributionByLogStream = "ByLogStream"
 )
 
+// Distribution_Values returns all elements of the Distribution enum
+func Distribution_Values() []string {
+	return []string{
+		DistributionRandom,
+		DistributionByLogStream,
+	}
+}
+
 const (
 	// ExportTaskStatusCodeCancelled is a ExportTaskStatusCode enum value
 	ExportTaskStatusCodeCancelled = "CANCELLED"
@@ -10043,6 +10051,18 @@ const (
 	ExportTaskStatusCodeRunning = "RUNNING"
 )
 
+// ExportTaskStatusCode_Values returns all elements of the ExportTaskStatusCode enum
+func ExportTaskStatusCode_Values() []string {
+	return []string{
+		ExportTaskStatusCodeCancelled,
+		ExportTaskStatusCodeCompleted,
+		ExportTaskStatusCodeFailed,
+		ExportTaskStatusCodePending,
+		ExportTaskStatusCodePendingCancel,
+		ExportTaskStatusCodeRunning,
+	}
+}
+
 const (
 	// OrderByLogStreamName is a OrderBy enum value
 	OrderByLogStreamName = "LogStreamName"
@@ -10050,6 +10070,14 @@ const (
 	// OrderByLastEventTime is a OrderBy enum value
 	OrderByLastEventTime = "LastEventTime"
 )
+
+// OrderBy_Values returns all elements of the OrderBy enum
+func OrderBy_Values() []string {
+	return []string{
+		OrderByLogStreamName,
+		OrderByLastEventTime,
+	}
+}
 
 const (
 	// QueryStatusScheduled is a QueryStatus enum value
@@ -10067,3 +10095,14 @@ const (
 	// QueryStatusCancelled is a QueryStatus enum value
 	QueryStatusCancelled = "Cancelled"
 )
+
+// QueryStatus_Values returns all elements of the QueryStatus enum
+func QueryStatus_Values() []string {
+	return []string{
+		QueryStatusScheduled,
+		QueryStatusRunning,
+		QueryStatusComplete,
+		QueryStatusFailed,
+		QueryStatusCancelled,
+	}
+}

--- a/service/codeartifact/api.go
+++ b/service/codeartifact/api.go
@@ -9390,10 +9390,25 @@ const (
 	DomainStatusDeleted = "Deleted"
 )
 
+// DomainStatus_Values returns all elements of the DomainStatus enum
+func DomainStatus_Values() []string {
+	return []string{
+		DomainStatusActive,
+		DomainStatusDeleted,
+	}
+}
+
 const (
 	// ExternalConnectionStatusAvailable is a ExternalConnectionStatus enum value
 	ExternalConnectionStatusAvailable = "Available"
 )
+
+// ExternalConnectionStatus_Values returns all elements of the ExternalConnectionStatus enum
+func ExternalConnectionStatus_Values() []string {
+	return []string{
+		ExternalConnectionStatusAvailable,
+	}
+}
 
 const (
 	// HashAlgorithmMd5 is a HashAlgorithm enum value
@@ -9409,6 +9424,16 @@ const (
 	HashAlgorithmSha512 = "SHA-512"
 )
 
+// HashAlgorithm_Values returns all elements of the HashAlgorithm enum
+func HashAlgorithm_Values() []string {
+	return []string{
+		HashAlgorithmMd5,
+		HashAlgorithmSha1,
+		HashAlgorithmSha256,
+		HashAlgorithmSha512,
+	}
+}
+
 const (
 	// PackageFormatNpm is a PackageFormat enum value
 	PackageFormatNpm = "npm"
@@ -9419,6 +9444,15 @@ const (
 	// PackageFormatMaven is a PackageFormat enum value
 	PackageFormatMaven = "maven"
 )
+
+// PackageFormat_Values returns all elements of the PackageFormat enum
+func PackageFormat_Values() []string {
+	return []string{
+		PackageFormatNpm,
+		PackageFormatPypi,
+		PackageFormatMaven,
+	}
+}
 
 const (
 	// PackageVersionErrorCodeAlreadyExists is a PackageVersionErrorCode enum value
@@ -9440,10 +9474,29 @@ const (
 	PackageVersionErrorCodeSkipped = "SKIPPED"
 )
 
+// PackageVersionErrorCode_Values returns all elements of the PackageVersionErrorCode enum
+func PackageVersionErrorCode_Values() []string {
+	return []string{
+		PackageVersionErrorCodeAlreadyExists,
+		PackageVersionErrorCodeMismatchedRevision,
+		PackageVersionErrorCodeMismatchedStatus,
+		PackageVersionErrorCodeNotAllowed,
+		PackageVersionErrorCodeNotFound,
+		PackageVersionErrorCodeSkipped,
+	}
+}
+
 const (
 	// PackageVersionSortTypePublishedTime is a PackageVersionSortType enum value
 	PackageVersionSortTypePublishedTime = "PUBLISHED_TIME"
 )
+
+// PackageVersionSortType_Values returns all elements of the PackageVersionSortType enum
+func PackageVersionSortType_Values() []string {
+	return []string{
+		PackageVersionSortTypePublishedTime,
+	}
+}
 
 const (
 	// PackageVersionStatusPublished is a PackageVersionStatus enum value
@@ -9465,6 +9518,18 @@ const (
 	PackageVersionStatusDeleted = "Deleted"
 )
 
+// PackageVersionStatus_Values returns all elements of the PackageVersionStatus enum
+func PackageVersionStatus_Values() []string {
+	return []string{
+		PackageVersionStatusPublished,
+		PackageVersionStatusUnfinished,
+		PackageVersionStatusUnlisted,
+		PackageVersionStatusArchived,
+		PackageVersionStatusDisposed,
+		PackageVersionStatusDeleted,
+	}
+}
+
 const (
 	// ResourceTypeDomain is a ResourceType enum value
 	ResourceTypeDomain = "domain"
@@ -9482,6 +9547,17 @@ const (
 	ResourceTypeAsset = "asset"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeDomain,
+		ResourceTypeRepository,
+		ResourceTypePackage,
+		ResourceTypePackageVersion,
+		ResourceTypeAsset,
+	}
+}
+
 const (
 	// ValidationExceptionReasonCannotParse is a ValidationExceptionReason enum value
 	ValidationExceptionReasonCannotParse = "CANNOT_PARSE"
@@ -9498,3 +9574,14 @@ const (
 	// ValidationExceptionReasonOther is a ValidationExceptionReason enum value
 	ValidationExceptionReasonOther = "OTHER"
 )
+
+// ValidationExceptionReason_Values returns all elements of the ValidationExceptionReason enum
+func ValidationExceptionReason_Values() []string {
+	return []string{
+		ValidationExceptionReasonCannotParse,
+		ValidationExceptionReasonEncryptionKeyError,
+		ValidationExceptionReasonFieldValidationFailed,
+		ValidationExceptionReasonUnknownOperation,
+		ValidationExceptionReasonOther,
+	}
+}

--- a/service/codebuild/api.go
+++ b/service/codebuild/api.go
@@ -14125,6 +14125,14 @@ const (
 	ArtifactNamespaceBuildId = "BUILD_ID"
 )
 
+// ArtifactNamespace_Values returns all elements of the ArtifactNamespace enum
+func ArtifactNamespace_Values() []string {
+	return []string{
+		ArtifactNamespaceNone,
+		ArtifactNamespaceBuildId,
+	}
+}
+
 const (
 	// ArtifactPackagingNone is a ArtifactPackaging enum value
 	ArtifactPackagingNone = "NONE"
@@ -14132,6 +14140,14 @@ const (
 	// ArtifactPackagingZip is a ArtifactPackaging enum value
 	ArtifactPackagingZip = "ZIP"
 )
+
+// ArtifactPackaging_Values returns all elements of the ArtifactPackaging enum
+func ArtifactPackaging_Values() []string {
+	return []string{
+		ArtifactPackagingNone,
+		ArtifactPackagingZip,
+	}
+}
 
 const (
 	// ArtifactsTypeCodepipeline is a ArtifactsType enum value
@@ -14144,6 +14160,15 @@ const (
 	ArtifactsTypeNoArtifacts = "NO_ARTIFACTS"
 )
 
+// ArtifactsType_Values returns all elements of the ArtifactsType enum
+func ArtifactsType_Values() []string {
+	return []string{
+		ArtifactsTypeCodepipeline,
+		ArtifactsTypeS3,
+		ArtifactsTypeNoArtifacts,
+	}
+}
+
 const (
 	// AuthTypeOauth is a AuthType enum value
 	AuthTypeOauth = "OAUTH"
@@ -14154,6 +14179,15 @@ const (
 	// AuthTypePersonalAccessToken is a AuthType enum value
 	AuthTypePersonalAccessToken = "PERSONAL_ACCESS_TOKEN"
 )
+
+// AuthType_Values returns all elements of the AuthType enum
+func AuthType_Values() []string {
+	return []string{
+		AuthTypeOauth,
+		AuthTypeBasicAuth,
+		AuthTypePersonalAccessToken,
+	}
+}
 
 const (
 	// BuildBatchPhaseTypeSubmitted is a BuildBatchPhaseType enum value
@@ -14177,6 +14211,19 @@ const (
 	// BuildBatchPhaseTypeStopped is a BuildBatchPhaseType enum value
 	BuildBatchPhaseTypeStopped = "STOPPED"
 )
+
+// BuildBatchPhaseType_Values returns all elements of the BuildBatchPhaseType enum
+func BuildBatchPhaseType_Values() []string {
+	return []string{
+		BuildBatchPhaseTypeSubmitted,
+		BuildBatchPhaseTypeDownloadBatchspec,
+		BuildBatchPhaseTypeInProgress,
+		BuildBatchPhaseTypeCombineArtifacts,
+		BuildBatchPhaseTypeSucceeded,
+		BuildBatchPhaseTypeFailed,
+		BuildBatchPhaseTypeStopped,
+	}
+}
 
 const (
 	// BuildPhaseTypeSubmitted is a BuildPhaseType enum value
@@ -14213,6 +14260,23 @@ const (
 	BuildPhaseTypeCompleted = "COMPLETED"
 )
 
+// BuildPhaseType_Values returns all elements of the BuildPhaseType enum
+func BuildPhaseType_Values() []string {
+	return []string{
+		BuildPhaseTypeSubmitted,
+		BuildPhaseTypeQueued,
+		BuildPhaseTypeProvisioning,
+		BuildPhaseTypeDownloadSource,
+		BuildPhaseTypeInstall,
+		BuildPhaseTypePreBuild,
+		BuildPhaseTypeBuild,
+		BuildPhaseTypePostBuild,
+		BuildPhaseTypeUploadArtifacts,
+		BuildPhaseTypeFinalizing,
+		BuildPhaseTypeCompleted,
+	}
+}
+
 const (
 	// CacheModeLocalDockerLayerCache is a CacheMode enum value
 	CacheModeLocalDockerLayerCache = "LOCAL_DOCKER_LAYER_CACHE"
@@ -14224,6 +14288,15 @@ const (
 	CacheModeLocalCustomCache = "LOCAL_CUSTOM_CACHE"
 )
 
+// CacheMode_Values returns all elements of the CacheMode enum
+func CacheMode_Values() []string {
+	return []string{
+		CacheModeLocalDockerLayerCache,
+		CacheModeLocalSourceCache,
+		CacheModeLocalCustomCache,
+	}
+}
+
 const (
 	// CacheTypeNoCache is a CacheType enum value
 	CacheTypeNoCache = "NO_CACHE"
@@ -14234,6 +14307,15 @@ const (
 	// CacheTypeLocal is a CacheType enum value
 	CacheTypeLocal = "LOCAL"
 )
+
+// CacheType_Values returns all elements of the CacheType enum
+func CacheType_Values() []string {
+	return []string{
+		CacheTypeNoCache,
+		CacheTypeS3,
+		CacheTypeLocal,
+	}
+}
 
 const (
 	// ComputeTypeBuildGeneral1Small is a ComputeType enum value
@@ -14249,10 +14331,27 @@ const (
 	ComputeTypeBuildGeneral12xlarge = "BUILD_GENERAL1_2XLARGE"
 )
 
+// ComputeType_Values returns all elements of the ComputeType enum
+func ComputeType_Values() []string {
+	return []string{
+		ComputeTypeBuildGeneral1Small,
+		ComputeTypeBuildGeneral1Medium,
+		ComputeTypeBuildGeneral1Large,
+		ComputeTypeBuildGeneral12xlarge,
+	}
+}
+
 const (
 	// CredentialProviderTypeSecretsManager is a CredentialProviderType enum value
 	CredentialProviderTypeSecretsManager = "SECRETS_MANAGER"
 )
+
+// CredentialProviderType_Values returns all elements of the CredentialProviderType enum
+func CredentialProviderType_Values() []string {
+	return []string{
+		CredentialProviderTypeSecretsManager,
+	}
+}
 
 const (
 	// EnvironmentTypeWindowsContainer is a EnvironmentType enum value
@@ -14271,6 +14370,17 @@ const (
 	EnvironmentTypeWindowsServer2019Container = "WINDOWS_SERVER_2019_CONTAINER"
 )
 
+// EnvironmentType_Values returns all elements of the EnvironmentType enum
+func EnvironmentType_Values() []string {
+	return []string{
+		EnvironmentTypeWindowsContainer,
+		EnvironmentTypeLinuxContainer,
+		EnvironmentTypeLinuxGpuContainer,
+		EnvironmentTypeArmContainer,
+		EnvironmentTypeWindowsServer2019Container,
+	}
+}
+
 const (
 	// EnvironmentVariableTypePlaintext is a EnvironmentVariableType enum value
 	EnvironmentVariableTypePlaintext = "PLAINTEXT"
@@ -14282,10 +14392,26 @@ const (
 	EnvironmentVariableTypeSecretsManager = "SECRETS_MANAGER"
 )
 
+// EnvironmentVariableType_Values returns all elements of the EnvironmentVariableType enum
+func EnvironmentVariableType_Values() []string {
+	return []string{
+		EnvironmentVariableTypePlaintext,
+		EnvironmentVariableTypeParameterStore,
+		EnvironmentVariableTypeSecretsManager,
+	}
+}
+
 const (
 	// FileSystemTypeEfs is a FileSystemType enum value
 	FileSystemTypeEfs = "EFS"
 )
+
+// FileSystemType_Values returns all elements of the FileSystemType enum
+func FileSystemType_Values() []string {
+	return []string{
+		FileSystemTypeEfs,
+	}
+}
 
 const (
 	// ImagePullCredentialsTypeCodebuild is a ImagePullCredentialsType enum value
@@ -14294,6 +14420,14 @@ const (
 	// ImagePullCredentialsTypeServiceRole is a ImagePullCredentialsType enum value
 	ImagePullCredentialsTypeServiceRole = "SERVICE_ROLE"
 )
+
+// ImagePullCredentialsType_Values returns all elements of the ImagePullCredentialsType enum
+func ImagePullCredentialsType_Values() []string {
+	return []string{
+		ImagePullCredentialsTypeCodebuild,
+		ImagePullCredentialsTypeServiceRole,
+	}
+}
 
 const (
 	// LanguageTypeJava is a LanguageType enum value
@@ -14327,6 +14461,22 @@ const (
 	LanguageTypePhp = "PHP"
 )
 
+// LanguageType_Values returns all elements of the LanguageType enum
+func LanguageType_Values() []string {
+	return []string{
+		LanguageTypeJava,
+		LanguageTypePython,
+		LanguageTypeNodeJs,
+		LanguageTypeRuby,
+		LanguageTypeGolang,
+		LanguageTypeDocker,
+		LanguageTypeAndroid,
+		LanguageTypeDotnet,
+		LanguageTypeBase,
+		LanguageTypePhp,
+	}
+}
+
 const (
 	// LogsConfigStatusTypeEnabled is a LogsConfigStatusType enum value
 	LogsConfigStatusTypeEnabled = "ENABLED"
@@ -14334,6 +14484,14 @@ const (
 	// LogsConfigStatusTypeDisabled is a LogsConfigStatusType enum value
 	LogsConfigStatusTypeDisabled = "DISABLED"
 )
+
+// LogsConfigStatusType_Values returns all elements of the LogsConfigStatusType enum
+func LogsConfigStatusType_Values() []string {
+	return []string{
+		LogsConfigStatusTypeEnabled,
+		LogsConfigStatusTypeDisabled,
+	}
+}
 
 const (
 	// PlatformTypeDebian is a PlatformType enum value
@@ -14349,6 +14507,16 @@ const (
 	PlatformTypeWindowsServer = "WINDOWS_SERVER"
 )
 
+// PlatformType_Values returns all elements of the PlatformType enum
+func PlatformType_Values() []string {
+	return []string{
+		PlatformTypeDebian,
+		PlatformTypeAmazonLinux,
+		PlatformTypeUbuntu,
+		PlatformTypeWindowsServer,
+	}
+}
+
 const (
 	// ProjectSortByTypeName is a ProjectSortByType enum value
 	ProjectSortByTypeName = "NAME"
@@ -14360,6 +14528,15 @@ const (
 	ProjectSortByTypeLastModifiedTime = "LAST_MODIFIED_TIME"
 )
 
+// ProjectSortByType_Values returns all elements of the ProjectSortByType enum
+func ProjectSortByType_Values() []string {
+	return []string{
+		ProjectSortByTypeName,
+		ProjectSortByTypeCreatedTime,
+		ProjectSortByTypeLastModifiedTime,
+	}
+}
+
 const (
 	// ReportCodeCoverageSortByTypeLineCoveragePercentage is a ReportCodeCoverageSortByType enum value
 	ReportCodeCoverageSortByTypeLineCoveragePercentage = "LINE_COVERAGE_PERCENTAGE"
@@ -14368,6 +14545,14 @@ const (
 	ReportCodeCoverageSortByTypeFilePath = "FILE_PATH"
 )
 
+// ReportCodeCoverageSortByType_Values returns all elements of the ReportCodeCoverageSortByType enum
+func ReportCodeCoverageSortByType_Values() []string {
+	return []string{
+		ReportCodeCoverageSortByTypeLineCoveragePercentage,
+		ReportCodeCoverageSortByTypeFilePath,
+	}
+}
+
 const (
 	// ReportExportConfigTypeS3 is a ReportExportConfigType enum value
 	ReportExportConfigTypeS3 = "S3"
@@ -14375,6 +14560,14 @@ const (
 	// ReportExportConfigTypeNoExport is a ReportExportConfigType enum value
 	ReportExportConfigTypeNoExport = "NO_EXPORT"
 )
+
+// ReportExportConfigType_Values returns all elements of the ReportExportConfigType enum
+func ReportExportConfigType_Values() []string {
+	return []string{
+		ReportExportConfigTypeS3,
+		ReportExportConfigTypeNoExport,
+	}
+}
 
 const (
 	// ReportGroupSortByTypeName is a ReportGroupSortByType enum value
@@ -14387,6 +14580,15 @@ const (
 	ReportGroupSortByTypeLastModifiedTime = "LAST_MODIFIED_TIME"
 )
 
+// ReportGroupSortByType_Values returns all elements of the ReportGroupSortByType enum
+func ReportGroupSortByType_Values() []string {
+	return []string{
+		ReportGroupSortByTypeName,
+		ReportGroupSortByTypeCreatedTime,
+		ReportGroupSortByTypeLastModifiedTime,
+	}
+}
+
 const (
 	// ReportPackagingTypeZip is a ReportPackagingType enum value
 	ReportPackagingTypeZip = "ZIP"
@@ -14394,6 +14596,14 @@ const (
 	// ReportPackagingTypeNone is a ReportPackagingType enum value
 	ReportPackagingTypeNone = "NONE"
 )
+
+// ReportPackagingType_Values returns all elements of the ReportPackagingType enum
+func ReportPackagingType_Values() []string {
+	return []string{
+		ReportPackagingTypeZip,
+		ReportPackagingTypeNone,
+	}
+}
 
 const (
 	// ReportStatusTypeGenerating is a ReportStatusType enum value
@@ -14412,6 +14622,17 @@ const (
 	ReportStatusTypeDeleting = "DELETING"
 )
 
+// ReportStatusType_Values returns all elements of the ReportStatusType enum
+func ReportStatusType_Values() []string {
+	return []string{
+		ReportStatusTypeGenerating,
+		ReportStatusTypeSucceeded,
+		ReportStatusTypeFailed,
+		ReportStatusTypeIncomplete,
+		ReportStatusTypeDeleting,
+	}
+}
+
 const (
 	// ReportTypeTest is a ReportType enum value
 	ReportTypeTest = "TEST"
@@ -14420,6 +14641,14 @@ const (
 	ReportTypeCodeCoverage = "CODE_COVERAGE"
 )
 
+// ReportType_Values returns all elements of the ReportType enum
+func ReportType_Values() []string {
+	return []string{
+		ReportTypeTest,
+		ReportTypeCodeCoverage,
+	}
+}
+
 const (
 	// RetryBuildBatchTypeRetryAllBuilds is a RetryBuildBatchType enum value
 	RetryBuildBatchTypeRetryAllBuilds = "RETRY_ALL_BUILDS"
@@ -14427,6 +14656,14 @@ const (
 	// RetryBuildBatchTypeRetryFailedBuilds is a RetryBuildBatchType enum value
 	RetryBuildBatchTypeRetryFailedBuilds = "RETRY_FAILED_BUILDS"
 )
+
+// RetryBuildBatchType_Values returns all elements of the RetryBuildBatchType enum
+func RetryBuildBatchType_Values() []string {
+	return []string{
+		RetryBuildBatchTypeRetryAllBuilds,
+		RetryBuildBatchTypeRetryFailedBuilds,
+	}
+}
 
 const (
 	// ServerTypeGithub is a ServerType enum value
@@ -14439,6 +14676,15 @@ const (
 	ServerTypeGithubEnterprise = "GITHUB_ENTERPRISE"
 )
 
+// ServerType_Values returns all elements of the ServerType enum
+func ServerType_Values() []string {
+	return []string{
+		ServerTypeGithub,
+		ServerTypeBitbucket,
+		ServerTypeGithubEnterprise,
+	}
+}
+
 const (
 	// SharedResourceSortByTypeArn is a SharedResourceSortByType enum value
 	SharedResourceSortByTypeArn = "ARN"
@@ -14446,6 +14692,14 @@ const (
 	// SharedResourceSortByTypeModifiedTime is a SharedResourceSortByType enum value
 	SharedResourceSortByTypeModifiedTime = "MODIFIED_TIME"
 )
+
+// SharedResourceSortByType_Values returns all elements of the SharedResourceSortByType enum
+func SharedResourceSortByType_Values() []string {
+	return []string{
+		SharedResourceSortByTypeArn,
+		SharedResourceSortByTypeModifiedTime,
+	}
+}
 
 const (
 	// SortOrderTypeAscending is a SortOrderType enum value
@@ -14455,10 +14709,25 @@ const (
 	SortOrderTypeDescending = "DESCENDING"
 )
 
+// SortOrderType_Values returns all elements of the SortOrderType enum
+func SortOrderType_Values() []string {
+	return []string{
+		SortOrderTypeAscending,
+		SortOrderTypeDescending,
+	}
+}
+
 const (
 	// SourceAuthTypeOauth is a SourceAuthType enum value
 	SourceAuthTypeOauth = "OAUTH"
 )
+
+// SourceAuthType_Values returns all elements of the SourceAuthType enum
+func SourceAuthType_Values() []string {
+	return []string{
+		SourceAuthTypeOauth,
+	}
+}
 
 const (
 	// SourceTypeCodecommit is a SourceType enum value
@@ -14483,6 +14752,19 @@ const (
 	SourceTypeNoSource = "NO_SOURCE"
 )
 
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeCodecommit,
+		SourceTypeCodepipeline,
+		SourceTypeGithub,
+		SourceTypeS3,
+		SourceTypeBitbucket,
+		SourceTypeGithubEnterprise,
+		SourceTypeNoSource,
+	}
+}
+
 const (
 	// StatusTypeSucceeded is a StatusType enum value
 	StatusTypeSucceeded = "SUCCEEDED"
@@ -14503,6 +14785,18 @@ const (
 	StatusTypeStopped = "STOPPED"
 )
 
+// StatusType_Values returns all elements of the StatusType enum
+func StatusType_Values() []string {
+	return []string{
+		StatusTypeSucceeded,
+		StatusTypeFailed,
+		StatusTypeFault,
+		StatusTypeTimedOut,
+		StatusTypeInProgress,
+		StatusTypeStopped,
+	}
+}
+
 const (
 	// WebhookBuildTypeBuild is a WebhookBuildType enum value
 	WebhookBuildTypeBuild = "BUILD"
@@ -14510,6 +14804,14 @@ const (
 	// WebhookBuildTypeBuildBatch is a WebhookBuildType enum value
 	WebhookBuildTypeBuildBatch = "BUILD_BATCH"
 )
+
+// WebhookBuildType_Values returns all elements of the WebhookBuildType enum
+func WebhookBuildType_Values() []string {
+	return []string{
+		WebhookBuildTypeBuild,
+		WebhookBuildTypeBuildBatch,
+	}
+}
 
 const (
 	// WebhookFilterTypeEvent is a WebhookFilterType enum value
@@ -14530,3 +14832,15 @@ const (
 	// WebhookFilterTypeCommitMessage is a WebhookFilterType enum value
 	WebhookFilterTypeCommitMessage = "COMMIT_MESSAGE"
 )
+
+// WebhookFilterType_Values returns all elements of the WebhookFilterType enum
+func WebhookFilterType_Values() []string {
+	return []string{
+		WebhookFilterTypeEvent,
+		WebhookFilterTypeBaseRef,
+		WebhookFilterTypeHeadRef,
+		WebhookFilterTypeActorAccountId,
+		WebhookFilterTypeFilePath,
+		WebhookFilterTypeCommitMessage,
+	}
+}

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -32781,6 +32781,14 @@ const (
 	ApprovalStateRevoke = "REVOKE"
 )
 
+// ApprovalState_Values returns all elements of the ApprovalState enum
+func ApprovalState_Values() []string {
+	return []string{
+		ApprovalStateApprove,
+		ApprovalStateRevoke,
+	}
+}
+
 const (
 	// ChangeTypeEnumA is a ChangeTypeEnum enum value
 	ChangeTypeEnumA = "A"
@@ -32792,6 +32800,15 @@ const (
 	ChangeTypeEnumD = "D"
 )
 
+// ChangeTypeEnum_Values returns all elements of the ChangeTypeEnum enum
+func ChangeTypeEnum_Values() []string {
+	return []string{
+		ChangeTypeEnumA,
+		ChangeTypeEnumM,
+		ChangeTypeEnumD,
+	}
+}
+
 const (
 	// ConflictDetailLevelTypeEnumFileLevel is a ConflictDetailLevelTypeEnum enum value
 	ConflictDetailLevelTypeEnumFileLevel = "FILE_LEVEL"
@@ -32799,6 +32816,14 @@ const (
 	// ConflictDetailLevelTypeEnumLineLevel is a ConflictDetailLevelTypeEnum enum value
 	ConflictDetailLevelTypeEnumLineLevel = "LINE_LEVEL"
 )
+
+// ConflictDetailLevelTypeEnum_Values returns all elements of the ConflictDetailLevelTypeEnum enum
+func ConflictDetailLevelTypeEnum_Values() []string {
+	return []string{
+		ConflictDetailLevelTypeEnumFileLevel,
+		ConflictDetailLevelTypeEnumLineLevel,
+	}
+}
 
 const (
 	// ConflictResolutionStrategyTypeEnumNone is a ConflictResolutionStrategyTypeEnum enum value
@@ -32814,6 +32839,16 @@ const (
 	ConflictResolutionStrategyTypeEnumAutomerge = "AUTOMERGE"
 )
 
+// ConflictResolutionStrategyTypeEnum_Values returns all elements of the ConflictResolutionStrategyTypeEnum enum
+func ConflictResolutionStrategyTypeEnum_Values() []string {
+	return []string{
+		ConflictResolutionStrategyTypeEnumNone,
+		ConflictResolutionStrategyTypeEnumAcceptSource,
+		ConflictResolutionStrategyTypeEnumAcceptDestination,
+		ConflictResolutionStrategyTypeEnumAutomerge,
+	}
+}
+
 const (
 	// FileModeTypeEnumExecutable is a FileModeTypeEnum enum value
 	FileModeTypeEnumExecutable = "EXECUTABLE"
@@ -32825,6 +32860,15 @@ const (
 	FileModeTypeEnumSymlink = "SYMLINK"
 )
 
+// FileModeTypeEnum_Values returns all elements of the FileModeTypeEnum enum
+func FileModeTypeEnum_Values() []string {
+	return []string{
+		FileModeTypeEnumExecutable,
+		FileModeTypeEnumNormal,
+		FileModeTypeEnumSymlink,
+	}
+}
+
 const (
 	// MergeOptionTypeEnumFastForwardMerge is a MergeOptionTypeEnum enum value
 	MergeOptionTypeEnumFastForwardMerge = "FAST_FORWARD_MERGE"
@@ -32835,6 +32879,15 @@ const (
 	// MergeOptionTypeEnumThreeWayMerge is a MergeOptionTypeEnum enum value
 	MergeOptionTypeEnumThreeWayMerge = "THREE_WAY_MERGE"
 )
+
+// MergeOptionTypeEnum_Values returns all elements of the MergeOptionTypeEnum enum
+func MergeOptionTypeEnum_Values() []string {
+	return []string{
+		MergeOptionTypeEnumFastForwardMerge,
+		MergeOptionTypeEnumSquashMerge,
+		MergeOptionTypeEnumThreeWayMerge,
+	}
+}
 
 const (
 	// ObjectTypeEnumFile is a ObjectTypeEnum enum value
@@ -32850,6 +32903,16 @@ const (
 	ObjectTypeEnumSymbolicLink = "SYMBOLIC_LINK"
 )
 
+// ObjectTypeEnum_Values returns all elements of the ObjectTypeEnum enum
+func ObjectTypeEnum_Values() []string {
+	return []string{
+		ObjectTypeEnumFile,
+		ObjectTypeEnumDirectory,
+		ObjectTypeEnumGitLink,
+		ObjectTypeEnumSymbolicLink,
+	}
+}
+
 const (
 	// OrderEnumAscending is a OrderEnum enum value
 	OrderEnumAscending = "ascending"
@@ -32858,6 +32921,14 @@ const (
 	OrderEnumDescending = "descending"
 )
 
+// OrderEnum_Values returns all elements of the OrderEnum enum
+func OrderEnum_Values() []string {
+	return []string{
+		OrderEnumAscending,
+		OrderEnumDescending,
+	}
+}
+
 const (
 	// OverrideStatusOverride is a OverrideStatus enum value
 	OverrideStatusOverride = "OVERRIDE"
@@ -32865,6 +32936,14 @@ const (
 	// OverrideStatusRevoke is a OverrideStatus enum value
 	OverrideStatusRevoke = "REVOKE"
 )
+
+// OverrideStatus_Values returns all elements of the OverrideStatus enum
+func OverrideStatus_Values() []string {
+	return []string{
+		OverrideStatusOverride,
+		OverrideStatusRevoke,
+	}
+}
 
 const (
 	// PullRequestEventTypePullRequestCreated is a PullRequestEventType enum value
@@ -32895,6 +32974,21 @@ const (
 	PullRequestEventTypePullRequestApprovalStateChanged = "PULL_REQUEST_APPROVAL_STATE_CHANGED"
 )
 
+// PullRequestEventType_Values returns all elements of the PullRequestEventType enum
+func PullRequestEventType_Values() []string {
+	return []string{
+		PullRequestEventTypePullRequestCreated,
+		PullRequestEventTypePullRequestStatusChanged,
+		PullRequestEventTypePullRequestSourceReferenceUpdated,
+		PullRequestEventTypePullRequestMergeStateChanged,
+		PullRequestEventTypePullRequestApprovalRuleCreated,
+		PullRequestEventTypePullRequestApprovalRuleUpdated,
+		PullRequestEventTypePullRequestApprovalRuleDeleted,
+		PullRequestEventTypePullRequestApprovalRuleOverridden,
+		PullRequestEventTypePullRequestApprovalStateChanged,
+	}
+}
+
 const (
 	// PullRequestStatusEnumOpen is a PullRequestStatusEnum enum value
 	PullRequestStatusEnumOpen = "OPEN"
@@ -32903,6 +32997,14 @@ const (
 	PullRequestStatusEnumClosed = "CLOSED"
 )
 
+// PullRequestStatusEnum_Values returns all elements of the PullRequestStatusEnum enum
+func PullRequestStatusEnum_Values() []string {
+	return []string{
+		PullRequestStatusEnumOpen,
+		PullRequestStatusEnumClosed,
+	}
+}
+
 const (
 	// RelativeFileVersionEnumBefore is a RelativeFileVersionEnum enum value
 	RelativeFileVersionEnumBefore = "BEFORE"
@@ -32910,6 +33012,14 @@ const (
 	// RelativeFileVersionEnumAfter is a RelativeFileVersionEnum enum value
 	RelativeFileVersionEnumAfter = "AFTER"
 )
+
+// RelativeFileVersionEnum_Values returns all elements of the RelativeFileVersionEnum enum
+func RelativeFileVersionEnum_Values() []string {
+	return []string{
+		RelativeFileVersionEnumBefore,
+		RelativeFileVersionEnumAfter,
+	}
+}
 
 const (
 	// ReplacementTypeEnumKeepBase is a ReplacementTypeEnum enum value
@@ -32925,6 +33035,16 @@ const (
 	ReplacementTypeEnumUseNewContent = "USE_NEW_CONTENT"
 )
 
+// ReplacementTypeEnum_Values returns all elements of the ReplacementTypeEnum enum
+func ReplacementTypeEnum_Values() []string {
+	return []string{
+		ReplacementTypeEnumKeepBase,
+		ReplacementTypeEnumKeepSource,
+		ReplacementTypeEnumKeepDestination,
+		ReplacementTypeEnumUseNewContent,
+	}
+}
+
 const (
 	// RepositoryTriggerEventEnumAll is a RepositoryTriggerEventEnum enum value
 	RepositoryTriggerEventEnumAll = "all"
@@ -32939,6 +33059,16 @@ const (
 	RepositoryTriggerEventEnumDeleteReference = "deleteReference"
 )
 
+// RepositoryTriggerEventEnum_Values returns all elements of the RepositoryTriggerEventEnum enum
+func RepositoryTriggerEventEnum_Values() []string {
+	return []string{
+		RepositoryTriggerEventEnumAll,
+		RepositoryTriggerEventEnumUpdateReference,
+		RepositoryTriggerEventEnumCreateReference,
+		RepositoryTriggerEventEnumDeleteReference,
+	}
+}
+
 const (
 	// SortByEnumRepositoryName is a SortByEnum enum value
 	SortByEnumRepositoryName = "repositoryName"
@@ -32946,3 +33076,11 @@ const (
 	// SortByEnumLastModifiedDate is a SortByEnum enum value
 	SortByEnumLastModifiedDate = "lastModifiedDate"
 )
+
+// SortByEnum_Values returns all elements of the SortByEnum enum
+func SortByEnum_Values() []string {
+	return []string{
+		SortByEnumRepositoryName,
+		SortByEnumLastModifiedDate,
+	}
+}

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -18594,6 +18594,15 @@ const (
 	ApplicationRevisionSortByLastUsedTime = "lastUsedTime"
 )
 
+// ApplicationRevisionSortBy_Values returns all elements of the ApplicationRevisionSortBy enum
+func ApplicationRevisionSortBy_Values() []string {
+	return []string{
+		ApplicationRevisionSortByRegisterTime,
+		ApplicationRevisionSortByFirstUsedTime,
+		ApplicationRevisionSortByLastUsedTime,
+	}
+}
+
 const (
 	// AutoRollbackEventDeploymentFailure is a AutoRollbackEvent enum value
 	AutoRollbackEventDeploymentFailure = "DEPLOYMENT_FAILURE"
@@ -18604,6 +18613,15 @@ const (
 	// AutoRollbackEventDeploymentStopOnRequest is a AutoRollbackEvent enum value
 	AutoRollbackEventDeploymentStopOnRequest = "DEPLOYMENT_STOP_ON_REQUEST"
 )
+
+// AutoRollbackEvent_Values returns all elements of the AutoRollbackEvent enum
+func AutoRollbackEvent_Values() []string {
+	return []string{
+		AutoRollbackEventDeploymentFailure,
+		AutoRollbackEventDeploymentStopOnAlarm,
+		AutoRollbackEventDeploymentStopOnRequest,
+	}
+}
 
 const (
 	// BundleTypeTar is a BundleType enum value
@@ -18622,6 +18640,17 @@ const (
 	BundleTypeJson = "JSON"
 )
 
+// BundleType_Values returns all elements of the BundleType enum
+func BundleType_Values() []string {
+	return []string{
+		BundleTypeTar,
+		BundleTypeTgz,
+		BundleTypeZip,
+		BundleTypeYaml,
+		BundleTypeJson,
+	}
+}
+
 const (
 	// ComputePlatformServer is a ComputePlatform enum value
 	ComputePlatformServer = "Server"
@@ -18632,6 +18661,15 @@ const (
 	// ComputePlatformEcs is a ComputePlatform enum value
 	ComputePlatformEcs = "ECS"
 )
+
+// ComputePlatform_Values returns all elements of the ComputePlatform enum
+func ComputePlatform_Values() []string {
+	return []string{
+		ComputePlatformServer,
+		ComputePlatformLambda,
+		ComputePlatformEcs,
+	}
+}
 
 const (
 	// DeploymentCreatorUser is a DeploymentCreator enum value
@@ -18653,6 +18691,18 @@ const (
 	DeploymentCreatorCloudFormationRollback = "CloudFormationRollback"
 )
 
+// DeploymentCreator_Values returns all elements of the DeploymentCreator enum
+func DeploymentCreator_Values() []string {
+	return []string{
+		DeploymentCreatorUser,
+		DeploymentCreatorAutoscaling,
+		DeploymentCreatorCodeDeployRollback,
+		DeploymentCreatorCodeDeploy,
+		DeploymentCreatorCloudFormation,
+		DeploymentCreatorCloudFormationRollback,
+	}
+}
+
 const (
 	// DeploymentOptionWithTrafficControl is a DeploymentOption enum value
 	DeploymentOptionWithTrafficControl = "WITH_TRAFFIC_CONTROL"
@@ -18661,6 +18711,14 @@ const (
 	DeploymentOptionWithoutTrafficControl = "WITHOUT_TRAFFIC_CONTROL"
 )
 
+// DeploymentOption_Values returns all elements of the DeploymentOption enum
+func DeploymentOption_Values() []string {
+	return []string{
+		DeploymentOptionWithTrafficControl,
+		DeploymentOptionWithoutTrafficControl,
+	}
+}
+
 const (
 	// DeploymentReadyActionContinueDeployment is a DeploymentReadyAction enum value
 	DeploymentReadyActionContinueDeployment = "CONTINUE_DEPLOYMENT"
@@ -18668,6 +18726,14 @@ const (
 	// DeploymentReadyActionStopDeployment is a DeploymentReadyAction enum value
 	DeploymentReadyActionStopDeployment = "STOP_DEPLOYMENT"
 )
+
+// DeploymentReadyAction_Values returns all elements of the DeploymentReadyAction enum
+func DeploymentReadyAction_Values() []string {
+	return []string{
+		DeploymentReadyActionContinueDeployment,
+		DeploymentReadyActionStopDeployment,
+	}
+}
 
 const (
 	// DeploymentStatusCreated is a DeploymentStatus enum value
@@ -18695,6 +18761,20 @@ const (
 	DeploymentStatusReady = "Ready"
 )
 
+// DeploymentStatus_Values returns all elements of the DeploymentStatus enum
+func DeploymentStatus_Values() []string {
+	return []string{
+		DeploymentStatusCreated,
+		DeploymentStatusQueued,
+		DeploymentStatusInProgress,
+		DeploymentStatusBaking,
+		DeploymentStatusSucceeded,
+		DeploymentStatusFailed,
+		DeploymentStatusStopped,
+		DeploymentStatusReady,
+	}
+}
+
 const (
 	// DeploymentTargetTypeInstanceTarget is a DeploymentTargetType enum value
 	DeploymentTargetTypeInstanceTarget = "InstanceTarget"
@@ -18709,6 +18789,16 @@ const (
 	DeploymentTargetTypeCloudFormationTarget = "CloudFormationTarget"
 )
 
+// DeploymentTargetType_Values returns all elements of the DeploymentTargetType enum
+func DeploymentTargetType_Values() []string {
+	return []string{
+		DeploymentTargetTypeInstanceTarget,
+		DeploymentTargetTypeLambdaTarget,
+		DeploymentTargetTypeEcstarget,
+		DeploymentTargetTypeCloudFormationTarget,
+	}
+}
+
 const (
 	// DeploymentTypeInPlace is a DeploymentType enum value
 	DeploymentTypeInPlace = "IN_PLACE"
@@ -18717,6 +18807,14 @@ const (
 	DeploymentTypeBlueGreen = "BLUE_GREEN"
 )
 
+// DeploymentType_Values returns all elements of the DeploymentType enum
+func DeploymentType_Values() []string {
+	return []string{
+		DeploymentTypeInPlace,
+		DeploymentTypeBlueGreen,
+	}
+}
+
 const (
 	// DeploymentWaitTypeReadyWait is a DeploymentWaitType enum value
 	DeploymentWaitTypeReadyWait = "READY_WAIT"
@@ -18724,6 +18822,14 @@ const (
 	// DeploymentWaitTypeTerminationWait is a DeploymentWaitType enum value
 	DeploymentWaitTypeTerminationWait = "TERMINATION_WAIT"
 )
+
+// DeploymentWaitType_Values returns all elements of the DeploymentWaitType enum
+func DeploymentWaitType_Values() []string {
+	return []string{
+		DeploymentWaitTypeReadyWait,
+		DeploymentWaitTypeTerminationWait,
+	}
+}
 
 const (
 	// EC2TagFilterTypeKeyOnly is a EC2TagFilterType enum value
@@ -18735,6 +18841,15 @@ const (
 	// EC2TagFilterTypeKeyAndValue is a EC2TagFilterType enum value
 	EC2TagFilterTypeKeyAndValue = "KEY_AND_VALUE"
 )
+
+// EC2TagFilterType_Values returns all elements of the EC2TagFilterType enum
+func EC2TagFilterType_Values() []string {
+	return []string{
+		EC2TagFilterTypeKeyOnly,
+		EC2TagFilterTypeValueOnly,
+		EC2TagFilterTypeKeyAndValue,
+	}
+}
 
 const (
 	// ErrorCodeAgentIssue is a ErrorCode enum value
@@ -18840,6 +18955,46 @@ const (
 	ErrorCodeCloudformationStackFailure = "CLOUDFORMATION_STACK_FAILURE"
 )
 
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeAgentIssue,
+		ErrorCodeAlarmActive,
+		ErrorCodeApplicationMissing,
+		ErrorCodeAutoscalingValidationError,
+		ErrorCodeAutoScalingConfiguration,
+		ErrorCodeAutoScalingIamRolePermissions,
+		ErrorCodeCodedeployResourceCannotBeFound,
+		ErrorCodeCustomerApplicationUnhealthy,
+		ErrorCodeDeploymentGroupMissing,
+		ErrorCodeEcsUpdateError,
+		ErrorCodeElasticLoadBalancingInvalid,
+		ErrorCodeElbInvalidInstance,
+		ErrorCodeHealthConstraints,
+		ErrorCodeHealthConstraintsInvalid,
+		ErrorCodeHookExecutionFailure,
+		ErrorCodeIamRoleMissing,
+		ErrorCodeIamRolePermissions,
+		ErrorCodeInternalError,
+		ErrorCodeInvalidEcsService,
+		ErrorCodeInvalidLambdaConfiguration,
+		ErrorCodeInvalidLambdaFunction,
+		ErrorCodeInvalidRevision,
+		ErrorCodeManualStop,
+		ErrorCodeMissingBlueGreenDeploymentConfiguration,
+		ErrorCodeMissingElbInformation,
+		ErrorCodeMissingGithubToken,
+		ErrorCodeNoEc2Subscription,
+		ErrorCodeNoInstances,
+		ErrorCodeOverMaxInstances,
+		ErrorCodeResourceLimitExceeded,
+		ErrorCodeRevisionMissing,
+		ErrorCodeThrottled,
+		ErrorCodeTimeout,
+		ErrorCodeCloudformationStackFailure,
+	}
+}
+
 const (
 	// FileExistsBehaviorDisallow is a FileExistsBehavior enum value
 	FileExistsBehaviorDisallow = "DISALLOW"
@@ -18851,6 +19006,15 @@ const (
 	FileExistsBehaviorRetain = "RETAIN"
 )
 
+// FileExistsBehavior_Values returns all elements of the FileExistsBehavior enum
+func FileExistsBehavior_Values() []string {
+	return []string{
+		FileExistsBehaviorDisallow,
+		FileExistsBehaviorOverwrite,
+		FileExistsBehaviorRetain,
+	}
+}
+
 const (
 	// GreenFleetProvisioningActionDiscoverExisting is a GreenFleetProvisioningAction enum value
 	GreenFleetProvisioningActionDiscoverExisting = "DISCOVER_EXISTING"
@@ -18859,6 +19023,14 @@ const (
 	GreenFleetProvisioningActionCopyAutoScalingGroup = "COPY_AUTO_SCALING_GROUP"
 )
 
+// GreenFleetProvisioningAction_Values returns all elements of the GreenFleetProvisioningAction enum
+func GreenFleetProvisioningAction_Values() []string {
+	return []string{
+		GreenFleetProvisioningActionDiscoverExisting,
+		GreenFleetProvisioningActionCopyAutoScalingGroup,
+	}
+}
+
 const (
 	// InstanceActionTerminate is a InstanceAction enum value
 	InstanceActionTerminate = "TERMINATE"
@@ -18866,6 +19038,14 @@ const (
 	// InstanceActionKeepAlive is a InstanceAction enum value
 	InstanceActionKeepAlive = "KEEP_ALIVE"
 )
+
+// InstanceAction_Values returns all elements of the InstanceAction enum
+func InstanceAction_Values() []string {
+	return []string{
+		InstanceActionTerminate,
+		InstanceActionKeepAlive,
+	}
+}
 
 const (
 	// InstanceStatusPending is a InstanceStatus enum value
@@ -18890,6 +19070,19 @@ const (
 	InstanceStatusReady = "Ready"
 )
 
+// InstanceStatus_Values returns all elements of the InstanceStatus enum
+func InstanceStatus_Values() []string {
+	return []string{
+		InstanceStatusPending,
+		InstanceStatusInProgress,
+		InstanceStatusSucceeded,
+		InstanceStatusFailed,
+		InstanceStatusSkipped,
+		InstanceStatusUnknown,
+		InstanceStatusReady,
+	}
+}
+
 const (
 	// InstanceTypeBlue is a InstanceType enum value
 	InstanceTypeBlue = "Blue"
@@ -18897,6 +19090,14 @@ const (
 	// InstanceTypeGreen is a InstanceType enum value
 	InstanceTypeGreen = "Green"
 )
+
+// InstanceType_Values returns all elements of the InstanceType enum
+func InstanceType_Values() []string {
+	return []string{
+		InstanceTypeBlue,
+		InstanceTypeGreen,
+	}
+}
 
 const (
 	// LifecycleErrorCodeSuccess is a LifecycleErrorCode enum value
@@ -18918,6 +19119,18 @@ const (
 	LifecycleErrorCodeUnknownError = "UnknownError"
 )
 
+// LifecycleErrorCode_Values returns all elements of the LifecycleErrorCode enum
+func LifecycleErrorCode_Values() []string {
+	return []string{
+		LifecycleErrorCodeSuccess,
+		LifecycleErrorCodeScriptMissing,
+		LifecycleErrorCodeScriptNotExecutable,
+		LifecycleErrorCodeScriptTimedOut,
+		LifecycleErrorCodeScriptFailed,
+		LifecycleErrorCodeUnknownError,
+	}
+}
+
 const (
 	// LifecycleEventStatusPending is a LifecycleEventStatus enum value
 	LifecycleEventStatusPending = "Pending"
@@ -18938,6 +19151,18 @@ const (
 	LifecycleEventStatusUnknown = "Unknown"
 )
 
+// LifecycleEventStatus_Values returns all elements of the LifecycleEventStatus enum
+func LifecycleEventStatus_Values() []string {
+	return []string{
+		LifecycleEventStatusPending,
+		LifecycleEventStatusInProgress,
+		LifecycleEventStatusSucceeded,
+		LifecycleEventStatusFailed,
+		LifecycleEventStatusSkipped,
+		LifecycleEventStatusUnknown,
+	}
+}
+
 const (
 	// ListStateFilterActionInclude is a ListStateFilterAction enum value
 	ListStateFilterActionInclude = "include"
@@ -18949,6 +19174,15 @@ const (
 	ListStateFilterActionIgnore = "ignore"
 )
 
+// ListStateFilterAction_Values returns all elements of the ListStateFilterAction enum
+func ListStateFilterAction_Values() []string {
+	return []string{
+		ListStateFilterActionInclude,
+		ListStateFilterActionExclude,
+		ListStateFilterActionIgnore,
+	}
+}
+
 const (
 	// MinimumHealthyHostsTypeHostCount is a MinimumHealthyHostsType enum value
 	MinimumHealthyHostsTypeHostCount = "HOST_COUNT"
@@ -18957,6 +19191,14 @@ const (
 	MinimumHealthyHostsTypeFleetPercent = "FLEET_PERCENT"
 )
 
+// MinimumHealthyHostsType_Values returns all elements of the MinimumHealthyHostsType enum
+func MinimumHealthyHostsType_Values() []string {
+	return []string{
+		MinimumHealthyHostsTypeHostCount,
+		MinimumHealthyHostsTypeFleetPercent,
+	}
+}
+
 const (
 	// RegistrationStatusRegistered is a RegistrationStatus enum value
 	RegistrationStatusRegistered = "Registered"
@@ -18964,6 +19206,14 @@ const (
 	// RegistrationStatusDeregistered is a RegistrationStatus enum value
 	RegistrationStatusDeregistered = "Deregistered"
 )
+
+// RegistrationStatus_Values returns all elements of the RegistrationStatus enum
+func RegistrationStatus_Values() []string {
+	return []string{
+		RegistrationStatusRegistered,
+		RegistrationStatusDeregistered,
+	}
+}
 
 const (
 	// RevisionLocationTypeS3 is a RevisionLocationType enum value
@@ -18979,6 +19229,16 @@ const (
 	RevisionLocationTypeAppSpecContent = "AppSpecContent"
 )
 
+// RevisionLocationType_Values returns all elements of the RevisionLocationType enum
+func RevisionLocationType_Values() []string {
+	return []string{
+		RevisionLocationTypeS3,
+		RevisionLocationTypeGitHub,
+		RevisionLocationTypeString,
+		RevisionLocationTypeAppSpecContent,
+	}
+}
+
 const (
 	// SortOrderAscending is a SortOrder enum value
 	SortOrderAscending = "ascending"
@@ -18987,6 +19247,14 @@ const (
 	SortOrderDescending = "descending"
 )
 
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderAscending,
+		SortOrderDescending,
+	}
+}
+
 const (
 	// StopStatusPending is a StopStatus enum value
 	StopStatusPending = "Pending"
@@ -18994,6 +19262,14 @@ const (
 	// StopStatusSucceeded is a StopStatus enum value
 	StopStatusSucceeded = "Succeeded"
 )
+
+// StopStatus_Values returns all elements of the StopStatus enum
+func StopStatus_Values() []string {
+	return []string{
+		StopStatusPending,
+		StopStatusSucceeded,
+	}
+}
 
 const (
 	// TagFilterTypeKeyOnly is a TagFilterType enum value
@@ -19006,6 +19282,15 @@ const (
 	TagFilterTypeKeyAndValue = "KEY_AND_VALUE"
 )
 
+// TagFilterType_Values returns all elements of the TagFilterType enum
+func TagFilterType_Values() []string {
+	return []string{
+		TagFilterTypeKeyOnly,
+		TagFilterTypeValueOnly,
+		TagFilterTypeKeyAndValue,
+	}
+}
+
 const (
 	// TargetFilterNameTargetStatus is a TargetFilterName enum value
 	TargetFilterNameTargetStatus = "TargetStatus"
@@ -19014,6 +19299,14 @@ const (
 	TargetFilterNameServerInstanceLabel = "ServerInstanceLabel"
 )
 
+// TargetFilterName_Values returns all elements of the TargetFilterName enum
+func TargetFilterName_Values() []string {
+	return []string{
+		TargetFilterNameTargetStatus,
+		TargetFilterNameServerInstanceLabel,
+	}
+}
+
 const (
 	// TargetLabelBlue is a TargetLabel enum value
 	TargetLabelBlue = "Blue"
@@ -19021,6 +19314,14 @@ const (
 	// TargetLabelGreen is a TargetLabel enum value
 	TargetLabelGreen = "Green"
 )
+
+// TargetLabel_Values returns all elements of the TargetLabel enum
+func TargetLabel_Values() []string {
+	return []string{
+		TargetLabelBlue,
+		TargetLabelGreen,
+	}
+}
 
 const (
 	// TargetStatusPending is a TargetStatus enum value
@@ -19045,6 +19346,19 @@ const (
 	TargetStatusReady = "Ready"
 )
 
+// TargetStatus_Values returns all elements of the TargetStatus enum
+func TargetStatus_Values() []string {
+	return []string{
+		TargetStatusPending,
+		TargetStatusInProgress,
+		TargetStatusSucceeded,
+		TargetStatusFailed,
+		TargetStatusSkipped,
+		TargetStatusUnknown,
+		TargetStatusReady,
+	}
+}
+
 const (
 	// TrafficRoutingTypeTimeBasedCanary is a TrafficRoutingType enum value
 	TrafficRoutingTypeTimeBasedCanary = "TimeBasedCanary"
@@ -19055,6 +19369,15 @@ const (
 	// TrafficRoutingTypeAllAtOnce is a TrafficRoutingType enum value
 	TrafficRoutingTypeAllAtOnce = "AllAtOnce"
 )
+
+// TrafficRoutingType_Values returns all elements of the TrafficRoutingType enum
+func TrafficRoutingType_Values() []string {
+	return []string{
+		TrafficRoutingTypeTimeBasedCanary,
+		TrafficRoutingTypeTimeBasedLinear,
+		TrafficRoutingTypeAllAtOnce,
+	}
+}
 
 const (
 	// TriggerEventTypeDeploymentStart is a TriggerEventType enum value
@@ -19087,3 +19410,19 @@ const (
 	// TriggerEventTypeInstanceReady is a TriggerEventType enum value
 	TriggerEventTypeInstanceReady = "InstanceReady"
 )
+
+// TriggerEventType_Values returns all elements of the TriggerEventType enum
+func TriggerEventType_Values() []string {
+	return []string{
+		TriggerEventTypeDeploymentStart,
+		TriggerEventTypeDeploymentSuccess,
+		TriggerEventTypeDeploymentFailure,
+		TriggerEventTypeDeploymentStop,
+		TriggerEventTypeDeploymentRollback,
+		TriggerEventTypeDeploymentReady,
+		TriggerEventTypeInstanceStart,
+		TriggerEventTypeInstanceSuccess,
+		TriggerEventTypeInstanceFailure,
+		TriggerEventTypeInstanceReady,
+	}
+}

--- a/service/codeguruprofiler/api.go
+++ b/service/codeguruprofiler/api.go
@@ -6317,6 +6317,13 @@ const (
 	ActionGroupAgentPermissions = "agentPermissions"
 )
 
+// ActionGroup_Values returns all elements of the ActionGroup enum
+func ActionGroup_Values() []string {
+	return []string{
+		ActionGroupAgentPermissions,
+	}
+}
+
 const (
 	// AgentParameterFieldMaxStackDepth is a AgentParameterField enum value
 	AgentParameterFieldMaxStackDepth = "MaxStackDepth"
@@ -6334,6 +6341,17 @@ const (
 	AgentParameterFieldSamplingIntervalInMilliseconds = "SamplingIntervalInMilliseconds"
 )
 
+// AgentParameterField_Values returns all elements of the AgentParameterField enum
+func AgentParameterField_Values() []string {
+	return []string{
+		AgentParameterFieldMaxStackDepth,
+		AgentParameterFieldMemoryUsageLimitPercent,
+		AgentParameterFieldMinimumTimeForReportingInMilliseconds,
+		AgentParameterFieldReportingIntervalInMilliseconds,
+		AgentParameterFieldSamplingIntervalInMilliseconds,
+	}
+}
+
 const (
 	// AggregationPeriodP1d is a AggregationPeriod enum value
 	AggregationPeriodP1d = "P1D"
@@ -6345,6 +6363,15 @@ const (
 	AggregationPeriodPt5m = "PT5M"
 )
 
+// AggregationPeriod_Values returns all elements of the AggregationPeriod enum
+func AggregationPeriod_Values() []string {
+	return []string{
+		AggregationPeriodP1d,
+		AggregationPeriodPt1h,
+		AggregationPeriodPt5m,
+	}
+}
+
 const (
 	// ComputePlatformAwslambda is a ComputePlatform enum value
 	ComputePlatformAwslambda = "AWSLambda"
@@ -6353,10 +6380,25 @@ const (
 	ComputePlatformDefault = "Default"
 )
 
+// ComputePlatform_Values returns all elements of the ComputePlatform enum
+func ComputePlatform_Values() []string {
+	return []string{
+		ComputePlatformAwslambda,
+		ComputePlatformDefault,
+	}
+}
+
 const (
 	// EventPublisherAnomalyDetection is a EventPublisher enum value
 	EventPublisherAnomalyDetection = "AnomalyDetection"
 )
+
+// EventPublisher_Values returns all elements of the EventPublisher enum
+func EventPublisher_Values() []string {
+	return []string{
+		EventPublisherAnomalyDetection,
+	}
+}
 
 const (
 	// FeedbackTypeNegative is a FeedbackType enum value
@@ -6365,6 +6407,14 @@ const (
 	// FeedbackTypePositive is a FeedbackType enum value
 	FeedbackTypePositive = "Positive"
 )
+
+// FeedbackType_Values returns all elements of the FeedbackType enum
+func FeedbackType_Values() []string {
+	return []string{
+		FeedbackTypeNegative,
+		FeedbackTypePositive,
+	}
+}
 
 const (
 	// MetadataFieldAgentId is a MetadataField enum value
@@ -6395,10 +6445,32 @@ const (
 	MetadataFieldLambdaTimeGapBetweenInvokesInMilliseconds = "LambdaTimeGapBetweenInvokesInMilliseconds"
 )
 
+// MetadataField_Values returns all elements of the MetadataField enum
+func MetadataField_Values() []string {
+	return []string{
+		MetadataFieldAgentId,
+		MetadataFieldAwsRequestId,
+		MetadataFieldComputePlatform,
+		MetadataFieldExecutionEnvironment,
+		MetadataFieldLambdaFunctionArn,
+		MetadataFieldLambdaMemoryLimitInMb,
+		MetadataFieldLambdaPreviousExecutionTimeInMilliseconds,
+		MetadataFieldLambdaRemainingTimeInMilliseconds,
+		MetadataFieldLambdaTimeGapBetweenInvokesInMilliseconds,
+	}
+}
+
 const (
 	// MetricTypeAggregatedRelativeTotalTime is a MetricType enum value
 	MetricTypeAggregatedRelativeTotalTime = "AggregatedRelativeTotalTime"
 )
+
+// MetricType_Values returns all elements of the MetricType enum
+func MetricType_Values() []string {
+	return []string{
+		MetricTypeAggregatedRelativeTotalTime,
+	}
+}
 
 const (
 	// OrderByTimestampAscending is a OrderBy enum value
@@ -6407,3 +6479,11 @@ const (
 	// OrderByTimestampDescending is a OrderBy enum value
 	OrderByTimestampDescending = "TimestampDescending"
 )
+
+// OrderBy_Values returns all elements of the OrderBy enum
+func OrderBy_Values() []string {
+	return []string{
+		OrderByTimestampAscending,
+		OrderByTimestampDescending,
+	}
+}

--- a/service/codegurureviewer/api.go
+++ b/service/codegurureviewer/api.go
@@ -3660,6 +3660,16 @@ const (
 	JobStateDeleting = "Deleting"
 )
 
+// JobState_Values returns all elements of the JobState enum
+func JobState_Values() []string {
+	return []string{
+		JobStateCompleted,
+		JobStatePending,
+		JobStateFailed,
+		JobStateDeleting,
+	}
+}
+
 const (
 	// ProviderTypeCodeCommit is a ProviderType enum value
 	ProviderTypeCodeCommit = "CodeCommit"
@@ -3674,6 +3684,16 @@ const (
 	ProviderTypeGitHubEnterpriseServer = "GitHubEnterpriseServer"
 )
 
+// ProviderType_Values returns all elements of the ProviderType enum
+func ProviderType_Values() []string {
+	return []string{
+		ProviderTypeCodeCommit,
+		ProviderTypeGitHub,
+		ProviderTypeBitbucket,
+		ProviderTypeGitHubEnterpriseServer,
+	}
+}
+
 const (
 	// ReactionThumbsUp is a Reaction enum value
 	ReactionThumbsUp = "ThumbsUp"
@@ -3681,6 +3701,14 @@ const (
 	// ReactionThumbsDown is a Reaction enum value
 	ReactionThumbsDown = "ThumbsDown"
 )
+
+// Reaction_Values returns all elements of the Reaction enum
+func Reaction_Values() []string {
+	return []string{
+		ReactionThumbsUp,
+		ReactionThumbsDown,
+	}
+}
 
 const (
 	// RepositoryAssociationStateAssociated is a RepositoryAssociationState enum value
@@ -3696,7 +3724,24 @@ const (
 	RepositoryAssociationStateDisassociating = "Disassociating"
 )
 
+// RepositoryAssociationState_Values returns all elements of the RepositoryAssociationState enum
+func RepositoryAssociationState_Values() []string {
+	return []string{
+		RepositoryAssociationStateAssociated,
+		RepositoryAssociationStateAssociating,
+		RepositoryAssociationStateFailed,
+		RepositoryAssociationStateDisassociating,
+	}
+}
+
 const (
 	// TypePullRequest is a Type enum value
 	TypePullRequest = "PullRequest"
 )
+
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypePullRequest,
+	}
+}

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -12747,6 +12747,18 @@ const (
 	ActionCategoryApproval = "Approval"
 )
 
+// ActionCategory_Values returns all elements of the ActionCategory enum
+func ActionCategory_Values() []string {
+	return []string{
+		ActionCategorySource,
+		ActionCategoryBuild,
+		ActionCategoryDeploy,
+		ActionCategoryTest,
+		ActionCategoryInvoke,
+		ActionCategoryApproval,
+	}
+}
+
 const (
 	// ActionConfigurationPropertyTypeString is a ActionConfigurationPropertyType enum value
 	ActionConfigurationPropertyTypeString = "String"
@@ -12757,6 +12769,15 @@ const (
 	// ActionConfigurationPropertyTypeBoolean is a ActionConfigurationPropertyType enum value
 	ActionConfigurationPropertyTypeBoolean = "Boolean"
 )
+
+// ActionConfigurationPropertyType_Values returns all elements of the ActionConfigurationPropertyType enum
+func ActionConfigurationPropertyType_Values() []string {
+	return []string{
+		ActionConfigurationPropertyTypeString,
+		ActionConfigurationPropertyTypeNumber,
+		ActionConfigurationPropertyTypeBoolean,
+	}
+}
 
 const (
 	// ActionExecutionStatusInProgress is a ActionExecutionStatus enum value
@@ -12772,6 +12793,16 @@ const (
 	ActionExecutionStatusFailed = "Failed"
 )
 
+// ActionExecutionStatus_Values returns all elements of the ActionExecutionStatus enum
+func ActionExecutionStatus_Values() []string {
+	return []string{
+		ActionExecutionStatusInProgress,
+		ActionExecutionStatusAbandoned,
+		ActionExecutionStatusSucceeded,
+		ActionExecutionStatusFailed,
+	}
+}
+
 const (
 	// ActionOwnerAws is a ActionOwner enum value
 	ActionOwnerAws = "AWS"
@@ -12783,6 +12814,15 @@ const (
 	ActionOwnerCustom = "Custom"
 )
 
+// ActionOwner_Values returns all elements of the ActionOwner enum
+func ActionOwner_Values() []string {
+	return []string{
+		ActionOwnerAws,
+		ActionOwnerThirdParty,
+		ActionOwnerCustom,
+	}
+}
+
 const (
 	// ApprovalStatusApproved is a ApprovalStatus enum value
 	ApprovalStatusApproved = "Approved"
@@ -12791,25 +12831,61 @@ const (
 	ApprovalStatusRejected = "Rejected"
 )
 
+// ApprovalStatus_Values returns all elements of the ApprovalStatus enum
+func ApprovalStatus_Values() []string {
+	return []string{
+		ApprovalStatusApproved,
+		ApprovalStatusRejected,
+	}
+}
+
 const (
 	// ArtifactLocationTypeS3 is a ArtifactLocationType enum value
 	ArtifactLocationTypeS3 = "S3"
 )
+
+// ArtifactLocationType_Values returns all elements of the ArtifactLocationType enum
+func ArtifactLocationType_Values() []string {
+	return []string{
+		ArtifactLocationTypeS3,
+	}
+}
 
 const (
 	// ArtifactStoreTypeS3 is a ArtifactStoreType enum value
 	ArtifactStoreTypeS3 = "S3"
 )
 
+// ArtifactStoreType_Values returns all elements of the ArtifactStoreType enum
+func ArtifactStoreType_Values() []string {
+	return []string{
+		ArtifactStoreTypeS3,
+	}
+}
+
 const (
 	// BlockerTypeSchedule is a BlockerType enum value
 	BlockerTypeSchedule = "Schedule"
 )
 
+// BlockerType_Values returns all elements of the BlockerType enum
+func BlockerType_Values() []string {
+	return []string{
+		BlockerTypeSchedule,
+	}
+}
+
 const (
 	// EncryptionKeyTypeKms is a EncryptionKeyType enum value
 	EncryptionKeyTypeKms = "KMS"
 )
+
+// EncryptionKeyType_Values returns all elements of the EncryptionKeyType enum
+func EncryptionKeyType_Values() []string {
+	return []string{
+		EncryptionKeyTypeKms,
+	}
+}
 
 const (
 	// FailureTypeJobFailed is a FailureType enum value
@@ -12830,6 +12906,18 @@ const (
 	// FailureTypeSystemUnavailable is a FailureType enum value
 	FailureTypeSystemUnavailable = "SystemUnavailable"
 )
+
+// FailureType_Values returns all elements of the FailureType enum
+func FailureType_Values() []string {
+	return []string{
+		FailureTypeJobFailed,
+		FailureTypeConfigurationError,
+		FailureTypePermissionError,
+		FailureTypeRevisionOutOfSync,
+		FailureTypeRevisionUnavailable,
+		FailureTypeSystemUnavailable,
+	}
+}
 
 const (
 	// JobStatusCreated is a JobStatus enum value
@@ -12854,6 +12942,19 @@ const (
 	JobStatusFailed = "Failed"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusCreated,
+		JobStatusQueued,
+		JobStatusDispatched,
+		JobStatusInProgress,
+		JobStatusTimedOut,
+		JobStatusSucceeded,
+		JobStatusFailed,
+	}
+}
+
 const (
 	// PipelineExecutionStatusInProgress is a PipelineExecutionStatus enum value
 	PipelineExecutionStatusInProgress = "InProgress"
@@ -12874,6 +12975,18 @@ const (
 	PipelineExecutionStatusFailed = "Failed"
 )
 
+// PipelineExecutionStatus_Values returns all elements of the PipelineExecutionStatus enum
+func PipelineExecutionStatus_Values() []string {
+	return []string{
+		PipelineExecutionStatusInProgress,
+		PipelineExecutionStatusStopped,
+		PipelineExecutionStatusStopping,
+		PipelineExecutionStatusSucceeded,
+		PipelineExecutionStatusSuperseded,
+		PipelineExecutionStatusFailed,
+	}
+}
+
 const (
 	// StageExecutionStatusInProgress is a StageExecutionStatus enum value
 	StageExecutionStatusInProgress = "InProgress"
@@ -12891,10 +13004,28 @@ const (
 	StageExecutionStatusSucceeded = "Succeeded"
 )
 
+// StageExecutionStatus_Values returns all elements of the StageExecutionStatus enum
+func StageExecutionStatus_Values() []string {
+	return []string{
+		StageExecutionStatusInProgress,
+		StageExecutionStatusFailed,
+		StageExecutionStatusStopped,
+		StageExecutionStatusStopping,
+		StageExecutionStatusSucceeded,
+	}
+}
+
 const (
 	// StageRetryModeFailedActions is a StageRetryMode enum value
 	StageRetryModeFailedActions = "FAILED_ACTIONS"
 )
+
+// StageRetryMode_Values returns all elements of the StageRetryMode enum
+func StageRetryMode_Values() []string {
+	return []string{
+		StageRetryModeFailedActions,
+	}
+}
 
 const (
 	// StageTransitionTypeInbound is a StageTransitionType enum value
@@ -12903,6 +13034,14 @@ const (
 	// StageTransitionTypeOutbound is a StageTransitionType enum value
 	StageTransitionTypeOutbound = "Outbound"
 )
+
+// StageTransitionType_Values returns all elements of the StageTransitionType enum
+func StageTransitionType_Values() []string {
+	return []string{
+		StageTransitionTypeInbound,
+		StageTransitionTypeOutbound,
+	}
+}
 
 const (
 	// TriggerTypeCreatePipeline is a TriggerType enum value
@@ -12924,6 +13063,18 @@ const (
 	TriggerTypePutActionRevision = "PutActionRevision"
 )
 
+// TriggerType_Values returns all elements of the TriggerType enum
+func TriggerType_Values() []string {
+	return []string{
+		TriggerTypeCreatePipeline,
+		TriggerTypeStartPipelineExecution,
+		TriggerTypePollForSourceChanges,
+		TriggerTypeWebhook,
+		TriggerTypeCloudWatchEvent,
+		TriggerTypePutActionRevision,
+	}
+}
+
 const (
 	// WebhookAuthenticationTypeGithubHmac is a WebhookAuthenticationType enum value
 	WebhookAuthenticationTypeGithubHmac = "GITHUB_HMAC"
@@ -12934,3 +13085,12 @@ const (
 	// WebhookAuthenticationTypeUnauthenticated is a WebhookAuthenticationType enum value
 	WebhookAuthenticationTypeUnauthenticated = "UNAUTHENTICATED"
 )
+
+// WebhookAuthenticationType_Values returns all elements of the WebhookAuthenticationType enum
+func WebhookAuthenticationType_Values() []string {
+	return []string{
+		WebhookAuthenticationTypeGithubHmac,
+		WebhookAuthenticationTypeIp,
+		WebhookAuthenticationTypeUnauthenticated,
+	}
+}

--- a/service/codestarconnections/api.go
+++ b/service/codestarconnections/api.go
@@ -2411,6 +2411,15 @@ const (
 	ConnectionStatusError = "ERROR"
 )
 
+// ConnectionStatus_Values returns all elements of the ConnectionStatus enum
+func ConnectionStatus_Values() []string {
+	return []string{
+		ConnectionStatusPending,
+		ConnectionStatusAvailable,
+		ConnectionStatusError,
+	}
+}
+
 const (
 	// ProviderTypeBitbucket is a ProviderType enum value
 	ProviderTypeBitbucket = "Bitbucket"
@@ -2418,3 +2427,11 @@ const (
 	// ProviderTypeGitHubEnterpriseServer is a ProviderType enum value
 	ProviderTypeGitHubEnterpriseServer = "GitHubEnterpriseServer"
 )
+
+// ProviderType_Values returns all elements of the ProviderType enum
+func ProviderType_Values() []string {
+	return []string{
+		ProviderTypeBitbucket,
+		ProviderTypeGitHubEnterpriseServer,
+	}
+}

--- a/service/codestarnotifications/api.go
+++ b/service/codestarnotifications/api.go
@@ -3374,6 +3374,14 @@ const (
 	DetailTypeFull = "FULL"
 )
 
+// DetailType_Values returns all elements of the DetailType enum
+func DetailType_Values() []string {
+	return []string{
+		DetailTypeBasic,
+		DetailTypeFull,
+	}
+}
+
 const (
 	// ListEventTypesFilterNameResourceType is a ListEventTypesFilterName enum value
 	ListEventTypesFilterNameResourceType = "RESOURCE_TYPE"
@@ -3381,6 +3389,14 @@ const (
 	// ListEventTypesFilterNameServiceName is a ListEventTypesFilterName enum value
 	ListEventTypesFilterNameServiceName = "SERVICE_NAME"
 )
+
+// ListEventTypesFilterName_Values returns all elements of the ListEventTypesFilterName enum
+func ListEventTypesFilterName_Values() []string {
+	return []string{
+		ListEventTypesFilterNameResourceType,
+		ListEventTypesFilterNameServiceName,
+	}
+}
 
 const (
 	// ListNotificationRulesFilterNameEventTypeId is a ListNotificationRulesFilterName enum value
@@ -3396,6 +3412,16 @@ const (
 	ListNotificationRulesFilterNameTargetAddress = "TARGET_ADDRESS"
 )
 
+// ListNotificationRulesFilterName_Values returns all elements of the ListNotificationRulesFilterName enum
+func ListNotificationRulesFilterName_Values() []string {
+	return []string{
+		ListNotificationRulesFilterNameEventTypeId,
+		ListNotificationRulesFilterNameCreatedBy,
+		ListNotificationRulesFilterNameResource,
+		ListNotificationRulesFilterNameTargetAddress,
+	}
+}
+
 const (
 	// ListTargetsFilterNameTargetType is a ListTargetsFilterName enum value
 	ListTargetsFilterNameTargetType = "TARGET_TYPE"
@@ -3407,6 +3433,15 @@ const (
 	ListTargetsFilterNameTargetStatus = "TARGET_STATUS"
 )
 
+// ListTargetsFilterName_Values returns all elements of the ListTargetsFilterName enum
+func ListTargetsFilterName_Values() []string {
+	return []string{
+		ListTargetsFilterNameTargetType,
+		ListTargetsFilterNameTargetAddress,
+		ListTargetsFilterNameTargetStatus,
+	}
+}
+
 const (
 	// NotificationRuleStatusEnabled is a NotificationRuleStatus enum value
 	NotificationRuleStatusEnabled = "ENABLED"
@@ -3414,6 +3449,14 @@ const (
 	// NotificationRuleStatusDisabled is a NotificationRuleStatus enum value
 	NotificationRuleStatusDisabled = "DISABLED"
 )
+
+// NotificationRuleStatus_Values returns all elements of the NotificationRuleStatus enum
+func NotificationRuleStatus_Values() []string {
+	return []string{
+		NotificationRuleStatusEnabled,
+		NotificationRuleStatusDisabled,
+	}
+}
 
 const (
 	// TargetStatusPending is a TargetStatus enum value
@@ -3431,3 +3474,14 @@ const (
 	// TargetStatusDeactivated is a TargetStatus enum value
 	TargetStatusDeactivated = "DEACTIVATED"
 )
+
+// TargetStatus_Values returns all elements of the TargetStatus enum
+func TargetStatus_Values() []string {
+	return []string{
+		TargetStatusPending,
+		TargetStatusActive,
+		TargetStatusUnreachable,
+		TargetStatusInactive,
+		TargetStatusDeactivated,
+	}
+}

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -5240,6 +5240,14 @@ const (
 	AmbiguousRoleResolutionTypeDeny = "Deny"
 )
 
+// AmbiguousRoleResolutionType_Values returns all elements of the AmbiguousRoleResolutionType enum
+func AmbiguousRoleResolutionType_Values() []string {
+	return []string{
+		AmbiguousRoleResolutionTypeAuthenticatedRole,
+		AmbiguousRoleResolutionTypeDeny,
+	}
+}
+
 const (
 	// ErrorCodeAccessDenied is a ErrorCode enum value
 	ErrorCodeAccessDenied = "AccessDenied"
@@ -5247,6 +5255,14 @@ const (
 	// ErrorCodeInternalServerError is a ErrorCode enum value
 	ErrorCodeInternalServerError = "InternalServerError"
 )
+
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeAccessDenied,
+		ErrorCodeInternalServerError,
+	}
+}
 
 const (
 	// MappingRuleMatchTypeEquals is a MappingRuleMatchType enum value
@@ -5262,6 +5278,16 @@ const (
 	MappingRuleMatchTypeNotEqual = "NotEqual"
 )
 
+// MappingRuleMatchType_Values returns all elements of the MappingRuleMatchType enum
+func MappingRuleMatchType_Values() []string {
+	return []string{
+		MappingRuleMatchTypeEquals,
+		MappingRuleMatchTypeContains,
+		MappingRuleMatchTypeStartsWith,
+		MappingRuleMatchTypeNotEqual,
+	}
+}
+
 const (
 	// RoleMappingTypeToken is a RoleMappingType enum value
 	RoleMappingTypeToken = "Token"
@@ -5269,3 +5295,11 @@ const (
 	// RoleMappingTypeRules is a RoleMappingType enum value
 	RoleMappingTypeRules = "Rules"
 )
+
+// RoleMappingType_Values returns all elements of the RoleMappingType enum
+func RoleMappingType_Values() []string {
+	return []string{
+		RoleMappingTypeToken,
+		RoleMappingTypeRules,
+	}
+}

--- a/service/cognitoidentityprovider/api.go
+++ b/service/cognitoidentityprovider/api.go
@@ -29240,6 +29240,16 @@ const (
 	AccountTakeoverEventActionTypeNoAction = "NO_ACTION"
 )
 
+// AccountTakeoverEventActionType_Values returns all elements of the AccountTakeoverEventActionType enum
+func AccountTakeoverEventActionType_Values() []string {
+	return []string{
+		AccountTakeoverEventActionTypeBlock,
+		AccountTakeoverEventActionTypeMfaIfConfigured,
+		AccountTakeoverEventActionTypeMfaRequired,
+		AccountTakeoverEventActionTypeNoAction,
+	}
+}
+
 const (
 	// AdvancedSecurityModeTypeOff is a AdvancedSecurityModeType enum value
 	AdvancedSecurityModeTypeOff = "OFF"
@@ -29251,6 +29261,15 @@ const (
 	AdvancedSecurityModeTypeEnforced = "ENFORCED"
 )
 
+// AdvancedSecurityModeType_Values returns all elements of the AdvancedSecurityModeType enum
+func AdvancedSecurityModeType_Values() []string {
+	return []string{
+		AdvancedSecurityModeTypeOff,
+		AdvancedSecurityModeTypeAudit,
+		AdvancedSecurityModeTypeEnforced,
+	}
+}
+
 const (
 	// AliasAttributeTypePhoneNumber is a AliasAttributeType enum value
 	AliasAttributeTypePhoneNumber = "phone_number"
@@ -29261,6 +29280,15 @@ const (
 	// AliasAttributeTypePreferredUsername is a AliasAttributeType enum value
 	AliasAttributeTypePreferredUsername = "preferred_username"
 )
+
+// AliasAttributeType_Values returns all elements of the AliasAttributeType enum
+func AliasAttributeType_Values() []string {
+	return []string{
+		AliasAttributeTypePhoneNumber,
+		AliasAttributeTypeEmail,
+		AliasAttributeTypePreferredUsername,
+	}
+}
 
 const (
 	// AttributeDataTypeString is a AttributeDataType enum value
@@ -29275,6 +29303,16 @@ const (
 	// AttributeDataTypeBoolean is a AttributeDataType enum value
 	AttributeDataTypeBoolean = "Boolean"
 )
+
+// AttributeDataType_Values returns all elements of the AttributeDataType enum
+func AttributeDataType_Values() []string {
+	return []string{
+		AttributeDataTypeString,
+		AttributeDataTypeNumber,
+		AttributeDataTypeDateTime,
+		AttributeDataTypeBoolean,
+	}
+}
 
 const (
 	// AuthFlowTypeUserSrpAuth is a AuthFlowType enum value
@@ -29299,6 +29337,19 @@ const (
 	AuthFlowTypeAdminUserPasswordAuth = "ADMIN_USER_PASSWORD_AUTH"
 )
 
+// AuthFlowType_Values returns all elements of the AuthFlowType enum
+func AuthFlowType_Values() []string {
+	return []string{
+		AuthFlowTypeUserSrpAuth,
+		AuthFlowTypeRefreshTokenAuth,
+		AuthFlowTypeRefreshToken,
+		AuthFlowTypeCustomAuth,
+		AuthFlowTypeAdminNoSrpAuth,
+		AuthFlowTypeUserPasswordAuth,
+		AuthFlowTypeAdminUserPasswordAuth,
+	}
+}
+
 const (
 	// ChallengeNamePassword is a ChallengeName enum value
 	ChallengeNamePassword = "Password"
@@ -29306,6 +29357,14 @@ const (
 	// ChallengeNameMfa is a ChallengeName enum value
 	ChallengeNameMfa = "Mfa"
 )
+
+// ChallengeName_Values returns all elements of the ChallengeName enum
+func ChallengeName_Values() []string {
+	return []string{
+		ChallengeNamePassword,
+		ChallengeNameMfa,
+	}
+}
 
 const (
 	// ChallengeNameTypeSmsMfa is a ChallengeNameType enum value
@@ -29339,6 +29398,22 @@ const (
 	ChallengeNameTypeNewPasswordRequired = "NEW_PASSWORD_REQUIRED"
 )
 
+// ChallengeNameType_Values returns all elements of the ChallengeNameType enum
+func ChallengeNameType_Values() []string {
+	return []string{
+		ChallengeNameTypeSmsMfa,
+		ChallengeNameTypeSoftwareTokenMfa,
+		ChallengeNameTypeSelectMfaType,
+		ChallengeNameTypeMfaSetup,
+		ChallengeNameTypePasswordVerifier,
+		ChallengeNameTypeCustomChallenge,
+		ChallengeNameTypeDeviceSrpAuth,
+		ChallengeNameTypeDevicePasswordVerifier,
+		ChallengeNameTypeAdminNoSrpAuth,
+		ChallengeNameTypeNewPasswordRequired,
+	}
+}
+
 const (
 	// ChallengeResponseSuccess is a ChallengeResponse enum value
 	ChallengeResponseSuccess = "Success"
@@ -29346,6 +29421,14 @@ const (
 	// ChallengeResponseFailure is a ChallengeResponse enum value
 	ChallengeResponseFailure = "Failure"
 )
+
+// ChallengeResponse_Values returns all elements of the ChallengeResponse enum
+func ChallengeResponse_Values() []string {
+	return []string{
+		ChallengeResponseSuccess,
+		ChallengeResponseFailure,
+	}
+}
 
 const (
 	// CompromisedCredentialsEventActionTypeBlock is a CompromisedCredentialsEventActionType enum value
@@ -29355,6 +29438,14 @@ const (
 	CompromisedCredentialsEventActionTypeNoAction = "NO_ACTION"
 )
 
+// CompromisedCredentialsEventActionType_Values returns all elements of the CompromisedCredentialsEventActionType enum
+func CompromisedCredentialsEventActionType_Values() []string {
+	return []string{
+		CompromisedCredentialsEventActionTypeBlock,
+		CompromisedCredentialsEventActionTypeNoAction,
+	}
+}
+
 const (
 	// DefaultEmailOptionTypeConfirmWithLink is a DefaultEmailOptionType enum value
 	DefaultEmailOptionTypeConfirmWithLink = "CONFIRM_WITH_LINK"
@@ -29362,6 +29453,14 @@ const (
 	// DefaultEmailOptionTypeConfirmWithCode is a DefaultEmailOptionType enum value
 	DefaultEmailOptionTypeConfirmWithCode = "CONFIRM_WITH_CODE"
 )
+
+// DefaultEmailOptionType_Values returns all elements of the DefaultEmailOptionType enum
+func DefaultEmailOptionType_Values() []string {
+	return []string{
+		DefaultEmailOptionTypeConfirmWithLink,
+		DefaultEmailOptionTypeConfirmWithCode,
+	}
+}
 
 const (
 	// DeliveryMediumTypeSms is a DeliveryMediumType enum value
@@ -29371,6 +29470,14 @@ const (
 	DeliveryMediumTypeEmail = "EMAIL"
 )
 
+// DeliveryMediumType_Values returns all elements of the DeliveryMediumType enum
+func DeliveryMediumType_Values() []string {
+	return []string{
+		DeliveryMediumTypeSms,
+		DeliveryMediumTypeEmail,
+	}
+}
+
 const (
 	// DeviceRememberedStatusTypeRemembered is a DeviceRememberedStatusType enum value
 	DeviceRememberedStatusTypeRemembered = "remembered"
@@ -29378,6 +29485,14 @@ const (
 	// DeviceRememberedStatusTypeNotRemembered is a DeviceRememberedStatusType enum value
 	DeviceRememberedStatusTypeNotRemembered = "not_remembered"
 )
+
+// DeviceRememberedStatusType_Values returns all elements of the DeviceRememberedStatusType enum
+func DeviceRememberedStatusType_Values() []string {
+	return []string{
+		DeviceRememberedStatusTypeRemembered,
+		DeviceRememberedStatusTypeNotRemembered,
+	}
+}
 
 const (
 	// DomainStatusTypeCreating is a DomainStatusType enum value
@@ -29396,6 +29511,17 @@ const (
 	DomainStatusTypeFailed = "FAILED"
 )
 
+// DomainStatusType_Values returns all elements of the DomainStatusType enum
+func DomainStatusType_Values() []string {
+	return []string{
+		DomainStatusTypeCreating,
+		DomainStatusTypeDeleting,
+		DomainStatusTypeUpdating,
+		DomainStatusTypeActive,
+		DomainStatusTypeFailed,
+	}
+}
+
 const (
 	// EmailSendingAccountTypeCognitoDefault is a EmailSendingAccountType enum value
 	EmailSendingAccountTypeCognitoDefault = "COGNITO_DEFAULT"
@@ -29403,6 +29529,14 @@ const (
 	// EmailSendingAccountTypeDeveloper is a EmailSendingAccountType enum value
 	EmailSendingAccountTypeDeveloper = "DEVELOPER"
 )
+
+// EmailSendingAccountType_Values returns all elements of the EmailSendingAccountType enum
+func EmailSendingAccountType_Values() []string {
+	return []string{
+		EmailSendingAccountTypeCognitoDefault,
+		EmailSendingAccountTypeDeveloper,
+	}
+}
 
 const (
 	// EventFilterTypeSignIn is a EventFilterType enum value
@@ -29415,6 +29549,15 @@ const (
 	EventFilterTypeSignUp = "SIGN_UP"
 )
 
+// EventFilterType_Values returns all elements of the EventFilterType enum
+func EventFilterType_Values() []string {
+	return []string{
+		EventFilterTypeSignIn,
+		EventFilterTypePasswordChange,
+		EventFilterTypeSignUp,
+	}
+}
+
 const (
 	// EventResponseTypeSuccess is a EventResponseType enum value
 	EventResponseTypeSuccess = "Success"
@@ -29422,6 +29565,14 @@ const (
 	// EventResponseTypeFailure is a EventResponseType enum value
 	EventResponseTypeFailure = "Failure"
 )
+
+// EventResponseType_Values returns all elements of the EventResponseType enum
+func EventResponseType_Values() []string {
+	return []string{
+		EventResponseTypeSuccess,
+		EventResponseTypeFailure,
+	}
+}
 
 const (
 	// EventTypeSignIn is a EventType enum value
@@ -29433,6 +29584,15 @@ const (
 	// EventTypeForgotPassword is a EventType enum value
 	EventTypeForgotPassword = "ForgotPassword"
 )
+
+// EventType_Values returns all elements of the EventType enum
+func EventType_Values() []string {
+	return []string{
+		EventTypeSignIn,
+		EventTypeSignUp,
+		EventTypeForgotPassword,
+	}
+}
 
 const (
 	// ExplicitAuthFlowsTypeAdminNoSrpAuth is a ExplicitAuthFlowsType enum value
@@ -29460,6 +29620,20 @@ const (
 	ExplicitAuthFlowsTypeAllowRefreshTokenAuth = "ALLOW_REFRESH_TOKEN_AUTH"
 )
 
+// ExplicitAuthFlowsType_Values returns all elements of the ExplicitAuthFlowsType enum
+func ExplicitAuthFlowsType_Values() []string {
+	return []string{
+		ExplicitAuthFlowsTypeAdminNoSrpAuth,
+		ExplicitAuthFlowsTypeCustomAuthFlowOnly,
+		ExplicitAuthFlowsTypeUserPasswordAuth,
+		ExplicitAuthFlowsTypeAllowAdminUserPasswordAuth,
+		ExplicitAuthFlowsTypeAllowCustomAuth,
+		ExplicitAuthFlowsTypeAllowUserPasswordAuth,
+		ExplicitAuthFlowsTypeAllowUserSrpAuth,
+		ExplicitAuthFlowsTypeAllowRefreshTokenAuth,
+	}
+}
+
 const (
 	// FeedbackValueTypeValid is a FeedbackValueType enum value
 	FeedbackValueTypeValid = "Valid"
@@ -29467,6 +29641,14 @@ const (
 	// FeedbackValueTypeInvalid is a FeedbackValueType enum value
 	FeedbackValueTypeInvalid = "Invalid"
 )
+
+// FeedbackValueType_Values returns all elements of the FeedbackValueType enum
+func FeedbackValueType_Values() []string {
+	return []string{
+		FeedbackValueTypeValid,
+		FeedbackValueTypeInvalid,
+	}
+}
 
 const (
 	// IdentityProviderTypeTypeSaml is a IdentityProviderTypeType enum value
@@ -29488,6 +29670,18 @@ const (
 	IdentityProviderTypeTypeOidc = "OIDC"
 )
 
+// IdentityProviderTypeType_Values returns all elements of the IdentityProviderTypeType enum
+func IdentityProviderTypeType_Values() []string {
+	return []string{
+		IdentityProviderTypeTypeSaml,
+		IdentityProviderTypeTypeFacebook,
+		IdentityProviderTypeTypeGoogle,
+		IdentityProviderTypeTypeLoginWithAmazon,
+		IdentityProviderTypeTypeSignInWithApple,
+		IdentityProviderTypeTypeOidc,
+	}
+}
+
 const (
 	// MessageActionTypeResend is a MessageActionType enum value
 	MessageActionTypeResend = "RESEND"
@@ -29495,6 +29689,14 @@ const (
 	// MessageActionTypeSuppress is a MessageActionType enum value
 	MessageActionTypeSuppress = "SUPPRESS"
 )
+
+// MessageActionType_Values returns all elements of the MessageActionType enum
+func MessageActionType_Values() []string {
+	return []string{
+		MessageActionTypeResend,
+		MessageActionTypeSuppress,
+	}
+}
 
 const (
 	// OAuthFlowTypeCode is a OAuthFlowType enum value
@@ -29507,6 +29709,15 @@ const (
 	OAuthFlowTypeClientCredentials = "client_credentials"
 )
 
+// OAuthFlowType_Values returns all elements of the OAuthFlowType enum
+func OAuthFlowType_Values() []string {
+	return []string{
+		OAuthFlowTypeCode,
+		OAuthFlowTypeImplicit,
+		OAuthFlowTypeClientCredentials,
+	}
+}
+
 const (
 	// PreventUserExistenceErrorTypesLegacy is a PreventUserExistenceErrorTypes enum value
 	PreventUserExistenceErrorTypesLegacy = "LEGACY"
@@ -29514,6 +29725,14 @@ const (
 	// PreventUserExistenceErrorTypesEnabled is a PreventUserExistenceErrorTypes enum value
 	PreventUserExistenceErrorTypesEnabled = "ENABLED"
 )
+
+// PreventUserExistenceErrorTypes_Values returns all elements of the PreventUserExistenceErrorTypes enum
+func PreventUserExistenceErrorTypes_Values() []string {
+	return []string{
+		PreventUserExistenceErrorTypesLegacy,
+		PreventUserExistenceErrorTypesEnabled,
+	}
+}
 
 const (
 	// RecoveryOptionNameTypeVerifiedEmail is a RecoveryOptionNameType enum value
@@ -29526,6 +29745,15 @@ const (
 	RecoveryOptionNameTypeAdminOnly = "admin_only"
 )
 
+// RecoveryOptionNameType_Values returns all elements of the RecoveryOptionNameType enum
+func RecoveryOptionNameType_Values() []string {
+	return []string{
+		RecoveryOptionNameTypeVerifiedEmail,
+		RecoveryOptionNameTypeVerifiedPhoneNumber,
+		RecoveryOptionNameTypeAdminOnly,
+	}
+}
+
 const (
 	// RiskDecisionTypeNoRisk is a RiskDecisionType enum value
 	RiskDecisionTypeNoRisk = "NoRisk"
@@ -29536,6 +29764,15 @@ const (
 	// RiskDecisionTypeBlock is a RiskDecisionType enum value
 	RiskDecisionTypeBlock = "Block"
 )
+
+// RiskDecisionType_Values returns all elements of the RiskDecisionType enum
+func RiskDecisionType_Values() []string {
+	return []string{
+		RiskDecisionTypeNoRisk,
+		RiskDecisionTypeAccountTakeover,
+		RiskDecisionTypeBlock,
+	}
+}
 
 const (
 	// RiskLevelTypeLow is a RiskLevelType enum value
@@ -29548,6 +29785,15 @@ const (
 	RiskLevelTypeHigh = "High"
 )
 
+// RiskLevelType_Values returns all elements of the RiskLevelType enum
+func RiskLevelType_Values() []string {
+	return []string{
+		RiskLevelTypeLow,
+		RiskLevelTypeMedium,
+		RiskLevelTypeHigh,
+	}
+}
+
 const (
 	// StatusTypeEnabled is a StatusType enum value
 	StatusTypeEnabled = "Enabled"
@@ -29555,6 +29801,14 @@ const (
 	// StatusTypeDisabled is a StatusType enum value
 	StatusTypeDisabled = "Disabled"
 )
+
+// StatusType_Values returns all elements of the StatusType enum
+func StatusType_Values() []string {
+	return []string{
+		StatusTypeEnabled,
+		StatusTypeDisabled,
+	}
+}
 
 const (
 	// UserImportJobStatusTypeCreated is a UserImportJobStatusType enum value
@@ -29582,6 +29836,20 @@ const (
 	UserImportJobStatusTypeSucceeded = "Succeeded"
 )
 
+// UserImportJobStatusType_Values returns all elements of the UserImportJobStatusType enum
+func UserImportJobStatusType_Values() []string {
+	return []string{
+		UserImportJobStatusTypeCreated,
+		UserImportJobStatusTypePending,
+		UserImportJobStatusTypeInProgress,
+		UserImportJobStatusTypeStopping,
+		UserImportJobStatusTypeExpired,
+		UserImportJobStatusTypeStopped,
+		UserImportJobStatusTypeFailed,
+		UserImportJobStatusTypeSucceeded,
+	}
+}
+
 const (
 	// UserPoolMfaTypeOff is a UserPoolMfaType enum value
 	UserPoolMfaTypeOff = "OFF"
@@ -29592,6 +29860,15 @@ const (
 	// UserPoolMfaTypeOptional is a UserPoolMfaType enum value
 	UserPoolMfaTypeOptional = "OPTIONAL"
 )
+
+// UserPoolMfaType_Values returns all elements of the UserPoolMfaType enum
+func UserPoolMfaType_Values() []string {
+	return []string{
+		UserPoolMfaTypeOff,
+		UserPoolMfaTypeOn,
+		UserPoolMfaTypeOptional,
+	}
+}
 
 const (
 	// UserStatusTypeUnconfirmed is a UserStatusType enum value
@@ -29616,6 +29893,19 @@ const (
 	UserStatusTypeForceChangePassword = "FORCE_CHANGE_PASSWORD"
 )
 
+// UserStatusType_Values returns all elements of the UserStatusType enum
+func UserStatusType_Values() []string {
+	return []string{
+		UserStatusTypeUnconfirmed,
+		UserStatusTypeConfirmed,
+		UserStatusTypeArchived,
+		UserStatusTypeCompromised,
+		UserStatusTypeUnknown,
+		UserStatusTypeResetRequired,
+		UserStatusTypeForceChangePassword,
+	}
+}
+
 const (
 	// UsernameAttributeTypePhoneNumber is a UsernameAttributeType enum value
 	UsernameAttributeTypePhoneNumber = "phone_number"
@@ -29623,6 +29913,14 @@ const (
 	// UsernameAttributeTypeEmail is a UsernameAttributeType enum value
 	UsernameAttributeTypeEmail = "email"
 )
+
+// UsernameAttributeType_Values returns all elements of the UsernameAttributeType enum
+func UsernameAttributeType_Values() []string {
+	return []string{
+		UsernameAttributeTypePhoneNumber,
+		UsernameAttributeTypeEmail,
+	}
+}
 
 const (
 	// VerifiedAttributeTypePhoneNumber is a VerifiedAttributeType enum value
@@ -29632,6 +29930,14 @@ const (
 	VerifiedAttributeTypeEmail = "email"
 )
 
+// VerifiedAttributeType_Values returns all elements of the VerifiedAttributeType enum
+func VerifiedAttributeType_Values() []string {
+	return []string{
+		VerifiedAttributeTypePhoneNumber,
+		VerifiedAttributeTypeEmail,
+	}
+}
+
 const (
 	// VerifySoftwareTokenResponseTypeSuccess is a VerifySoftwareTokenResponseType enum value
 	VerifySoftwareTokenResponseTypeSuccess = "SUCCESS"
@@ -29639,3 +29945,11 @@ const (
 	// VerifySoftwareTokenResponseTypeError is a VerifySoftwareTokenResponseType enum value
 	VerifySoftwareTokenResponseTypeError = "ERROR"
 )
+
+// VerifySoftwareTokenResponseType_Values returns all elements of the VerifySoftwareTokenResponseType enum
+func VerifySoftwareTokenResponseType_Values() []string {
+	return []string{
+		VerifySoftwareTokenResponseTypeSuccess,
+		VerifySoftwareTokenResponseTypeError,
+	}
+}

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -4688,6 +4688,16 @@ const (
 	BulkPublishStatusSucceeded = "SUCCEEDED"
 )
 
+// BulkPublishStatus_Values returns all elements of the BulkPublishStatus enum
+func BulkPublishStatus_Values() []string {
+	return []string{
+		BulkPublishStatusNotStarted,
+		BulkPublishStatusInProgress,
+		BulkPublishStatusFailed,
+		BulkPublishStatusSucceeded,
+	}
+}
+
 const (
 	// OperationReplace is a Operation enum value
 	OperationReplace = "replace"
@@ -4695,6 +4705,14 @@ const (
 	// OperationRemove is a Operation enum value
 	OperationRemove = "remove"
 )
+
+// Operation_Values returns all elements of the Operation enum
+func Operation_Values() []string {
+	return []string{
+		OperationReplace,
+		OperationRemove,
+	}
+}
 
 const (
 	// PlatformApns is a Platform enum value
@@ -4710,6 +4728,16 @@ const (
 	PlatformAdm = "ADM"
 )
 
+// Platform_Values returns all elements of the Platform enum
+func Platform_Values() []string {
+	return []string{
+		PlatformApns,
+		PlatformApnsSandbox,
+		PlatformGcm,
+		PlatformAdm,
+	}
+}
+
 const (
 	// StreamingStatusEnabled is a StreamingStatus enum value
 	StreamingStatusEnabled = "ENABLED"
@@ -4717,3 +4745,11 @@ const (
 	// StreamingStatusDisabled is a StreamingStatus enum value
 	StreamingStatusDisabled = "DISABLED"
 )
+
+// StreamingStatus_Values returns all elements of the StreamingStatus enum
+func StreamingStatus_Values() []string {
+	return []string{
+		StreamingStatusEnabled,
+		StreamingStatusDisabled,
+	}
+}

--- a/service/comprehend/api.go
+++ b/service/comprehend/api.go
@@ -14550,6 +14550,14 @@ const (
 	DocumentClassifierModeMultiLabel = "MULTI_LABEL"
 )
 
+// DocumentClassifierMode_Values returns all elements of the DocumentClassifierMode enum
+func DocumentClassifierMode_Values() []string {
+	return []string{
+		DocumentClassifierModeMultiClass,
+		DocumentClassifierModeMultiLabel,
+	}
+}
+
 const (
 	// EndpointStatusCreating is a EndpointStatus enum value
 	EndpointStatusCreating = "CREATING"
@@ -14566,6 +14574,17 @@ const (
 	// EndpointStatusUpdating is a EndpointStatus enum value
 	EndpointStatusUpdating = "UPDATING"
 )
+
+// EndpointStatus_Values returns all elements of the EndpointStatus enum
+func EndpointStatus_Values() []string {
+	return []string{
+		EndpointStatusCreating,
+		EndpointStatusDeleting,
+		EndpointStatusFailed,
+		EndpointStatusInService,
+		EndpointStatusUpdating,
+	}
+}
 
 const (
 	// EntityTypePerson is a EntityType enum value
@@ -14596,6 +14615,21 @@ const (
 	EntityTypeOther = "OTHER"
 )
 
+// EntityType_Values returns all elements of the EntityType enum
+func EntityType_Values() []string {
+	return []string{
+		EntityTypePerson,
+		EntityTypeLocation,
+		EntityTypeOrganization,
+		EntityTypeCommercialItem,
+		EntityTypeEvent,
+		EntityTypeDate,
+		EntityTypeQuantity,
+		EntityTypeTitle,
+		EntityTypeOther,
+	}
+}
+
 const (
 	// InputFormatOneDocPerFile is a InputFormat enum value
 	InputFormatOneDocPerFile = "ONE_DOC_PER_FILE"
@@ -14603,6 +14637,14 @@ const (
 	// InputFormatOneDocPerLine is a InputFormat enum value
 	InputFormatOneDocPerLine = "ONE_DOC_PER_LINE"
 )
+
+// InputFormat_Values returns all elements of the InputFormat enum
+func InputFormat_Values() []string {
+	return []string{
+		InputFormatOneDocPerFile,
+		InputFormatOneDocPerLine,
+	}
+}
 
 const (
 	// JobStatusSubmitted is a JobStatus enum value
@@ -14623,6 +14665,18 @@ const (
 	// JobStatusStopped is a JobStatus enum value
 	JobStatusStopped = "STOPPED"
 )
+
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusSubmitted,
+		JobStatusInProgress,
+		JobStatusCompleted,
+		JobStatusFailed,
+		JobStatusStopRequested,
+		JobStatusStopped,
+	}
+}
 
 const (
 	// LanguageCodeEn is a LanguageCode enum value
@@ -14662,6 +14716,24 @@ const (
 	LanguageCodeZhTw = "zh-TW"
 )
 
+// LanguageCode_Values returns all elements of the LanguageCode enum
+func LanguageCode_Values() []string {
+	return []string{
+		LanguageCodeEn,
+		LanguageCodeEs,
+		LanguageCodeFr,
+		LanguageCodeDe,
+		LanguageCodeIt,
+		LanguageCodePt,
+		LanguageCodeAr,
+		LanguageCodeHi,
+		LanguageCodeJa,
+		LanguageCodeKo,
+		LanguageCodeZh,
+		LanguageCodeZhTw,
+	}
+}
+
 const (
 	// ModelStatusSubmitted is a ModelStatus enum value
 	ModelStatusSubmitted = "SUBMITTED"
@@ -14684,6 +14756,19 @@ const (
 	// ModelStatusTrained is a ModelStatus enum value
 	ModelStatusTrained = "TRAINED"
 )
+
+// ModelStatus_Values returns all elements of the ModelStatus enum
+func ModelStatus_Values() []string {
+	return []string{
+		ModelStatusSubmitted,
+		ModelStatusTraining,
+		ModelStatusDeleting,
+		ModelStatusStopRequested,
+		ModelStatusStopped,
+		ModelStatusInError,
+		ModelStatusTrained,
+	}
+}
 
 const (
 	// PartOfSpeechTagTypeAdj is a PartOfSpeechTagType enum value
@@ -14741,6 +14826,30 @@ const (
 	PartOfSpeechTagTypeVerb = "VERB"
 )
 
+// PartOfSpeechTagType_Values returns all elements of the PartOfSpeechTagType enum
+func PartOfSpeechTagType_Values() []string {
+	return []string{
+		PartOfSpeechTagTypeAdj,
+		PartOfSpeechTagTypeAdp,
+		PartOfSpeechTagTypeAdv,
+		PartOfSpeechTagTypeAux,
+		PartOfSpeechTagTypeConj,
+		PartOfSpeechTagTypeCconj,
+		PartOfSpeechTagTypeDet,
+		PartOfSpeechTagTypeIntj,
+		PartOfSpeechTagTypeNoun,
+		PartOfSpeechTagTypeNum,
+		PartOfSpeechTagTypeO,
+		PartOfSpeechTagTypePart,
+		PartOfSpeechTagTypePron,
+		PartOfSpeechTagTypePropn,
+		PartOfSpeechTagTypePunct,
+		PartOfSpeechTagTypeSconj,
+		PartOfSpeechTagTypeSym,
+		PartOfSpeechTagTypeVerb,
+	}
+}
+
 const (
 	// SentimentTypePositive is a SentimentType enum value
 	SentimentTypePositive = "POSITIVE"
@@ -14754,6 +14863,16 @@ const (
 	// SentimentTypeMixed is a SentimentType enum value
 	SentimentTypeMixed = "MIXED"
 )
+
+// SentimentType_Values returns all elements of the SentimentType enum
+func SentimentType_Values() []string {
+	return []string{
+		SentimentTypePositive,
+		SentimentTypeNegative,
+		SentimentTypeNeutral,
+		SentimentTypeMixed,
+	}
+}
 
 const (
 	// SyntaxLanguageCodeEn is a SyntaxLanguageCode enum value
@@ -14774,3 +14893,15 @@ const (
 	// SyntaxLanguageCodePt is a SyntaxLanguageCode enum value
 	SyntaxLanguageCodePt = "pt"
 )
+
+// SyntaxLanguageCode_Values returns all elements of the SyntaxLanguageCode enum
+func SyntaxLanguageCode_Values() []string {
+	return []string{
+		SyntaxLanguageCodeEn,
+		SyntaxLanguageCodeEs,
+		SyntaxLanguageCodeFr,
+		SyntaxLanguageCodeDe,
+		SyntaxLanguageCodeIt,
+		SyntaxLanguageCodePt,
+	}
+}

--- a/service/comprehendmedical/api.go
+++ b/service/comprehendmedical/api.go
@@ -5694,6 +5694,16 @@ const (
 	AttributeNameNegation = "NEGATION"
 )
 
+// AttributeName_Values returns all elements of the AttributeName enum
+func AttributeName_Values() []string {
+	return []string{
+		AttributeNameSign,
+		AttributeNameSymptom,
+		AttributeNameDiagnosis,
+		AttributeNameNegation,
+	}
+}
+
 const (
 	// EntitySubTypeName is a EntitySubType enum value
 	EntitySubTypeName = "NAME"
@@ -5798,6 +5808,46 @@ const (
 	EntitySubTypeTimeToTreatmentName = "TIME_TO_TREATMENT_NAME"
 )
 
+// EntitySubType_Values returns all elements of the EntitySubType enum
+func EntitySubType_Values() []string {
+	return []string{
+		EntitySubTypeName,
+		EntitySubTypeDosage,
+		EntitySubTypeRouteOrMode,
+		EntitySubTypeForm,
+		EntitySubTypeFrequency,
+		EntitySubTypeDuration,
+		EntitySubTypeGenericName,
+		EntitySubTypeBrandName,
+		EntitySubTypeStrength,
+		EntitySubTypeRate,
+		EntitySubTypeAcuity,
+		EntitySubTypeTestName,
+		EntitySubTypeTestValue,
+		EntitySubTypeTestUnits,
+		EntitySubTypeProcedureName,
+		EntitySubTypeTreatmentName,
+		EntitySubTypeDate,
+		EntitySubTypeAge,
+		EntitySubTypeContactPoint,
+		EntitySubTypeEmail,
+		EntitySubTypeIdentifier,
+		EntitySubTypeUrl,
+		EntitySubTypeAddress,
+		EntitySubTypeProfession,
+		EntitySubTypeSystemOrganSite,
+		EntitySubTypeDirection,
+		EntitySubTypeQuality,
+		EntitySubTypeQuantity,
+		EntitySubTypeTimeExpression,
+		EntitySubTypeTimeToMedicationName,
+		EntitySubTypeTimeToDxName,
+		EntitySubTypeTimeToTestName,
+		EntitySubTypeTimeToProcedureName,
+		EntitySubTypeTimeToTreatmentName,
+	}
+}
+
 const (
 	// EntityTypeMedication is a EntityType enum value
 	EntityTypeMedication = "MEDICATION"
@@ -5818,6 +5868,18 @@ const (
 	EntityTypeTimeExpression = "TIME_EXPRESSION"
 )
 
+// EntityType_Values returns all elements of the EntityType enum
+func EntityType_Values() []string {
+	return []string{
+		EntityTypeMedication,
+		EntityTypeMedicalCondition,
+		EntityTypeProtectedHealthInformation,
+		EntityTypeTestTreatmentProcedure,
+		EntityTypeAnatomy,
+		EntityTypeTimeExpression,
+	}
+}
+
 const (
 	// ICD10CMAttributeTypeAcuity is a ICD10CMAttributeType enum value
 	ICD10CMAttributeTypeAcuity = "ACUITY"
@@ -5835,15 +5897,40 @@ const (
 	ICD10CMAttributeTypeQuantity = "QUANTITY"
 )
 
+// ICD10CMAttributeType_Values returns all elements of the ICD10CMAttributeType enum
+func ICD10CMAttributeType_Values() []string {
+	return []string{
+		ICD10CMAttributeTypeAcuity,
+		ICD10CMAttributeTypeDirection,
+		ICD10CMAttributeTypeSystemOrganSite,
+		ICD10CMAttributeTypeQuality,
+		ICD10CMAttributeTypeQuantity,
+	}
+}
+
 const (
 	// ICD10CMEntityCategoryMedicalCondition is a ICD10CMEntityCategory enum value
 	ICD10CMEntityCategoryMedicalCondition = "MEDICAL_CONDITION"
 )
 
+// ICD10CMEntityCategory_Values returns all elements of the ICD10CMEntityCategory enum
+func ICD10CMEntityCategory_Values() []string {
+	return []string{
+		ICD10CMEntityCategoryMedicalCondition,
+	}
+}
+
 const (
 	// ICD10CMEntityTypeDxName is a ICD10CMEntityType enum value
 	ICD10CMEntityTypeDxName = "DX_NAME"
 )
+
+// ICD10CMEntityType_Values returns all elements of the ICD10CMEntityType enum
+func ICD10CMEntityType_Values() []string {
+	return []string{
+		ICD10CMEntityTypeDxName,
+	}
+}
 
 const (
 	// ICD10CMTraitNameNegation is a ICD10CMTraitName enum value
@@ -5858,6 +5945,16 @@ const (
 	// ICD10CMTraitNameSymptom is a ICD10CMTraitName enum value
 	ICD10CMTraitNameSymptom = "SYMPTOM"
 )
+
+// ICD10CMTraitName_Values returns all elements of the ICD10CMTraitName enum
+func ICD10CMTraitName_Values() []string {
+	return []string{
+		ICD10CMTraitNameNegation,
+		ICD10CMTraitNameDiagnosis,
+		ICD10CMTraitNameSign,
+		ICD10CMTraitNameSymptom,
+	}
+}
 
 const (
 	// JobStatusSubmitted is a JobStatus enum value
@@ -5882,10 +5979,30 @@ const (
 	JobStatusStopped = "STOPPED"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusSubmitted,
+		JobStatusInProgress,
+		JobStatusCompleted,
+		JobStatusPartialSuccess,
+		JobStatusFailed,
+		JobStatusStopRequested,
+		JobStatusStopped,
+	}
+}
+
 const (
 	// LanguageCodeEn is a LanguageCode enum value
 	LanguageCodeEn = "en"
 )
+
+// LanguageCode_Values returns all elements of the LanguageCode enum
+func LanguageCode_Values() []string {
+	return []string{
+		LanguageCodeEn,
+	}
+}
 
 const (
 	// RelationshipTypeEvery is a RelationshipType enum value
@@ -5943,6 +6060,30 @@ const (
 	RelationshipTypeSystemOrganSite = "SYSTEM_ORGAN_SITE"
 )
 
+// RelationshipType_Values returns all elements of the RelationshipType enum
+func RelationshipType_Values() []string {
+	return []string{
+		RelationshipTypeEvery,
+		RelationshipTypeWithDosage,
+		RelationshipTypeAdministeredVia,
+		RelationshipTypeFor,
+		RelationshipTypeNegative,
+		RelationshipTypeOverlap,
+		RelationshipTypeDosage,
+		RelationshipTypeRouteOrMode,
+		RelationshipTypeForm,
+		RelationshipTypeFrequency,
+		RelationshipTypeDuration,
+		RelationshipTypeStrength,
+		RelationshipTypeRate,
+		RelationshipTypeAcuity,
+		RelationshipTypeTestValue,
+		RelationshipTypeTestUnits,
+		RelationshipTypeDirection,
+		RelationshipTypeSystemOrganSite,
+	}
+}
+
 const (
 	// RxNormAttributeTypeDosage is a RxNormAttributeType enum value
 	RxNormAttributeTypeDosage = "DOSAGE"
@@ -5966,10 +6107,30 @@ const (
 	RxNormAttributeTypeStrength = "STRENGTH"
 )
 
+// RxNormAttributeType_Values returns all elements of the RxNormAttributeType enum
+func RxNormAttributeType_Values() []string {
+	return []string{
+		RxNormAttributeTypeDosage,
+		RxNormAttributeTypeDuration,
+		RxNormAttributeTypeForm,
+		RxNormAttributeTypeFrequency,
+		RxNormAttributeTypeRate,
+		RxNormAttributeTypeRouteOrMode,
+		RxNormAttributeTypeStrength,
+	}
+}
+
 const (
 	// RxNormEntityCategoryMedication is a RxNormEntityCategory enum value
 	RxNormEntityCategoryMedication = "MEDICATION"
 )
+
+// RxNormEntityCategory_Values returns all elements of the RxNormEntityCategory enum
+func RxNormEntityCategory_Values() []string {
+	return []string{
+		RxNormEntityCategoryMedication,
+	}
+}
 
 const (
 	// RxNormEntityTypeBrandName is a RxNormEntityType enum value
@@ -5979,7 +6140,22 @@ const (
 	RxNormEntityTypeGenericName = "GENERIC_NAME"
 )
 
+// RxNormEntityType_Values returns all elements of the RxNormEntityType enum
+func RxNormEntityType_Values() []string {
+	return []string{
+		RxNormEntityTypeBrandName,
+		RxNormEntityTypeGenericName,
+	}
+}
+
 const (
 	// RxNormTraitNameNegation is a RxNormTraitName enum value
 	RxNormTraitNameNegation = "NEGATION"
 )
+
+// RxNormTraitName_Values returns all elements of the RxNormTraitName enum
+func RxNormTraitName_Values() []string {
+	return []string{
+		RxNormTraitNameNegation,
+	}
+}

--- a/service/computeoptimizer/api.go
+++ b/service/computeoptimizer/api.go
@@ -3549,6 +3549,45 @@ const (
 	ExportableAutoScalingGroupFieldLastRefreshTimestamp = "LastRefreshTimestamp"
 )
 
+// ExportableAutoScalingGroupField_Values returns all elements of the ExportableAutoScalingGroupField enum
+func ExportableAutoScalingGroupField_Values() []string {
+	return []string{
+		ExportableAutoScalingGroupFieldAccountId,
+		ExportableAutoScalingGroupFieldAutoScalingGroupArn,
+		ExportableAutoScalingGroupFieldAutoScalingGroupName,
+		ExportableAutoScalingGroupFieldFinding,
+		ExportableAutoScalingGroupFieldUtilizationMetricsCpuMaximum,
+		ExportableAutoScalingGroupFieldUtilizationMetricsMemoryMaximum,
+		ExportableAutoScalingGroupFieldLookbackPeriodInDays,
+		ExportableAutoScalingGroupFieldCurrentConfigurationInstanceType,
+		ExportableAutoScalingGroupFieldCurrentConfigurationDesiredCapacity,
+		ExportableAutoScalingGroupFieldCurrentConfigurationMinSize,
+		ExportableAutoScalingGroupFieldCurrentConfigurationMaxSize,
+		ExportableAutoScalingGroupFieldCurrentOnDemandPrice,
+		ExportableAutoScalingGroupFieldCurrentStandardOneYearNoUpfrontReservedPrice,
+		ExportableAutoScalingGroupFieldCurrentStandardThreeYearNoUpfrontReservedPrice,
+		ExportableAutoScalingGroupFieldCurrentVcpus,
+		ExportableAutoScalingGroupFieldCurrentMemory,
+		ExportableAutoScalingGroupFieldCurrentStorage,
+		ExportableAutoScalingGroupFieldCurrentNetwork,
+		ExportableAutoScalingGroupFieldRecommendationOptionsConfigurationInstanceType,
+		ExportableAutoScalingGroupFieldRecommendationOptionsConfigurationDesiredCapacity,
+		ExportableAutoScalingGroupFieldRecommendationOptionsConfigurationMinSize,
+		ExportableAutoScalingGroupFieldRecommendationOptionsConfigurationMaxSize,
+		ExportableAutoScalingGroupFieldRecommendationOptionsProjectedUtilizationMetricsCpuMaximum,
+		ExportableAutoScalingGroupFieldRecommendationOptionsProjectedUtilizationMetricsMemoryMaximum,
+		ExportableAutoScalingGroupFieldRecommendationOptionsPerformanceRisk,
+		ExportableAutoScalingGroupFieldRecommendationOptionsOnDemandPrice,
+		ExportableAutoScalingGroupFieldRecommendationOptionsStandardOneYearNoUpfrontReservedPrice,
+		ExportableAutoScalingGroupFieldRecommendationOptionsStandardThreeYearNoUpfrontReservedPrice,
+		ExportableAutoScalingGroupFieldRecommendationOptionsVcpus,
+		ExportableAutoScalingGroupFieldRecommendationOptionsMemory,
+		ExportableAutoScalingGroupFieldRecommendationOptionsStorage,
+		ExportableAutoScalingGroupFieldRecommendationOptionsNetwork,
+		ExportableAutoScalingGroupFieldLastRefreshTimestamp,
+	}
+}
+
 const (
 	// ExportableInstanceFieldAccountId is a ExportableInstanceField enum value
 	ExportableInstanceFieldAccountId = "AccountId"
@@ -3638,10 +3677,52 @@ const (
 	ExportableInstanceFieldLastRefreshTimestamp = "LastRefreshTimestamp"
 )
 
+// ExportableInstanceField_Values returns all elements of the ExportableInstanceField enum
+func ExportableInstanceField_Values() []string {
+	return []string{
+		ExportableInstanceFieldAccountId,
+		ExportableInstanceFieldInstanceArn,
+		ExportableInstanceFieldInstanceName,
+		ExportableInstanceFieldFinding,
+		ExportableInstanceFieldLookbackPeriodInDays,
+		ExportableInstanceFieldCurrentInstanceType,
+		ExportableInstanceFieldUtilizationMetricsCpuMaximum,
+		ExportableInstanceFieldUtilizationMetricsMemoryMaximum,
+		ExportableInstanceFieldCurrentOnDemandPrice,
+		ExportableInstanceFieldCurrentStandardOneYearNoUpfrontReservedPrice,
+		ExportableInstanceFieldCurrentStandardThreeYearNoUpfrontReservedPrice,
+		ExportableInstanceFieldCurrentVcpus,
+		ExportableInstanceFieldCurrentMemory,
+		ExportableInstanceFieldCurrentStorage,
+		ExportableInstanceFieldCurrentNetwork,
+		ExportableInstanceFieldRecommendationOptionsInstanceType,
+		ExportableInstanceFieldRecommendationOptionsProjectedUtilizationMetricsCpuMaximum,
+		ExportableInstanceFieldRecommendationOptionsProjectedUtilizationMetricsMemoryMaximum,
+		ExportableInstanceFieldRecommendationOptionsPerformanceRisk,
+		ExportableInstanceFieldRecommendationOptionsVcpus,
+		ExportableInstanceFieldRecommendationOptionsMemory,
+		ExportableInstanceFieldRecommendationOptionsStorage,
+		ExportableInstanceFieldRecommendationOptionsNetwork,
+		ExportableInstanceFieldRecommendationOptionsOnDemandPrice,
+		ExportableInstanceFieldRecommendationOptionsStandardOneYearNoUpfrontReservedPrice,
+		ExportableInstanceFieldRecommendationOptionsStandardThreeYearNoUpfrontReservedPrice,
+		ExportableInstanceFieldRecommendationsSourcesRecommendationSourceArn,
+		ExportableInstanceFieldRecommendationsSourcesRecommendationSourceType,
+		ExportableInstanceFieldLastRefreshTimestamp,
+	}
+}
+
 const (
 	// FileFormatCsv is a FileFormat enum value
 	FileFormatCsv = "Csv"
 )
+
+// FileFormat_Values returns all elements of the FileFormat enum
+func FileFormat_Values() []string {
+	return []string{
+		FileFormatCsv,
+	}
+}
 
 const (
 	// FilterNameFinding is a FilterName enum value
@@ -3650,6 +3731,14 @@ const (
 	// FilterNameRecommendationSourceType is a FilterName enum value
 	FilterNameRecommendationSourceType = "RecommendationSourceType"
 )
+
+// FilterName_Values returns all elements of the FilterName enum
+func FilterName_Values() []string {
+	return []string{
+		FilterNameFinding,
+		FilterNameRecommendationSourceType,
+	}
+}
 
 const (
 	// FindingUnderprovisioned is a Finding enum value
@@ -3665,6 +3754,16 @@ const (
 	FindingNotOptimized = "NotOptimized"
 )
 
+// Finding_Values returns all elements of the Finding enum
+func Finding_Values() []string {
+	return []string{
+		FindingUnderprovisioned,
+		FindingOverprovisioned,
+		FindingOptimized,
+		FindingNotOptimized,
+	}
+}
+
 const (
 	// JobFilterNameResourceType is a JobFilterName enum value
 	JobFilterNameResourceType = "ResourceType"
@@ -3672,6 +3771,14 @@ const (
 	// JobFilterNameJobStatus is a JobFilterName enum value
 	JobFilterNameJobStatus = "JobStatus"
 )
+
+// JobFilterName_Values returns all elements of the JobFilterName enum
+func JobFilterName_Values() []string {
+	return []string{
+		JobFilterNameResourceType,
+		JobFilterNameJobStatus,
+	}
+}
 
 const (
 	// JobStatusQueued is a JobStatus enum value
@@ -3687,6 +3794,16 @@ const (
 	JobStatusFailed = "Failed"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusQueued,
+		JobStatusInProgress,
+		JobStatusComplete,
+		JobStatusFailed,
+	}
+}
+
 const (
 	// MetricNameCpu is a MetricName enum value
 	MetricNameCpu = "Cpu"
@@ -3694,6 +3811,14 @@ const (
 	// MetricNameMemory is a MetricName enum value
 	MetricNameMemory = "Memory"
 )
+
+// MetricName_Values returns all elements of the MetricName enum
+func MetricName_Values() []string {
+	return []string{
+		MetricNameCpu,
+		MetricNameMemory,
+	}
+}
 
 const (
 	// MetricStatisticMaximum is a MetricStatistic enum value
@@ -3703,6 +3828,14 @@ const (
 	MetricStatisticAverage = "Average"
 )
 
+// MetricStatistic_Values returns all elements of the MetricStatistic enum
+func MetricStatistic_Values() []string {
+	return []string{
+		MetricStatisticMaximum,
+		MetricStatisticAverage,
+	}
+}
+
 const (
 	// RecommendationSourceTypeEc2instance is a RecommendationSourceType enum value
 	RecommendationSourceTypeEc2instance = "Ec2Instance"
@@ -3711,6 +3844,14 @@ const (
 	RecommendationSourceTypeAutoScalingGroup = "AutoScalingGroup"
 )
 
+// RecommendationSourceType_Values returns all elements of the RecommendationSourceType enum
+func RecommendationSourceType_Values() []string {
+	return []string{
+		RecommendationSourceTypeEc2instance,
+		RecommendationSourceTypeAutoScalingGroup,
+	}
+}
+
 const (
 	// ResourceTypeEc2instance is a ResourceType enum value
 	ResourceTypeEc2instance = "Ec2Instance"
@@ -3718,6 +3859,14 @@ const (
 	// ResourceTypeAutoScalingGroup is a ResourceType enum value
 	ResourceTypeAutoScalingGroup = "AutoScalingGroup"
 )
+
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeEc2instance,
+		ResourceTypeAutoScalingGroup,
+	}
+}
 
 const (
 	// StatusActive is a Status enum value
@@ -3732,3 +3881,13 @@ const (
 	// StatusFailed is a Status enum value
 	StatusFailed = "Failed"
 )
+
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusActive,
+		StatusInactive,
+		StatusPending,
+		StatusFailed,
+	}
+}

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -23401,6 +23401,15 @@ const (
 	AggregatedSourceStatusTypeOutdated = "OUTDATED"
 )
 
+// AggregatedSourceStatusType_Values returns all elements of the AggregatedSourceStatusType enum
+func AggregatedSourceStatusType_Values() []string {
+	return []string{
+		AggregatedSourceStatusTypeFailed,
+		AggregatedSourceStatusTypeSucceeded,
+		AggregatedSourceStatusTypeOutdated,
+	}
+}
+
 const (
 	// AggregatedSourceTypeAccount is a AggregatedSourceType enum value
 	AggregatedSourceTypeAccount = "ACCOUNT"
@@ -23409,6 +23418,14 @@ const (
 	AggregatedSourceTypeOrganization = "ORGANIZATION"
 )
 
+// AggregatedSourceType_Values returns all elements of the AggregatedSourceType enum
+func AggregatedSourceType_Values() []string {
+	return []string{
+		AggregatedSourceTypeAccount,
+		AggregatedSourceTypeOrganization,
+	}
+}
+
 const (
 	// ChronologicalOrderReverse is a ChronologicalOrder enum value
 	ChronologicalOrderReverse = "Reverse"
@@ -23416,6 +23433,14 @@ const (
 	// ChronologicalOrderForward is a ChronologicalOrder enum value
 	ChronologicalOrderForward = "Forward"
 )
+
+// ChronologicalOrder_Values returns all elements of the ChronologicalOrder enum
+func ChronologicalOrder_Values() []string {
+	return []string{
+		ChronologicalOrderReverse,
+		ChronologicalOrderForward,
+	}
+}
 
 const (
 	// ComplianceTypeCompliant is a ComplianceType enum value
@@ -23431,6 +23456,16 @@ const (
 	ComplianceTypeInsufficientData = "INSUFFICIENT_DATA"
 )
 
+// ComplianceType_Values returns all elements of the ComplianceType enum
+func ComplianceType_Values() []string {
+	return []string{
+		ComplianceTypeCompliant,
+		ComplianceTypeNonCompliant,
+		ComplianceTypeNotApplicable,
+		ComplianceTypeInsufficientData,
+	}
+}
+
 const (
 	// ConfigRuleComplianceSummaryGroupKeyAccountId is a ConfigRuleComplianceSummaryGroupKey enum value
 	ConfigRuleComplianceSummaryGroupKeyAccountId = "ACCOUNT_ID"
@@ -23438,6 +23473,14 @@ const (
 	// ConfigRuleComplianceSummaryGroupKeyAwsRegion is a ConfigRuleComplianceSummaryGroupKey enum value
 	ConfigRuleComplianceSummaryGroupKeyAwsRegion = "AWS_REGION"
 )
+
+// ConfigRuleComplianceSummaryGroupKey_Values returns all elements of the ConfigRuleComplianceSummaryGroupKey enum
+func ConfigRuleComplianceSummaryGroupKey_Values() []string {
+	return []string{
+		ConfigRuleComplianceSummaryGroupKeyAccountId,
+		ConfigRuleComplianceSummaryGroupKeyAwsRegion,
+	}
+}
 
 const (
 	// ConfigRuleStateActive is a ConfigRuleState enum value
@@ -23452,6 +23495,16 @@ const (
 	// ConfigRuleStateEvaluating is a ConfigRuleState enum value
 	ConfigRuleStateEvaluating = "EVALUATING"
 )
+
+// ConfigRuleState_Values returns all elements of the ConfigRuleState enum
+func ConfigRuleState_Values() []string {
+	return []string{
+		ConfigRuleStateActive,
+		ConfigRuleStateDeleting,
+		ConfigRuleStateDeletingResults,
+		ConfigRuleStateEvaluating,
+	}
+}
 
 const (
 	// ConfigurationItemStatusOk is a ConfigurationItemStatus enum value
@@ -23470,6 +23523,17 @@ const (
 	ConfigurationItemStatusResourceDeletedNotRecorded = "ResourceDeletedNotRecorded"
 )
 
+// ConfigurationItemStatus_Values returns all elements of the ConfigurationItemStatus enum
+func ConfigurationItemStatus_Values() []string {
+	return []string{
+		ConfigurationItemStatusOk,
+		ConfigurationItemStatusResourceDiscovered,
+		ConfigurationItemStatusResourceNotRecorded,
+		ConfigurationItemStatusResourceDeleted,
+		ConfigurationItemStatusResourceDeletedNotRecorded,
+	}
+}
+
 const (
 	// ConformancePackComplianceTypeCompliant is a ConformancePackComplianceType enum value
 	ConformancePackComplianceTypeCompliant = "COMPLIANT"
@@ -23477,6 +23541,14 @@ const (
 	// ConformancePackComplianceTypeNonCompliant is a ConformancePackComplianceType enum value
 	ConformancePackComplianceTypeNonCompliant = "NON_COMPLIANT"
 )
+
+// ConformancePackComplianceType_Values returns all elements of the ConformancePackComplianceType enum
+func ConformancePackComplianceType_Values() []string {
+	return []string{
+		ConformancePackComplianceTypeCompliant,
+		ConformancePackComplianceTypeNonCompliant,
+	}
+}
 
 const (
 	// ConformancePackStateCreateInProgress is a ConformancePackState enum value
@@ -23495,6 +23567,17 @@ const (
 	ConformancePackStateDeleteFailed = "DELETE_FAILED"
 )
 
+// ConformancePackState_Values returns all elements of the ConformancePackState enum
+func ConformancePackState_Values() []string {
+	return []string{
+		ConformancePackStateCreateInProgress,
+		ConformancePackStateCreateComplete,
+		ConformancePackStateCreateFailed,
+		ConformancePackStateDeleteInProgress,
+		ConformancePackStateDeleteFailed,
+	}
+}
+
 const (
 	// DeliveryStatusSuccess is a DeliveryStatus enum value
 	DeliveryStatusSuccess = "Success"
@@ -23506,10 +23589,26 @@ const (
 	DeliveryStatusNotApplicable = "Not_Applicable"
 )
 
+// DeliveryStatus_Values returns all elements of the DeliveryStatus enum
+func DeliveryStatus_Values() []string {
+	return []string{
+		DeliveryStatusSuccess,
+		DeliveryStatusFailure,
+		DeliveryStatusNotApplicable,
+	}
+}
+
 const (
 	// EventSourceAwsConfig is a EventSource enum value
 	EventSourceAwsConfig = "aws.config"
 )
+
+// EventSource_Values returns all elements of the EventSource enum
+func EventSource_Values() []string {
+	return []string{
+		EventSourceAwsConfig,
+	}
+}
 
 const (
 	// MaximumExecutionFrequencyOneHour is a MaximumExecutionFrequency enum value
@@ -23527,6 +23626,17 @@ const (
 	// MaximumExecutionFrequencyTwentyFourHours is a MaximumExecutionFrequency enum value
 	MaximumExecutionFrequencyTwentyFourHours = "TwentyFour_Hours"
 )
+
+// MaximumExecutionFrequency_Values returns all elements of the MaximumExecutionFrequency enum
+func MaximumExecutionFrequency_Values() []string {
+	return []string{
+		MaximumExecutionFrequencyOneHour,
+		MaximumExecutionFrequencyThreeHours,
+		MaximumExecutionFrequencySixHours,
+		MaximumExecutionFrequencyTwelveHours,
+		MaximumExecutionFrequencyTwentyFourHours,
+	}
+}
 
 const (
 	// MemberAccountRuleStatusCreateSuccessful is a MemberAccountRuleStatus enum value
@@ -23557,6 +23667,21 @@ const (
 	MemberAccountRuleStatusUpdateFailed = "UPDATE_FAILED"
 )
 
+// MemberAccountRuleStatus_Values returns all elements of the MemberAccountRuleStatus enum
+func MemberAccountRuleStatus_Values() []string {
+	return []string{
+		MemberAccountRuleStatusCreateSuccessful,
+		MemberAccountRuleStatusCreateInProgress,
+		MemberAccountRuleStatusCreateFailed,
+		MemberAccountRuleStatusDeleteSuccessful,
+		MemberAccountRuleStatusDeleteFailed,
+		MemberAccountRuleStatusDeleteInProgress,
+		MemberAccountRuleStatusUpdateSuccessful,
+		MemberAccountRuleStatusUpdateInProgress,
+		MemberAccountRuleStatusUpdateFailed,
+	}
+}
+
 const (
 	// MessageTypeConfigurationItemChangeNotification is a MessageType enum value
 	MessageTypeConfigurationItemChangeNotification = "ConfigurationItemChangeNotification"
@@ -23571,6 +23696,16 @@ const (
 	MessageTypeOversizedConfigurationItemChangeNotification = "OversizedConfigurationItemChangeNotification"
 )
 
+// MessageType_Values returns all elements of the MessageType enum
+func MessageType_Values() []string {
+	return []string{
+		MessageTypeConfigurationItemChangeNotification,
+		MessageTypeConfigurationSnapshotDeliveryCompleted,
+		MessageTypeScheduledNotification,
+		MessageTypeOversizedConfigurationItemChangeNotification,
+	}
+}
+
 const (
 	// OrganizationConfigRuleTriggerTypeConfigurationItemChangeNotification is a OrganizationConfigRuleTriggerType enum value
 	OrganizationConfigRuleTriggerTypeConfigurationItemChangeNotification = "ConfigurationItemChangeNotification"
@@ -23581,6 +23716,15 @@ const (
 	// OrganizationConfigRuleTriggerTypeScheduledNotification is a OrganizationConfigRuleTriggerType enum value
 	OrganizationConfigRuleTriggerTypeScheduledNotification = "ScheduledNotification"
 )
+
+// OrganizationConfigRuleTriggerType_Values returns all elements of the OrganizationConfigRuleTriggerType enum
+func OrganizationConfigRuleTriggerType_Values() []string {
+	return []string{
+		OrganizationConfigRuleTriggerTypeConfigurationItemChangeNotification,
+		OrganizationConfigRuleTriggerTypeOversizedConfigurationItemChangeNotification,
+		OrganizationConfigRuleTriggerTypeScheduledNotification,
+	}
+}
 
 const (
 	// OrganizationResourceDetailedStatusCreateSuccessful is a OrganizationResourceDetailedStatus enum value
@@ -23611,6 +23755,21 @@ const (
 	OrganizationResourceDetailedStatusUpdateFailed = "UPDATE_FAILED"
 )
 
+// OrganizationResourceDetailedStatus_Values returns all elements of the OrganizationResourceDetailedStatus enum
+func OrganizationResourceDetailedStatus_Values() []string {
+	return []string{
+		OrganizationResourceDetailedStatusCreateSuccessful,
+		OrganizationResourceDetailedStatusCreateInProgress,
+		OrganizationResourceDetailedStatusCreateFailed,
+		OrganizationResourceDetailedStatusDeleteSuccessful,
+		OrganizationResourceDetailedStatusDeleteFailed,
+		OrganizationResourceDetailedStatusDeleteInProgress,
+		OrganizationResourceDetailedStatusUpdateSuccessful,
+		OrganizationResourceDetailedStatusUpdateInProgress,
+		OrganizationResourceDetailedStatusUpdateFailed,
+	}
+}
+
 const (
 	// OrganizationResourceStatusCreateSuccessful is a OrganizationResourceStatus enum value
 	OrganizationResourceStatusCreateSuccessful = "CREATE_SUCCESSFUL"
@@ -23639,6 +23798,21 @@ const (
 	// OrganizationResourceStatusUpdateFailed is a OrganizationResourceStatus enum value
 	OrganizationResourceStatusUpdateFailed = "UPDATE_FAILED"
 )
+
+// OrganizationResourceStatus_Values returns all elements of the OrganizationResourceStatus enum
+func OrganizationResourceStatus_Values() []string {
+	return []string{
+		OrganizationResourceStatusCreateSuccessful,
+		OrganizationResourceStatusCreateInProgress,
+		OrganizationResourceStatusCreateFailed,
+		OrganizationResourceStatusDeleteSuccessful,
+		OrganizationResourceStatusDeleteFailed,
+		OrganizationResourceStatusDeleteInProgress,
+		OrganizationResourceStatusUpdateSuccessful,
+		OrganizationResourceStatusUpdateInProgress,
+		OrganizationResourceStatusUpdateFailed,
+	}
+}
 
 const (
 	// OrganizationRuleStatusCreateSuccessful is a OrganizationRuleStatus enum value
@@ -23669,6 +23843,21 @@ const (
 	OrganizationRuleStatusUpdateFailed = "UPDATE_FAILED"
 )
 
+// OrganizationRuleStatus_Values returns all elements of the OrganizationRuleStatus enum
+func OrganizationRuleStatus_Values() []string {
+	return []string{
+		OrganizationRuleStatusCreateSuccessful,
+		OrganizationRuleStatusCreateInProgress,
+		OrganizationRuleStatusCreateFailed,
+		OrganizationRuleStatusDeleteSuccessful,
+		OrganizationRuleStatusDeleteFailed,
+		OrganizationRuleStatusDeleteInProgress,
+		OrganizationRuleStatusUpdateSuccessful,
+		OrganizationRuleStatusUpdateInProgress,
+		OrganizationRuleStatusUpdateFailed,
+	}
+}
+
 const (
 	// OwnerCustomLambda is a Owner enum value
 	OwnerCustomLambda = "CUSTOM_LAMBDA"
@@ -23676,6 +23865,14 @@ const (
 	// OwnerAws is a Owner enum value
 	OwnerAws = "AWS"
 )
+
+// Owner_Values returns all elements of the Owner enum
+func Owner_Values() []string {
+	return []string{
+		OwnerCustomLambda,
+		OwnerAws,
+	}
+}
 
 const (
 	// RecorderStatusPending is a RecorderStatus enum value
@@ -23687,6 +23884,15 @@ const (
 	// RecorderStatusFailure is a RecorderStatus enum value
 	RecorderStatusFailure = "Failure"
 )
+
+// RecorderStatus_Values returns all elements of the RecorderStatus enum
+func RecorderStatus_Values() []string {
+	return []string{
+		RecorderStatusPending,
+		RecorderStatusSuccess,
+		RecorderStatusFailure,
+	}
+}
 
 const (
 	// RemediationExecutionStateQueued is a RemediationExecutionState enum value
@@ -23702,6 +23908,16 @@ const (
 	RemediationExecutionStateFailed = "FAILED"
 )
 
+// RemediationExecutionState_Values returns all elements of the RemediationExecutionState enum
+func RemediationExecutionState_Values() []string {
+	return []string{
+		RemediationExecutionStateQueued,
+		RemediationExecutionStateInProgress,
+		RemediationExecutionStateSucceeded,
+		RemediationExecutionStateFailed,
+	}
+}
+
 const (
 	// RemediationExecutionStepStateSucceeded is a RemediationExecutionStepState enum value
 	RemediationExecutionStepStateSucceeded = "SUCCEEDED"
@@ -23713,10 +23929,26 @@ const (
 	RemediationExecutionStepStateFailed = "FAILED"
 )
 
+// RemediationExecutionStepState_Values returns all elements of the RemediationExecutionStepState enum
+func RemediationExecutionStepState_Values() []string {
+	return []string{
+		RemediationExecutionStepStateSucceeded,
+		RemediationExecutionStepStatePending,
+		RemediationExecutionStepStateFailed,
+	}
+}
+
 const (
 	// RemediationTargetTypeSsmDocument is a RemediationTargetType enum value
 	RemediationTargetTypeSsmDocument = "SSM_DOCUMENT"
 )
+
+// RemediationTargetType_Values returns all elements of the RemediationTargetType enum
+func RemediationTargetType_Values() []string {
+	return []string{
+		RemediationTargetTypeSsmDocument,
+	}
+}
 
 const (
 	// ResourceCountGroupKeyResourceType is a ResourceCountGroupKey enum value
@@ -23728,6 +23960,15 @@ const (
 	// ResourceCountGroupKeyAwsRegion is a ResourceCountGroupKey enum value
 	ResourceCountGroupKeyAwsRegion = "AWS_REGION"
 )
+
+// ResourceCountGroupKey_Values returns all elements of the ResourceCountGroupKey enum
+func ResourceCountGroupKey_Values() []string {
+	return []string{
+		ResourceCountGroupKeyResourceType,
+		ResourceCountGroupKeyAccountId,
+		ResourceCountGroupKeyAwsRegion,
+	}
+}
 
 const (
 	// ResourceTypeAwsEc2CustomerGateway is a ResourceType enum value
@@ -24010,7 +24251,113 @@ const (
 	ResourceTypeAwsSsmFileData = "AWS::SSM::FileData"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeAwsEc2CustomerGateway,
+		ResourceTypeAwsEc2Eip,
+		ResourceTypeAwsEc2Host,
+		ResourceTypeAwsEc2Instance,
+		ResourceTypeAwsEc2InternetGateway,
+		ResourceTypeAwsEc2NetworkAcl,
+		ResourceTypeAwsEc2NetworkInterface,
+		ResourceTypeAwsEc2RouteTable,
+		ResourceTypeAwsEc2SecurityGroup,
+		ResourceTypeAwsEc2Subnet,
+		ResourceTypeAwsCloudTrailTrail,
+		ResourceTypeAwsEc2Volume,
+		ResourceTypeAwsEc2Vpc,
+		ResourceTypeAwsEc2Vpnconnection,
+		ResourceTypeAwsEc2Vpngateway,
+		ResourceTypeAwsEc2RegisteredHainstance,
+		ResourceTypeAwsEc2NatGateway,
+		ResourceTypeAwsEc2EgressOnlyInternetGateway,
+		ResourceTypeAwsEc2Vpcendpoint,
+		ResourceTypeAwsEc2VpcendpointService,
+		ResourceTypeAwsEc2FlowLog,
+		ResourceTypeAwsEc2VpcpeeringConnection,
+		ResourceTypeAwsElasticsearchDomain,
+		ResourceTypeAwsIamGroup,
+		ResourceTypeAwsIamPolicy,
+		ResourceTypeAwsIamRole,
+		ResourceTypeAwsIamUser,
+		ResourceTypeAwsElasticLoadBalancingV2LoadBalancer,
+		ResourceTypeAwsAcmCertificate,
+		ResourceTypeAwsRdsDbinstance,
+		ResourceTypeAwsRdsDbsubnetGroup,
+		ResourceTypeAwsRdsDbsecurityGroup,
+		ResourceTypeAwsRdsDbsnapshot,
+		ResourceTypeAwsRdsDbcluster,
+		ResourceTypeAwsRdsDbclusterSnapshot,
+		ResourceTypeAwsRdsEventSubscription,
+		ResourceTypeAwsS3Bucket,
+		ResourceTypeAwsS3AccountPublicAccessBlock,
+		ResourceTypeAwsRedshiftCluster,
+		ResourceTypeAwsRedshiftClusterSnapshot,
+		ResourceTypeAwsRedshiftClusterParameterGroup,
+		ResourceTypeAwsRedshiftClusterSecurityGroup,
+		ResourceTypeAwsRedshiftClusterSubnetGroup,
+		ResourceTypeAwsRedshiftEventSubscription,
+		ResourceTypeAwsSsmManagedInstanceInventory,
+		ResourceTypeAwsCloudWatchAlarm,
+		ResourceTypeAwsCloudFormationStack,
+		ResourceTypeAwsElasticLoadBalancingLoadBalancer,
+		ResourceTypeAwsAutoScalingAutoScalingGroup,
+		ResourceTypeAwsAutoScalingLaunchConfiguration,
+		ResourceTypeAwsAutoScalingScalingPolicy,
+		ResourceTypeAwsAutoScalingScheduledAction,
+		ResourceTypeAwsDynamoDbTable,
+		ResourceTypeAwsCodeBuildProject,
+		ResourceTypeAwsWafRateBasedRule,
+		ResourceTypeAwsWafRule,
+		ResourceTypeAwsWafRuleGroup,
+		ResourceTypeAwsWafWebAcl,
+		ResourceTypeAwsWafregionalRateBasedRule,
+		ResourceTypeAwsWafregionalRule,
+		ResourceTypeAwsWafregionalRuleGroup,
+		ResourceTypeAwsWafregionalWebAcl,
+		ResourceTypeAwsCloudFrontDistribution,
+		ResourceTypeAwsCloudFrontStreamingDistribution,
+		ResourceTypeAwsLambdaFunction,
+		ResourceTypeAwsElasticBeanstalkApplication,
+		ResourceTypeAwsElasticBeanstalkApplicationVersion,
+		ResourceTypeAwsElasticBeanstalkEnvironment,
+		ResourceTypeAwsWafv2WebAcl,
+		ResourceTypeAwsWafv2RuleGroup,
+		ResourceTypeAwsWafv2Ipset,
+		ResourceTypeAwsWafv2RegexPatternSet,
+		ResourceTypeAwsWafv2ManagedRuleSet,
+		ResourceTypeAwsXrayEncryptionConfig,
+		ResourceTypeAwsSsmAssociationCompliance,
+		ResourceTypeAwsSsmPatchCompliance,
+		ResourceTypeAwsShieldProtection,
+		ResourceTypeAwsShieldRegionalProtection,
+		ResourceTypeAwsConfigResourceCompliance,
+		ResourceTypeAwsApiGatewayStage,
+		ResourceTypeAwsApiGatewayRestApi,
+		ResourceTypeAwsApiGatewayV2Stage,
+		ResourceTypeAwsApiGatewayV2Api,
+		ResourceTypeAwsCodePipelinePipeline,
+		ResourceTypeAwsServiceCatalogCloudFormationProvisionedProduct,
+		ResourceTypeAwsServiceCatalogCloudFormationProduct,
+		ResourceTypeAwsServiceCatalogPortfolio,
+		ResourceTypeAwsSqsQueue,
+		ResourceTypeAwsKmsKey,
+		ResourceTypeAwsQldbLedger,
+		ResourceTypeAwsSecretsManagerSecret,
+		ResourceTypeAwsSnsTopic,
+		ResourceTypeAwsSsmFileData,
+	}
+}
+
 const (
 	// ResourceValueTypeResourceId is a ResourceValueType enum value
 	ResourceValueTypeResourceId = "RESOURCE_ID"
 )
+
+// ResourceValueType_Values returns all elements of the ResourceValueType enum
+func ResourceValueType_Values() []string {
+	return []string{
+		ResourceValueTypeResourceId,
+	}
+}

--- a/service/connect/api.go
+++ b/service/connect/api.go
@@ -9169,10 +9169,25 @@ const (
 	ChannelChat = "CHAT"
 )
 
+// Channel_Values returns all elements of the Channel enum
+func Channel_Values() []string {
+	return []string{
+		ChannelVoice,
+		ChannelChat,
+	}
+}
+
 const (
 	// ComparisonLt is a Comparison enum value
 	ComparisonLt = "LT"
 )
+
+// Comparison_Values returns all elements of the Comparison enum
+func Comparison_Values() []string {
+	return []string{
+		ComparisonLt,
+	}
+}
 
 const (
 	// ContactFlowTypeContactFlow is a ContactFlowType enum value
@@ -9202,6 +9217,21 @@ const (
 	// ContactFlowTypeQueueTransfer is a ContactFlowType enum value
 	ContactFlowTypeQueueTransfer = "QUEUE_TRANSFER"
 )
+
+// ContactFlowType_Values returns all elements of the ContactFlowType enum
+func ContactFlowType_Values() []string {
+	return []string{
+		ContactFlowTypeContactFlow,
+		ContactFlowTypeCustomerQueue,
+		ContactFlowTypeCustomerHold,
+		ContactFlowTypeCustomerWhisper,
+		ContactFlowTypeAgentHold,
+		ContactFlowTypeAgentWhisper,
+		ContactFlowTypeOutboundWhisper,
+		ContactFlowTypeAgentTransfer,
+		ContactFlowTypeQueueTransfer,
+	}
+}
 
 // The current metric names.
 const (
@@ -9245,6 +9275,25 @@ const (
 	CurrentMetricNameSlotsAvailable = "SLOTS_AVAILABLE"
 )
 
+// CurrentMetricName_Values returns all elements of the CurrentMetricName enum
+func CurrentMetricName_Values() []string {
+	return []string{
+		CurrentMetricNameAgentsOnline,
+		CurrentMetricNameAgentsAvailable,
+		CurrentMetricNameAgentsOnCall,
+		CurrentMetricNameAgentsNonProductive,
+		CurrentMetricNameAgentsAfterContactWork,
+		CurrentMetricNameAgentsError,
+		CurrentMetricNameAgentsStaffed,
+		CurrentMetricNameContactsInQueue,
+		CurrentMetricNameOldestContactAge,
+		CurrentMetricNameContactsScheduled,
+		CurrentMetricNameAgentsOnContact,
+		CurrentMetricNameSlotsActive,
+		CurrentMetricNameSlotsAvailable,
+	}
+}
+
 const (
 	// GroupingQueue is a Grouping enum value
 	GroupingQueue = "QUEUE"
@@ -9252,6 +9301,14 @@ const (
 	// GroupingChannel is a Grouping enum value
 	GroupingChannel = "CHANNEL"
 )
+
+// Grouping_Values returns all elements of the Grouping enum
+func Grouping_Values() []string {
+	return []string{
+		GroupingQueue,
+		GroupingChannel,
+	}
+}
 
 // The historical metric names.
 const (
@@ -9330,6 +9387,37 @@ const (
 	// HistoricalMetricNameServiceLevel is a HistoricalMetricName enum value
 	HistoricalMetricNameServiceLevel = "SERVICE_LEVEL"
 )
+
+// HistoricalMetricName_Values returns all elements of the HistoricalMetricName enum
+func HistoricalMetricName_Values() []string {
+	return []string{
+		HistoricalMetricNameContactsQueued,
+		HistoricalMetricNameContactsHandled,
+		HistoricalMetricNameContactsAbandoned,
+		HistoricalMetricNameContactsConsulted,
+		HistoricalMetricNameContactsAgentHungUpFirst,
+		HistoricalMetricNameContactsHandledIncoming,
+		HistoricalMetricNameContactsHandledOutbound,
+		HistoricalMetricNameContactsHoldAbandons,
+		HistoricalMetricNameContactsTransferredIn,
+		HistoricalMetricNameContactsTransferredOut,
+		HistoricalMetricNameContactsTransferredInFromQueue,
+		HistoricalMetricNameContactsTransferredOutFromQueue,
+		HistoricalMetricNameContactsMissed,
+		HistoricalMetricNameCallbackContactsHandled,
+		HistoricalMetricNameApiContactsHandled,
+		HistoricalMetricNameOccupancy,
+		HistoricalMetricNameHandleTime,
+		HistoricalMetricNameAfterContactWorkTime,
+		HistoricalMetricNameQueuedTime,
+		HistoricalMetricNameAbandonTime,
+		HistoricalMetricNameQueueAnswerTime,
+		HistoricalMetricNameHoldTime,
+		HistoricalMetricNameInteractionTime,
+		HistoricalMetricNameInteractionAndHoldTime,
+		HistoricalMetricNameServiceLevel,
+	}
+}
 
 const (
 	// PhoneNumberCountryCodeAf is a PhoneNumberCountryCode enum value
@@ -10044,6 +10132,249 @@ const (
 	PhoneNumberCountryCodeZw = "ZW"
 )
 
+// PhoneNumberCountryCode_Values returns all elements of the PhoneNumberCountryCode enum
+func PhoneNumberCountryCode_Values() []string {
+	return []string{
+		PhoneNumberCountryCodeAf,
+		PhoneNumberCountryCodeAl,
+		PhoneNumberCountryCodeDz,
+		PhoneNumberCountryCodeAs,
+		PhoneNumberCountryCodeAd,
+		PhoneNumberCountryCodeAo,
+		PhoneNumberCountryCodeAi,
+		PhoneNumberCountryCodeAq,
+		PhoneNumberCountryCodeAg,
+		PhoneNumberCountryCodeAr,
+		PhoneNumberCountryCodeAm,
+		PhoneNumberCountryCodeAw,
+		PhoneNumberCountryCodeAu,
+		PhoneNumberCountryCodeAt,
+		PhoneNumberCountryCodeAz,
+		PhoneNumberCountryCodeBs,
+		PhoneNumberCountryCodeBh,
+		PhoneNumberCountryCodeBd,
+		PhoneNumberCountryCodeBb,
+		PhoneNumberCountryCodeBy,
+		PhoneNumberCountryCodeBe,
+		PhoneNumberCountryCodeBz,
+		PhoneNumberCountryCodeBj,
+		PhoneNumberCountryCodeBm,
+		PhoneNumberCountryCodeBt,
+		PhoneNumberCountryCodeBo,
+		PhoneNumberCountryCodeBa,
+		PhoneNumberCountryCodeBw,
+		PhoneNumberCountryCodeBr,
+		PhoneNumberCountryCodeIo,
+		PhoneNumberCountryCodeVg,
+		PhoneNumberCountryCodeBn,
+		PhoneNumberCountryCodeBg,
+		PhoneNumberCountryCodeBf,
+		PhoneNumberCountryCodeBi,
+		PhoneNumberCountryCodeKh,
+		PhoneNumberCountryCodeCm,
+		PhoneNumberCountryCodeCa,
+		PhoneNumberCountryCodeCv,
+		PhoneNumberCountryCodeKy,
+		PhoneNumberCountryCodeCf,
+		PhoneNumberCountryCodeTd,
+		PhoneNumberCountryCodeCl,
+		PhoneNumberCountryCodeCn,
+		PhoneNumberCountryCodeCx,
+		PhoneNumberCountryCodeCc,
+		PhoneNumberCountryCodeCo,
+		PhoneNumberCountryCodeKm,
+		PhoneNumberCountryCodeCk,
+		PhoneNumberCountryCodeCr,
+		PhoneNumberCountryCodeHr,
+		PhoneNumberCountryCodeCu,
+		PhoneNumberCountryCodeCw,
+		PhoneNumberCountryCodeCy,
+		PhoneNumberCountryCodeCz,
+		PhoneNumberCountryCodeCd,
+		PhoneNumberCountryCodeDk,
+		PhoneNumberCountryCodeDj,
+		PhoneNumberCountryCodeDm,
+		PhoneNumberCountryCodeDo,
+		PhoneNumberCountryCodeTl,
+		PhoneNumberCountryCodeEc,
+		PhoneNumberCountryCodeEg,
+		PhoneNumberCountryCodeSv,
+		PhoneNumberCountryCodeGq,
+		PhoneNumberCountryCodeEr,
+		PhoneNumberCountryCodeEe,
+		PhoneNumberCountryCodeEt,
+		PhoneNumberCountryCodeFk,
+		PhoneNumberCountryCodeFo,
+		PhoneNumberCountryCodeFj,
+		PhoneNumberCountryCodeFi,
+		PhoneNumberCountryCodeFr,
+		PhoneNumberCountryCodePf,
+		PhoneNumberCountryCodeGa,
+		PhoneNumberCountryCodeGm,
+		PhoneNumberCountryCodeGe,
+		PhoneNumberCountryCodeDe,
+		PhoneNumberCountryCodeGh,
+		PhoneNumberCountryCodeGi,
+		PhoneNumberCountryCodeGr,
+		PhoneNumberCountryCodeGl,
+		PhoneNumberCountryCodeGd,
+		PhoneNumberCountryCodeGu,
+		PhoneNumberCountryCodeGt,
+		PhoneNumberCountryCodeGg,
+		PhoneNumberCountryCodeGn,
+		PhoneNumberCountryCodeGw,
+		PhoneNumberCountryCodeGy,
+		PhoneNumberCountryCodeHt,
+		PhoneNumberCountryCodeHn,
+		PhoneNumberCountryCodeHk,
+		PhoneNumberCountryCodeHu,
+		PhoneNumberCountryCodeIs,
+		PhoneNumberCountryCodeIn,
+		PhoneNumberCountryCodeId,
+		PhoneNumberCountryCodeIr,
+		PhoneNumberCountryCodeIq,
+		PhoneNumberCountryCodeIe,
+		PhoneNumberCountryCodeIm,
+		PhoneNumberCountryCodeIl,
+		PhoneNumberCountryCodeIt,
+		PhoneNumberCountryCodeCi,
+		PhoneNumberCountryCodeJm,
+		PhoneNumberCountryCodeJp,
+		PhoneNumberCountryCodeJe,
+		PhoneNumberCountryCodeJo,
+		PhoneNumberCountryCodeKz,
+		PhoneNumberCountryCodeKe,
+		PhoneNumberCountryCodeKi,
+		PhoneNumberCountryCodeKw,
+		PhoneNumberCountryCodeKg,
+		PhoneNumberCountryCodeLa,
+		PhoneNumberCountryCodeLv,
+		PhoneNumberCountryCodeLb,
+		PhoneNumberCountryCodeLs,
+		PhoneNumberCountryCodeLr,
+		PhoneNumberCountryCodeLy,
+		PhoneNumberCountryCodeLi,
+		PhoneNumberCountryCodeLt,
+		PhoneNumberCountryCodeLu,
+		PhoneNumberCountryCodeMo,
+		PhoneNumberCountryCodeMk,
+		PhoneNumberCountryCodeMg,
+		PhoneNumberCountryCodeMw,
+		PhoneNumberCountryCodeMy,
+		PhoneNumberCountryCodeMv,
+		PhoneNumberCountryCodeMl,
+		PhoneNumberCountryCodeMt,
+		PhoneNumberCountryCodeMh,
+		PhoneNumberCountryCodeMr,
+		PhoneNumberCountryCodeMu,
+		PhoneNumberCountryCodeYt,
+		PhoneNumberCountryCodeMx,
+		PhoneNumberCountryCodeFm,
+		PhoneNumberCountryCodeMd,
+		PhoneNumberCountryCodeMc,
+		PhoneNumberCountryCodeMn,
+		PhoneNumberCountryCodeMe,
+		PhoneNumberCountryCodeMs,
+		PhoneNumberCountryCodeMa,
+		PhoneNumberCountryCodeMz,
+		PhoneNumberCountryCodeMm,
+		PhoneNumberCountryCodeNa,
+		PhoneNumberCountryCodeNr,
+		PhoneNumberCountryCodeNp,
+		PhoneNumberCountryCodeNl,
+		PhoneNumberCountryCodeAn,
+		PhoneNumberCountryCodeNc,
+		PhoneNumberCountryCodeNz,
+		PhoneNumberCountryCodeNi,
+		PhoneNumberCountryCodeNe,
+		PhoneNumberCountryCodeNg,
+		PhoneNumberCountryCodeNu,
+		PhoneNumberCountryCodeKp,
+		PhoneNumberCountryCodeMp,
+		PhoneNumberCountryCodeNo,
+		PhoneNumberCountryCodeOm,
+		PhoneNumberCountryCodePk,
+		PhoneNumberCountryCodePw,
+		PhoneNumberCountryCodePa,
+		PhoneNumberCountryCodePg,
+		PhoneNumberCountryCodePy,
+		PhoneNumberCountryCodePe,
+		PhoneNumberCountryCodePh,
+		PhoneNumberCountryCodePn,
+		PhoneNumberCountryCodePl,
+		PhoneNumberCountryCodePt,
+		PhoneNumberCountryCodePr,
+		PhoneNumberCountryCodeQa,
+		PhoneNumberCountryCodeCg,
+		PhoneNumberCountryCodeRe,
+		PhoneNumberCountryCodeRo,
+		PhoneNumberCountryCodeRu,
+		PhoneNumberCountryCodeRw,
+		PhoneNumberCountryCodeBl,
+		PhoneNumberCountryCodeSh,
+		PhoneNumberCountryCodeKn,
+		PhoneNumberCountryCodeLc,
+		PhoneNumberCountryCodeMf,
+		PhoneNumberCountryCodePm,
+		PhoneNumberCountryCodeVc,
+		PhoneNumberCountryCodeWs,
+		PhoneNumberCountryCodeSm,
+		PhoneNumberCountryCodeSt,
+		PhoneNumberCountryCodeSa,
+		PhoneNumberCountryCodeSn,
+		PhoneNumberCountryCodeRs,
+		PhoneNumberCountryCodeSc,
+		PhoneNumberCountryCodeSl,
+		PhoneNumberCountryCodeSg,
+		PhoneNumberCountryCodeSx,
+		PhoneNumberCountryCodeSk,
+		PhoneNumberCountryCodeSi,
+		PhoneNumberCountryCodeSb,
+		PhoneNumberCountryCodeSo,
+		PhoneNumberCountryCodeZa,
+		PhoneNumberCountryCodeKr,
+		PhoneNumberCountryCodeEs,
+		PhoneNumberCountryCodeLk,
+		PhoneNumberCountryCodeSd,
+		PhoneNumberCountryCodeSr,
+		PhoneNumberCountryCodeSj,
+		PhoneNumberCountryCodeSz,
+		PhoneNumberCountryCodeSe,
+		PhoneNumberCountryCodeCh,
+		PhoneNumberCountryCodeSy,
+		PhoneNumberCountryCodeTw,
+		PhoneNumberCountryCodeTj,
+		PhoneNumberCountryCodeTz,
+		PhoneNumberCountryCodeTh,
+		PhoneNumberCountryCodeTg,
+		PhoneNumberCountryCodeTk,
+		PhoneNumberCountryCodeTo,
+		PhoneNumberCountryCodeTt,
+		PhoneNumberCountryCodeTn,
+		PhoneNumberCountryCodeTr,
+		PhoneNumberCountryCodeTm,
+		PhoneNumberCountryCodeTc,
+		PhoneNumberCountryCodeTv,
+		PhoneNumberCountryCodeVi,
+		PhoneNumberCountryCodeUg,
+		PhoneNumberCountryCodeUa,
+		PhoneNumberCountryCodeAe,
+		PhoneNumberCountryCodeGb,
+		PhoneNumberCountryCodeUs,
+		PhoneNumberCountryCodeUy,
+		PhoneNumberCountryCodeUz,
+		PhoneNumberCountryCodeVu,
+		PhoneNumberCountryCodeVa,
+		PhoneNumberCountryCodeVe,
+		PhoneNumberCountryCodeVn,
+		PhoneNumberCountryCodeWf,
+		PhoneNumberCountryCodeEh,
+		PhoneNumberCountryCodeYe,
+		PhoneNumberCountryCodeZm,
+		PhoneNumberCountryCodeZw,
+	}
+}
+
 const (
 	// PhoneNumberTypeTollFree is a PhoneNumberType enum value
 	PhoneNumberTypeTollFree = "TOLL_FREE"
@@ -10051,6 +10382,14 @@ const (
 	// PhoneNumberTypeDid is a PhoneNumberType enum value
 	PhoneNumberTypeDid = "DID"
 )
+
+// PhoneNumberType_Values returns all elements of the PhoneNumberType enum
+func PhoneNumberType_Values() []string {
+	return []string{
+		PhoneNumberTypeTollFree,
+		PhoneNumberTypeDid,
+	}
+}
 
 const (
 	// PhoneTypeSoftPhone is a PhoneType enum value
@@ -10060,6 +10399,14 @@ const (
 	PhoneTypeDeskPhone = "DESK_PHONE"
 )
 
+// PhoneType_Values returns all elements of the PhoneType enum
+func PhoneType_Values() []string {
+	return []string{
+		PhoneTypeSoftPhone,
+		PhoneTypeDeskPhone,
+	}
+}
+
 const (
 	// QueueTypeStandard is a QueueType enum value
 	QueueTypeStandard = "STANDARD"
@@ -10067,6 +10414,14 @@ const (
 	// QueueTypeAgent is a QueueType enum value
 	QueueTypeAgent = "AGENT"
 )
+
+// QueueType_Values returns all elements of the QueueType enum
+func QueueType_Values() []string {
+	return []string{
+		QueueTypeStandard,
+		QueueTypeAgent,
+	}
+}
 
 const (
 	// StatisticSum is a Statistic enum value
@@ -10079,6 +10434,15 @@ const (
 	StatisticAvg = "AVG"
 )
 
+// Statistic_Values returns all elements of the Statistic enum
+func Statistic_Values() []string {
+	return []string{
+		StatisticSum,
+		StatisticMax,
+		StatisticAvg,
+	}
+}
+
 const (
 	// UnitSeconds is a Unit enum value
 	UnitSeconds = "SECONDS"
@@ -10090,6 +10454,15 @@ const (
 	UnitPercent = "PERCENT"
 )
 
+// Unit_Values returns all elements of the Unit enum
+func Unit_Values() []string {
+	return []string{
+		UnitSeconds,
+		UnitCount,
+		UnitPercent,
+	}
+}
+
 const (
 	// VoiceRecordingTrackFromAgent is a VoiceRecordingTrack enum value
 	VoiceRecordingTrackFromAgent = "FROM_AGENT"
@@ -10100,3 +10473,12 @@ const (
 	// VoiceRecordingTrackAll is a VoiceRecordingTrack enum value
 	VoiceRecordingTrackAll = "ALL"
 )
+
+// VoiceRecordingTrack_Values returns all elements of the VoiceRecordingTrack enum
+func VoiceRecordingTrack_Values() []string {
+	return []string{
+		VoiceRecordingTrackFromAgent,
+		VoiceRecordingTrackToAgent,
+		VoiceRecordingTrackAll,
+	}
+}

--- a/service/connectparticipant/api.go
+++ b/service/connectparticipant/api.go
@@ -1544,6 +1544,15 @@ const (
 	ChatItemTypeConnectionAck = "CONNECTION_ACK"
 )
 
+// ChatItemType_Values returns all elements of the ChatItemType enum
+func ChatItemType_Values() []string {
+	return []string{
+		ChatItemTypeMessage,
+		ChatItemTypeEvent,
+		ChatItemTypeConnectionAck,
+	}
+}
+
 const (
 	// ConnectionTypeWebsocket is a ConnectionType enum value
 	ConnectionTypeWebsocket = "WEBSOCKET"
@@ -1551,6 +1560,14 @@ const (
 	// ConnectionTypeConnectionCredentials is a ConnectionType enum value
 	ConnectionTypeConnectionCredentials = "CONNECTION_CREDENTIALS"
 )
+
+// ConnectionType_Values returns all elements of the ConnectionType enum
+func ConnectionType_Values() []string {
+	return []string{
+		ConnectionTypeWebsocket,
+		ConnectionTypeConnectionCredentials,
+	}
+}
 
 const (
 	// ParticipantRoleAgent is a ParticipantRole enum value
@@ -1563,6 +1580,15 @@ const (
 	ParticipantRoleSystem = "SYSTEM"
 )
 
+// ParticipantRole_Values returns all elements of the ParticipantRole enum
+func ParticipantRole_Values() []string {
+	return []string{
+		ParticipantRoleAgent,
+		ParticipantRoleCustomer,
+		ParticipantRoleSystem,
+	}
+}
+
 const (
 	// ScanDirectionForward is a ScanDirection enum value
 	ScanDirectionForward = "FORWARD"
@@ -1571,6 +1597,14 @@ const (
 	ScanDirectionBackward = "BACKWARD"
 )
 
+// ScanDirection_Values returns all elements of the ScanDirection enum
+func ScanDirection_Values() []string {
+	return []string{
+		ScanDirectionForward,
+		ScanDirectionBackward,
+	}
+}
+
 const (
 	// SortKeyDescending is a SortKey enum value
 	SortKeyDescending = "DESCENDING"
@@ -1578,3 +1612,11 @@ const (
 	// SortKeyAscending is a SortKey enum value
 	SortKeyAscending = "ASCENDING"
 )
+
+// SortKey_Values returns all elements of the SortKey enum
+func SortKey_Values() []string {
+	return []string{
+		SortKeyDescending,
+		SortKeyAscending,
+	}
+}

--- a/service/costandusagereportservice/api.go
+++ b/service/costandusagereportservice/api.go
@@ -1112,6 +1112,23 @@ const (
 	AWSRegionApEast1 = "ap-east-1"
 )
 
+// AWSRegion_Values returns all elements of the AWSRegion enum
+func AWSRegion_Values() []string {
+	return []string{
+		AWSRegionUsEast1,
+		AWSRegionUsWest1,
+		AWSRegionUsWest2,
+		AWSRegionEuCentral1,
+		AWSRegionEuWest1,
+		AWSRegionApSoutheast1,
+		AWSRegionApSoutheast2,
+		AWSRegionApNortheast1,
+		AWSRegionEuNorth1,
+		AWSRegionApNortheast3,
+		AWSRegionApEast1,
+	}
+}
+
 // The types of manifest that you want AWS to create for this report.
 const (
 	// AdditionalArtifactRedshift is a AdditionalArtifact enum value
@@ -1123,6 +1140,15 @@ const (
 	// AdditionalArtifactAthena is a AdditionalArtifact enum value
 	AdditionalArtifactAthena = "ATHENA"
 )
+
+// AdditionalArtifact_Values returns all elements of the AdditionalArtifact enum
+func AdditionalArtifact_Values() []string {
+	return []string{
+		AdditionalArtifactRedshift,
+		AdditionalArtifactQuicksight,
+		AdditionalArtifactAthena,
+	}
+}
 
 // The compression format that AWS uses for the report.
 const (
@@ -1136,6 +1162,15 @@ const (
 	CompressionFormatParquet = "Parquet"
 )
 
+// CompressionFormat_Values returns all elements of the CompressionFormat enum
+func CompressionFormat_Values() []string {
+	return []string{
+		CompressionFormatZip,
+		CompressionFormatGzip,
+		CompressionFormatParquet,
+	}
+}
+
 // The format that AWS saves the report in.
 const (
 	// ReportFormatTextOrcsv is a ReportFormat enum value
@@ -1145,6 +1180,14 @@ const (
 	ReportFormatParquet = "Parquet"
 )
 
+// ReportFormat_Values returns all elements of the ReportFormat enum
+func ReportFormat_Values() []string {
+	return []string{
+		ReportFormatTextOrcsv,
+		ReportFormatParquet,
+	}
+}
+
 const (
 	// ReportVersioningCreateNewReport is a ReportVersioning enum value
 	ReportVersioningCreateNewReport = "CREATE_NEW_REPORT"
@@ -1153,11 +1196,26 @@ const (
 	ReportVersioningOverwriteReport = "OVERWRITE_REPORT"
 )
 
+// ReportVersioning_Values returns all elements of the ReportVersioning enum
+func ReportVersioning_Values() []string {
+	return []string{
+		ReportVersioningCreateNewReport,
+		ReportVersioningOverwriteReport,
+	}
+}
+
 // Whether or not AWS includes resource IDs in the report.
 const (
 	// SchemaElementResources is a SchemaElement enum value
 	SchemaElementResources = "RESOURCES"
 )
+
+// SchemaElement_Values returns all elements of the SchemaElement enum
+func SchemaElement_Values() []string {
+	return []string{
+		SchemaElementResources,
+	}
+}
 
 // The length of time covered by the report.
 const (
@@ -1167,3 +1225,11 @@ const (
 	// TimeUnitDaily is a TimeUnit enum value
 	TimeUnitDaily = "DAILY"
 )
+
+// TimeUnit_Values returns all elements of the TimeUnit enum
+func TimeUnit_Values() []string {
+	return []string{
+		TimeUnitHourly,
+		TimeUnitDaily,
+	}
+}

--- a/service/costexplorer/api.go
+++ b/service/costexplorer/api.go
@@ -8939,6 +8939,14 @@ const (
 	AccountScopeLinked = "LINKED"
 )
 
+// AccountScope_Values returns all elements of the AccountScope enum
+func AccountScope_Values() []string {
+	return []string{
+		AccountScopePayer,
+		AccountScopeLinked,
+	}
+}
+
 const (
 	// ContextCostAndUsage is a Context enum value
 	ContextCostAndUsage = "COST_AND_USAGE"
@@ -8950,11 +8958,27 @@ const (
 	ContextSavingsPlans = "SAVINGS_PLANS"
 )
 
+// Context_Values returns all elements of the Context enum
+func Context_Values() []string {
+	return []string{
+		ContextCostAndUsage,
+		ContextReservations,
+		ContextSavingsPlans,
+	}
+}
+
 // The rule schema version in this particular Cost Category.
 const (
 	// CostCategoryRuleVersionCostCategoryExpressionV1 is a CostCategoryRuleVersion enum value
 	CostCategoryRuleVersionCostCategoryExpressionV1 = "CostCategoryExpression.v1"
 )
+
+// CostCategoryRuleVersion_Values returns all elements of the CostCategoryRuleVersion enum
+func CostCategoryRuleVersion_Values() []string {
+	return []string{
+		CostCategoryRuleVersionCostCategoryExpressionV1,
+	}
+}
 
 const (
 	// DimensionAz is a Dimension enum value
@@ -9045,6 +9069,41 @@ const (
 	DimensionPaymentOption = "PAYMENT_OPTION"
 )
 
+// Dimension_Values returns all elements of the Dimension enum
+func Dimension_Values() []string {
+	return []string{
+		DimensionAz,
+		DimensionInstanceType,
+		DimensionLinkedAccount,
+		DimensionLinkedAccountName,
+		DimensionOperation,
+		DimensionPurchaseType,
+		DimensionRegion,
+		DimensionService,
+		DimensionServiceCode,
+		DimensionUsageType,
+		DimensionUsageTypeGroup,
+		DimensionRecordType,
+		DimensionOperatingSystem,
+		DimensionTenancy,
+		DimensionScope,
+		DimensionPlatform,
+		DimensionSubscriptionId,
+		DimensionLegalEntityName,
+		DimensionDeploymentOption,
+		DimensionDatabaseEngine,
+		DimensionCacheEngine,
+		DimensionInstanceTypeFamily,
+		DimensionBillingEntity,
+		DimensionReservationId,
+		DimensionResourceId,
+		DimensionRightsizingType,
+		DimensionSavingsPlansType,
+		DimensionSavingsPlanArn,
+		DimensionPaymentOption,
+	}
+}
+
 const (
 	// GranularityDaily is a Granularity enum value
 	GranularityDaily = "DAILY"
@@ -9055,6 +9114,15 @@ const (
 	// GranularityHourly is a Granularity enum value
 	GranularityHourly = "HOURLY"
 )
+
+// Granularity_Values returns all elements of the Granularity enum
+func Granularity_Values() []string {
+	return []string{
+		GranularityDaily,
+		GranularityMonthly,
+		GranularityHourly,
+	}
+}
 
 const (
 	// GroupDefinitionTypeDimension is a GroupDefinitionType enum value
@@ -9067,6 +9135,15 @@ const (
 	GroupDefinitionTypeCostCategory = "COST_CATEGORY"
 )
 
+// GroupDefinitionType_Values returns all elements of the GroupDefinitionType enum
+func GroupDefinitionType_Values() []string {
+	return []string{
+		GroupDefinitionTypeDimension,
+		GroupDefinitionTypeTag,
+		GroupDefinitionTypeCostCategory,
+	}
+}
+
 const (
 	// LookbackPeriodInDaysSevenDays is a LookbackPeriodInDays enum value
 	LookbackPeriodInDaysSevenDays = "SEVEN_DAYS"
@@ -9077,6 +9154,15 @@ const (
 	// LookbackPeriodInDaysSixtyDays is a LookbackPeriodInDays enum value
 	LookbackPeriodInDaysSixtyDays = "SIXTY_DAYS"
 )
+
+// LookbackPeriodInDays_Values returns all elements of the LookbackPeriodInDays enum
+func LookbackPeriodInDays_Values() []string {
+	return []string{
+		LookbackPeriodInDaysSevenDays,
+		LookbackPeriodInDaysThirtyDays,
+		LookbackPeriodInDaysSixtyDays,
+	}
+}
 
 const (
 	// MatchOptionEquals is a MatchOption enum value
@@ -9097,6 +9183,18 @@ const (
 	// MatchOptionCaseInsensitive is a MatchOption enum value
 	MatchOptionCaseInsensitive = "CASE_INSENSITIVE"
 )
+
+// MatchOption_Values returns all elements of the MatchOption enum
+func MatchOption_Values() []string {
+	return []string{
+		MatchOptionEquals,
+		MatchOptionStartsWith,
+		MatchOptionEndsWith,
+		MatchOptionContains,
+		MatchOptionCaseSensitive,
+		MatchOptionCaseInsensitive,
+	}
+}
 
 const (
 	// MetricBlendedCost is a Metric enum value
@@ -9121,6 +9219,19 @@ const (
 	MetricNormalizedUsageAmount = "NORMALIZED_USAGE_AMOUNT"
 )
 
+// Metric_Values returns all elements of the Metric enum
+func Metric_Values() []string {
+	return []string{
+		MetricBlendedCost,
+		MetricUnblendedCost,
+		MetricAmortizedCost,
+		MetricNetUnblendedCost,
+		MetricNetAmortizedCost,
+		MetricUsageQuantity,
+		MetricNormalizedUsageAmount,
+	}
+}
+
 const (
 	// OfferingClassStandard is a OfferingClass enum value
 	OfferingClassStandard = "STANDARD"
@@ -9128,6 +9239,14 @@ const (
 	// OfferingClassConvertible is a OfferingClass enum value
 	OfferingClassConvertible = "CONVERTIBLE"
 )
+
+// OfferingClass_Values returns all elements of the OfferingClass enum
+func OfferingClass_Values() []string {
+	return []string{
+		OfferingClassStandard,
+		OfferingClassConvertible,
+	}
+}
 
 const (
 	// PaymentOptionNoUpfront is a PaymentOption enum value
@@ -9149,6 +9268,18 @@ const (
 	PaymentOptionHeavyUtilization = "HEAVY_UTILIZATION"
 )
 
+// PaymentOption_Values returns all elements of the PaymentOption enum
+func PaymentOption_Values() []string {
+	return []string{
+		PaymentOptionNoUpfront,
+		PaymentOptionPartialUpfront,
+		PaymentOptionAllUpfront,
+		PaymentOptionLightUtilization,
+		PaymentOptionMediumUtilization,
+		PaymentOptionHeavyUtilization,
+	}
+}
+
 const (
 	// RecommendationTargetSameInstanceFamily is a RecommendationTarget enum value
 	RecommendationTargetSameInstanceFamily = "SAME_INSTANCE_FAMILY"
@@ -9156,6 +9287,14 @@ const (
 	// RecommendationTargetCrossInstanceFamily is a RecommendationTarget enum value
 	RecommendationTargetCrossInstanceFamily = "CROSS_INSTANCE_FAMILY"
 )
+
+// RecommendationTarget_Values returns all elements of the RecommendationTarget enum
+func RecommendationTarget_Values() []string {
+	return []string{
+		RecommendationTargetSameInstanceFamily,
+		RecommendationTargetCrossInstanceFamily,
+	}
+}
 
 const (
 	// RightsizingTypeTerminate is a RightsizingType enum value
@@ -9165,6 +9304,14 @@ const (
 	RightsizingTypeModify = "MODIFY"
 )
 
+// RightsizingType_Values returns all elements of the RightsizingType enum
+func RightsizingType_Values() []string {
+	return []string{
+		RightsizingTypeTerminate,
+		RightsizingTypeModify,
+	}
+}
+
 const (
 	// SupportedSavingsPlansTypeComputeSp is a SupportedSavingsPlansType enum value
 	SupportedSavingsPlansTypeComputeSp = "COMPUTE_SP"
@@ -9173,6 +9320,14 @@ const (
 	SupportedSavingsPlansTypeEc2InstanceSp = "EC2_INSTANCE_SP"
 )
 
+// SupportedSavingsPlansType_Values returns all elements of the SupportedSavingsPlansType enum
+func SupportedSavingsPlansType_Values() []string {
+	return []string{
+		SupportedSavingsPlansTypeComputeSp,
+		SupportedSavingsPlansTypeEc2InstanceSp,
+	}
+}
+
 const (
 	// TermInYearsOneYear is a TermInYears enum value
 	TermInYearsOneYear = "ONE_YEAR"
@@ -9180,3 +9335,11 @@ const (
 	// TermInYearsThreeYears is a TermInYears enum value
 	TermInYearsThreeYears = "THREE_YEARS"
 )
+
+// TermInYears_Values returns all elements of the TermInYears enum
+func TermInYears_Values() []string {
+	return []string{
+		TermInYearsOneYear,
+		TermInYearsThreeYears,
+	}
+}

--- a/service/databasemigrationservice/api.go
+++ b/service/databasemigrationservice/api.go
@@ -17432,6 +17432,15 @@ const (
 	AuthMechanismValueScramSha1 = "scram_sha_1"
 )
 
+// AuthMechanismValue_Values returns all elements of the AuthMechanismValue enum
+func AuthMechanismValue_Values() []string {
+	return []string{
+		AuthMechanismValueDefault,
+		AuthMechanismValueMongodbCr,
+		AuthMechanismValueScramSha1,
+	}
+}
+
 const (
 	// AuthTypeValueNo is a AuthTypeValue enum value
 	AuthTypeValueNo = "no"
@@ -17439,6 +17448,14 @@ const (
 	// AuthTypeValuePassword is a AuthTypeValue enum value
 	AuthTypeValuePassword = "password"
 )
+
+// AuthTypeValue_Values returns all elements of the AuthTypeValue enum
+func AuthTypeValue_Values() []string {
+	return []string{
+		AuthTypeValueNo,
+		AuthTypeValuePassword,
+	}
+}
 
 const (
 	// CompressionTypeValueNone is a CompressionTypeValue enum value
@@ -17448,6 +17465,14 @@ const (
 	CompressionTypeValueGzip = "gzip"
 )
 
+// CompressionTypeValue_Values returns all elements of the CompressionTypeValue enum
+func CompressionTypeValue_Values() []string {
+	return []string{
+		CompressionTypeValueNone,
+		CompressionTypeValueGzip,
+	}
+}
+
 const (
 	// DataFormatValueCsv is a DataFormatValue enum value
 	DataFormatValueCsv = "csv"
@@ -17455,6 +17480,14 @@ const (
 	// DataFormatValueParquet is a DataFormatValue enum value
 	DataFormatValueParquet = "parquet"
 )
+
+// DataFormatValue_Values returns all elements of the DataFormatValue enum
+func DataFormatValue_Values() []string {
+	return []string{
+		DataFormatValueCsv,
+		DataFormatValueParquet,
+	}
+}
 
 const (
 	// DmsSslModeValueNone is a DmsSslModeValue enum value
@@ -17470,6 +17503,16 @@ const (
 	DmsSslModeValueVerifyFull = "verify-full"
 )
 
+// DmsSslModeValue_Values returns all elements of the DmsSslModeValue enum
+func DmsSslModeValue_Values() []string {
+	return []string{
+		DmsSslModeValueNone,
+		DmsSslModeValueRequire,
+		DmsSslModeValueVerifyCa,
+		DmsSslModeValueVerifyFull,
+	}
+}
+
 const (
 	// EncodingTypeValuePlain is a EncodingTypeValue enum value
 	EncodingTypeValuePlain = "plain"
@@ -17481,6 +17524,15 @@ const (
 	EncodingTypeValueRleDictionary = "rle-dictionary"
 )
 
+// EncodingTypeValue_Values returns all elements of the EncodingTypeValue enum
+func EncodingTypeValue_Values() []string {
+	return []string{
+		EncodingTypeValuePlain,
+		EncodingTypeValuePlainDictionary,
+		EncodingTypeValueRleDictionary,
+	}
+}
+
 const (
 	// EncryptionModeValueSseS3 is a EncryptionModeValue enum value
 	EncryptionModeValueSseS3 = "sse-s3"
@@ -17489,6 +17541,14 @@ const (
 	EncryptionModeValueSseKms = "sse-kms"
 )
 
+// EncryptionModeValue_Values returns all elements of the EncryptionModeValue enum
+func EncryptionModeValue_Values() []string {
+	return []string{
+		EncryptionModeValueSseS3,
+		EncryptionModeValueSseKms,
+	}
+}
+
 const (
 	// MessageFormatValueJson is a MessageFormatValue enum value
 	MessageFormatValueJson = "json"
@@ -17496,6 +17556,14 @@ const (
 	// MessageFormatValueJsonUnformatted is a MessageFormatValue enum value
 	MessageFormatValueJsonUnformatted = "json-unformatted"
 )
+
+// MessageFormatValue_Values returns all elements of the MessageFormatValue enum
+func MessageFormatValue_Values() []string {
+	return []string{
+		MessageFormatValueJson,
+		MessageFormatValueJsonUnformatted,
+	}
+}
 
 const (
 	// MigrationTypeValueFullLoad is a MigrationTypeValue enum value
@@ -17508,6 +17576,15 @@ const (
 	MigrationTypeValueFullLoadAndCdc = "full-load-and-cdc"
 )
 
+// MigrationTypeValue_Values returns all elements of the MigrationTypeValue enum
+func MigrationTypeValue_Values() []string {
+	return []string{
+		MigrationTypeValueFullLoad,
+		MigrationTypeValueCdc,
+		MigrationTypeValueFullLoadAndCdc,
+	}
+}
+
 const (
 	// NestingLevelValueNone is a NestingLevelValue enum value
 	NestingLevelValueNone = "none"
@@ -17516,6 +17593,14 @@ const (
 	NestingLevelValueOne = "one"
 )
 
+// NestingLevelValue_Values returns all elements of the NestingLevelValue enum
+func NestingLevelValue_Values() []string {
+	return []string{
+		NestingLevelValueNone,
+		NestingLevelValueOne,
+	}
+}
+
 const (
 	// ParquetVersionValueParquet10 is a ParquetVersionValue enum value
 	ParquetVersionValueParquet10 = "parquet-1-0"
@@ -17523,6 +17608,14 @@ const (
 	// ParquetVersionValueParquet20 is a ParquetVersionValue enum value
 	ParquetVersionValueParquet20 = "parquet-2-0"
 )
+
+// ParquetVersionValue_Values returns all elements of the ParquetVersionValue enum
+func ParquetVersionValue_Values() []string {
+	return []string{
+		ParquetVersionValueParquet10,
+		ParquetVersionValueParquet20,
+	}
+}
 
 const (
 	// RefreshSchemasStatusTypeValueSuccessful is a RefreshSchemasStatusTypeValue enum value
@@ -17535,10 +17628,26 @@ const (
 	RefreshSchemasStatusTypeValueRefreshing = "refreshing"
 )
 
+// RefreshSchemasStatusTypeValue_Values returns all elements of the RefreshSchemasStatusTypeValue enum
+func RefreshSchemasStatusTypeValue_Values() []string {
+	return []string{
+		RefreshSchemasStatusTypeValueSuccessful,
+		RefreshSchemasStatusTypeValueFailed,
+		RefreshSchemasStatusTypeValueRefreshing,
+	}
+}
+
 const (
 	// ReleaseStatusValuesBeta is a ReleaseStatusValues enum value
 	ReleaseStatusValuesBeta = "beta"
 )
+
+// ReleaseStatusValues_Values returns all elements of the ReleaseStatusValues enum
+func ReleaseStatusValues_Values() []string {
+	return []string{
+		ReleaseStatusValuesBeta,
+	}
+}
 
 const (
 	// ReloadOptionValueDataReload is a ReloadOptionValue enum value
@@ -17548,6 +17657,14 @@ const (
 	ReloadOptionValueValidateOnly = "validate-only"
 )
 
+// ReloadOptionValue_Values returns all elements of the ReloadOptionValue enum
+func ReloadOptionValue_Values() []string {
+	return []string{
+		ReloadOptionValueDataReload,
+		ReloadOptionValueValidateOnly,
+	}
+}
+
 const (
 	// ReplicationEndpointTypeValueSource is a ReplicationEndpointTypeValue enum value
 	ReplicationEndpointTypeValueSource = "source"
@@ -17556,10 +17673,25 @@ const (
 	ReplicationEndpointTypeValueTarget = "target"
 )
 
+// ReplicationEndpointTypeValue_Values returns all elements of the ReplicationEndpointTypeValue enum
+func ReplicationEndpointTypeValue_Values() []string {
+	return []string{
+		ReplicationEndpointTypeValueSource,
+		ReplicationEndpointTypeValueTarget,
+	}
+}
+
 const (
 	// SourceTypeReplicationInstance is a SourceType enum value
 	SourceTypeReplicationInstance = "replication-instance"
 )
+
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeReplicationInstance,
+	}
+}
 
 const (
 	// StartReplicationTaskTypeValueStartReplication is a StartReplicationTaskTypeValue enum value
@@ -17571,3 +17703,12 @@ const (
 	// StartReplicationTaskTypeValueReloadTarget is a StartReplicationTaskTypeValue enum value
 	StartReplicationTaskTypeValueReloadTarget = "reload-target"
 )
+
+// StartReplicationTaskTypeValue_Values returns all elements of the StartReplicationTaskTypeValue enum
+func StartReplicationTaskTypeValue_Values() []string {
+	return []string{
+		StartReplicationTaskTypeValueStartReplication,
+		StartReplicationTaskTypeValueResumeProcessing,
+		StartReplicationTaskTypeValueReloadTarget,
+	}
+}

--- a/service/dataexchange/api.go
+++ b/service/dataexchange/api.go
@@ -6661,6 +6661,13 @@ const (
 	AssetTypeS3Snapshot = "S3_SNAPSHOT"
 )
 
+// AssetType_Values returns all elements of the AssetType enum
+func AssetType_Values() []string {
+	return []string{
+		AssetTypeS3Snapshot,
+	}
+}
+
 const (
 	// CodeAccessDeniedException is a Code enum value
 	CodeAccessDeniedException = "ACCESS_DENIED_EXCEPTION"
@@ -6684,6 +6691,19 @@ const (
 	CodeMalwareScanEncryptedFile = "MALWARE_SCAN_ENCRYPTED_FILE"
 )
 
+// Code_Values returns all elements of the Code enum
+func Code_Values() []string {
+	return []string{
+		CodeAccessDeniedException,
+		CodeInternalServerException,
+		CodeMalwareDetected,
+		CodeResourceNotFoundException,
+		CodeServiceQuotaExceededException,
+		CodeValidationException,
+		CodeMalwareScanEncryptedFile,
+	}
+}
+
 // The name of the limit that was reached.
 const (
 	// JobErrorLimitNameAssetsperrevision is a JobErrorLimitName enum value
@@ -6693,6 +6713,14 @@ const (
 	JobErrorLimitNameAssetsizeinGb = "Asset size in GB"
 )
 
+// JobErrorLimitName_Values returns all elements of the JobErrorLimitName enum
+func JobErrorLimitName_Values() []string {
+	return []string{
+		JobErrorLimitNameAssetsperrevision,
+		JobErrorLimitNameAssetsizeinGb,
+	}
+}
+
 // The types of resource which the job error can apply to.
 const (
 	// JobErrorResourceTypesRevision is a JobErrorResourceTypes enum value
@@ -6701,6 +6729,14 @@ const (
 	// JobErrorResourceTypesAsset is a JobErrorResourceTypes enum value
 	JobErrorResourceTypesAsset = "ASSET"
 )
+
+// JobErrorResourceTypes_Values returns all elements of the JobErrorResourceTypes enum
+func JobErrorResourceTypes_Values() []string {
+	return []string{
+		JobErrorResourceTypesRevision,
+		JobErrorResourceTypesAsset,
+	}
+}
 
 const (
 	// LimitNameProductsperaccount is a LimitName enum value
@@ -6740,6 +6776,24 @@ const (
 	LimitNameConcurrentinprogressjobstoexportassetstoasignedUrl = "Concurrent in progress jobs to export assets to a signed URL"
 )
 
+// LimitName_Values returns all elements of the LimitName enum
+func LimitName_Values() []string {
+	return []string{
+		LimitNameProductsperaccount,
+		LimitNameDatasetsperaccount,
+		LimitNameDatasetsperproduct,
+		LimitNameRevisionsperdataset,
+		LimitNameAssetsperrevision,
+		LimitNameAssetsperimportjobfromAmazonS3,
+		LimitNameAssetperexportjobfromAmazonS3,
+		LimitNameAssetsizeinGb,
+		LimitNameConcurrentinprogressjobstoimportassetsfromAmazonS3,
+		LimitNameConcurrentinprogressjobstoimportassetsfromasignedUrl,
+		LimitNameConcurrentinprogressjobstoexportassetstoAmazonS3,
+		LimitNameConcurrentinprogressjobstoexportassetstoasignedUrl,
+	}
+}
+
 // A property that defines the data set as OWNED by the account (for providers)
 // or ENTITLED to the account (for subscribers). When an owned data set is published
 // in a product, AWS Data Exchange creates a copy of the data set. Subscribers
@@ -6751,6 +6805,14 @@ const (
 	// OriginEntitled is a Origin enum value
 	OriginEntitled = "ENTITLED"
 )
+
+// Origin_Values returns all elements of the Origin enum
+func Origin_Values() []string {
+	return []string{
+		OriginOwned,
+		OriginEntitled,
+	}
+}
 
 const (
 	// ResourceTypeDataSet is a ResourceType enum value
@@ -6766,6 +6828,16 @@ const (
 	ResourceTypeJob = "JOB"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeDataSet,
+		ResourceTypeRevision,
+		ResourceTypeAsset,
+		ResourceTypeJob,
+	}
+}
+
 // The types of encryption supported in export jobs to Amazon S3.
 const (
 	// ServerSideEncryptionTypesAwsKms is a ServerSideEncryptionTypes enum value
@@ -6774,6 +6846,14 @@ const (
 	// ServerSideEncryptionTypesAes256 is a ServerSideEncryptionTypes enum value
 	ServerSideEncryptionTypesAes256 = "AES256"
 )
+
+// ServerSideEncryptionTypes_Values returns all elements of the ServerSideEncryptionTypes enum
+func ServerSideEncryptionTypes_Values() []string {
+	return []string{
+		ServerSideEncryptionTypesAwsKms,
+		ServerSideEncryptionTypesAes256,
+	}
+}
 
 const (
 	// StateWaiting is a State enum value
@@ -6795,6 +6875,18 @@ const (
 	StateTimedOut = "TIMED_OUT"
 )
 
+// State_Values returns all elements of the State enum
+func State_Values() []string {
+	return []string{
+		StateWaiting,
+		StateInProgress,
+		StateError,
+		StateCompleted,
+		StateCancelled,
+		StateTimedOut,
+	}
+}
+
 const (
 	// TypeImportAssetsFromS3 is a Type enum value
 	TypeImportAssetsFromS3 = "IMPORT_ASSETS_FROM_S3"
@@ -6808,3 +6900,13 @@ const (
 	// TypeExportAssetToSignedUrl is a Type enum value
 	TypeExportAssetToSignedUrl = "EXPORT_ASSET_TO_SIGNED_URL"
 )
+
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypeImportAssetsFromS3,
+		TypeImportAssetFromSignedUrl,
+		TypeExportAssetsToS3,
+		TypeExportAssetToSignedUrl,
+	}
+}

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -4956,6 +4956,17 @@ const (
 	OperatorTypeBetween = "BETWEEN"
 )
 
+// OperatorType_Values returns all elements of the OperatorType enum
+func OperatorType_Values() []string {
+	return []string{
+		OperatorTypeEq,
+		OperatorTypeRefEq,
+		OperatorTypeLe,
+		OperatorTypeGe,
+		OperatorTypeBetween,
+	}
+}
+
 const (
 	// TaskStatusFinished is a TaskStatus enum value
 	TaskStatusFinished = "FINISHED"
@@ -4966,3 +4977,12 @@ const (
 	// TaskStatusFalse is a TaskStatus enum value
 	TaskStatusFalse = "FALSE"
 )
+
+// TaskStatus_Values returns all elements of the TaskStatus enum
+func TaskStatus_Values() []string {
+	return []string{
+		TaskStatusFinished,
+		TaskStatusFailed,
+		TaskStatusFalse,
+	}
+}

--- a/service/datasync/api.go
+++ b/service/datasync/api.go
@@ -7486,6 +7486,14 @@ const (
 	AgentStatusOffline = "OFFLINE"
 )
 
+// AgentStatus_Values returns all elements of the AgentStatus enum
+func AgentStatus_Values() []string {
+	return []string{
+		AgentStatusOnline,
+		AgentStatusOffline,
+	}
+}
+
 const (
 	// AtimeNone is a Atime enum value
 	AtimeNone = "NONE"
@@ -7493,6 +7501,14 @@ const (
 	// AtimeBestEffort is a Atime enum value
 	AtimeBestEffort = "BEST_EFFORT"
 )
+
+// Atime_Values returns all elements of the Atime enum
+func Atime_Values() []string {
+	return []string{
+		AtimeNone,
+		AtimeBestEffort,
+	}
+}
 
 const (
 	// EndpointTypePublic is a EndpointType enum value
@@ -7505,10 +7521,26 @@ const (
 	EndpointTypeFips = "FIPS"
 )
 
+// EndpointType_Values returns all elements of the EndpointType enum
+func EndpointType_Values() []string {
+	return []string{
+		EndpointTypePublic,
+		EndpointTypePrivateLink,
+		EndpointTypeFips,
+	}
+}
+
 const (
 	// FilterTypeSimplePattern is a FilterType enum value
 	FilterTypeSimplePattern = "SIMPLE_PATTERN"
 )
+
+// FilterType_Values returns all elements of the FilterType enum
+func FilterType_Values() []string {
+	return []string{
+		FilterTypeSimplePattern,
+	}
+}
 
 const (
 	// GidNone is a Gid enum value
@@ -7524,6 +7556,16 @@ const (
 	GidBoth = "BOTH"
 )
 
+// Gid_Values returns all elements of the Gid enum
+func Gid_Values() []string {
+	return []string{
+		GidNone,
+		GidIntValue,
+		GidName,
+		GidBoth,
+	}
+}
+
 const (
 	// LogLevelOff is a LogLevel enum value
 	LogLevelOff = "OFF"
@@ -7535,6 +7577,15 @@ const (
 	LogLevelTransfer = "TRANSFER"
 )
 
+// LogLevel_Values returns all elements of the LogLevel enum
+func LogLevel_Values() []string {
+	return []string{
+		LogLevelOff,
+		LogLevelBasic,
+		LogLevelTransfer,
+	}
+}
+
 const (
 	// MtimeNone is a Mtime enum value
 	MtimeNone = "NONE"
@@ -7542,6 +7593,14 @@ const (
 	// MtimePreserve is a Mtime enum value
 	MtimePreserve = "PRESERVE"
 )
+
+// Mtime_Values returns all elements of the Mtime enum
+func Mtime_Values() []string {
+	return []string{
+		MtimeNone,
+		MtimePreserve,
+	}
+}
 
 const (
 	// NfsVersionAutomatic is a NfsVersion enum value
@@ -7557,6 +7616,16 @@ const (
 	NfsVersionNfs41 = "NFS4_1"
 )
 
+// NfsVersion_Values returns all elements of the NfsVersion enum
+func NfsVersion_Values() []string {
+	return []string{
+		NfsVersionAutomatic,
+		NfsVersionNfs3,
+		NfsVersionNfs40,
+		NfsVersionNfs41,
+	}
+}
+
 const (
 	// ObjectStorageServerProtocolHttps is a ObjectStorageServerProtocol enum value
 	ObjectStorageServerProtocolHttps = "HTTPS"
@@ -7565,6 +7634,14 @@ const (
 	ObjectStorageServerProtocolHttp = "HTTP"
 )
 
+// ObjectStorageServerProtocol_Values returns all elements of the ObjectStorageServerProtocol enum
+func ObjectStorageServerProtocol_Values() []string {
+	return []string{
+		ObjectStorageServerProtocolHttps,
+		ObjectStorageServerProtocolHttp,
+	}
+}
+
 const (
 	// OverwriteModeAlways is a OverwriteMode enum value
 	OverwriteModeAlways = "ALWAYS"
@@ -7572,6 +7649,14 @@ const (
 	// OverwriteModeNever is a OverwriteMode enum value
 	OverwriteModeNever = "NEVER"
 )
+
+// OverwriteMode_Values returns all elements of the OverwriteMode enum
+func OverwriteMode_Values() []string {
+	return []string{
+		OverwriteModeAlways,
+		OverwriteModeNever,
+	}
+}
 
 const (
 	// PhaseStatusPending is a PhaseStatus enum value
@@ -7584,6 +7669,15 @@ const (
 	PhaseStatusError = "ERROR"
 )
 
+// PhaseStatus_Values returns all elements of the PhaseStatus enum
+func PhaseStatus_Values() []string {
+	return []string{
+		PhaseStatusPending,
+		PhaseStatusSuccess,
+		PhaseStatusError,
+	}
+}
+
 const (
 	// PosixPermissionsNone is a PosixPermissions enum value
 	PosixPermissionsNone = "NONE"
@@ -7591,6 +7685,14 @@ const (
 	// PosixPermissionsPreserve is a PosixPermissions enum value
 	PosixPermissionsPreserve = "PRESERVE"
 )
+
+// PosixPermissions_Values returns all elements of the PosixPermissions enum
+func PosixPermissions_Values() []string {
+	return []string{
+		PosixPermissionsNone,
+		PosixPermissionsPreserve,
+	}
+}
 
 const (
 	// PreserveDeletedFilesPreserve is a PreserveDeletedFiles enum value
@@ -7600,6 +7702,14 @@ const (
 	PreserveDeletedFilesRemove = "REMOVE"
 )
 
+// PreserveDeletedFiles_Values returns all elements of the PreserveDeletedFiles enum
+func PreserveDeletedFiles_Values() []string {
+	return []string{
+		PreserveDeletedFilesPreserve,
+		PreserveDeletedFilesRemove,
+	}
+}
+
 const (
 	// PreserveDevicesNone is a PreserveDevices enum value
 	PreserveDevicesNone = "NONE"
@@ -7607,6 +7717,14 @@ const (
 	// PreserveDevicesPreserve is a PreserveDevices enum value
 	PreserveDevicesPreserve = "PRESERVE"
 )
+
+// PreserveDevices_Values returns all elements of the PreserveDevices enum
+func PreserveDevices_Values() []string {
+	return []string{
+		PreserveDevicesNone,
+		PreserveDevicesPreserve,
+	}
+}
 
 const (
 	// S3StorageClassStandard is a S3StorageClass enum value
@@ -7628,6 +7746,18 @@ const (
 	S3StorageClassDeepArchive = "DEEP_ARCHIVE"
 )
 
+// S3StorageClass_Values returns all elements of the S3StorageClass enum
+func S3StorageClass_Values() []string {
+	return []string{
+		S3StorageClassStandard,
+		S3StorageClassStandardIa,
+		S3StorageClassOnezoneIa,
+		S3StorageClassIntelligentTiering,
+		S3StorageClassGlacier,
+		S3StorageClassDeepArchive,
+	}
+}
+
 const (
 	// SmbVersionAutomatic is a SmbVersion enum value
 	SmbVersionAutomatic = "AUTOMATIC"
@@ -7638,6 +7768,15 @@ const (
 	// SmbVersionSmb3 is a SmbVersion enum value
 	SmbVersionSmb3 = "SMB3"
 )
+
+// SmbVersion_Values returns all elements of the SmbVersion enum
+func SmbVersion_Values() []string {
+	return []string{
+		SmbVersionAutomatic,
+		SmbVersionSmb2,
+		SmbVersionSmb3,
+	}
+}
 
 const (
 	// TaskExecutionStatusQueued is a TaskExecutionStatus enum value
@@ -7662,6 +7801,19 @@ const (
 	TaskExecutionStatusError = "ERROR"
 )
 
+// TaskExecutionStatus_Values returns all elements of the TaskExecutionStatus enum
+func TaskExecutionStatus_Values() []string {
+	return []string{
+		TaskExecutionStatusQueued,
+		TaskExecutionStatusLaunching,
+		TaskExecutionStatusPreparing,
+		TaskExecutionStatusTransferring,
+		TaskExecutionStatusVerifying,
+		TaskExecutionStatusSuccess,
+		TaskExecutionStatusError,
+	}
+}
+
 const (
 	// TaskQueueingEnabled is a TaskQueueing enum value
 	TaskQueueingEnabled = "ENABLED"
@@ -7669,6 +7821,14 @@ const (
 	// TaskQueueingDisabled is a TaskQueueing enum value
 	TaskQueueingDisabled = "DISABLED"
 )
+
+// TaskQueueing_Values returns all elements of the TaskQueueing enum
+func TaskQueueing_Values() []string {
+	return []string{
+		TaskQueueingEnabled,
+		TaskQueueingDisabled,
+	}
+}
 
 const (
 	// TaskStatusAvailable is a TaskStatus enum value
@@ -7687,6 +7847,17 @@ const (
 	TaskStatusUnavailable = "UNAVAILABLE"
 )
 
+// TaskStatus_Values returns all elements of the TaskStatus enum
+func TaskStatus_Values() []string {
+	return []string{
+		TaskStatusAvailable,
+		TaskStatusCreating,
+		TaskStatusQueued,
+		TaskStatusRunning,
+		TaskStatusUnavailable,
+	}
+}
+
 const (
 	// TransferModeChanged is a TransferMode enum value
 	TransferModeChanged = "CHANGED"
@@ -7694,6 +7865,14 @@ const (
 	// TransferModeAll is a TransferMode enum value
 	TransferModeAll = "ALL"
 )
+
+// TransferMode_Values returns all elements of the TransferMode enum
+func TransferMode_Values() []string {
+	return []string{
+		TransferModeChanged,
+		TransferModeAll,
+	}
+}
 
 const (
 	// UidNone is a Uid enum value
@@ -7709,6 +7888,16 @@ const (
 	UidBoth = "BOTH"
 )
 
+// Uid_Values returns all elements of the Uid enum
+func Uid_Values() []string {
+	return []string{
+		UidNone,
+		UidIntValue,
+		UidName,
+		UidBoth,
+	}
+}
+
 const (
 	// VerifyModePointInTimeConsistent is a VerifyMode enum value
 	VerifyModePointInTimeConsistent = "POINT_IN_TIME_CONSISTENT"
@@ -7719,3 +7908,12 @@ const (
 	// VerifyModeNone is a VerifyMode enum value
 	VerifyModeNone = "NONE"
 )
+
+// VerifyMode_Values returns all elements of the VerifyMode enum
+func VerifyMode_Values() []string {
+	return []string{
+		VerifyModePointInTimeConsistent,
+		VerifyModeOnlyFilesTransferred,
+		VerifyModeNone,
+	}
+}

--- a/service/dax/api.go
+++ b/service/dax/api.go
@@ -6218,6 +6218,14 @@ const (
 	ChangeTypeRequiresReboot = "REQUIRES_REBOOT"
 )
 
+// ChangeType_Values returns all elements of the ChangeType enum
+func ChangeType_Values() []string {
+	return []string{
+		ChangeTypeImmediate,
+		ChangeTypeRequiresReboot,
+	}
+}
+
 const (
 	// IsModifiableTrue is a IsModifiable enum value
 	IsModifiableTrue = "TRUE"
@@ -6229,6 +6237,15 @@ const (
 	IsModifiableConditional = "CONDITIONAL"
 )
 
+// IsModifiable_Values returns all elements of the IsModifiable enum
+func IsModifiable_Values() []string {
+	return []string{
+		IsModifiableTrue,
+		IsModifiableFalse,
+		IsModifiableConditional,
+	}
+}
+
 const (
 	// ParameterTypeDefault is a ParameterType enum value
 	ParameterTypeDefault = "DEFAULT"
@@ -6236,6 +6253,14 @@ const (
 	// ParameterTypeNodeTypeSpecific is a ParameterType enum value
 	ParameterTypeNodeTypeSpecific = "NODE_TYPE_SPECIFIC"
 )
+
+// ParameterType_Values returns all elements of the ParameterType enum
+func ParameterType_Values() []string {
+	return []string{
+		ParameterTypeDefault,
+		ParameterTypeNodeTypeSpecific,
+	}
+}
 
 const (
 	// SSEStatusEnabling is a SSEStatus enum value
@@ -6251,6 +6276,16 @@ const (
 	SSEStatusDisabled = "DISABLED"
 )
 
+// SSEStatus_Values returns all elements of the SSEStatus enum
+func SSEStatus_Values() []string {
+	return []string{
+		SSEStatusEnabling,
+		SSEStatusEnabled,
+		SSEStatusDisabling,
+		SSEStatusDisabled,
+	}
+}
+
 const (
 	// SourceTypeCluster is a SourceType enum value
 	SourceTypeCluster = "CLUSTER"
@@ -6261,3 +6296,12 @@ const (
 	// SourceTypeSubnetGroup is a SourceType enum value
 	SourceTypeSubnetGroup = "SUBNET_GROUP"
 )
+
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeCluster,
+		SourceTypeParameterGroup,
+		SourceTypeSubnetGroup,
+	}
+}

--- a/service/detective/api.go
+++ b/service/detective/api.go
@@ -2808,6 +2808,14 @@ const (
 	MemberDisabledReasonVolumeUnknown = "VOLUME_UNKNOWN"
 )
 
+// MemberDisabledReason_Values returns all elements of the MemberDisabledReason enum
+func MemberDisabledReason_Values() []string {
+	return []string{
+		MemberDisabledReasonVolumeTooHigh,
+		MemberDisabledReasonVolumeUnknown,
+	}
+}
+
 const (
 	// MemberStatusInvited is a MemberStatus enum value
 	MemberStatusInvited = "INVITED"
@@ -2824,3 +2832,14 @@ const (
 	// MemberStatusAcceptedButDisabled is a MemberStatus enum value
 	MemberStatusAcceptedButDisabled = "ACCEPTED_BUT_DISABLED"
 )
+
+// MemberStatus_Values returns all elements of the MemberStatus enum
+func MemberStatus_Values() []string {
+	return []string{
+		MemberStatusInvited,
+		MemberStatusVerificationInProgress,
+		MemberStatusVerificationFailed,
+		MemberStatusEnabled,
+		MemberStatusAcceptedButDisabled,
+	}
+}

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -19903,6 +19903,15 @@ const (
 	ArtifactCategoryLog = "LOG"
 )
 
+// ArtifactCategory_Values returns all elements of the ArtifactCategory enum
+func ArtifactCategory_Values() []string {
+	return []string{
+		ArtifactCategoryScreenshot,
+		ArtifactCategoryFile,
+		ArtifactCategoryLog,
+	}
+}
+
 const (
 	// ArtifactTypeUnknown is a ArtifactType enum value
 	ArtifactTypeUnknown = "UNKNOWN"
@@ -19989,6 +19998,40 @@ const (
 	ArtifactTypeTestspecOutput = "TESTSPEC_OUTPUT"
 )
 
+// ArtifactType_Values returns all elements of the ArtifactType enum
+func ArtifactType_Values() []string {
+	return []string{
+		ArtifactTypeUnknown,
+		ArtifactTypeScreenshot,
+		ArtifactTypeDeviceLog,
+		ArtifactTypeMessageLog,
+		ArtifactTypeVideoLog,
+		ArtifactTypeResultLog,
+		ArtifactTypeServiceLog,
+		ArtifactTypeWebkitLog,
+		ArtifactTypeInstrumentationOutput,
+		ArtifactTypeExerciserMonkeyOutput,
+		ArtifactTypeCalabashJsonOutput,
+		ArtifactTypeCalabashPrettyOutput,
+		ArtifactTypeCalabashStandardOutput,
+		ArtifactTypeCalabashJavaXmlOutput,
+		ArtifactTypeAutomationOutput,
+		ArtifactTypeAppiumServerOutput,
+		ArtifactTypeAppiumJavaOutput,
+		ArtifactTypeAppiumJavaXmlOutput,
+		ArtifactTypeAppiumPythonOutput,
+		ArtifactTypeAppiumPythonXmlOutput,
+		ArtifactTypeExplorerEventLog,
+		ArtifactTypeExplorerSummaryLog,
+		ArtifactTypeApplicationCrashReport,
+		ArtifactTypeXctestLog,
+		ArtifactTypeVideo,
+		ArtifactTypeCustomerArtifact,
+		ArtifactTypeCustomerArtifactLog,
+		ArtifactTypeTestspecOutput,
+	}
+}
+
 const (
 	// BillingMethodMetered is a BillingMethod enum value
 	BillingMethodMetered = "METERED"
@@ -19997,10 +20040,25 @@ const (
 	BillingMethodUnmetered = "UNMETERED"
 )
 
+// BillingMethod_Values returns all elements of the BillingMethod enum
+func BillingMethod_Values() []string {
+	return []string{
+		BillingMethodMetered,
+		BillingMethodUnmetered,
+	}
+}
+
 const (
 	// CurrencyCodeUsd is a CurrencyCode enum value
 	CurrencyCodeUsd = "USD"
 )
+
+// CurrencyCode_Values returns all elements of the CurrencyCode enum
+func CurrencyCode_Values() []string {
+	return []string{
+		CurrencyCodeUsd,
+	}
+}
 
 const (
 	// DeviceAttributeArn is a DeviceAttribute enum value
@@ -20043,6 +20101,25 @@ const (
 	DeviceAttributeAvailability = "AVAILABILITY"
 )
 
+// DeviceAttribute_Values returns all elements of the DeviceAttribute enum
+func DeviceAttribute_Values() []string {
+	return []string{
+		DeviceAttributeArn,
+		DeviceAttributePlatform,
+		DeviceAttributeFormFactor,
+		DeviceAttributeManufacturer,
+		DeviceAttributeRemoteAccessEnabled,
+		DeviceAttributeRemoteDebugEnabled,
+		DeviceAttributeAppiumVersion,
+		DeviceAttributeInstanceArn,
+		DeviceAttributeInstanceLabels,
+		DeviceAttributeFleetType,
+		DeviceAttributeOsVersion,
+		DeviceAttributeModel,
+		DeviceAttributeAvailability,
+	}
+}
+
 const (
 	// DeviceAvailabilityTemporaryNotAvailable is a DeviceAvailability enum value
 	DeviceAvailabilityTemporaryNotAvailable = "TEMPORARY_NOT_AVAILABLE"
@@ -20056,6 +20133,16 @@ const (
 	// DeviceAvailabilityHighlyAvailable is a DeviceAvailability enum value
 	DeviceAvailabilityHighlyAvailable = "HIGHLY_AVAILABLE"
 )
+
+// DeviceAvailability_Values returns all elements of the DeviceAvailability enum
+func DeviceAvailability_Values() []string {
+	return []string{
+		DeviceAvailabilityTemporaryNotAvailable,
+		DeviceAvailabilityBusy,
+		DeviceAvailabilityAvailable,
+		DeviceAvailabilityHighlyAvailable,
+	}
+}
 
 const (
 	// DeviceFilterAttributeArn is a DeviceFilterAttribute enum value
@@ -20095,6 +20182,24 @@ const (
 	DeviceFilterAttributeFleetType = "FLEET_TYPE"
 )
 
+// DeviceFilterAttribute_Values returns all elements of the DeviceFilterAttribute enum
+func DeviceFilterAttribute_Values() []string {
+	return []string{
+		DeviceFilterAttributeArn,
+		DeviceFilterAttributePlatform,
+		DeviceFilterAttributeOsVersion,
+		DeviceFilterAttributeModel,
+		DeviceFilterAttributeAvailability,
+		DeviceFilterAttributeFormFactor,
+		DeviceFilterAttributeManufacturer,
+		DeviceFilterAttributeRemoteAccessEnabled,
+		DeviceFilterAttributeRemoteDebugEnabled,
+		DeviceFilterAttributeInstanceArn,
+		DeviceFilterAttributeInstanceLabels,
+		DeviceFilterAttributeFleetType,
+	}
+}
+
 const (
 	// DeviceFormFactorPhone is a DeviceFormFactor enum value
 	DeviceFormFactorPhone = "PHONE"
@@ -20102,6 +20207,14 @@ const (
 	// DeviceFormFactorTablet is a DeviceFormFactor enum value
 	DeviceFormFactorTablet = "TABLET"
 )
+
+// DeviceFormFactor_Values returns all elements of the DeviceFormFactor enum
+func DeviceFormFactor_Values() []string {
+	return []string{
+		DeviceFormFactorPhone,
+		DeviceFormFactorTablet,
+	}
+}
 
 const (
 	// DevicePlatformAndroid is a DevicePlatform enum value
@@ -20111,6 +20224,14 @@ const (
 	DevicePlatformIos = "IOS"
 )
 
+// DevicePlatform_Values returns all elements of the DevicePlatform enum
+func DevicePlatform_Values() []string {
+	return []string{
+		DevicePlatformAndroid,
+		DevicePlatformIos,
+	}
+}
+
 const (
 	// DevicePoolTypeCurated is a DevicePoolType enum value
 	DevicePoolTypeCurated = "CURATED"
@@ -20118,6 +20239,14 @@ const (
 	// DevicePoolTypePrivate is a DevicePoolType enum value
 	DevicePoolTypePrivate = "PRIVATE"
 )
+
+// DevicePoolType_Values returns all elements of the DevicePoolType enum
+func DevicePoolType_Values() []string {
+	return []string{
+		DevicePoolTypeCurated,
+		DevicePoolTypePrivate,
+	}
+}
 
 const (
 	// ExecutionResultPending is a ExecutionResult enum value
@@ -20142,6 +20271,19 @@ const (
 	ExecutionResultStopped = "STOPPED"
 )
 
+// ExecutionResult_Values returns all elements of the ExecutionResult enum
+func ExecutionResult_Values() []string {
+	return []string{
+		ExecutionResultPending,
+		ExecutionResultPassed,
+		ExecutionResultWarned,
+		ExecutionResultFailed,
+		ExecutionResultSkipped,
+		ExecutionResultErrored,
+		ExecutionResultStopped,
+	}
+}
+
 const (
 	// ExecutionResultCodeParsingFailed is a ExecutionResultCode enum value
 	ExecutionResultCodeParsingFailed = "PARSING_FAILED"
@@ -20149,6 +20291,14 @@ const (
 	// ExecutionResultCodeVpcEndpointSetupFailed is a ExecutionResultCode enum value
 	ExecutionResultCodeVpcEndpointSetupFailed = "VPC_ENDPOINT_SETUP_FAILED"
 )
+
+// ExecutionResultCode_Values returns all elements of the ExecutionResultCode enum
+func ExecutionResultCode_Values() []string {
+	return []string{
+		ExecutionResultCodeParsingFailed,
+		ExecutionResultCodeVpcEndpointSetupFailed,
+	}
+}
 
 const (
 	// ExecutionStatusPending is a ExecutionStatus enum value
@@ -20179,6 +20329,21 @@ const (
 	ExecutionStatusStopping = "STOPPING"
 )
 
+// ExecutionStatus_Values returns all elements of the ExecutionStatus enum
+func ExecutionStatus_Values() []string {
+	return []string{
+		ExecutionStatusPending,
+		ExecutionStatusPendingConcurrency,
+		ExecutionStatusPendingDevice,
+		ExecutionStatusProcessing,
+		ExecutionStatusScheduling,
+		ExecutionStatusPreparing,
+		ExecutionStatusRunning,
+		ExecutionStatusCompleted,
+		ExecutionStatusStopping,
+	}
+}
+
 const (
 	// InstanceStatusInUse is a InstanceStatus enum value
 	InstanceStatusInUse = "IN_USE"
@@ -20193,6 +20358,16 @@ const (
 	InstanceStatusNotAvailable = "NOT_AVAILABLE"
 )
 
+// InstanceStatus_Values returns all elements of the InstanceStatus enum
+func InstanceStatus_Values() []string {
+	return []string{
+		InstanceStatusInUse,
+		InstanceStatusPreparing,
+		InstanceStatusAvailable,
+		InstanceStatusNotAvailable,
+	}
+}
+
 const (
 	// InteractionModeInteractive is a InteractionMode enum value
 	InteractionModeInteractive = "INTERACTIVE"
@@ -20204,6 +20379,15 @@ const (
 	InteractionModeVideoOnly = "VIDEO_ONLY"
 )
 
+// InteractionMode_Values returns all elements of the InteractionMode enum
+func InteractionMode_Values() []string {
+	return []string{
+		InteractionModeInteractive,
+		InteractionModeNoVideo,
+		InteractionModeVideoOnly,
+	}
+}
+
 const (
 	// NetworkProfileTypeCurated is a NetworkProfileType enum value
 	NetworkProfileTypeCurated = "CURATED"
@@ -20211,6 +20395,14 @@ const (
 	// NetworkProfileTypePrivate is a NetworkProfileType enum value
 	NetworkProfileTypePrivate = "PRIVATE"
 )
+
+// NetworkProfileType_Values returns all elements of the NetworkProfileType enum
+func NetworkProfileType_Values() []string {
+	return []string{
+		NetworkProfileTypeCurated,
+		NetworkProfileTypePrivate,
+	}
+}
 
 const (
 	// OfferingTransactionTypePurchase is a OfferingTransactionType enum value
@@ -20223,15 +20415,38 @@ const (
 	OfferingTransactionTypeSystem = "SYSTEM"
 )
 
+// OfferingTransactionType_Values returns all elements of the OfferingTransactionType enum
+func OfferingTransactionType_Values() []string {
+	return []string{
+		OfferingTransactionTypePurchase,
+		OfferingTransactionTypeRenew,
+		OfferingTransactionTypeSystem,
+	}
+}
+
 const (
 	// OfferingTypeRecurring is a OfferingType enum value
 	OfferingTypeRecurring = "RECURRING"
 )
 
+// OfferingType_Values returns all elements of the OfferingType enum
+func OfferingType_Values() []string {
+	return []string{
+		OfferingTypeRecurring,
+	}
+}
+
 const (
 	// RecurringChargeFrequencyMonthly is a RecurringChargeFrequency enum value
 	RecurringChargeFrequencyMonthly = "MONTHLY"
 )
+
+// RecurringChargeFrequency_Values returns all elements of the RecurringChargeFrequency enum
+func RecurringChargeFrequency_Values() []string {
+	return []string{
+		RecurringChargeFrequencyMonthly,
+	}
+}
 
 const (
 	// RuleOperatorEquals is a RuleOperator enum value
@@ -20258,6 +20473,20 @@ const (
 	// RuleOperatorContains is a RuleOperator enum value
 	RuleOperatorContains = "CONTAINS"
 )
+
+// RuleOperator_Values returns all elements of the RuleOperator enum
+func RuleOperator_Values() []string {
+	return []string{
+		RuleOperatorEquals,
+		RuleOperatorLessThan,
+		RuleOperatorLessThanOrEquals,
+		RuleOperatorGreaterThan,
+		RuleOperatorGreaterThanOrEquals,
+		RuleOperatorIn,
+		RuleOperatorNotIn,
+		RuleOperatorContains,
+	}
+}
 
 const (
 	// SampleTypeCpu is a SampleType enum value
@@ -20312,6 +20541,29 @@ const (
 	SampleTypeOpenglMaxDrawtime = "OPENGL_MAX_DRAWTIME"
 )
 
+// SampleType_Values returns all elements of the SampleType enum
+func SampleType_Values() []string {
+	return []string{
+		SampleTypeCpu,
+		SampleTypeMemory,
+		SampleTypeThreads,
+		SampleTypeRxRate,
+		SampleTypeTxRate,
+		SampleTypeRx,
+		SampleTypeTx,
+		SampleTypeNativeFrames,
+		SampleTypeNativeFps,
+		SampleTypeNativeMinDrawtime,
+		SampleTypeNativeAvgDrawtime,
+		SampleTypeNativeMaxDrawtime,
+		SampleTypeOpenglFrames,
+		SampleTypeOpenglFps,
+		SampleTypeOpenglMinDrawtime,
+		SampleTypeOpenglAvgDrawtime,
+		SampleTypeOpenglMaxDrawtime,
+	}
+}
+
 const (
 	// TestGridSessionArtifactCategoryVideo is a TestGridSessionArtifactCategory enum value
 	TestGridSessionArtifactCategoryVideo = "VIDEO"
@@ -20319,6 +20571,14 @@ const (
 	// TestGridSessionArtifactCategoryLog is a TestGridSessionArtifactCategory enum value
 	TestGridSessionArtifactCategoryLog = "LOG"
 )
+
+// TestGridSessionArtifactCategory_Values returns all elements of the TestGridSessionArtifactCategory enum
+func TestGridSessionArtifactCategory_Values() []string {
+	return []string{
+		TestGridSessionArtifactCategoryVideo,
+		TestGridSessionArtifactCategoryLog,
+	}
+}
 
 const (
 	// TestGridSessionArtifactTypeUnknown is a TestGridSessionArtifactType enum value
@@ -20331,6 +20591,15 @@ const (
 	TestGridSessionArtifactTypeSeleniumLog = "SELENIUM_LOG"
 )
 
+// TestGridSessionArtifactType_Values returns all elements of the TestGridSessionArtifactType enum
+func TestGridSessionArtifactType_Values() []string {
+	return []string{
+		TestGridSessionArtifactTypeUnknown,
+		TestGridSessionArtifactTypeVideo,
+		TestGridSessionArtifactTypeSeleniumLog,
+	}
+}
+
 const (
 	// TestGridSessionStatusActive is a TestGridSessionStatus enum value
 	TestGridSessionStatusActive = "ACTIVE"
@@ -20341,6 +20610,15 @@ const (
 	// TestGridSessionStatusErrored is a TestGridSessionStatus enum value
 	TestGridSessionStatusErrored = "ERRORED"
 )
+
+// TestGridSessionStatus_Values returns all elements of the TestGridSessionStatus enum
+func TestGridSessionStatus_Values() []string {
+	return []string{
+		TestGridSessionStatusActive,
+		TestGridSessionStatusClosed,
+		TestGridSessionStatusErrored,
+	}
+}
 
 const (
 	// TestTypeBuiltinFuzz is a TestType enum value
@@ -20407,6 +20685,33 @@ const (
 	TestTypeRemoteAccessReplay = "REMOTE_ACCESS_REPLAY"
 )
 
+// TestType_Values returns all elements of the TestType enum
+func TestType_Values() []string {
+	return []string{
+		TestTypeBuiltinFuzz,
+		TestTypeBuiltinExplorer,
+		TestTypeWebPerformanceProfile,
+		TestTypeAppiumJavaJunit,
+		TestTypeAppiumJavaTestng,
+		TestTypeAppiumPython,
+		TestTypeAppiumNode,
+		TestTypeAppiumRuby,
+		TestTypeAppiumWebJavaJunit,
+		TestTypeAppiumWebJavaTestng,
+		TestTypeAppiumWebPython,
+		TestTypeAppiumWebNode,
+		TestTypeAppiumWebRuby,
+		TestTypeCalabash,
+		TestTypeInstrumentation,
+		TestTypeUiautomation,
+		TestTypeUiautomator,
+		TestTypeXctest,
+		TestTypeXctestUi,
+		TestTypeRemoteAccessRecord,
+		TestTypeRemoteAccessReplay,
+	}
+}
+
 const (
 	// UploadCategoryCurated is a UploadCategory enum value
 	UploadCategoryCurated = "CURATED"
@@ -20414,6 +20719,14 @@ const (
 	// UploadCategoryPrivate is a UploadCategory enum value
 	UploadCategoryPrivate = "PRIVATE"
 )
+
+// UploadCategory_Values returns all elements of the UploadCategory enum
+func UploadCategory_Values() []string {
+	return []string{
+		UploadCategoryCurated,
+		UploadCategoryPrivate,
+	}
+}
 
 const (
 	// UploadStatusInitialized is a UploadStatus enum value
@@ -20428,6 +20741,16 @@ const (
 	// UploadStatusFailed is a UploadStatus enum value
 	UploadStatusFailed = "FAILED"
 )
+
+// UploadStatus_Values returns all elements of the UploadStatus enum
+func UploadStatus_Values() []string {
+	return []string{
+		UploadStatusInitialized,
+		UploadStatusProcessing,
+		UploadStatusSucceeded,
+		UploadStatusFailed,
+	}
+}
 
 const (
 	// UploadTypeAndroidApp is a UploadType enum value
@@ -20526,3 +20849,41 @@ const (
 	// UploadTypeXctestUiTestSpec is a UploadType enum value
 	UploadTypeXctestUiTestSpec = "XCTEST_UI_TEST_SPEC"
 )
+
+// UploadType_Values returns all elements of the UploadType enum
+func UploadType_Values() []string {
+	return []string{
+		UploadTypeAndroidApp,
+		UploadTypeIosApp,
+		UploadTypeWebApp,
+		UploadTypeExternalData,
+		UploadTypeAppiumJavaJunitTestPackage,
+		UploadTypeAppiumJavaTestngTestPackage,
+		UploadTypeAppiumPythonTestPackage,
+		UploadTypeAppiumNodeTestPackage,
+		UploadTypeAppiumRubyTestPackage,
+		UploadTypeAppiumWebJavaJunitTestPackage,
+		UploadTypeAppiumWebJavaTestngTestPackage,
+		UploadTypeAppiumWebPythonTestPackage,
+		UploadTypeAppiumWebNodeTestPackage,
+		UploadTypeAppiumWebRubyTestPackage,
+		UploadTypeCalabashTestPackage,
+		UploadTypeInstrumentationTestPackage,
+		UploadTypeUiautomationTestPackage,
+		UploadTypeUiautomatorTestPackage,
+		UploadTypeXctestTestPackage,
+		UploadTypeXctestUiTestPackage,
+		UploadTypeAppiumJavaJunitTestSpec,
+		UploadTypeAppiumJavaTestngTestSpec,
+		UploadTypeAppiumPythonTestSpec,
+		UploadTypeAppiumNodeTestSpec,
+		UploadTypeAppiumRubyTestSpec,
+		UploadTypeAppiumWebJavaJunitTestSpec,
+		UploadTypeAppiumWebJavaTestngTestSpec,
+		UploadTypeAppiumWebPythonTestSpec,
+		UploadTypeAppiumWebNodeTestSpec,
+		UploadTypeAppiumWebRubyTestSpec,
+		UploadTypeInstrumentationTestSpec,
+		UploadTypeXctestUiTestSpec,
+	}
+}

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -12212,6 +12212,14 @@ const (
 	AddressFamilyIpv6 = "ipv6"
 )
 
+// AddressFamily_Values returns all elements of the AddressFamily enum
+func AddressFamily_Values() []string {
+	return []string{
+		AddressFamilyIpv4,
+		AddressFamilyIpv6,
+	}
+}
+
 const (
 	// BGPPeerStateVerifying is a BGPPeerState enum value
 	BGPPeerStateVerifying = "verifying"
@@ -12229,6 +12237,17 @@ const (
 	BGPPeerStateDeleted = "deleted"
 )
 
+// BGPPeerState_Values returns all elements of the BGPPeerState enum
+func BGPPeerState_Values() []string {
+	return []string{
+		BGPPeerStateVerifying,
+		BGPPeerStatePending,
+		BGPPeerStateAvailable,
+		BGPPeerStateDeleting,
+		BGPPeerStateDeleted,
+	}
+}
+
 const (
 	// BGPStatusUp is a BGPStatus enum value
 	BGPStatusUp = "up"
@@ -12239,6 +12258,15 @@ const (
 	// BGPStatusUnknown is a BGPStatus enum value
 	BGPStatusUnknown = "unknown"
 )
+
+// BGPStatus_Values returns all elements of the BGPStatus enum
+func BGPStatus_Values() []string {
+	return []string{
+		BGPStatusUp,
+		BGPStatusDown,
+		BGPStatusUnknown,
+	}
+}
 
 const (
 	// ConnectionStateOrdering is a ConnectionState enum value
@@ -12269,6 +12297,21 @@ const (
 	ConnectionStateUnknown = "unknown"
 )
 
+// ConnectionState_Values returns all elements of the ConnectionState enum
+func ConnectionState_Values() []string {
+	return []string{
+		ConnectionStateOrdering,
+		ConnectionStateRequested,
+		ConnectionStatePending,
+		ConnectionStateAvailable,
+		ConnectionStateDown,
+		ConnectionStateDeleting,
+		ConnectionStateDeleted,
+		ConnectionStateRejected,
+		ConnectionStateUnknown,
+	}
+}
+
 const (
 	// GatewayAssociationProposalStateRequested is a GatewayAssociationProposalState enum value
 	GatewayAssociationProposalStateRequested = "requested"
@@ -12279,6 +12322,15 @@ const (
 	// GatewayAssociationProposalStateDeleted is a GatewayAssociationProposalState enum value
 	GatewayAssociationProposalStateDeleted = "deleted"
 )
+
+// GatewayAssociationProposalState_Values returns all elements of the GatewayAssociationProposalState enum
+func GatewayAssociationProposalState_Values() []string {
+	return []string{
+		GatewayAssociationProposalStateRequested,
+		GatewayAssociationProposalStateAccepted,
+		GatewayAssociationProposalStateDeleted,
+	}
+}
 
 const (
 	// GatewayAssociationStateAssociating is a GatewayAssociationState enum value
@@ -12297,6 +12349,17 @@ const (
 	GatewayAssociationStateUpdating = "updating"
 )
 
+// GatewayAssociationState_Values returns all elements of the GatewayAssociationState enum
+func GatewayAssociationState_Values() []string {
+	return []string{
+		GatewayAssociationStateAssociating,
+		GatewayAssociationStateAssociated,
+		GatewayAssociationStateDisassociating,
+		GatewayAssociationStateDisassociated,
+		GatewayAssociationStateUpdating,
+	}
+}
+
 const (
 	// GatewayAttachmentStateAttaching is a GatewayAttachmentState enum value
 	GatewayAttachmentStateAttaching = "attaching"
@@ -12311,6 +12374,16 @@ const (
 	GatewayAttachmentStateDetached = "detached"
 )
 
+// GatewayAttachmentState_Values returns all elements of the GatewayAttachmentState enum
+func GatewayAttachmentState_Values() []string {
+	return []string{
+		GatewayAttachmentStateAttaching,
+		GatewayAttachmentStateAttached,
+		GatewayAttachmentStateDetaching,
+		GatewayAttachmentStateDetached,
+	}
+}
+
 const (
 	// GatewayAttachmentTypeTransitVirtualInterface is a GatewayAttachmentType enum value
 	GatewayAttachmentTypeTransitVirtualInterface = "TransitVirtualInterface"
@@ -12318,6 +12391,14 @@ const (
 	// GatewayAttachmentTypePrivateVirtualInterface is a GatewayAttachmentType enum value
 	GatewayAttachmentTypePrivateVirtualInterface = "PrivateVirtualInterface"
 )
+
+// GatewayAttachmentType_Values returns all elements of the GatewayAttachmentType enum
+func GatewayAttachmentType_Values() []string {
+	return []string{
+		GatewayAttachmentTypeTransitVirtualInterface,
+		GatewayAttachmentTypePrivateVirtualInterface,
+	}
+}
 
 const (
 	// GatewayStatePending is a GatewayState enum value
@@ -12333,6 +12414,16 @@ const (
 	GatewayStateDeleted = "deleted"
 )
 
+// GatewayState_Values returns all elements of the GatewayState enum
+func GatewayState_Values() []string {
+	return []string{
+		GatewayStatePending,
+		GatewayStateAvailable,
+		GatewayStateDeleting,
+		GatewayStateDeleted,
+	}
+}
+
 const (
 	// GatewayTypeVirtualPrivateGateway is a GatewayType enum value
 	GatewayTypeVirtualPrivateGateway = "virtualPrivateGateway"
@@ -12340,6 +12431,14 @@ const (
 	// GatewayTypeTransitGateway is a GatewayType enum value
 	GatewayTypeTransitGateway = "transitGateway"
 )
+
+// GatewayType_Values returns all elements of the GatewayType enum
+func GatewayType_Values() []string {
+	return []string{
+		GatewayTypeVirtualPrivateGateway,
+		GatewayTypeTransitGateway,
+	}
+}
 
 const (
 	// HasLogicalRedundancyUnknown is a HasLogicalRedundancy enum value
@@ -12351,6 +12450,15 @@ const (
 	// HasLogicalRedundancyNo is a HasLogicalRedundancy enum value
 	HasLogicalRedundancyNo = "no"
 )
+
+// HasLogicalRedundancy_Values returns all elements of the HasLogicalRedundancy enum
+func HasLogicalRedundancy_Values() []string {
+	return []string{
+		HasLogicalRedundancyUnknown,
+		HasLogicalRedundancyYes,
+		HasLogicalRedundancyNo,
+	}
+}
 
 const (
 	// InterconnectStateRequested is a InterconnectState enum value
@@ -12375,6 +12483,19 @@ const (
 	InterconnectStateUnknown = "unknown"
 )
 
+// InterconnectState_Values returns all elements of the InterconnectState enum
+func InterconnectState_Values() []string {
+	return []string{
+		InterconnectStateRequested,
+		InterconnectStatePending,
+		InterconnectStateAvailable,
+		InterconnectStateDown,
+		InterconnectStateDeleting,
+		InterconnectStateDeleted,
+		InterconnectStateUnknown,
+	}
+}
+
 const (
 	// LagStateRequested is a LagState enum value
 	LagStateRequested = "requested"
@@ -12398,10 +12519,30 @@ const (
 	LagStateUnknown = "unknown"
 )
 
+// LagState_Values returns all elements of the LagState enum
+func LagState_Values() []string {
+	return []string{
+		LagStateRequested,
+		LagStatePending,
+		LagStateAvailable,
+		LagStateDown,
+		LagStateDeleting,
+		LagStateDeleted,
+		LagStateUnknown,
+	}
+}
+
 const (
 	// LoaContentTypeApplicationPdf is a LoaContentType enum value
 	LoaContentTypeApplicationPdf = "application/pdf"
 )
+
+// LoaContentType_Values returns all elements of the LoaContentType enum
+func LoaContentType_Values() []string {
+	return []string{
+		LoaContentTypeApplicationPdf,
+	}
+}
 
 const (
 	// VirtualInterfaceStateConfirming is a VirtualInterfaceState enum value
@@ -12431,3 +12572,18 @@ const (
 	// VirtualInterfaceStateUnknown is a VirtualInterfaceState enum value
 	VirtualInterfaceStateUnknown = "unknown"
 )
+
+// VirtualInterfaceState_Values returns all elements of the VirtualInterfaceState enum
+func VirtualInterfaceState_Values() []string {
+	return []string{
+		VirtualInterfaceStateConfirming,
+		VirtualInterfaceStateVerifying,
+		VirtualInterfaceStatePending,
+		VirtualInterfaceStateAvailable,
+		VirtualInterfaceStateDown,
+		VirtualInterfaceStateDeleting,
+		VirtualInterfaceStateDeleted,
+		VirtualInterfaceStateRejected,
+		VirtualInterfaceStateUnknown,
+	}
+}

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -14162,6 +14162,18 @@ const (
 	CertificateStateDeregisterFailed = "DeregisterFailed"
 )
 
+// CertificateState_Values returns all elements of the CertificateState enum
+func CertificateState_Values() []string {
+	return []string{
+		CertificateStateRegistering,
+		CertificateStateRegistered,
+		CertificateStateRegisterFailed,
+		CertificateStateDeregistering,
+		CertificateStateDeregistered,
+		CertificateStateDeregisterFailed,
+	}
+}
+
 const (
 	// DirectoryEditionEnterprise is a DirectoryEdition enum value
 	DirectoryEditionEnterprise = "Enterprise"
@@ -14170,6 +14182,14 @@ const (
 	DirectoryEditionStandard = "Standard"
 )
 
+// DirectoryEdition_Values returns all elements of the DirectoryEdition enum
+func DirectoryEdition_Values() []string {
+	return []string{
+		DirectoryEditionEnterprise,
+		DirectoryEditionStandard,
+	}
+}
+
 const (
 	// DirectorySizeSmall is a DirectorySize enum value
 	DirectorySizeSmall = "Small"
@@ -14177,6 +14197,14 @@ const (
 	// DirectorySizeLarge is a DirectorySize enum value
 	DirectorySizeLarge = "Large"
 )
+
+// DirectorySize_Values returns all elements of the DirectorySize enum
+func DirectorySize_Values() []string {
+	return []string{
+		DirectorySizeSmall,
+		DirectorySizeLarge,
+	}
+}
 
 const (
 	// DirectoryStageRequested is a DirectoryStage enum value
@@ -14213,6 +14241,23 @@ const (
 	DirectoryStageFailed = "Failed"
 )
 
+// DirectoryStage_Values returns all elements of the DirectoryStage enum
+func DirectoryStage_Values() []string {
+	return []string{
+		DirectoryStageRequested,
+		DirectoryStageCreating,
+		DirectoryStageCreated,
+		DirectoryStageActive,
+		DirectoryStageInoperable,
+		DirectoryStageImpaired,
+		DirectoryStageRestoring,
+		DirectoryStageRestoreFailed,
+		DirectoryStageDeleting,
+		DirectoryStageDeleted,
+		DirectoryStageFailed,
+	}
+}
+
 const (
 	// DirectoryTypeSimpleAd is a DirectoryType enum value
 	DirectoryTypeSimpleAd = "SimpleAD"
@@ -14226,6 +14271,16 @@ const (
 	// DirectoryTypeSharedMicrosoftAd is a DirectoryType enum value
 	DirectoryTypeSharedMicrosoftAd = "SharedMicrosoftAD"
 )
+
+// DirectoryType_Values returns all elements of the DirectoryType enum
+func DirectoryType_Values() []string {
+	return []string{
+		DirectoryTypeSimpleAd,
+		DirectoryTypeAdconnector,
+		DirectoryTypeMicrosoftAd,
+		DirectoryTypeSharedMicrosoftAd,
+	}
+}
 
 const (
 	// DomainControllerStatusCreating is a DomainControllerStatus enum value
@@ -14250,6 +14305,19 @@ const (
 	DomainControllerStatusFailed = "Failed"
 )
 
+// DomainControllerStatus_Values returns all elements of the DomainControllerStatus enum
+func DomainControllerStatus_Values() []string {
+	return []string{
+		DomainControllerStatusCreating,
+		DomainControllerStatusActive,
+		DomainControllerStatusImpaired,
+		DomainControllerStatusRestoring,
+		DomainControllerStatusDeleting,
+		DomainControllerStatusDeleted,
+		DomainControllerStatusFailed,
+	}
+}
+
 const (
 	// IpRouteStatusMsgAdding is a IpRouteStatusMsg enum value
 	IpRouteStatusMsgAdding = "Adding"
@@ -14270,6 +14338,18 @@ const (
 	IpRouteStatusMsgRemoveFailed = "RemoveFailed"
 )
 
+// IpRouteStatusMsg_Values returns all elements of the IpRouteStatusMsg enum
+func IpRouteStatusMsg_Values() []string {
+	return []string{
+		IpRouteStatusMsgAdding,
+		IpRouteStatusMsgAdded,
+		IpRouteStatusMsgRemoving,
+		IpRouteStatusMsgRemoved,
+		IpRouteStatusMsgAddFailed,
+		IpRouteStatusMsgRemoveFailed,
+	}
+}
+
 const (
 	// LDAPSStatusEnabling is a LDAPSStatus enum value
 	LDAPSStatusEnabling = "Enabling"
@@ -14284,10 +14364,27 @@ const (
 	LDAPSStatusDisabled = "Disabled"
 )
 
+// LDAPSStatus_Values returns all elements of the LDAPSStatus enum
+func LDAPSStatus_Values() []string {
+	return []string{
+		LDAPSStatusEnabling,
+		LDAPSStatusEnabled,
+		LDAPSStatusEnableFailed,
+		LDAPSStatusDisabled,
+	}
+}
+
 const (
 	// LDAPSTypeClient is a LDAPSType enum value
 	LDAPSTypeClient = "Client"
 )
+
+// LDAPSType_Values returns all elements of the LDAPSType enum
+func LDAPSType_Values() []string {
+	return []string{
+		LDAPSTypeClient,
+	}
+}
 
 const (
 	// RadiusAuthenticationProtocolPap is a RadiusAuthenticationProtocol enum value
@@ -14303,6 +14400,16 @@ const (
 	RadiusAuthenticationProtocolMsChapv2 = "MS-CHAPv2"
 )
 
+// RadiusAuthenticationProtocol_Values returns all elements of the RadiusAuthenticationProtocol enum
+func RadiusAuthenticationProtocol_Values() []string {
+	return []string{
+		RadiusAuthenticationProtocolPap,
+		RadiusAuthenticationProtocolChap,
+		RadiusAuthenticationProtocolMsChapv1,
+		RadiusAuthenticationProtocolMsChapv2,
+	}
+}
+
 const (
 	// RadiusStatusCreating is a RadiusStatus enum value
 	RadiusStatusCreating = "Creating"
@@ -14314,10 +14421,26 @@ const (
 	RadiusStatusFailed = "Failed"
 )
 
+// RadiusStatus_Values returns all elements of the RadiusStatus enum
+func RadiusStatus_Values() []string {
+	return []string{
+		RadiusStatusCreating,
+		RadiusStatusCompleted,
+		RadiusStatusFailed,
+	}
+}
+
 const (
 	// ReplicationScopeDomain is a ReplicationScope enum value
 	ReplicationScopeDomain = "Domain"
 )
+
+// ReplicationScope_Values returns all elements of the ReplicationScope enum
+func ReplicationScope_Values() []string {
+	return []string{
+		ReplicationScopeDomain,
+	}
+}
 
 const (
 	// SchemaExtensionStatusInitializing is a SchemaExtensionStatus enum value
@@ -14348,6 +14471,21 @@ const (
 	SchemaExtensionStatusCompleted = "Completed"
 )
 
+// SchemaExtensionStatus_Values returns all elements of the SchemaExtensionStatus enum
+func SchemaExtensionStatus_Values() []string {
+	return []string{
+		SchemaExtensionStatusInitializing,
+		SchemaExtensionStatusCreatingSnapshot,
+		SchemaExtensionStatusUpdatingSchema,
+		SchemaExtensionStatusReplicating,
+		SchemaExtensionStatusCancelInProgress,
+		SchemaExtensionStatusRollbackInProgress,
+		SchemaExtensionStatusCancelled,
+		SchemaExtensionStatusFailed,
+		SchemaExtensionStatusCompleted,
+	}
+}
+
 const (
 	// SelectiveAuthEnabled is a SelectiveAuth enum value
 	SelectiveAuthEnabled = "Enabled"
@@ -14356,6 +14494,14 @@ const (
 	SelectiveAuthDisabled = "Disabled"
 )
 
+// SelectiveAuth_Values returns all elements of the SelectiveAuth enum
+func SelectiveAuth_Values() []string {
+	return []string{
+		SelectiveAuthEnabled,
+		SelectiveAuthDisabled,
+	}
+}
+
 const (
 	// ShareMethodOrganizations is a ShareMethod enum value
 	ShareMethodOrganizations = "ORGANIZATIONS"
@@ -14363,6 +14509,14 @@ const (
 	// ShareMethodHandshake is a ShareMethod enum value
 	ShareMethodHandshake = "HANDSHAKE"
 )
+
+// ShareMethod_Values returns all elements of the ShareMethod enum
+func ShareMethod_Values() []string {
+	return []string{
+		ShareMethodOrganizations,
+		ShareMethodHandshake,
+	}
+}
 
 const (
 	// ShareStatusShared is a ShareStatus enum value
@@ -14393,6 +14547,21 @@ const (
 	ShareStatusDeleting = "Deleting"
 )
 
+// ShareStatus_Values returns all elements of the ShareStatus enum
+func ShareStatus_Values() []string {
+	return []string{
+		ShareStatusShared,
+		ShareStatusPendingAcceptance,
+		ShareStatusRejected,
+		ShareStatusRejecting,
+		ShareStatusRejectFailed,
+		ShareStatusSharing,
+		ShareStatusShareFailed,
+		ShareStatusDeleted,
+		ShareStatusDeleting,
+	}
+}
+
 const (
 	// SnapshotStatusCreating is a SnapshotStatus enum value
 	SnapshotStatusCreating = "Creating"
@@ -14404,6 +14573,15 @@ const (
 	SnapshotStatusFailed = "Failed"
 )
 
+// SnapshotStatus_Values returns all elements of the SnapshotStatus enum
+func SnapshotStatus_Values() []string {
+	return []string{
+		SnapshotStatusCreating,
+		SnapshotStatusCompleted,
+		SnapshotStatusFailed,
+	}
+}
+
 const (
 	// SnapshotTypeAuto is a SnapshotType enum value
 	SnapshotTypeAuto = "Auto"
@@ -14412,10 +14590,25 @@ const (
 	SnapshotTypeManual = "Manual"
 )
 
+// SnapshotType_Values returns all elements of the SnapshotType enum
+func SnapshotType_Values() []string {
+	return []string{
+		SnapshotTypeAuto,
+		SnapshotTypeManual,
+	}
+}
+
 const (
 	// TargetTypeAccount is a TargetType enum value
 	TargetTypeAccount = "ACCOUNT"
 )
+
+// TargetType_Values returns all elements of the TargetType enum
+func TargetType_Values() []string {
+	return []string{
+		TargetTypeAccount,
+	}
+}
 
 const (
 	// TopicStatusRegistered is a TopicStatus enum value
@@ -14431,6 +14624,16 @@ const (
 	TopicStatusDeleted = "Deleted"
 )
 
+// TopicStatus_Values returns all elements of the TopicStatus enum
+func TopicStatus_Values() []string {
+	return []string{
+		TopicStatusRegistered,
+		TopicStatusTopicnotfound,
+		TopicStatusFailed,
+		TopicStatusDeleted,
+	}
+}
+
 const (
 	// TrustDirectionOneWayOutgoing is a TrustDirection enum value
 	TrustDirectionOneWayOutgoing = "One-Way: Outgoing"
@@ -14441,6 +14644,15 @@ const (
 	// TrustDirectionTwoWay is a TrustDirection enum value
 	TrustDirectionTwoWay = "Two-Way"
 )
+
+// TrustDirection_Values returns all elements of the TrustDirection enum
+func TrustDirection_Values() []string {
+	return []string{
+		TrustDirectionOneWayOutgoing,
+		TrustDirectionOneWayIncoming,
+		TrustDirectionTwoWay,
+	}
+}
 
 const (
 	// TrustStateCreating is a TrustState enum value
@@ -14477,6 +14689,23 @@ const (
 	TrustStateFailed = "Failed"
 )
 
+// TrustState_Values returns all elements of the TrustState enum
+func TrustState_Values() []string {
+	return []string{
+		TrustStateCreating,
+		TrustStateCreated,
+		TrustStateVerifying,
+		TrustStateVerifyFailed,
+		TrustStateVerified,
+		TrustStateUpdating,
+		TrustStateUpdateFailed,
+		TrustStateUpdated,
+		TrustStateDeleting,
+		TrustStateDeleted,
+		TrustStateFailed,
+	}
+}
+
 const (
 	// TrustTypeForest is a TrustType enum value
 	TrustTypeForest = "Forest"
@@ -14484,3 +14713,11 @@ const (
 	// TrustTypeExternal is a TrustType enum value
 	TrustTypeExternal = "External"
 )
+
+// TrustType_Values returns all elements of the TrustType enum
+func TrustType_Values() []string {
+	return []string{
+		TrustTypeForest,
+		TrustTypeExternal,
+	}
+}

--- a/service/dlm/api.go
+++ b/service/dlm/api.go
@@ -2453,15 +2453,38 @@ const (
 	GettablePolicyStateValuesError = "ERROR"
 )
 
+// GettablePolicyStateValues_Values returns all elements of the GettablePolicyStateValues enum
+func GettablePolicyStateValues_Values() []string {
+	return []string{
+		GettablePolicyStateValuesEnabled,
+		GettablePolicyStateValuesDisabled,
+		GettablePolicyStateValuesError,
+	}
+}
+
 const (
 	// IntervalUnitValuesHours is a IntervalUnitValues enum value
 	IntervalUnitValuesHours = "HOURS"
 )
 
+// IntervalUnitValues_Values returns all elements of the IntervalUnitValues enum
+func IntervalUnitValues_Values() []string {
+	return []string{
+		IntervalUnitValuesHours,
+	}
+}
+
 const (
 	// PolicyTypeValuesEbsSnapshotManagement is a PolicyTypeValues enum value
 	PolicyTypeValuesEbsSnapshotManagement = "EBS_SNAPSHOT_MANAGEMENT"
 )
+
+// PolicyTypeValues_Values returns all elements of the PolicyTypeValues enum
+func PolicyTypeValues_Values() []string {
+	return []string{
+		PolicyTypeValuesEbsSnapshotManagement,
+	}
+}
 
 const (
 	// ResourceTypeValuesVolume is a ResourceTypeValues enum value
@@ -2470,6 +2493,14 @@ const (
 	// ResourceTypeValuesInstance is a ResourceTypeValues enum value
 	ResourceTypeValuesInstance = "INSTANCE"
 )
+
+// ResourceTypeValues_Values returns all elements of the ResourceTypeValues enum
+func ResourceTypeValues_Values() []string {
+	return []string{
+		ResourceTypeValuesVolume,
+		ResourceTypeValuesInstance,
+	}
+}
 
 const (
 	// RetentionIntervalUnitValuesDays is a RetentionIntervalUnitValues enum value
@@ -2485,6 +2516,16 @@ const (
 	RetentionIntervalUnitValuesYears = "YEARS"
 )
 
+// RetentionIntervalUnitValues_Values returns all elements of the RetentionIntervalUnitValues enum
+func RetentionIntervalUnitValues_Values() []string {
+	return []string{
+		RetentionIntervalUnitValuesDays,
+		RetentionIntervalUnitValuesWeeks,
+		RetentionIntervalUnitValuesMonths,
+		RetentionIntervalUnitValuesYears,
+	}
+}
+
 const (
 	// SettablePolicyStateValuesEnabled is a SettablePolicyStateValues enum value
 	SettablePolicyStateValuesEnabled = "ENABLED"
@@ -2492,3 +2533,11 @@ const (
 	// SettablePolicyStateValuesDisabled is a SettablePolicyStateValues enum value
 	SettablePolicyStateValuesDisabled = "DISABLED"
 )
+
+// SettablePolicyStateValues_Values returns all elements of the SettablePolicyStateValues enum
+func SettablePolicyStateValues_Values() []string {
+	return []string{
+		SettablePolicyStateValuesEnabled,
+		SettablePolicyStateValuesDisabled,
+	}
+}

--- a/service/docdb/api.go
+++ b/service/docdb/api.go
@@ -11628,6 +11628,14 @@ const (
 	ApplyMethodPendingReboot = "pending-reboot"
 )
 
+// ApplyMethod_Values returns all elements of the ApplyMethod enum
+func ApplyMethod_Values() []string {
+	return []string{
+		ApplyMethodImmediate,
+		ApplyMethodPendingReboot,
+	}
+}
+
 const (
 	// SourceTypeDbInstance is a SourceType enum value
 	SourceTypeDbInstance = "db-instance"
@@ -11647,3 +11655,15 @@ const (
 	// SourceTypeDbClusterSnapshot is a SourceType enum value
 	SourceTypeDbClusterSnapshot = "db-cluster-snapshot"
 )
+
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeDbInstance,
+		SourceTypeDbParameterGroup,
+		SourceTypeDbSecurityGroup,
+		SourceTypeDbSnapshot,
+		SourceTypeDbCluster,
+		SourceTypeDbClusterSnapshot,
+	}
+}

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -19885,6 +19885,15 @@ const (
 	AttributeActionDelete = "DELETE"
 )
 
+// AttributeAction_Values returns all elements of the AttributeAction enum
+func AttributeAction_Values() []string {
+	return []string{
+		AttributeActionAdd,
+		AttributeActionPut,
+		AttributeActionDelete,
+	}
+}
+
 const (
 	// BackupStatusCreating is a BackupStatus enum value
 	BackupStatusCreating = "CREATING"
@@ -19896,6 +19905,15 @@ const (
 	BackupStatusAvailable = "AVAILABLE"
 )
 
+// BackupStatus_Values returns all elements of the BackupStatus enum
+func BackupStatus_Values() []string {
+	return []string{
+		BackupStatusCreating,
+		BackupStatusDeleted,
+		BackupStatusAvailable,
+	}
+}
+
 const (
 	// BackupTypeUser is a BackupType enum value
 	BackupTypeUser = "USER"
@@ -19906,6 +19924,15 @@ const (
 	// BackupTypeAwsBackup is a BackupType enum value
 	BackupTypeAwsBackup = "AWS_BACKUP"
 )
+
+// BackupType_Values returns all elements of the BackupType enum
+func BackupType_Values() []string {
+	return []string{
+		BackupTypeUser,
+		BackupTypeSystem,
+		BackupTypeAwsBackup,
+	}
+}
 
 const (
 	// BackupTypeFilterUser is a BackupTypeFilter enum value
@@ -19921,6 +19948,16 @@ const (
 	BackupTypeFilterAll = "ALL"
 )
 
+// BackupTypeFilter_Values returns all elements of the BackupTypeFilter enum
+func BackupTypeFilter_Values() []string {
+	return []string{
+		BackupTypeFilterUser,
+		BackupTypeFilterSystem,
+		BackupTypeFilterAwsBackup,
+		BackupTypeFilterAll,
+	}
+}
+
 const (
 	// BillingModeProvisioned is a BillingMode enum value
 	BillingModeProvisioned = "PROVISIONED"
@@ -19928,6 +19965,14 @@ const (
 	// BillingModePayPerRequest is a BillingMode enum value
 	BillingModePayPerRequest = "PAY_PER_REQUEST"
 )
+
+// BillingMode_Values returns all elements of the BillingMode enum
+func BillingMode_Values() []string {
+	return []string{
+		BillingModeProvisioned,
+		BillingModePayPerRequest,
+	}
+}
 
 const (
 	// ComparisonOperatorEq is a ComparisonOperator enum value
@@ -19970,6 +20015,25 @@ const (
 	ComparisonOperatorBeginsWith = "BEGINS_WITH"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorEq,
+		ComparisonOperatorNe,
+		ComparisonOperatorIn,
+		ComparisonOperatorLe,
+		ComparisonOperatorLt,
+		ComparisonOperatorGe,
+		ComparisonOperatorGt,
+		ComparisonOperatorBetween,
+		ComparisonOperatorNotNull,
+		ComparisonOperatorNull,
+		ComparisonOperatorContains,
+		ComparisonOperatorNotContains,
+		ComparisonOperatorBeginsWith,
+	}
+}
+
 const (
 	// ConditionalOperatorAnd is a ConditionalOperator enum value
 	ConditionalOperatorAnd = "AND"
@@ -19977,6 +20041,14 @@ const (
 	// ConditionalOperatorOr is a ConditionalOperator enum value
 	ConditionalOperatorOr = "OR"
 )
+
+// ConditionalOperator_Values returns all elements of the ConditionalOperator enum
+func ConditionalOperator_Values() []string {
+	return []string{
+		ConditionalOperatorAnd,
+		ConditionalOperatorOr,
+	}
+}
 
 const (
 	// ContinuousBackupsStatusEnabled is a ContinuousBackupsStatus enum value
@@ -19986,6 +20058,14 @@ const (
 	ContinuousBackupsStatusDisabled = "DISABLED"
 )
 
+// ContinuousBackupsStatus_Values returns all elements of the ContinuousBackupsStatus enum
+func ContinuousBackupsStatus_Values() []string {
+	return []string{
+		ContinuousBackupsStatusEnabled,
+		ContinuousBackupsStatusDisabled,
+	}
+}
+
 const (
 	// ContributorInsightsActionEnable is a ContributorInsightsAction enum value
 	ContributorInsightsActionEnable = "ENABLE"
@@ -19993,6 +20073,14 @@ const (
 	// ContributorInsightsActionDisable is a ContributorInsightsAction enum value
 	ContributorInsightsActionDisable = "DISABLE"
 )
+
+// ContributorInsightsAction_Values returns all elements of the ContributorInsightsAction enum
+func ContributorInsightsAction_Values() []string {
+	return []string{
+		ContributorInsightsActionEnable,
+		ContributorInsightsActionDisable,
+	}
+}
 
 const (
 	// ContributorInsightsStatusEnabling is a ContributorInsightsStatus enum value
@@ -20011,6 +20099,17 @@ const (
 	ContributorInsightsStatusFailed = "FAILED"
 )
 
+// ContributorInsightsStatus_Values returns all elements of the ContributorInsightsStatus enum
+func ContributorInsightsStatus_Values() []string {
+	return []string{
+		ContributorInsightsStatusEnabling,
+		ContributorInsightsStatusEnabled,
+		ContributorInsightsStatusDisabling,
+		ContributorInsightsStatusDisabled,
+		ContributorInsightsStatusFailed,
+	}
+}
+
 const (
 	// GlobalTableStatusCreating is a GlobalTableStatus enum value
 	GlobalTableStatusCreating = "CREATING"
@@ -20024,6 +20123,16 @@ const (
 	// GlobalTableStatusUpdating is a GlobalTableStatus enum value
 	GlobalTableStatusUpdating = "UPDATING"
 )
+
+// GlobalTableStatus_Values returns all elements of the GlobalTableStatus enum
+func GlobalTableStatus_Values() []string {
+	return []string{
+		GlobalTableStatusCreating,
+		GlobalTableStatusActive,
+		GlobalTableStatusDeleting,
+		GlobalTableStatusUpdating,
+	}
+}
 
 const (
 	// IndexStatusCreating is a IndexStatus enum value
@@ -20039,6 +20148,16 @@ const (
 	IndexStatusActive = "ACTIVE"
 )
 
+// IndexStatus_Values returns all elements of the IndexStatus enum
+func IndexStatus_Values() []string {
+	return []string{
+		IndexStatusCreating,
+		IndexStatusUpdating,
+		IndexStatusDeleting,
+		IndexStatusActive,
+	}
+}
+
 const (
 	// KeyTypeHash is a KeyType enum value
 	KeyTypeHash = "HASH"
@@ -20047,6 +20166,14 @@ const (
 	KeyTypeRange = "RANGE"
 )
 
+// KeyType_Values returns all elements of the KeyType enum
+func KeyType_Values() []string {
+	return []string{
+		KeyTypeHash,
+		KeyTypeRange,
+	}
+}
+
 const (
 	// PointInTimeRecoveryStatusEnabled is a PointInTimeRecoveryStatus enum value
 	PointInTimeRecoveryStatusEnabled = "ENABLED"
@@ -20054,6 +20181,14 @@ const (
 	// PointInTimeRecoveryStatusDisabled is a PointInTimeRecoveryStatus enum value
 	PointInTimeRecoveryStatusDisabled = "DISABLED"
 )
+
+// PointInTimeRecoveryStatus_Values returns all elements of the PointInTimeRecoveryStatus enum
+func PointInTimeRecoveryStatus_Values() []string {
+	return []string{
+		PointInTimeRecoveryStatusEnabled,
+		PointInTimeRecoveryStatusDisabled,
+	}
+}
 
 const (
 	// ProjectionTypeAll is a ProjectionType enum value
@@ -20065,6 +20200,15 @@ const (
 	// ProjectionTypeInclude is a ProjectionType enum value
 	ProjectionTypeInclude = "INCLUDE"
 )
+
+// ProjectionType_Values returns all elements of the ProjectionType enum
+func ProjectionType_Values() []string {
+	return []string{
+		ProjectionTypeAll,
+		ProjectionTypeKeysOnly,
+		ProjectionTypeInclude,
+	}
+}
 
 const (
 	// ReplicaStatusCreating is a ReplicaStatus enum value
@@ -20082,6 +20226,17 @@ const (
 	// ReplicaStatusActive is a ReplicaStatus enum value
 	ReplicaStatusActive = "ACTIVE"
 )
+
+// ReplicaStatus_Values returns all elements of the ReplicaStatus enum
+func ReplicaStatus_Values() []string {
+	return []string{
+		ReplicaStatusCreating,
+		ReplicaStatusCreationFailed,
+		ReplicaStatusUpdating,
+		ReplicaStatusDeleting,
+		ReplicaStatusActive,
+	}
+}
 
 // Determines the level of detail about provisioned throughput consumption that
 // is returned in the response:
@@ -20107,6 +20262,15 @@ const (
 	ReturnConsumedCapacityNone = "NONE"
 )
 
+// ReturnConsumedCapacity_Values returns all elements of the ReturnConsumedCapacity enum
+func ReturnConsumedCapacity_Values() []string {
+	return []string{
+		ReturnConsumedCapacityIndexes,
+		ReturnConsumedCapacityTotal,
+		ReturnConsumedCapacityNone,
+	}
+}
+
 const (
 	// ReturnItemCollectionMetricsSize is a ReturnItemCollectionMetrics enum value
 	ReturnItemCollectionMetricsSize = "SIZE"
@@ -20114,6 +20278,14 @@ const (
 	// ReturnItemCollectionMetricsNone is a ReturnItemCollectionMetrics enum value
 	ReturnItemCollectionMetricsNone = "NONE"
 )
+
+// ReturnItemCollectionMetrics_Values returns all elements of the ReturnItemCollectionMetrics enum
+func ReturnItemCollectionMetrics_Values() []string {
+	return []string{
+		ReturnItemCollectionMetricsSize,
+		ReturnItemCollectionMetricsNone,
+	}
+}
 
 const (
 	// ReturnValueNone is a ReturnValue enum value
@@ -20132,6 +20304,17 @@ const (
 	ReturnValueUpdatedNew = "UPDATED_NEW"
 )
 
+// ReturnValue_Values returns all elements of the ReturnValue enum
+func ReturnValue_Values() []string {
+	return []string{
+		ReturnValueNone,
+		ReturnValueAllOld,
+		ReturnValueUpdatedOld,
+		ReturnValueAllNew,
+		ReturnValueUpdatedNew,
+	}
+}
+
 const (
 	// ReturnValuesOnConditionCheckFailureAllOld is a ReturnValuesOnConditionCheckFailure enum value
 	ReturnValuesOnConditionCheckFailureAllOld = "ALL_OLD"
@@ -20139,6 +20322,14 @@ const (
 	// ReturnValuesOnConditionCheckFailureNone is a ReturnValuesOnConditionCheckFailure enum value
 	ReturnValuesOnConditionCheckFailureNone = "NONE"
 )
+
+// ReturnValuesOnConditionCheckFailure_Values returns all elements of the ReturnValuesOnConditionCheckFailure enum
+func ReturnValuesOnConditionCheckFailure_Values() []string {
+	return []string{
+		ReturnValuesOnConditionCheckFailureAllOld,
+		ReturnValuesOnConditionCheckFailureNone,
+	}
+}
 
 const (
 	// SSEStatusEnabling is a SSEStatus enum value
@@ -20157,6 +20348,17 @@ const (
 	SSEStatusUpdating = "UPDATING"
 )
 
+// SSEStatus_Values returns all elements of the SSEStatus enum
+func SSEStatus_Values() []string {
+	return []string{
+		SSEStatusEnabling,
+		SSEStatusEnabled,
+		SSEStatusDisabling,
+		SSEStatusDisabled,
+		SSEStatusUpdating,
+	}
+}
+
 const (
 	// SSETypeAes256 is a SSEType enum value
 	SSETypeAes256 = "AES256"
@@ -20164,6 +20366,14 @@ const (
 	// SSETypeKms is a SSEType enum value
 	SSETypeKms = "KMS"
 )
+
+// SSEType_Values returns all elements of the SSEType enum
+func SSEType_Values() []string {
+	return []string{
+		SSETypeAes256,
+		SSETypeKms,
+	}
+}
 
 const (
 	// ScalarAttributeTypeS is a ScalarAttributeType enum value
@@ -20175,6 +20385,15 @@ const (
 	// ScalarAttributeTypeB is a ScalarAttributeType enum value
 	ScalarAttributeTypeB = "B"
 )
+
+// ScalarAttributeType_Values returns all elements of the ScalarAttributeType enum
+func ScalarAttributeType_Values() []string {
+	return []string{
+		ScalarAttributeTypeS,
+		ScalarAttributeTypeN,
+		ScalarAttributeTypeB,
+	}
+}
 
 const (
 	// SelectAllAttributes is a Select enum value
@@ -20190,6 +20409,16 @@ const (
 	SelectCount = "COUNT"
 )
 
+// Select_Values returns all elements of the Select enum
+func Select_Values() []string {
+	return []string{
+		SelectAllAttributes,
+		SelectAllProjectedAttributes,
+		SelectSpecificAttributes,
+		SelectCount,
+	}
+}
+
 const (
 	// StreamViewTypeNewImage is a StreamViewType enum value
 	StreamViewTypeNewImage = "NEW_IMAGE"
@@ -20203,6 +20432,16 @@ const (
 	// StreamViewTypeKeysOnly is a StreamViewType enum value
 	StreamViewTypeKeysOnly = "KEYS_ONLY"
 )
+
+// StreamViewType_Values returns all elements of the StreamViewType enum
+func StreamViewType_Values() []string {
+	return []string{
+		StreamViewTypeNewImage,
+		StreamViewTypeOldImage,
+		StreamViewTypeNewAndOldImages,
+		StreamViewTypeKeysOnly,
+	}
+}
 
 const (
 	// TableStatusCreating is a TableStatus enum value
@@ -20227,6 +20466,19 @@ const (
 	TableStatusArchived = "ARCHIVED"
 )
 
+// TableStatus_Values returns all elements of the TableStatus enum
+func TableStatus_Values() []string {
+	return []string{
+		TableStatusCreating,
+		TableStatusUpdating,
+		TableStatusDeleting,
+		TableStatusActive,
+		TableStatusInaccessibleEncryptionCredentials,
+		TableStatusArchiving,
+		TableStatusArchived,
+	}
+}
+
 const (
 	// TimeToLiveStatusEnabling is a TimeToLiveStatus enum value
 	TimeToLiveStatusEnabling = "ENABLING"
@@ -20240,3 +20492,13 @@ const (
 	// TimeToLiveStatusDisabled is a TimeToLiveStatus enum value
 	TimeToLiveStatusDisabled = "DISABLED"
 )
+
+// TimeToLiveStatus_Values returns all elements of the TimeToLiveStatus enum
+func TimeToLiveStatus_Values() []string {
+	return []string{
+		TimeToLiveStatusEnabling,
+		TimeToLiveStatusDisabling,
+		TimeToLiveStatusEnabled,
+		TimeToLiveStatusDisabled,
+	}
+}

--- a/service/dynamodbstreams/api.go
+++ b/service/dynamodbstreams/api.go
@@ -1624,6 +1624,14 @@ const (
 	KeyTypeRange = "RANGE"
 )
 
+// KeyType_Values returns all elements of the KeyType enum
+func KeyType_Values() []string {
+	return []string{
+		KeyTypeHash,
+		KeyTypeRange,
+	}
+}
+
 const (
 	// OperationTypeInsert is a OperationType enum value
 	OperationTypeInsert = "INSERT"
@@ -1634,6 +1642,15 @@ const (
 	// OperationTypeRemove is a OperationType enum value
 	OperationTypeRemove = "REMOVE"
 )
+
+// OperationType_Values returns all elements of the OperationType enum
+func OperationType_Values() []string {
+	return []string{
+		OperationTypeInsert,
+		OperationTypeModify,
+		OperationTypeRemove,
+	}
+}
 
 const (
 	// ShardIteratorTypeTrimHorizon is a ShardIteratorType enum value
@@ -1649,6 +1666,16 @@ const (
 	ShardIteratorTypeAfterSequenceNumber = "AFTER_SEQUENCE_NUMBER"
 )
 
+// ShardIteratorType_Values returns all elements of the ShardIteratorType enum
+func ShardIteratorType_Values() []string {
+	return []string{
+		ShardIteratorTypeTrimHorizon,
+		ShardIteratorTypeLatest,
+		ShardIteratorTypeAtSequenceNumber,
+		ShardIteratorTypeAfterSequenceNumber,
+	}
+}
+
 const (
 	// StreamStatusEnabling is a StreamStatus enum value
 	StreamStatusEnabling = "ENABLING"
@@ -1663,6 +1690,16 @@ const (
 	StreamStatusDisabled = "DISABLED"
 )
 
+// StreamStatus_Values returns all elements of the StreamStatus enum
+func StreamStatus_Values() []string {
+	return []string{
+		StreamStatusEnabling,
+		StreamStatusEnabled,
+		StreamStatusDisabling,
+		StreamStatusDisabled,
+	}
+}
+
 const (
 	// StreamViewTypeNewImage is a StreamViewType enum value
 	StreamViewTypeNewImage = "NEW_IMAGE"
@@ -1676,3 +1713,13 @@ const (
 	// StreamViewTypeKeysOnly is a StreamViewType enum value
 	StreamViewTypeKeysOnly = "KEYS_ONLY"
 )
+
+// StreamViewType_Values returns all elements of the StreamViewType enum
+func StreamViewType_Values() []string {
+	return []string{
+		StreamViewTypeNewImage,
+		StreamViewTypeOldImage,
+		StreamViewTypeNewAndOldImages,
+		StreamViewTypeKeysOnly,
+	}
+}

--- a/service/ebs/api.go
+++ b/service/ebs/api.go
@@ -2273,15 +2273,37 @@ const (
 	AccessDeniedExceptionReasonDependencyAccessDenied = "DEPENDENCY_ACCESS_DENIED"
 )
 
+// AccessDeniedExceptionReason_Values returns all elements of the AccessDeniedExceptionReason enum
+func AccessDeniedExceptionReason_Values() []string {
+	return []string{
+		AccessDeniedExceptionReasonUnauthorizedAccount,
+		AccessDeniedExceptionReasonDependencyAccessDenied,
+	}
+}
+
 const (
 	// ChecksumAggregationMethodLinear is a ChecksumAggregationMethod enum value
 	ChecksumAggregationMethodLinear = "LINEAR"
 )
 
+// ChecksumAggregationMethod_Values returns all elements of the ChecksumAggregationMethod enum
+func ChecksumAggregationMethod_Values() []string {
+	return []string{
+		ChecksumAggregationMethodLinear,
+	}
+}
+
 const (
 	// ChecksumAlgorithmSha256 is a ChecksumAlgorithm enum value
 	ChecksumAlgorithmSha256 = "SHA256"
 )
+
+// ChecksumAlgorithm_Values returns all elements of the ChecksumAlgorithm enum
+func ChecksumAlgorithm_Values() []string {
+	return []string{
+		ChecksumAlgorithmSha256,
+	}
+}
 
 const (
 	// RequestThrottledExceptionReasonAccountThrottled is a RequestThrottledExceptionReason enum value
@@ -2291,6 +2313,14 @@ const (
 	RequestThrottledExceptionReasonDependencyRequestThrottled = "DEPENDENCY_REQUEST_THROTTLED"
 )
 
+// RequestThrottledExceptionReason_Values returns all elements of the RequestThrottledExceptionReason enum
+func RequestThrottledExceptionReason_Values() []string {
+	return []string{
+		RequestThrottledExceptionReasonAccountThrottled,
+		RequestThrottledExceptionReasonDependencyRequestThrottled,
+	}
+}
+
 const (
 	// ResourceNotFoundExceptionReasonSnapshotNotFound is a ResourceNotFoundExceptionReason enum value
 	ResourceNotFoundExceptionReasonSnapshotNotFound = "SNAPSHOT_NOT_FOUND"
@@ -2299,10 +2329,25 @@ const (
 	ResourceNotFoundExceptionReasonDependencyResourceNotFound = "DEPENDENCY_RESOURCE_NOT_FOUND"
 )
 
+// ResourceNotFoundExceptionReason_Values returns all elements of the ResourceNotFoundExceptionReason enum
+func ResourceNotFoundExceptionReason_Values() []string {
+	return []string{
+		ResourceNotFoundExceptionReasonSnapshotNotFound,
+		ResourceNotFoundExceptionReasonDependencyResourceNotFound,
+	}
+}
+
 const (
 	// ServiceQuotaExceededExceptionReasonDependencyServiceQuotaExceeded is a ServiceQuotaExceededExceptionReason enum value
 	ServiceQuotaExceededExceptionReasonDependencyServiceQuotaExceeded = "DEPENDENCY_SERVICE_QUOTA_EXCEEDED"
 )
+
+// ServiceQuotaExceededExceptionReason_Values returns all elements of the ServiceQuotaExceededExceptionReason enum
+func ServiceQuotaExceededExceptionReason_Values() []string {
+	return []string{
+		ServiceQuotaExceededExceptionReasonDependencyServiceQuotaExceeded,
+	}
+}
 
 const (
 	// StatusCompleted is a Status enum value
@@ -2314,6 +2359,15 @@ const (
 	// StatusError is a Status enum value
 	StatusError = "error"
 )
+
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusCompleted,
+		StatusPending,
+		StatusError,
+	}
+}
 
 const (
 	// ValidationExceptionReasonInvalidCustomerKey is a ValidationExceptionReason enum value
@@ -2349,3 +2403,20 @@ const (
 	// ValidationExceptionReasonInvalidVolumeSize is a ValidationExceptionReason enum value
 	ValidationExceptionReasonInvalidVolumeSize = "INVALID_VOLUME_SIZE"
 )
+
+// ValidationExceptionReason_Values returns all elements of the ValidationExceptionReason enum
+func ValidationExceptionReason_Values() []string {
+	return []string{
+		ValidationExceptionReasonInvalidCustomerKey,
+		ValidationExceptionReasonInvalidPageToken,
+		ValidationExceptionReasonInvalidBlockToken,
+		ValidationExceptionReasonInvalidSnapshotId,
+		ValidationExceptionReasonUnrelatedSnapshots,
+		ValidationExceptionReasonInvalidBlock,
+		ValidationExceptionReasonInvalidContentEncoding,
+		ValidationExceptionReasonInvalidTag,
+		ValidationExceptionReasonInvalidDependencyRequest,
+		ValidationExceptionReasonInvalidParameterValue,
+		ValidationExceptionReasonInvalidVolumeSize,
+	}
+}

--- a/service/ecr/api.go
+++ b/service/ecr/api.go
@@ -8975,6 +8975,14 @@ const (
 	EncryptionTypeKms = "KMS"
 )
 
+// EncryptionType_Values returns all elements of the EncryptionType enum
+func EncryptionType_Values() []string {
+	return []string{
+		EncryptionTypeAes256,
+		EncryptionTypeKms,
+	}
+}
+
 const (
 	// FindingSeverityInformational is a FindingSeverity enum value
 	FindingSeverityInformational = "INFORMATIONAL"
@@ -8995,10 +9003,29 @@ const (
 	FindingSeverityUndefined = "UNDEFINED"
 )
 
+// FindingSeverity_Values returns all elements of the FindingSeverity enum
+func FindingSeverity_Values() []string {
+	return []string{
+		FindingSeverityInformational,
+		FindingSeverityLow,
+		FindingSeverityMedium,
+		FindingSeverityHigh,
+		FindingSeverityCritical,
+		FindingSeverityUndefined,
+	}
+}
+
 const (
 	// ImageActionTypeExpire is a ImageActionType enum value
 	ImageActionTypeExpire = "EXPIRE"
 )
+
+// ImageActionType_Values returns all elements of the ImageActionType enum
+func ImageActionType_Values() []string {
+	return []string{
+		ImageActionTypeExpire,
+	}
+}
 
 const (
 	// ImageFailureCodeInvalidImageDigest is a ImageFailureCode enum value
@@ -9023,6 +9050,19 @@ const (
 	ImageFailureCodeKmsError = "KmsError"
 )
 
+// ImageFailureCode_Values returns all elements of the ImageFailureCode enum
+func ImageFailureCode_Values() []string {
+	return []string{
+		ImageFailureCodeInvalidImageDigest,
+		ImageFailureCodeInvalidImageTag,
+		ImageFailureCodeImageTagDoesNotMatchDigest,
+		ImageFailureCodeImageNotFound,
+		ImageFailureCodeMissingDigestAndTag,
+		ImageFailureCodeImageReferencedByManifestList,
+		ImageFailureCodeKmsError,
+	}
+}
+
 const (
 	// ImageTagMutabilityMutable is a ImageTagMutability enum value
 	ImageTagMutabilityMutable = "MUTABLE"
@@ -9030,6 +9070,14 @@ const (
 	// ImageTagMutabilityImmutable is a ImageTagMutability enum value
 	ImageTagMutabilityImmutable = "IMMUTABLE"
 )
+
+// ImageTagMutability_Values returns all elements of the ImageTagMutability enum
+func ImageTagMutability_Values() []string {
+	return []string{
+		ImageTagMutabilityMutable,
+		ImageTagMutabilityImmutable,
+	}
+}
 
 const (
 	// LayerAvailabilityAvailable is a LayerAvailability enum value
@@ -9039,6 +9087,14 @@ const (
 	LayerAvailabilityUnavailable = "UNAVAILABLE"
 )
 
+// LayerAvailability_Values returns all elements of the LayerAvailability enum
+func LayerAvailability_Values() []string {
+	return []string{
+		LayerAvailabilityAvailable,
+		LayerAvailabilityUnavailable,
+	}
+}
+
 const (
 	// LayerFailureCodeInvalidLayerDigest is a LayerFailureCode enum value
 	LayerFailureCodeInvalidLayerDigest = "InvalidLayerDigest"
@@ -9046,6 +9102,14 @@ const (
 	// LayerFailureCodeMissingLayerDigest is a LayerFailureCode enum value
 	LayerFailureCodeMissingLayerDigest = "MissingLayerDigest"
 )
+
+// LayerFailureCode_Values returns all elements of the LayerFailureCode enum
+func LayerFailureCode_Values() []string {
+	return []string{
+		LayerFailureCodeInvalidLayerDigest,
+		LayerFailureCodeMissingLayerDigest,
+	}
+}
 
 const (
 	// LifecyclePolicyPreviewStatusInProgress is a LifecyclePolicyPreviewStatus enum value
@@ -9061,6 +9125,16 @@ const (
 	LifecyclePolicyPreviewStatusFailed = "FAILED"
 )
 
+// LifecyclePolicyPreviewStatus_Values returns all elements of the LifecyclePolicyPreviewStatus enum
+func LifecyclePolicyPreviewStatus_Values() []string {
+	return []string{
+		LifecyclePolicyPreviewStatusInProgress,
+		LifecyclePolicyPreviewStatusComplete,
+		LifecyclePolicyPreviewStatusExpired,
+		LifecyclePolicyPreviewStatusFailed,
+	}
+}
+
 const (
 	// ScanStatusInProgress is a ScanStatus enum value
 	ScanStatusInProgress = "IN_PROGRESS"
@@ -9072,6 +9146,15 @@ const (
 	ScanStatusFailed = "FAILED"
 )
 
+// ScanStatus_Values returns all elements of the ScanStatus enum
+func ScanStatus_Values() []string {
+	return []string{
+		ScanStatusInProgress,
+		ScanStatusComplete,
+		ScanStatusFailed,
+	}
+}
+
 const (
 	// TagStatusTagged is a TagStatus enum value
 	TagStatusTagged = "TAGGED"
@@ -9082,3 +9165,12 @@ const (
 	// TagStatusAny is a TagStatus enum value
 	TagStatusAny = "ANY"
 )
+
+// TagStatus_Values returns all elements of the TagStatus enum
+func TagStatus_Values() []string {
+	return []string{
+		TagStatusTagged,
+		TagStatusUntagged,
+		TagStatusAny,
+	}
+}

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -20220,6 +20220,18 @@ const (
 	AgentUpdateStatusFailed = "FAILED"
 )
 
+// AgentUpdateStatus_Values returns all elements of the AgentUpdateStatus enum
+func AgentUpdateStatus_Values() []string {
+	return []string{
+		AgentUpdateStatusPending,
+		AgentUpdateStatusStaging,
+		AgentUpdateStatusStaged,
+		AgentUpdateStatusUpdating,
+		AgentUpdateStatusUpdated,
+		AgentUpdateStatusFailed,
+	}
+}
+
 const (
 	// AssignPublicIpEnabled is a AssignPublicIp enum value
 	AssignPublicIpEnabled = "ENABLED"
@@ -20228,10 +20240,25 @@ const (
 	AssignPublicIpDisabled = "DISABLED"
 )
 
+// AssignPublicIp_Values returns all elements of the AssignPublicIp enum
+func AssignPublicIp_Values() []string {
+	return []string{
+		AssignPublicIpEnabled,
+		AssignPublicIpDisabled,
+	}
+}
+
 const (
 	// CapacityProviderFieldTags is a CapacityProviderField enum value
 	CapacityProviderFieldTags = "TAGS"
 )
+
+// CapacityProviderField_Values returns all elements of the CapacityProviderField enum
+func CapacityProviderField_Values() []string {
+	return []string{
+		CapacityProviderFieldTags,
+	}
+}
 
 const (
 	// CapacityProviderStatusActive is a CapacityProviderStatus enum value
@@ -20240,6 +20267,14 @@ const (
 	// CapacityProviderStatusInactive is a CapacityProviderStatus enum value
 	CapacityProviderStatusInactive = "INACTIVE"
 )
+
+// CapacityProviderStatus_Values returns all elements of the CapacityProviderStatus enum
+func CapacityProviderStatus_Values() []string {
+	return []string{
+		CapacityProviderStatusActive,
+		CapacityProviderStatusInactive,
+	}
+}
 
 const (
 	// CapacityProviderUpdateStatusDeleteInProgress is a CapacityProviderUpdateStatus enum value
@@ -20251,6 +20286,15 @@ const (
 	// CapacityProviderUpdateStatusDeleteFailed is a CapacityProviderUpdateStatus enum value
 	CapacityProviderUpdateStatusDeleteFailed = "DELETE_FAILED"
 )
+
+// CapacityProviderUpdateStatus_Values returns all elements of the CapacityProviderUpdateStatus enum
+func CapacityProviderUpdateStatus_Values() []string {
+	return []string{
+		CapacityProviderUpdateStatusDeleteInProgress,
+		CapacityProviderUpdateStatusDeleteComplete,
+		CapacityProviderUpdateStatusDeleteFailed,
+	}
+}
 
 const (
 	// ClusterFieldAttachments is a ClusterField enum value
@@ -20266,10 +20310,27 @@ const (
 	ClusterFieldTags = "TAGS"
 )
 
+// ClusterField_Values returns all elements of the ClusterField enum
+func ClusterField_Values() []string {
+	return []string{
+		ClusterFieldAttachments,
+		ClusterFieldSettings,
+		ClusterFieldStatistics,
+		ClusterFieldTags,
+	}
+}
+
 const (
 	// ClusterSettingNameContainerInsights is a ClusterSettingName enum value
 	ClusterSettingNameContainerInsights = "containerInsights"
 )
+
+// ClusterSettingName_Values returns all elements of the ClusterSettingName enum
+func ClusterSettingName_Values() []string {
+	return []string{
+		ClusterSettingNameContainerInsights,
+	}
+}
 
 const (
 	// CompatibilityEc2 is a Compatibility enum value
@@ -20279,6 +20340,14 @@ const (
 	CompatibilityFargate = "FARGATE"
 )
 
+// Compatibility_Values returns all elements of the Compatibility enum
+func Compatibility_Values() []string {
+	return []string{
+		CompatibilityEc2,
+		CompatibilityFargate,
+	}
+}
+
 const (
 	// ConnectivityConnected is a Connectivity enum value
 	ConnectivityConnected = "CONNECTED"
@@ -20286,6 +20355,14 @@ const (
 	// ConnectivityDisconnected is a Connectivity enum value
 	ConnectivityDisconnected = "DISCONNECTED"
 )
+
+// Connectivity_Values returns all elements of the Connectivity enum
+func Connectivity_Values() []string {
+	return []string{
+		ConnectivityConnected,
+		ConnectivityDisconnected,
+	}
+}
 
 const (
 	// ContainerConditionStart is a ContainerCondition enum value
@@ -20301,10 +20378,27 @@ const (
 	ContainerConditionHealthy = "HEALTHY"
 )
 
+// ContainerCondition_Values returns all elements of the ContainerCondition enum
+func ContainerCondition_Values() []string {
+	return []string{
+		ContainerConditionStart,
+		ContainerConditionComplete,
+		ContainerConditionSuccess,
+		ContainerConditionHealthy,
+	}
+}
+
 const (
 	// ContainerInstanceFieldTags is a ContainerInstanceField enum value
 	ContainerInstanceFieldTags = "TAGS"
 )
+
+// ContainerInstanceField_Values returns all elements of the ContainerInstanceField enum
+func ContainerInstanceField_Values() []string {
+	return []string{
+		ContainerInstanceFieldTags,
+	}
+}
 
 const (
 	// ContainerInstanceStatusActive is a ContainerInstanceStatus enum value
@@ -20323,6 +20417,17 @@ const (
 	ContainerInstanceStatusRegistrationFailed = "REGISTRATION_FAILED"
 )
 
+// ContainerInstanceStatus_Values returns all elements of the ContainerInstanceStatus enum
+func ContainerInstanceStatus_Values() []string {
+	return []string{
+		ContainerInstanceStatusActive,
+		ContainerInstanceStatusDraining,
+		ContainerInstanceStatusRegistering,
+		ContainerInstanceStatusDeregistering,
+		ContainerInstanceStatusRegistrationFailed,
+	}
+}
+
 const (
 	// DeploymentControllerTypeEcs is a DeploymentControllerType enum value
 	DeploymentControllerTypeEcs = "ECS"
@@ -20333,6 +20438,15 @@ const (
 	// DeploymentControllerTypeExternal is a DeploymentControllerType enum value
 	DeploymentControllerTypeExternal = "EXTERNAL"
 )
+
+// DeploymentControllerType_Values returns all elements of the DeploymentControllerType enum
+func DeploymentControllerType_Values() []string {
+	return []string{
+		DeploymentControllerTypeEcs,
+		DeploymentControllerTypeCodeDeploy,
+		DeploymentControllerTypeExternal,
+	}
+}
 
 const (
 	// DesiredStatusRunning is a DesiredStatus enum value
@@ -20345,6 +20459,15 @@ const (
 	DesiredStatusStopped = "STOPPED"
 )
 
+// DesiredStatus_Values returns all elements of the DesiredStatus enum
+func DesiredStatus_Values() []string {
+	return []string{
+		DesiredStatusRunning,
+		DesiredStatusPending,
+		DesiredStatusStopped,
+	}
+}
+
 const (
 	// DeviceCgroupPermissionRead is a DeviceCgroupPermission enum value
 	DeviceCgroupPermissionRead = "read"
@@ -20356,6 +20479,15 @@ const (
 	DeviceCgroupPermissionMknod = "mknod"
 )
 
+// DeviceCgroupPermission_Values returns all elements of the DeviceCgroupPermission enum
+func DeviceCgroupPermission_Values() []string {
+	return []string{
+		DeviceCgroupPermissionRead,
+		DeviceCgroupPermissionWrite,
+		DeviceCgroupPermissionMknod,
+	}
+}
+
 const (
 	// EFSAuthorizationConfigIAMEnabled is a EFSAuthorizationConfigIAM enum value
 	EFSAuthorizationConfigIAMEnabled = "ENABLED"
@@ -20363,6 +20495,14 @@ const (
 	// EFSAuthorizationConfigIAMDisabled is a EFSAuthorizationConfigIAM enum value
 	EFSAuthorizationConfigIAMDisabled = "DISABLED"
 )
+
+// EFSAuthorizationConfigIAM_Values returns all elements of the EFSAuthorizationConfigIAM enum
+func EFSAuthorizationConfigIAM_Values() []string {
+	return []string{
+		EFSAuthorizationConfigIAMEnabled,
+		EFSAuthorizationConfigIAMDisabled,
+	}
+}
 
 const (
 	// EFSTransitEncryptionEnabled is a EFSTransitEncryption enum value
@@ -20372,10 +20512,25 @@ const (
 	EFSTransitEncryptionDisabled = "DISABLED"
 )
 
+// EFSTransitEncryption_Values returns all elements of the EFSTransitEncryption enum
+func EFSTransitEncryption_Values() []string {
+	return []string{
+		EFSTransitEncryptionEnabled,
+		EFSTransitEncryptionDisabled,
+	}
+}
+
 const (
 	// EnvironmentFileTypeS3 is a EnvironmentFileType enum value
 	EnvironmentFileTypeS3 = "s3"
 )
+
+// EnvironmentFileType_Values returns all elements of the EnvironmentFileType enum
+func EnvironmentFileType_Values() []string {
+	return []string{
+		EnvironmentFileTypeS3,
+	}
+}
 
 const (
 	// FirelensConfigurationTypeFluentd is a FirelensConfigurationType enum value
@@ -20384,6 +20539,14 @@ const (
 	// FirelensConfigurationTypeFluentbit is a FirelensConfigurationType enum value
 	FirelensConfigurationTypeFluentbit = "fluentbit"
 )
+
+// FirelensConfigurationType_Values returns all elements of the FirelensConfigurationType enum
+func FirelensConfigurationType_Values() []string {
+	return []string{
+		FirelensConfigurationTypeFluentd,
+		FirelensConfigurationTypeFluentbit,
+	}
+}
 
 const (
 	// HealthStatusHealthy is a HealthStatus enum value
@@ -20396,6 +20559,15 @@ const (
 	HealthStatusUnknown = "UNKNOWN"
 )
 
+// HealthStatus_Values returns all elements of the HealthStatus enum
+func HealthStatus_Values() []string {
+	return []string{
+		HealthStatusHealthy,
+		HealthStatusUnhealthy,
+		HealthStatusUnknown,
+	}
+}
+
 const (
 	// IpcModeHost is a IpcMode enum value
 	IpcModeHost = "host"
@@ -20407,6 +20579,15 @@ const (
 	IpcModeNone = "none"
 )
 
+// IpcMode_Values returns all elements of the IpcMode enum
+func IpcMode_Values() []string {
+	return []string{
+		IpcModeHost,
+		IpcModeTask,
+		IpcModeNone,
+	}
+}
+
 const (
 	// LaunchTypeEc2 is a LaunchType enum value
 	LaunchTypeEc2 = "EC2"
@@ -20414,6 +20595,14 @@ const (
 	// LaunchTypeFargate is a LaunchType enum value
 	LaunchTypeFargate = "FARGATE"
 )
+
+// LaunchType_Values returns all elements of the LaunchType enum
+func LaunchType_Values() []string {
+	return []string{
+		LaunchTypeEc2,
+		LaunchTypeFargate,
+	}
+}
 
 const (
 	// LogDriverJsonFile is a LogDriver enum value
@@ -20441,6 +20630,20 @@ const (
 	LogDriverAwsfirelens = "awsfirelens"
 )
 
+// LogDriver_Values returns all elements of the LogDriver enum
+func LogDriver_Values() []string {
+	return []string{
+		LogDriverJsonFile,
+		LogDriverSyslog,
+		LogDriverJournald,
+		LogDriverGelf,
+		LogDriverFluentd,
+		LogDriverAwslogs,
+		LogDriverSplunk,
+		LogDriverAwsfirelens,
+	}
+}
+
 const (
 	// ManagedScalingStatusEnabled is a ManagedScalingStatus enum value
 	ManagedScalingStatusEnabled = "ENABLED"
@@ -20449,6 +20652,14 @@ const (
 	ManagedScalingStatusDisabled = "DISABLED"
 )
 
+// ManagedScalingStatus_Values returns all elements of the ManagedScalingStatus enum
+func ManagedScalingStatus_Values() []string {
+	return []string{
+		ManagedScalingStatusEnabled,
+		ManagedScalingStatusDisabled,
+	}
+}
+
 const (
 	// ManagedTerminationProtectionEnabled is a ManagedTerminationProtection enum value
 	ManagedTerminationProtectionEnabled = "ENABLED"
@@ -20456,6 +20667,14 @@ const (
 	// ManagedTerminationProtectionDisabled is a ManagedTerminationProtection enum value
 	ManagedTerminationProtectionDisabled = "DISABLED"
 )
+
+// ManagedTerminationProtection_Values returns all elements of the ManagedTerminationProtection enum
+func ManagedTerminationProtection_Values() []string {
+	return []string{
+		ManagedTerminationProtectionEnabled,
+		ManagedTerminationProtectionDisabled,
+	}
+}
 
 const (
 	// NetworkModeBridge is a NetworkMode enum value
@@ -20471,6 +20690,16 @@ const (
 	NetworkModeNone = "none"
 )
 
+// NetworkMode_Values returns all elements of the NetworkMode enum
+func NetworkMode_Values() []string {
+	return []string{
+		NetworkModeBridge,
+		NetworkModeHost,
+		NetworkModeAwsvpc,
+		NetworkModeNone,
+	}
+}
+
 const (
 	// PidModeHost is a PidMode enum value
 	PidModeHost = "host"
@@ -20479,6 +20708,14 @@ const (
 	PidModeTask = "task"
 )
 
+// PidMode_Values returns all elements of the PidMode enum
+func PidMode_Values() []string {
+	return []string{
+		PidModeHost,
+		PidModeTask,
+	}
+}
+
 const (
 	// PlacementConstraintTypeDistinctInstance is a PlacementConstraintType enum value
 	PlacementConstraintTypeDistinctInstance = "distinctInstance"
@@ -20486,6 +20723,14 @@ const (
 	// PlacementConstraintTypeMemberOf is a PlacementConstraintType enum value
 	PlacementConstraintTypeMemberOf = "memberOf"
 )
+
+// PlacementConstraintType_Values returns all elements of the PlacementConstraintType enum
+func PlacementConstraintType_Values() []string {
+	return []string{
+		PlacementConstraintTypeDistinctInstance,
+		PlacementConstraintTypeMemberOf,
+	}
+}
 
 const (
 	// PlacementStrategyTypeRandom is a PlacementStrategyType enum value
@@ -20498,10 +20743,26 @@ const (
 	PlacementStrategyTypeBinpack = "binpack"
 )
 
+// PlacementStrategyType_Values returns all elements of the PlacementStrategyType enum
+func PlacementStrategyType_Values() []string {
+	return []string{
+		PlacementStrategyTypeRandom,
+		PlacementStrategyTypeSpread,
+		PlacementStrategyTypeBinpack,
+	}
+}
+
 const (
 	// PlatformDeviceTypeGpu is a PlatformDeviceType enum value
 	PlatformDeviceTypeGpu = "GPU"
 )
+
+// PlatformDeviceType_Values returns all elements of the PlatformDeviceType enum
+func PlatformDeviceType_Values() []string {
+	return []string{
+		PlatformDeviceTypeGpu,
+	}
+}
 
 const (
 	// PropagateTagsTaskDefinition is a PropagateTags enum value
@@ -20511,10 +20772,25 @@ const (
 	PropagateTagsService = "SERVICE"
 )
 
+// PropagateTags_Values returns all elements of the PropagateTags enum
+func PropagateTags_Values() []string {
+	return []string{
+		PropagateTagsTaskDefinition,
+		PropagateTagsService,
+	}
+}
+
 const (
 	// ProxyConfigurationTypeAppmesh is a ProxyConfigurationType enum value
 	ProxyConfigurationTypeAppmesh = "APPMESH"
 )
+
+// ProxyConfigurationType_Values returns all elements of the ProxyConfigurationType enum
+func ProxyConfigurationType_Values() []string {
+	return []string{
+		ProxyConfigurationTypeAppmesh,
+	}
+}
 
 const (
 	// ResourceTypeGpu is a ResourceType enum value
@@ -20524,10 +20800,25 @@ const (
 	ResourceTypeInferenceAccelerator = "InferenceAccelerator"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeGpu,
+		ResourceTypeInferenceAccelerator,
+	}
+}
+
 const (
 	// ScaleUnitPercent is a ScaleUnit enum value
 	ScaleUnitPercent = "PERCENT"
 )
+
+// ScaleUnit_Values returns all elements of the ScaleUnit enum
+func ScaleUnit_Values() []string {
+	return []string{
+		ScaleUnitPercent,
+	}
+}
 
 const (
 	// SchedulingStrategyReplica is a SchedulingStrategy enum value
@@ -20537,6 +20828,14 @@ const (
 	SchedulingStrategyDaemon = "DAEMON"
 )
 
+// SchedulingStrategy_Values returns all elements of the SchedulingStrategy enum
+func SchedulingStrategy_Values() []string {
+	return []string{
+		SchedulingStrategyReplica,
+		SchedulingStrategyDaemon,
+	}
+}
+
 const (
 	// ScopeTask is a Scope enum value
 	ScopeTask = "task"
@@ -20545,10 +20844,25 @@ const (
 	ScopeShared = "shared"
 )
 
+// Scope_Values returns all elements of the Scope enum
+func Scope_Values() []string {
+	return []string{
+		ScopeTask,
+		ScopeShared,
+	}
+}
+
 const (
 	// ServiceFieldTags is a ServiceField enum value
 	ServiceFieldTags = "TAGS"
 )
+
+// ServiceField_Values returns all elements of the ServiceField enum
+func ServiceField_Values() []string {
+	return []string{
+		ServiceFieldTags,
+	}
+}
 
 const (
 	// SettingNameServiceLongArnFormat is a SettingName enum value
@@ -20567,6 +20881,17 @@ const (
 	SettingNameContainerInsights = "containerInsights"
 )
 
+// SettingName_Values returns all elements of the SettingName enum
+func SettingName_Values() []string {
+	return []string{
+		SettingNameServiceLongArnFormat,
+		SettingNameTaskLongArnFormat,
+		SettingNameContainerInstanceLongArnFormat,
+		SettingNameAwsvpcTrunking,
+		SettingNameContainerInsights,
+	}
+}
+
 const (
 	// SortOrderAsc is a SortOrder enum value
 	SortOrderAsc = "ASC"
@@ -20574,6 +20899,14 @@ const (
 	// SortOrderDesc is a SortOrder enum value
 	SortOrderDesc = "DESC"
 )
+
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderAsc,
+		SortOrderDesc,
+	}
+}
 
 const (
 	// StabilityStatusSteadyState is a StabilityStatus enum value
@@ -20583,10 +20916,25 @@ const (
 	StabilityStatusStabilizing = "STABILIZING"
 )
 
+// StabilityStatus_Values returns all elements of the StabilityStatus enum
+func StabilityStatus_Values() []string {
+	return []string{
+		StabilityStatusSteadyState,
+		StabilityStatusStabilizing,
+	}
+}
+
 const (
 	// TargetTypeContainerInstance is a TargetType enum value
 	TargetTypeContainerInstance = "container-instance"
 )
+
+// TargetType_Values returns all elements of the TargetType enum
+func TargetType_Values() []string {
+	return []string{
+		TargetTypeContainerInstance,
+	}
+}
 
 const (
 	// TaskDefinitionFamilyStatusActive is a TaskDefinitionFamilyStatus enum value
@@ -20599,15 +20947,38 @@ const (
 	TaskDefinitionFamilyStatusAll = "ALL"
 )
 
+// TaskDefinitionFamilyStatus_Values returns all elements of the TaskDefinitionFamilyStatus enum
+func TaskDefinitionFamilyStatus_Values() []string {
+	return []string{
+		TaskDefinitionFamilyStatusActive,
+		TaskDefinitionFamilyStatusInactive,
+		TaskDefinitionFamilyStatusAll,
+	}
+}
+
 const (
 	// TaskDefinitionFieldTags is a TaskDefinitionField enum value
 	TaskDefinitionFieldTags = "TAGS"
 )
 
+// TaskDefinitionField_Values returns all elements of the TaskDefinitionField enum
+func TaskDefinitionField_Values() []string {
+	return []string{
+		TaskDefinitionFieldTags,
+	}
+}
+
 const (
 	// TaskDefinitionPlacementConstraintTypeMemberOf is a TaskDefinitionPlacementConstraintType enum value
 	TaskDefinitionPlacementConstraintTypeMemberOf = "memberOf"
 )
+
+// TaskDefinitionPlacementConstraintType_Values returns all elements of the TaskDefinitionPlacementConstraintType enum
+func TaskDefinitionPlacementConstraintType_Values() []string {
+	return []string{
+		TaskDefinitionPlacementConstraintTypeMemberOf,
+	}
+}
 
 const (
 	// TaskDefinitionStatusActive is a TaskDefinitionStatus enum value
@@ -20617,15 +20988,37 @@ const (
 	TaskDefinitionStatusInactive = "INACTIVE"
 )
 
+// TaskDefinitionStatus_Values returns all elements of the TaskDefinitionStatus enum
+func TaskDefinitionStatus_Values() []string {
+	return []string{
+		TaskDefinitionStatusActive,
+		TaskDefinitionStatusInactive,
+	}
+}
+
 const (
 	// TaskFieldTags is a TaskField enum value
 	TaskFieldTags = "TAGS"
 )
 
+// TaskField_Values returns all elements of the TaskField enum
+func TaskField_Values() []string {
+	return []string{
+		TaskFieldTags,
+	}
+}
+
 const (
 	// TaskSetFieldTags is a TaskSetField enum value
 	TaskSetFieldTags = "TAGS"
 )
+
+// TaskSetField_Values returns all elements of the TaskSetField enum
+func TaskSetField_Values() []string {
+	return []string{
+		TaskSetFieldTags,
+	}
+}
 
 const (
 	// TaskStopCodeTaskFailedToStart is a TaskStopCode enum value
@@ -20638,6 +21031,15 @@ const (
 	TaskStopCodeUserInitiated = "UserInitiated"
 )
 
+// TaskStopCode_Values returns all elements of the TaskStopCode enum
+func TaskStopCode_Values() []string {
+	return []string{
+		TaskStopCodeTaskFailedToStart,
+		TaskStopCodeEssentialContainerExited,
+		TaskStopCodeUserInitiated,
+	}
+}
+
 const (
 	// TransportProtocolTcp is a TransportProtocol enum value
 	TransportProtocolTcp = "tcp"
@@ -20645,6 +21047,14 @@ const (
 	// TransportProtocolUdp is a TransportProtocol enum value
 	TransportProtocolUdp = "udp"
 )
+
+// TransportProtocol_Values returns all elements of the TransportProtocol enum
+func TransportProtocol_Values() []string {
+	return []string{
+		TransportProtocolTcp,
+		TransportProtocolUdp,
+	}
+}
 
 const (
 	// UlimitNameCore is a UlimitName enum value
@@ -20692,3 +21102,24 @@ const (
 	// UlimitNameStack is a UlimitName enum value
 	UlimitNameStack = "stack"
 )
+
+// UlimitName_Values returns all elements of the UlimitName enum
+func UlimitName_Values() []string {
+	return []string{
+		UlimitNameCore,
+		UlimitNameCpu,
+		UlimitNameData,
+		UlimitNameFsize,
+		UlimitNameLocks,
+		UlimitNameMemlock,
+		UlimitNameMsgqueue,
+		UlimitNameNice,
+		UlimitNameNofile,
+		UlimitNameNproc,
+		UlimitNameRss,
+		UlimitNameRtprio,
+		UlimitNameRttime,
+		UlimitNameSigpending,
+		UlimitNameStack,
+	}
+}

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -7795,6 +7795,17 @@ const (
 	LifeCycleStateDeleted = "deleted"
 )
 
+// LifeCycleState_Values returns all elements of the LifeCycleState enum
+func LifeCycleState_Values() []string {
+	return []string{
+		LifeCycleStateCreating,
+		LifeCycleStateAvailable,
+		LifeCycleStateUpdating,
+		LifeCycleStateDeleting,
+		LifeCycleStateDeleted,
+	}
+}
+
 const (
 	// PerformanceModeGeneralPurpose is a PerformanceMode enum value
 	PerformanceModeGeneralPurpose = "generalPurpose"
@@ -7802,6 +7813,14 @@ const (
 	// PerformanceModeMaxIo is a PerformanceMode enum value
 	PerformanceModeMaxIo = "maxIO"
 )
+
+// PerformanceMode_Values returns all elements of the PerformanceMode enum
+func PerformanceMode_Values() []string {
+	return []string{
+		PerformanceModeGeneralPurpose,
+		PerformanceModeMaxIo,
+	}
+}
 
 const (
 	// StatusEnabled is a Status enum value
@@ -7817,6 +7836,16 @@ const (
 	StatusDisabling = "DISABLING"
 )
 
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusEnabled,
+		StatusEnabling,
+		StatusDisabled,
+		StatusDisabling,
+	}
+}
+
 const (
 	// ThroughputModeBursting is a ThroughputMode enum value
 	ThroughputModeBursting = "bursting"
@@ -7824,6 +7853,14 @@ const (
 	// ThroughputModeProvisioned is a ThroughputMode enum value
 	ThroughputModeProvisioned = "provisioned"
 )
+
+// ThroughputMode_Values returns all elements of the ThroughputMode enum
+func ThroughputMode_Values() []string {
+	return []string{
+		ThroughputModeBursting,
+		ThroughputModeProvisioned,
+	}
+}
 
 const (
 	// TransitionToIARulesAfter7Days is a TransitionToIARules enum value
@@ -7841,3 +7878,14 @@ const (
 	// TransitionToIARulesAfter90Days is a TransitionToIARules enum value
 	TransitionToIARulesAfter90Days = "AFTER_90_DAYS"
 )
+
+// TransitionToIARules_Values returns all elements of the TransitionToIARules enum
+func TransitionToIARules_Values() []string {
+	return []string{
+		TransitionToIARulesAfter7Days,
+		TransitionToIARulesAfter14Days,
+		TransitionToIARulesAfter30Days,
+		TransitionToIARulesAfter60Days,
+		TransitionToIARulesAfter90Days,
+	}
+}

--- a/service/eks/api.go
+++ b/service/eks/api.go
@@ -6637,6 +6637,14 @@ const (
 	AMITypesAl2X8664Gpu = "AL2_x86_64_GPU"
 )
 
+// AMITypes_Values returns all elements of the AMITypes enum
+func AMITypes_Values() []string {
+	return []string{
+		AMITypesAl2X8664,
+		AMITypesAl2X8664Gpu,
+	}
+}
+
 const (
 	// ClusterStatusCreating is a ClusterStatus enum value
 	ClusterStatusCreating = "CREATING"
@@ -6653,6 +6661,17 @@ const (
 	// ClusterStatusUpdating is a ClusterStatus enum value
 	ClusterStatusUpdating = "UPDATING"
 )
+
+// ClusterStatus_Values returns all elements of the ClusterStatus enum
+func ClusterStatus_Values() []string {
+	return []string{
+		ClusterStatusCreating,
+		ClusterStatusActive,
+		ClusterStatusDeleting,
+		ClusterStatusFailed,
+		ClusterStatusUpdating,
+	}
+}
 
 const (
 	// ErrorCodeSubnetNotFound is a ErrorCode enum value
@@ -6689,6 +6708,23 @@ const (
 	ErrorCodeInsufficientFreeAddresses = "InsufficientFreeAddresses"
 )
 
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeSubnetNotFound,
+		ErrorCodeSecurityGroupNotFound,
+		ErrorCodeEniLimitReached,
+		ErrorCodeIpNotAvailable,
+		ErrorCodeAccessDenied,
+		ErrorCodeOperationNotPermitted,
+		ErrorCodeVpcIdNotFound,
+		ErrorCodeUnknown,
+		ErrorCodeNodeCreationFailure,
+		ErrorCodePodEvictionFailure,
+		ErrorCodeInsufficientFreeAddresses,
+	}
+}
+
 const (
 	// FargateProfileStatusCreating is a FargateProfileStatus enum value
 	FargateProfileStatusCreating = "CREATING"
@@ -6706,6 +6742,17 @@ const (
 	FargateProfileStatusDeleteFailed = "DELETE_FAILED"
 )
 
+// FargateProfileStatus_Values returns all elements of the FargateProfileStatus enum
+func FargateProfileStatus_Values() []string {
+	return []string{
+		FargateProfileStatusCreating,
+		FargateProfileStatusActive,
+		FargateProfileStatusDeleting,
+		FargateProfileStatusCreateFailed,
+		FargateProfileStatusDeleteFailed,
+	}
+}
+
 const (
 	// LogTypeApi is a LogType enum value
 	LogTypeApi = "api"
@@ -6722,6 +6769,17 @@ const (
 	// LogTypeScheduler is a LogType enum value
 	LogTypeScheduler = "scheduler"
 )
+
+// LogType_Values returns all elements of the LogType enum
+func LogType_Values() []string {
+	return []string{
+		LogTypeApi,
+		LogTypeAudit,
+		LogTypeAuthenticator,
+		LogTypeControllerManager,
+		LogTypeScheduler,
+	}
+}
 
 const (
 	// NodegroupIssueCodeAutoScalingGroupNotFound is a NodegroupIssueCode enum value
@@ -6776,6 +6834,29 @@ const (
 	NodegroupIssueCodeInternalFailure = "InternalFailure"
 )
 
+// NodegroupIssueCode_Values returns all elements of the NodegroupIssueCode enum
+func NodegroupIssueCode_Values() []string {
+	return []string{
+		NodegroupIssueCodeAutoScalingGroupNotFound,
+		NodegroupIssueCodeAutoScalingGroupInvalidConfiguration,
+		NodegroupIssueCodeEc2securityGroupNotFound,
+		NodegroupIssueCodeEc2securityGroupDeletionFailure,
+		NodegroupIssueCodeEc2launchTemplateNotFound,
+		NodegroupIssueCodeEc2launchTemplateVersionMismatch,
+		NodegroupIssueCodeEc2subnetNotFound,
+		NodegroupIssueCodeEc2subnetInvalidConfiguration,
+		NodegroupIssueCodeIamInstanceProfileNotFound,
+		NodegroupIssueCodeIamLimitExceeded,
+		NodegroupIssueCodeIamNodeRoleNotFound,
+		NodegroupIssueCodeNodeCreationFailure,
+		NodegroupIssueCodeAsgInstanceLaunchFailures,
+		NodegroupIssueCodeInstanceLimitExceeded,
+		NodegroupIssueCodeInsufficientFreeAddresses,
+		NodegroupIssueCodeAccessDenied,
+		NodegroupIssueCodeInternalFailure,
+	}
+}
+
 const (
 	// NodegroupStatusCreating is a NodegroupStatus enum value
 	NodegroupStatusCreating = "CREATING"
@@ -6798,6 +6879,19 @@ const (
 	// NodegroupStatusDegraded is a NodegroupStatus enum value
 	NodegroupStatusDegraded = "DEGRADED"
 )
+
+// NodegroupStatus_Values returns all elements of the NodegroupStatus enum
+func NodegroupStatus_Values() []string {
+	return []string{
+		NodegroupStatusCreating,
+		NodegroupStatusActive,
+		NodegroupStatusUpdating,
+		NodegroupStatusDeleting,
+		NodegroupStatusCreateFailed,
+		NodegroupStatusDeleteFailed,
+		NodegroupStatusDegraded,
+	}
+}
 
 const (
 	// UpdateParamTypeVersion is a UpdateParamType enum value
@@ -6837,6 +6931,24 @@ const (
 	UpdateParamTypePublicAccessCidrs = "PublicAccessCidrs"
 )
 
+// UpdateParamType_Values returns all elements of the UpdateParamType enum
+func UpdateParamType_Values() []string {
+	return []string{
+		UpdateParamTypeVersion,
+		UpdateParamTypePlatformVersion,
+		UpdateParamTypeEndpointPrivateAccess,
+		UpdateParamTypeEndpointPublicAccess,
+		UpdateParamTypeClusterLogging,
+		UpdateParamTypeDesiredSize,
+		UpdateParamTypeLabelsToAdd,
+		UpdateParamTypeLabelsToRemove,
+		UpdateParamTypeMaxSize,
+		UpdateParamTypeMinSize,
+		UpdateParamTypeReleaseVersion,
+		UpdateParamTypePublicAccessCidrs,
+	}
+}
+
 const (
 	// UpdateStatusInProgress is a UpdateStatus enum value
 	UpdateStatusInProgress = "InProgress"
@@ -6851,6 +6963,16 @@ const (
 	UpdateStatusSuccessful = "Successful"
 )
 
+// UpdateStatus_Values returns all elements of the UpdateStatus enum
+func UpdateStatus_Values() []string {
+	return []string{
+		UpdateStatusInProgress,
+		UpdateStatusFailed,
+		UpdateStatusCancelled,
+		UpdateStatusSuccessful,
+	}
+}
+
 const (
 	// UpdateTypeVersionUpdate is a UpdateType enum value
 	UpdateTypeVersionUpdate = "VersionUpdate"
@@ -6864,3 +6986,13 @@ const (
 	// UpdateTypeConfigUpdate is a UpdateType enum value
 	UpdateTypeConfigUpdate = "ConfigUpdate"
 )
+
+// UpdateType_Values returns all elements of the UpdateType enum
+func UpdateType_Values() []string {
+	return []string{
+		UpdateTypeVersionUpdate,
+		UpdateTypeEndpointAccessUpdate,
+		UpdateTypeLoggingUpdate,
+		UpdateTypeConfigUpdate,
+	}
+}

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -17248,6 +17248,14 @@ const (
 	AZModeCrossAz = "cross-az"
 )
 
+// AZMode_Values returns all elements of the AZMode enum
+func AZMode_Values() []string {
+	return []string{
+		AZModeSingleAz,
+		AZModeCrossAz,
+	}
+}
+
 const (
 	// AuthTokenUpdateStatusSetting is a AuthTokenUpdateStatus enum value
 	AuthTokenUpdateStatusSetting = "SETTING"
@@ -17256,6 +17264,14 @@ const (
 	AuthTokenUpdateStatusRotating = "ROTATING"
 )
 
+// AuthTokenUpdateStatus_Values returns all elements of the AuthTokenUpdateStatus enum
+func AuthTokenUpdateStatus_Values() []string {
+	return []string{
+		AuthTokenUpdateStatusSetting,
+		AuthTokenUpdateStatusRotating,
+	}
+}
+
 const (
 	// AuthTokenUpdateStrategyTypeSet is a AuthTokenUpdateStrategyType enum value
 	AuthTokenUpdateStrategyTypeSet = "SET"
@@ -17263,6 +17279,14 @@ const (
 	// AuthTokenUpdateStrategyTypeRotate is a AuthTokenUpdateStrategyType enum value
 	AuthTokenUpdateStrategyTypeRotate = "ROTATE"
 )
+
+// AuthTokenUpdateStrategyType_Values returns all elements of the AuthTokenUpdateStrategyType enum
+func AuthTokenUpdateStrategyType_Values() []string {
+	return []string{
+		AuthTokenUpdateStrategyTypeSet,
+		AuthTokenUpdateStrategyTypeRotate,
+	}
+}
 
 const (
 	// AutomaticFailoverStatusEnabled is a AutomaticFailoverStatus enum value
@@ -17278,6 +17302,16 @@ const (
 	AutomaticFailoverStatusDisabling = "disabling"
 )
 
+// AutomaticFailoverStatus_Values returns all elements of the AutomaticFailoverStatus enum
+func AutomaticFailoverStatus_Values() []string {
+	return []string{
+		AutomaticFailoverStatusEnabled,
+		AutomaticFailoverStatusDisabled,
+		AutomaticFailoverStatusEnabling,
+		AutomaticFailoverStatusDisabling,
+	}
+}
+
 const (
 	// ChangeTypeImmediate is a ChangeType enum value
 	ChangeTypeImmediate = "immediate"
@@ -17285,6 +17319,14 @@ const (
 	// ChangeTypeRequiresReboot is a ChangeType enum value
 	ChangeTypeRequiresReboot = "requires-reboot"
 )
+
+// ChangeType_Values returns all elements of the ChangeType enum
+func ChangeType_Values() []string {
+	return []string{
+		ChangeTypeImmediate,
+		ChangeTypeRequiresReboot,
+	}
+}
 
 const (
 	// MultiAZStatusEnabled is a MultiAZStatus enum value
@@ -17294,6 +17336,14 @@ const (
 	MultiAZStatusDisabled = "disabled"
 )
 
+// MultiAZStatus_Values returns all elements of the MultiAZStatus enum
+func MultiAZStatus_Values() []string {
+	return []string{
+		MultiAZStatusEnabled,
+		MultiAZStatusDisabled,
+	}
+}
+
 const (
 	// NodeUpdateInitiatedBySystem is a NodeUpdateInitiatedBy enum value
 	NodeUpdateInitiatedBySystem = "system"
@@ -17301,6 +17351,14 @@ const (
 	// NodeUpdateInitiatedByCustomer is a NodeUpdateInitiatedBy enum value
 	NodeUpdateInitiatedByCustomer = "customer"
 )
+
+// NodeUpdateInitiatedBy_Values returns all elements of the NodeUpdateInitiatedBy enum
+func NodeUpdateInitiatedBy_Values() []string {
+	return []string{
+		NodeUpdateInitiatedBySystem,
+		NodeUpdateInitiatedByCustomer,
+	}
+}
 
 const (
 	// NodeUpdateStatusNotApplied is a NodeUpdateStatus enum value
@@ -17322,6 +17380,18 @@ const (
 	NodeUpdateStatusComplete = "complete"
 )
 
+// NodeUpdateStatus_Values returns all elements of the NodeUpdateStatus enum
+func NodeUpdateStatus_Values() []string {
+	return []string{
+		NodeUpdateStatusNotApplied,
+		NodeUpdateStatusWaitingToStart,
+		NodeUpdateStatusInProgress,
+		NodeUpdateStatusStopping,
+		NodeUpdateStatusStopped,
+		NodeUpdateStatusComplete,
+	}
+}
+
 const (
 	// PendingAutomaticFailoverStatusEnabled is a PendingAutomaticFailoverStatus enum value
 	PendingAutomaticFailoverStatusEnabled = "enabled"
@@ -17329,6 +17399,14 @@ const (
 	// PendingAutomaticFailoverStatusDisabled is a PendingAutomaticFailoverStatus enum value
 	PendingAutomaticFailoverStatusDisabled = "disabled"
 )
+
+// PendingAutomaticFailoverStatus_Values returns all elements of the PendingAutomaticFailoverStatus enum
+func PendingAutomaticFailoverStatus_Values() []string {
+	return []string{
+		PendingAutomaticFailoverStatusEnabled,
+		PendingAutomaticFailoverStatusDisabled,
+	}
+}
 
 const (
 	// ServiceUpdateSeverityCritical is a ServiceUpdateSeverity enum value
@@ -17344,6 +17422,16 @@ const (
 	ServiceUpdateSeverityLow = "low"
 )
 
+// ServiceUpdateSeverity_Values returns all elements of the ServiceUpdateSeverity enum
+func ServiceUpdateSeverity_Values() []string {
+	return []string{
+		ServiceUpdateSeverityCritical,
+		ServiceUpdateSeverityImportant,
+		ServiceUpdateSeverityMedium,
+		ServiceUpdateSeverityLow,
+	}
+}
+
 const (
 	// ServiceUpdateStatusAvailable is a ServiceUpdateStatus enum value
 	ServiceUpdateStatusAvailable = "available"
@@ -17355,10 +17443,26 @@ const (
 	ServiceUpdateStatusExpired = "expired"
 )
 
+// ServiceUpdateStatus_Values returns all elements of the ServiceUpdateStatus enum
+func ServiceUpdateStatus_Values() []string {
+	return []string{
+		ServiceUpdateStatusAvailable,
+		ServiceUpdateStatusCancelled,
+		ServiceUpdateStatusExpired,
+	}
+}
+
 const (
 	// ServiceUpdateTypeSecurityUpdate is a ServiceUpdateType enum value
 	ServiceUpdateTypeSecurityUpdate = "security-update"
 )
+
+// ServiceUpdateType_Values returns all elements of the ServiceUpdateType enum
+func ServiceUpdateType_Values() []string {
+	return []string{
+		ServiceUpdateTypeSecurityUpdate,
+	}
+}
 
 const (
 	// SlaMetYes is a SlaMet enum value
@@ -17370,6 +17474,15 @@ const (
 	// SlaMetNA is a SlaMet enum value
 	SlaMetNA = "n/a"
 )
+
+// SlaMet_Values returns all elements of the SlaMet enum
+func SlaMet_Values() []string {
+	return []string{
+		SlaMetYes,
+		SlaMetNo,
+		SlaMetNA,
+	}
+}
 
 const (
 	// SourceTypeCacheCluster is a SourceType enum value
@@ -17387,6 +17500,17 @@ const (
 	// SourceTypeReplicationGroup is a SourceType enum value
 	SourceTypeReplicationGroup = "replication-group"
 )
+
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeCacheCluster,
+		SourceTypeCacheParameterGroup,
+		SourceTypeCacheSecurityGroup,
+		SourceTypeCacheSubnetGroup,
+		SourceTypeReplicationGroup,
+	}
+}
 
 const (
 	// UpdateActionStatusNotApplied is a UpdateActionStatus enum value
@@ -17416,3 +17540,18 @@ const (
 	// UpdateActionStatusNotApplicable is a UpdateActionStatus enum value
 	UpdateActionStatusNotApplicable = "not-applicable"
 )
+
+// UpdateActionStatus_Values returns all elements of the UpdateActionStatus enum
+func UpdateActionStatus_Values() []string {
+	return []string{
+		UpdateActionStatusNotApplied,
+		UpdateActionStatusWaitingToStart,
+		UpdateActionStatusInProgress,
+		UpdateActionStatusStopping,
+		UpdateActionStatusStopped,
+		UpdateActionStatusComplete,
+		UpdateActionStatusScheduling,
+		UpdateActionStatusScheduled,
+		UpdateActionStatusNotApplicable,
+	}
+}

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -12505,6 +12505,15 @@ const (
 	ActionHistoryStatusUnknown = "Unknown"
 )
 
+// ActionHistoryStatus_Values returns all elements of the ActionHistoryStatus enum
+func ActionHistoryStatus_Values() []string {
+	return []string{
+		ActionHistoryStatusCompleted,
+		ActionHistoryStatusFailed,
+		ActionHistoryStatusUnknown,
+	}
+}
+
 const (
 	// ActionStatusScheduled is a ActionStatus enum value
 	ActionStatusScheduled = "Scheduled"
@@ -12519,6 +12528,16 @@ const (
 	ActionStatusUnknown = "Unknown"
 )
 
+// ActionStatus_Values returns all elements of the ActionStatus enum
+func ActionStatus_Values() []string {
+	return []string{
+		ActionStatusScheduled,
+		ActionStatusPending,
+		ActionStatusRunning,
+		ActionStatusUnknown,
+	}
+}
+
 const (
 	// ActionTypeInstanceRefresh is a ActionType enum value
 	ActionTypeInstanceRefresh = "InstanceRefresh"
@@ -12529,6 +12548,15 @@ const (
 	// ActionTypeUnknown is a ActionType enum value
 	ActionTypeUnknown = "Unknown"
 )
+
+// ActionType_Values returns all elements of the ActionType enum
+func ActionType_Values() []string {
+	return []string{
+		ActionTypeInstanceRefresh,
+		ActionTypePlatformUpdate,
+		ActionTypeUnknown,
+	}
+}
 
 const (
 	// ApplicationVersionStatusProcessed is a ApplicationVersionStatus enum value
@@ -12547,6 +12575,17 @@ const (
 	ApplicationVersionStatusBuilding = "Building"
 )
 
+// ApplicationVersionStatus_Values returns all elements of the ApplicationVersionStatus enum
+func ApplicationVersionStatus_Values() []string {
+	return []string{
+		ApplicationVersionStatusProcessed,
+		ApplicationVersionStatusUnprocessed,
+		ApplicationVersionStatusFailed,
+		ApplicationVersionStatusProcessing,
+		ApplicationVersionStatusBuilding,
+	}
+}
+
 const (
 	// ComputeTypeBuildGeneral1Small is a ComputeType enum value
 	ComputeTypeBuildGeneral1Small = "BUILD_GENERAL1_SMALL"
@@ -12557,6 +12596,15 @@ const (
 	// ComputeTypeBuildGeneral1Large is a ComputeType enum value
 	ComputeTypeBuildGeneral1Large = "BUILD_GENERAL1_LARGE"
 )
+
+// ComputeType_Values returns all elements of the ComputeType enum
+func ComputeType_Values() []string {
+	return []string{
+		ComputeTypeBuildGeneral1Small,
+		ComputeTypeBuildGeneral1Medium,
+		ComputeTypeBuildGeneral1Large,
+	}
+}
 
 const (
 	// ConfigurationDeploymentStatusDeployed is a ConfigurationDeploymentStatus enum value
@@ -12569,6 +12617,15 @@ const (
 	ConfigurationDeploymentStatusFailed = "failed"
 )
 
+// ConfigurationDeploymentStatus_Values returns all elements of the ConfigurationDeploymentStatus enum
+func ConfigurationDeploymentStatus_Values() []string {
+	return []string{
+		ConfigurationDeploymentStatusDeployed,
+		ConfigurationDeploymentStatusPending,
+		ConfigurationDeploymentStatusFailed,
+	}
+}
+
 const (
 	// ConfigurationOptionValueTypeScalar is a ConfigurationOptionValueType enum value
 	ConfigurationOptionValueTypeScalar = "Scalar"
@@ -12576,6 +12633,14 @@ const (
 	// ConfigurationOptionValueTypeList is a ConfigurationOptionValueType enum value
 	ConfigurationOptionValueTypeList = "List"
 )
+
+// ConfigurationOptionValueType_Values returns all elements of the ConfigurationOptionValueType enum
+func ConfigurationOptionValueType_Values() []string {
+	return []string{
+		ConfigurationOptionValueTypeScalar,
+		ConfigurationOptionValueTypeList,
+	}
+}
 
 const (
 	// EnvironmentHealthGreen is a EnvironmentHealth enum value
@@ -12590,6 +12655,16 @@ const (
 	// EnvironmentHealthGrey is a EnvironmentHealth enum value
 	EnvironmentHealthGrey = "Grey"
 )
+
+// EnvironmentHealth_Values returns all elements of the EnvironmentHealth enum
+func EnvironmentHealth_Values() []string {
+	return []string{
+		EnvironmentHealthGreen,
+		EnvironmentHealthYellow,
+		EnvironmentHealthRed,
+		EnvironmentHealthGrey,
+	}
+}
 
 const (
 	// EnvironmentHealthAttributeStatus is a EnvironmentHealthAttribute enum value
@@ -12616,6 +12691,20 @@ const (
 	// EnvironmentHealthAttributeRefreshedAt is a EnvironmentHealthAttribute enum value
 	EnvironmentHealthAttributeRefreshedAt = "RefreshedAt"
 )
+
+// EnvironmentHealthAttribute_Values returns all elements of the EnvironmentHealthAttribute enum
+func EnvironmentHealthAttribute_Values() []string {
+	return []string{
+		EnvironmentHealthAttributeStatus,
+		EnvironmentHealthAttributeColor,
+		EnvironmentHealthAttributeCauses,
+		EnvironmentHealthAttributeApplicationMetrics,
+		EnvironmentHealthAttributeInstancesHealth,
+		EnvironmentHealthAttributeAll,
+		EnvironmentHealthAttributeHealthStatus,
+		EnvironmentHealthAttributeRefreshedAt,
+	}
+}
 
 const (
 	// EnvironmentHealthStatusNoData is a EnvironmentHealthStatus enum value
@@ -12646,6 +12735,21 @@ const (
 	EnvironmentHealthStatusSuspended = "Suspended"
 )
 
+// EnvironmentHealthStatus_Values returns all elements of the EnvironmentHealthStatus enum
+func EnvironmentHealthStatus_Values() []string {
+	return []string{
+		EnvironmentHealthStatusNoData,
+		EnvironmentHealthStatusUnknown,
+		EnvironmentHealthStatusPending,
+		EnvironmentHealthStatusOk,
+		EnvironmentHealthStatusInfo,
+		EnvironmentHealthStatusWarning,
+		EnvironmentHealthStatusDegraded,
+		EnvironmentHealthStatusSevere,
+		EnvironmentHealthStatusSuspended,
+	}
+}
+
 const (
 	// EnvironmentInfoTypeTail is a EnvironmentInfoType enum value
 	EnvironmentInfoTypeTail = "tail"
@@ -12653,6 +12757,14 @@ const (
 	// EnvironmentInfoTypeBundle is a EnvironmentInfoType enum value
 	EnvironmentInfoTypeBundle = "bundle"
 )
+
+// EnvironmentInfoType_Values returns all elements of the EnvironmentInfoType enum
+func EnvironmentInfoType_Values() []string {
+	return []string{
+		EnvironmentInfoTypeTail,
+		EnvironmentInfoTypeBundle,
+	}
+}
 
 const (
 	// EnvironmentStatusLaunching is a EnvironmentStatus enum value
@@ -12670,6 +12782,17 @@ const (
 	// EnvironmentStatusTerminated is a EnvironmentStatus enum value
 	EnvironmentStatusTerminated = "Terminated"
 )
+
+// EnvironmentStatus_Values returns all elements of the EnvironmentStatus enum
+func EnvironmentStatus_Values() []string {
+	return []string{
+		EnvironmentStatusLaunching,
+		EnvironmentStatusUpdating,
+		EnvironmentStatusReady,
+		EnvironmentStatusTerminating,
+		EnvironmentStatusTerminated,
+	}
+}
 
 const (
 	// EventSeverityTrace is a EventSeverity enum value
@@ -12690,6 +12813,18 @@ const (
 	// EventSeverityFatal is a EventSeverity enum value
 	EventSeverityFatal = "FATAL"
 )
+
+// EventSeverity_Values returns all elements of the EventSeverity enum
+func EventSeverity_Values() []string {
+	return []string{
+		EventSeverityTrace,
+		EventSeverityDebug,
+		EventSeverityInfo,
+		EventSeverityWarn,
+		EventSeverityError,
+		EventSeverityFatal,
+	}
+}
 
 const (
 	// FailureTypeUpdateCancelled is a FailureType enum value
@@ -12713,6 +12848,19 @@ const (
 	// FailureTypePermissionsError is a FailureType enum value
 	FailureTypePermissionsError = "PermissionsError"
 )
+
+// FailureType_Values returns all elements of the FailureType enum
+func FailureType_Values() []string {
+	return []string{
+		FailureTypeUpdateCancelled,
+		FailureTypeCancellationFailed,
+		FailureTypeRollbackFailed,
+		FailureTypeRollbackSuccessful,
+		FailureTypeInternalFailure,
+		FailureTypeInvalidEnvironmentState,
+		FailureTypePermissionsError,
+	}
+}
 
 const (
 	// InstancesHealthAttributeHealthStatus is a InstancesHealthAttribute enum value
@@ -12749,6 +12897,23 @@ const (
 	InstancesHealthAttributeAll = "All"
 )
 
+// InstancesHealthAttribute_Values returns all elements of the InstancesHealthAttribute enum
+func InstancesHealthAttribute_Values() []string {
+	return []string{
+		InstancesHealthAttributeHealthStatus,
+		InstancesHealthAttributeColor,
+		InstancesHealthAttributeCauses,
+		InstancesHealthAttributeApplicationMetrics,
+		InstancesHealthAttributeRefreshedAt,
+		InstancesHealthAttributeLaunchedAt,
+		InstancesHealthAttributeSystem,
+		InstancesHealthAttributeDeployment,
+		InstancesHealthAttributeAvailabilityZone,
+		InstancesHealthAttributeInstanceType,
+		InstancesHealthAttributeAll,
+	}
+}
+
 const (
 	// PlatformStatusCreating is a PlatformStatus enum value
 	PlatformStatusCreating = "Creating"
@@ -12766,6 +12931,17 @@ const (
 	PlatformStatusDeleted = "Deleted"
 )
 
+// PlatformStatus_Values returns all elements of the PlatformStatus enum
+func PlatformStatus_Values() []string {
+	return []string{
+		PlatformStatusCreating,
+		PlatformStatusFailed,
+		PlatformStatusReady,
+		PlatformStatusDeleting,
+		PlatformStatusDeleted,
+	}
+}
+
 const (
 	// SourceRepositoryCodeCommit is a SourceRepository enum value
 	SourceRepositoryCodeCommit = "CodeCommit"
@@ -12773,6 +12949,14 @@ const (
 	// SourceRepositoryS3 is a SourceRepository enum value
 	SourceRepositoryS3 = "S3"
 )
+
+// SourceRepository_Values returns all elements of the SourceRepository enum
+func SourceRepository_Values() []string {
+	return []string{
+		SourceRepositoryCodeCommit,
+		SourceRepositoryS3,
+	}
+}
 
 const (
 	// SourceTypeGit is a SourceType enum value
@@ -12782,6 +12966,14 @@ const (
 	SourceTypeZip = "Zip"
 )
 
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeGit,
+		SourceTypeZip,
+	}
+}
+
 const (
 	// ValidationSeverityError is a ValidationSeverity enum value
 	ValidationSeverityError = "error"
@@ -12789,3 +12981,11 @@ const (
 	// ValidationSeverityWarning is a ValidationSeverity enum value
 	ValidationSeverityWarning = "warning"
 )
+
+// ValidationSeverity_Values returns all elements of the ValidationSeverity enum
+func ValidationSeverity_Values() []string {
+	return []string{
+		ValidationSeverityError,
+		ValidationSeverityWarning,
+	}
+}

--- a/service/elasticinference/api.go
+++ b/service/elasticinference/api.go
@@ -1476,3 +1476,12 @@ const (
 	// LocationTypeAvailabilityZoneId is a LocationType enum value
 	LocationTypeAvailabilityZoneId = "availability-zone-id"
 )
+
+// LocationType_Values returns all elements of the LocationType enum
+func LocationType_Values() []string {
+	return []string{
+		LocationTypeRegion,
+		LocationTypeAvailabilityZone,
+		LocationTypeAvailabilityZoneId,
+	}
+}

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -10943,6 +10943,17 @@ const (
 	DeploymentStatusEligible = "ELIGIBLE"
 )
 
+// DeploymentStatus_Values returns all elements of the DeploymentStatus enum
+func DeploymentStatus_Values() []string {
+	return []string{
+		DeploymentStatusPendingUpdate,
+		DeploymentStatusInProgress,
+		DeploymentStatusCompleted,
+		DeploymentStatusNotEligible,
+		DeploymentStatusEligible,
+	}
+}
+
 const (
 	// DescribePackagesFilterNamePackageId is a DescribePackagesFilterName enum value
 	DescribePackagesFilterNamePackageId = "PackageID"
@@ -10953,6 +10964,15 @@ const (
 	// DescribePackagesFilterNamePackageStatus is a DescribePackagesFilterName enum value
 	DescribePackagesFilterNamePackageStatus = "PackageStatus"
 )
+
+// DescribePackagesFilterName_Values returns all elements of the DescribePackagesFilterName enum
+func DescribePackagesFilterName_Values() []string {
+	return []string{
+		DescribePackagesFilterNamePackageId,
+		DescribePackagesFilterNamePackageName,
+		DescribePackagesFilterNamePackageStatus,
+	}
+}
 
 const (
 	// DomainPackageStatusAssociating is a DomainPackageStatus enum value
@@ -10970,6 +10990,17 @@ const (
 	// DomainPackageStatusDissociationFailed is a DomainPackageStatus enum value
 	DomainPackageStatusDissociationFailed = "DISSOCIATION_FAILED"
 )
+
+// DomainPackageStatus_Values returns all elements of the DomainPackageStatus enum
+func DomainPackageStatus_Values() []string {
+	return []string{
+		DomainPackageStatusAssociating,
+		DomainPackageStatusAssociationFailed,
+		DomainPackageStatusActive,
+		DomainPackageStatusDissociating,
+		DomainPackageStatusDissociationFailed,
+	}
+}
 
 const (
 	// ESPartitionInstanceTypeM3MediumElasticsearch is a ESPartitionInstanceType enum value
@@ -11147,6 +11178,70 @@ const (
 	ESPartitionInstanceTypeI316xlargeElasticsearch = "i3.16xlarge.elasticsearch"
 )
 
+// ESPartitionInstanceType_Values returns all elements of the ESPartitionInstanceType enum
+func ESPartitionInstanceType_Values() []string {
+	return []string{
+		ESPartitionInstanceTypeM3MediumElasticsearch,
+		ESPartitionInstanceTypeM3LargeElasticsearch,
+		ESPartitionInstanceTypeM3XlargeElasticsearch,
+		ESPartitionInstanceTypeM32xlargeElasticsearch,
+		ESPartitionInstanceTypeM4LargeElasticsearch,
+		ESPartitionInstanceTypeM4XlargeElasticsearch,
+		ESPartitionInstanceTypeM42xlargeElasticsearch,
+		ESPartitionInstanceTypeM44xlargeElasticsearch,
+		ESPartitionInstanceTypeM410xlargeElasticsearch,
+		ESPartitionInstanceTypeM5LargeElasticsearch,
+		ESPartitionInstanceTypeM5XlargeElasticsearch,
+		ESPartitionInstanceTypeM52xlargeElasticsearch,
+		ESPartitionInstanceTypeM54xlargeElasticsearch,
+		ESPartitionInstanceTypeM512xlargeElasticsearch,
+		ESPartitionInstanceTypeR5LargeElasticsearch,
+		ESPartitionInstanceTypeR5XlargeElasticsearch,
+		ESPartitionInstanceTypeR52xlargeElasticsearch,
+		ESPartitionInstanceTypeR54xlargeElasticsearch,
+		ESPartitionInstanceTypeR512xlargeElasticsearch,
+		ESPartitionInstanceTypeC5LargeElasticsearch,
+		ESPartitionInstanceTypeC5XlargeElasticsearch,
+		ESPartitionInstanceTypeC52xlargeElasticsearch,
+		ESPartitionInstanceTypeC54xlargeElasticsearch,
+		ESPartitionInstanceTypeC59xlargeElasticsearch,
+		ESPartitionInstanceTypeC518xlargeElasticsearch,
+		ESPartitionInstanceTypeUltrawarm1MediumElasticsearch,
+		ESPartitionInstanceTypeUltrawarm1LargeElasticsearch,
+		ESPartitionInstanceTypeT2MicroElasticsearch,
+		ESPartitionInstanceTypeT2SmallElasticsearch,
+		ESPartitionInstanceTypeT2MediumElasticsearch,
+		ESPartitionInstanceTypeR3LargeElasticsearch,
+		ESPartitionInstanceTypeR3XlargeElasticsearch,
+		ESPartitionInstanceTypeR32xlargeElasticsearch,
+		ESPartitionInstanceTypeR34xlargeElasticsearch,
+		ESPartitionInstanceTypeR38xlargeElasticsearch,
+		ESPartitionInstanceTypeI2XlargeElasticsearch,
+		ESPartitionInstanceTypeI22xlargeElasticsearch,
+		ESPartitionInstanceTypeD2XlargeElasticsearch,
+		ESPartitionInstanceTypeD22xlargeElasticsearch,
+		ESPartitionInstanceTypeD24xlargeElasticsearch,
+		ESPartitionInstanceTypeD28xlargeElasticsearch,
+		ESPartitionInstanceTypeC4LargeElasticsearch,
+		ESPartitionInstanceTypeC4XlargeElasticsearch,
+		ESPartitionInstanceTypeC42xlargeElasticsearch,
+		ESPartitionInstanceTypeC44xlargeElasticsearch,
+		ESPartitionInstanceTypeC48xlargeElasticsearch,
+		ESPartitionInstanceTypeR4LargeElasticsearch,
+		ESPartitionInstanceTypeR4XlargeElasticsearch,
+		ESPartitionInstanceTypeR42xlargeElasticsearch,
+		ESPartitionInstanceTypeR44xlargeElasticsearch,
+		ESPartitionInstanceTypeR48xlargeElasticsearch,
+		ESPartitionInstanceTypeR416xlargeElasticsearch,
+		ESPartitionInstanceTypeI3LargeElasticsearch,
+		ESPartitionInstanceTypeI3XlargeElasticsearch,
+		ESPartitionInstanceTypeI32xlargeElasticsearch,
+		ESPartitionInstanceTypeI34xlargeElasticsearch,
+		ESPartitionInstanceTypeI38xlargeElasticsearch,
+		ESPartitionInstanceTypeI316xlargeElasticsearch,
+	}
+}
+
 const (
 	// ESWarmPartitionInstanceTypeUltrawarm1MediumElasticsearch is a ESWarmPartitionInstanceType enum value
 	ESWarmPartitionInstanceTypeUltrawarm1MediumElasticsearch = "ultrawarm1.medium.elasticsearch"
@@ -11154,6 +11249,14 @@ const (
 	// ESWarmPartitionInstanceTypeUltrawarm1LargeElasticsearch is a ESWarmPartitionInstanceType enum value
 	ESWarmPartitionInstanceTypeUltrawarm1LargeElasticsearch = "ultrawarm1.large.elasticsearch"
 )
+
+// ESWarmPartitionInstanceType_Values returns all elements of the ESWarmPartitionInstanceType enum
+func ESWarmPartitionInstanceType_Values() []string {
+	return []string{
+		ESWarmPartitionInstanceTypeUltrawarm1MediumElasticsearch,
+		ESWarmPartitionInstanceTypeUltrawarm1LargeElasticsearch,
+	}
+}
 
 const (
 	// InboundCrossClusterSearchConnectionStatusCodePendingAcceptance is a InboundCrossClusterSearchConnectionStatusCode enum value
@@ -11174,6 +11277,18 @@ const (
 	// InboundCrossClusterSearchConnectionStatusCodeDeleted is a InboundCrossClusterSearchConnectionStatusCode enum value
 	InboundCrossClusterSearchConnectionStatusCodeDeleted = "DELETED"
 )
+
+// InboundCrossClusterSearchConnectionStatusCode_Values returns all elements of the InboundCrossClusterSearchConnectionStatusCode enum
+func InboundCrossClusterSearchConnectionStatusCode_Values() []string {
+	return []string{
+		InboundCrossClusterSearchConnectionStatusCodePendingAcceptance,
+		InboundCrossClusterSearchConnectionStatusCodeApproved,
+		InboundCrossClusterSearchConnectionStatusCodeRejecting,
+		InboundCrossClusterSearchConnectionStatusCodeRejected,
+		InboundCrossClusterSearchConnectionStatusCodeDeleting,
+		InboundCrossClusterSearchConnectionStatusCodeDeleted,
+	}
+}
 
 // Type of Log File, it can be one of the following:
 //    * INDEX_SLOW_LOGS: Index slow logs contain insert requests that took more
@@ -11196,6 +11311,15 @@ const (
 	LogTypeEsApplicationLogs = "ES_APPLICATION_LOGS"
 )
 
+// LogType_Values returns all elements of the LogType enum
+func LogType_Values() []string {
+	return []string{
+		LogTypeIndexSlowLogs,
+		LogTypeSearchSlowLogs,
+		LogTypeEsApplicationLogs,
+	}
+}
+
 // The state of a requested change. One of the following:
 //
 //    * Processing: The request change is still in-process.
@@ -11212,6 +11336,15 @@ const (
 	// OptionStateActive is a OptionState enum value
 	OptionStateActive = "Active"
 )
+
+// OptionState_Values returns all elements of the OptionState enum
+func OptionState_Values() []string {
+	return []string{
+		OptionStateRequiresIndexDocuments,
+		OptionStateProcessing,
+		OptionStateActive,
+	}
+}
 
 const (
 	// OutboundCrossClusterSearchConnectionStatusCodePendingAcceptance is a OutboundCrossClusterSearchConnectionStatusCode enum value
@@ -11239,6 +11372,20 @@ const (
 	OutboundCrossClusterSearchConnectionStatusCodeDeleted = "DELETED"
 )
 
+// OutboundCrossClusterSearchConnectionStatusCode_Values returns all elements of the OutboundCrossClusterSearchConnectionStatusCode enum
+func OutboundCrossClusterSearchConnectionStatusCode_Values() []string {
+	return []string{
+		OutboundCrossClusterSearchConnectionStatusCodePendingAcceptance,
+		OutboundCrossClusterSearchConnectionStatusCodeValidating,
+		OutboundCrossClusterSearchConnectionStatusCodeValidationFailed,
+		OutboundCrossClusterSearchConnectionStatusCodeProvisioning,
+		OutboundCrossClusterSearchConnectionStatusCodeActive,
+		OutboundCrossClusterSearchConnectionStatusCodeRejected,
+		OutboundCrossClusterSearchConnectionStatusCodeDeleting,
+		OutboundCrossClusterSearchConnectionStatusCodeDeleted,
+	}
+}
+
 const (
 	// PackageStatusCopying is a PackageStatus enum value
 	PackageStatusCopying = "COPYING"
@@ -11265,10 +11412,31 @@ const (
 	PackageStatusDeleteFailed = "DELETE_FAILED"
 )
 
+// PackageStatus_Values returns all elements of the PackageStatus enum
+func PackageStatus_Values() []string {
+	return []string{
+		PackageStatusCopying,
+		PackageStatusCopyFailed,
+		PackageStatusValidating,
+		PackageStatusValidationFailed,
+		PackageStatusAvailable,
+		PackageStatusDeleting,
+		PackageStatusDeleted,
+		PackageStatusDeleteFailed,
+	}
+}
+
 const (
 	// PackageTypeTxtDictionary is a PackageType enum value
 	PackageTypeTxtDictionary = "TXT-DICTIONARY"
 )
+
+// PackageType_Values returns all elements of the PackageType enum
+func PackageType_Values() []string {
+	return []string{
+		PackageTypeTxtDictionary,
+	}
+}
 
 const (
 	// ReservedElasticsearchInstancePaymentOptionAllUpfront is a ReservedElasticsearchInstancePaymentOption enum value
@@ -11281,6 +11449,15 @@ const (
 	ReservedElasticsearchInstancePaymentOptionNoUpfront = "NO_UPFRONT"
 )
 
+// ReservedElasticsearchInstancePaymentOption_Values returns all elements of the ReservedElasticsearchInstancePaymentOption enum
+func ReservedElasticsearchInstancePaymentOption_Values() []string {
+	return []string{
+		ReservedElasticsearchInstancePaymentOptionAllUpfront,
+		ReservedElasticsearchInstancePaymentOptionPartialUpfront,
+		ReservedElasticsearchInstancePaymentOptionNoUpfront,
+	}
+}
+
 const (
 	// TLSSecurityPolicyPolicyMinTls10201907 is a TLSSecurityPolicy enum value
 	TLSSecurityPolicyPolicyMinTls10201907 = "Policy-Min-TLS-1-0-2019-07"
@@ -11288,6 +11465,14 @@ const (
 	// TLSSecurityPolicyPolicyMinTls12201907 is a TLSSecurityPolicy enum value
 	TLSSecurityPolicyPolicyMinTls12201907 = "Policy-Min-TLS-1-2-2019-07"
 )
+
+// TLSSecurityPolicy_Values returns all elements of the TLSSecurityPolicy enum
+func TLSSecurityPolicy_Values() []string {
+	return []string{
+		TLSSecurityPolicyPolicyMinTls10201907,
+		TLSSecurityPolicyPolicyMinTls12201907,
+	}
+}
 
 const (
 	// UpgradeStatusInProgress is a UpgradeStatus enum value
@@ -11303,6 +11488,16 @@ const (
 	UpgradeStatusFailed = "FAILED"
 )
 
+// UpgradeStatus_Values returns all elements of the UpgradeStatus enum
+func UpgradeStatus_Values() []string {
+	return []string{
+		UpgradeStatusInProgress,
+		UpgradeStatusSucceeded,
+		UpgradeStatusSucceededWithIssues,
+		UpgradeStatusFailed,
+	}
+}
+
 const (
 	// UpgradeStepPreUpgradeCheck is a UpgradeStep enum value
 	UpgradeStepPreUpgradeCheck = "PRE_UPGRADE_CHECK"
@@ -11313,6 +11508,15 @@ const (
 	// UpgradeStepUpgrade is a UpgradeStep enum value
 	UpgradeStepUpgrade = "UPGRADE"
 )
+
+// UpgradeStep_Values returns all elements of the UpgradeStep enum
+func UpgradeStep_Values() []string {
+	return []string{
+		UpgradeStepPreUpgradeCheck,
+		UpgradeStepSnapshot,
+		UpgradeStepUpgrade,
+	}
+}
 
 // The type of EBS volume, standard, gp2, or io1. See Configuring EBS-based
 // Storage (http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-ebs)for
@@ -11327,3 +11531,12 @@ const (
 	// VolumeTypeIo1 is a VolumeType enum value
 	VolumeTypeIo1 = "io1"
 )
+
+// VolumeType_Values returns all elements of the VolumeType enum
+func VolumeType_Values() []string {
+	return []string{
+		VolumeTypeStandard,
+		VolumeTypeGp2,
+		VolumeTypeIo1,
+	}
+}

--- a/service/elbv2/api.go
+++ b/service/elbv2/api.go
@@ -9168,6 +9168,17 @@ const (
 	ActionTypeEnumFixedResponse = "fixed-response"
 )
 
+// ActionTypeEnum_Values returns all elements of the ActionTypeEnum enum
+func ActionTypeEnum_Values() []string {
+	return []string{
+		ActionTypeEnumForward,
+		ActionTypeEnumAuthenticateOidc,
+		ActionTypeEnumAuthenticateCognito,
+		ActionTypeEnumRedirect,
+		ActionTypeEnumFixedResponse,
+	}
+}
+
 const (
 	// AuthenticateCognitoActionConditionalBehaviorEnumDeny is a AuthenticateCognitoActionConditionalBehaviorEnum enum value
 	AuthenticateCognitoActionConditionalBehaviorEnumDeny = "deny"
@@ -9178,6 +9189,15 @@ const (
 	// AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate is a AuthenticateCognitoActionConditionalBehaviorEnum enum value
 	AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate = "authenticate"
 )
+
+// AuthenticateCognitoActionConditionalBehaviorEnum_Values returns all elements of the AuthenticateCognitoActionConditionalBehaviorEnum enum
+func AuthenticateCognitoActionConditionalBehaviorEnum_Values() []string {
+	return []string{
+		AuthenticateCognitoActionConditionalBehaviorEnumDeny,
+		AuthenticateCognitoActionConditionalBehaviorEnumAllow,
+		AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate,
+	}
+}
 
 const (
 	// AuthenticateOidcActionConditionalBehaviorEnumDeny is a AuthenticateOidcActionConditionalBehaviorEnum enum value
@@ -9190,6 +9210,15 @@ const (
 	AuthenticateOidcActionConditionalBehaviorEnumAuthenticate = "authenticate"
 )
 
+// AuthenticateOidcActionConditionalBehaviorEnum_Values returns all elements of the AuthenticateOidcActionConditionalBehaviorEnum enum
+func AuthenticateOidcActionConditionalBehaviorEnum_Values() []string {
+	return []string{
+		AuthenticateOidcActionConditionalBehaviorEnumDeny,
+		AuthenticateOidcActionConditionalBehaviorEnumAllow,
+		AuthenticateOidcActionConditionalBehaviorEnumAuthenticate,
+	}
+}
+
 const (
 	// IpAddressTypeIpv4 is a IpAddressType enum value
 	IpAddressTypeIpv4 = "ipv4"
@@ -9198,6 +9227,14 @@ const (
 	IpAddressTypeDualstack = "dualstack"
 )
 
+// IpAddressType_Values returns all elements of the IpAddressType enum
+func IpAddressType_Values() []string {
+	return []string{
+		IpAddressTypeIpv4,
+		IpAddressTypeDualstack,
+	}
+}
+
 const (
 	// LoadBalancerSchemeEnumInternetFacing is a LoadBalancerSchemeEnum enum value
 	LoadBalancerSchemeEnumInternetFacing = "internet-facing"
@@ -9205,6 +9242,14 @@ const (
 	// LoadBalancerSchemeEnumInternal is a LoadBalancerSchemeEnum enum value
 	LoadBalancerSchemeEnumInternal = "internal"
 )
+
+// LoadBalancerSchemeEnum_Values returns all elements of the LoadBalancerSchemeEnum enum
+func LoadBalancerSchemeEnum_Values() []string {
+	return []string{
+		LoadBalancerSchemeEnumInternetFacing,
+		LoadBalancerSchemeEnumInternal,
+	}
+}
 
 const (
 	// LoadBalancerStateEnumActive is a LoadBalancerStateEnum enum value
@@ -9220,6 +9265,16 @@ const (
 	LoadBalancerStateEnumFailed = "failed"
 )
 
+// LoadBalancerStateEnum_Values returns all elements of the LoadBalancerStateEnum enum
+func LoadBalancerStateEnum_Values() []string {
+	return []string{
+		LoadBalancerStateEnumActive,
+		LoadBalancerStateEnumProvisioning,
+		LoadBalancerStateEnumActiveImpaired,
+		LoadBalancerStateEnumFailed,
+	}
+}
+
 const (
 	// LoadBalancerTypeEnumApplication is a LoadBalancerTypeEnum enum value
 	LoadBalancerTypeEnumApplication = "application"
@@ -9227,6 +9282,14 @@ const (
 	// LoadBalancerTypeEnumNetwork is a LoadBalancerTypeEnum enum value
 	LoadBalancerTypeEnumNetwork = "network"
 )
+
+// LoadBalancerTypeEnum_Values returns all elements of the LoadBalancerTypeEnum enum
+func LoadBalancerTypeEnum_Values() []string {
+	return []string{
+		LoadBalancerTypeEnumApplication,
+		LoadBalancerTypeEnumNetwork,
+	}
+}
 
 const (
 	// ProtocolEnumHttp is a ProtocolEnum enum value
@@ -9248,6 +9311,18 @@ const (
 	ProtocolEnumTcpUdp = "TCP_UDP"
 )
 
+// ProtocolEnum_Values returns all elements of the ProtocolEnum enum
+func ProtocolEnum_Values() []string {
+	return []string{
+		ProtocolEnumHttp,
+		ProtocolEnumHttps,
+		ProtocolEnumTcp,
+		ProtocolEnumTls,
+		ProtocolEnumUdp,
+		ProtocolEnumTcpUdp,
+	}
+}
+
 const (
 	// RedirectActionStatusCodeEnumHttp301 is a RedirectActionStatusCodeEnum enum value
 	RedirectActionStatusCodeEnumHttp301 = "HTTP_301"
@@ -9255,6 +9330,14 @@ const (
 	// RedirectActionStatusCodeEnumHttp302 is a RedirectActionStatusCodeEnum enum value
 	RedirectActionStatusCodeEnumHttp302 = "HTTP_302"
 )
+
+// RedirectActionStatusCodeEnum_Values returns all elements of the RedirectActionStatusCodeEnum enum
+func RedirectActionStatusCodeEnum_Values() []string {
+	return []string{
+		RedirectActionStatusCodeEnumHttp301,
+		RedirectActionStatusCodeEnumHttp302,
+	}
+}
 
 const (
 	// TargetHealthReasonEnumElbRegistrationInProgress is a TargetHealthReasonEnum enum value
@@ -9294,6 +9377,24 @@ const (
 	TargetHealthReasonEnumElbInternalError = "Elb.InternalError"
 )
 
+// TargetHealthReasonEnum_Values returns all elements of the TargetHealthReasonEnum enum
+func TargetHealthReasonEnum_Values() []string {
+	return []string{
+		TargetHealthReasonEnumElbRegistrationInProgress,
+		TargetHealthReasonEnumElbInitialHealthChecking,
+		TargetHealthReasonEnumTargetResponseCodeMismatch,
+		TargetHealthReasonEnumTargetTimeout,
+		TargetHealthReasonEnumTargetFailedHealthChecks,
+		TargetHealthReasonEnumTargetNotRegistered,
+		TargetHealthReasonEnumTargetNotInUse,
+		TargetHealthReasonEnumTargetDeregistrationInProgress,
+		TargetHealthReasonEnumTargetInvalidState,
+		TargetHealthReasonEnumTargetIpUnusable,
+		TargetHealthReasonEnumTargetHealthCheckDisabled,
+		TargetHealthReasonEnumElbInternalError,
+	}
+}
+
 const (
 	// TargetHealthStateEnumInitial is a TargetHealthStateEnum enum value
 	TargetHealthStateEnumInitial = "initial"
@@ -9314,6 +9415,18 @@ const (
 	TargetHealthStateEnumUnavailable = "unavailable"
 )
 
+// TargetHealthStateEnum_Values returns all elements of the TargetHealthStateEnum enum
+func TargetHealthStateEnum_Values() []string {
+	return []string{
+		TargetHealthStateEnumInitial,
+		TargetHealthStateEnumHealthy,
+		TargetHealthStateEnumUnhealthy,
+		TargetHealthStateEnumUnused,
+		TargetHealthStateEnumDraining,
+		TargetHealthStateEnumUnavailable,
+	}
+}
+
 const (
 	// TargetTypeEnumInstance is a TargetTypeEnum enum value
 	TargetTypeEnumInstance = "instance"
@@ -9324,3 +9437,12 @@ const (
 	// TargetTypeEnumLambda is a TargetTypeEnum enum value
 	TargetTypeEnumLambda = "lambda"
 )
+
+// TargetTypeEnum_Values returns all elements of the TargetTypeEnum enum
+func TargetTypeEnum_Values() []string {
+	return []string{
+		TargetTypeEnumInstance,
+		TargetTypeEnumIp,
+		TargetTypeEnumLambda,
+	}
+}

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -11987,6 +11987,16 @@ const (
 	ActionOnFailureContinue = "CONTINUE"
 )
 
+// ActionOnFailure_Values returns all elements of the ActionOnFailure enum
+func ActionOnFailure_Values() []string {
+	return []string{
+		ActionOnFailureTerminateJobFlow,
+		ActionOnFailureTerminateCluster,
+		ActionOnFailureCancelAndWait,
+		ActionOnFailureContinue,
+	}
+}
+
 const (
 	// AdjustmentTypeChangeInCapacity is a AdjustmentType enum value
 	AdjustmentTypeChangeInCapacity = "CHANGE_IN_CAPACITY"
@@ -11997,6 +12007,15 @@ const (
 	// AdjustmentTypeExactCapacity is a AdjustmentType enum value
 	AdjustmentTypeExactCapacity = "EXACT_CAPACITY"
 )
+
+// AdjustmentType_Values returns all elements of the AdjustmentType enum
+func AdjustmentType_Values() []string {
+	return []string{
+		AdjustmentTypeChangeInCapacity,
+		AdjustmentTypePercentChangeInCapacity,
+		AdjustmentTypeExactCapacity,
+	}
+}
 
 const (
 	// AutoScalingPolicyStatePending is a AutoScalingPolicyState enum value
@@ -12018,6 +12037,18 @@ const (
 	AutoScalingPolicyStateFailed = "FAILED"
 )
 
+// AutoScalingPolicyState_Values returns all elements of the AutoScalingPolicyState enum
+func AutoScalingPolicyState_Values() []string {
+	return []string{
+		AutoScalingPolicyStatePending,
+		AutoScalingPolicyStateAttaching,
+		AutoScalingPolicyStateAttached,
+		AutoScalingPolicyStateDetaching,
+		AutoScalingPolicyStateDetached,
+		AutoScalingPolicyStateFailed,
+	}
+}
+
 const (
 	// AutoScalingPolicyStateChangeReasonCodeUserRequest is a AutoScalingPolicyStateChangeReasonCode enum value
 	AutoScalingPolicyStateChangeReasonCodeUserRequest = "USER_REQUEST"
@@ -12029,6 +12060,15 @@ const (
 	AutoScalingPolicyStateChangeReasonCodeCleanupFailure = "CLEANUP_FAILURE"
 )
 
+// AutoScalingPolicyStateChangeReasonCode_Values returns all elements of the AutoScalingPolicyStateChangeReasonCode enum
+func AutoScalingPolicyStateChangeReasonCode_Values() []string {
+	return []string{
+		AutoScalingPolicyStateChangeReasonCodeUserRequest,
+		AutoScalingPolicyStateChangeReasonCodeProvisionFailure,
+		AutoScalingPolicyStateChangeReasonCodeCleanupFailure,
+	}
+}
+
 const (
 	// CancelStepsRequestStatusSubmitted is a CancelStepsRequestStatus enum value
 	CancelStepsRequestStatusSubmitted = "SUBMITTED"
@@ -12036,6 +12076,14 @@ const (
 	// CancelStepsRequestStatusFailed is a CancelStepsRequestStatus enum value
 	CancelStepsRequestStatusFailed = "FAILED"
 )
+
+// CancelStepsRequestStatus_Values returns all elements of the CancelStepsRequestStatus enum
+func CancelStepsRequestStatus_Values() []string {
+	return []string{
+		CancelStepsRequestStatusSubmitted,
+		CancelStepsRequestStatusFailed,
+	}
+}
 
 const (
 	// ClusterStateStarting is a ClusterState enum value
@@ -12059,6 +12107,19 @@ const (
 	// ClusterStateTerminatedWithErrors is a ClusterState enum value
 	ClusterStateTerminatedWithErrors = "TERMINATED_WITH_ERRORS"
 )
+
+// ClusterState_Values returns all elements of the ClusterState enum
+func ClusterState_Values() []string {
+	return []string{
+		ClusterStateStarting,
+		ClusterStateBootstrapping,
+		ClusterStateRunning,
+		ClusterStateWaiting,
+		ClusterStateTerminating,
+		ClusterStateTerminated,
+		ClusterStateTerminatedWithErrors,
+	}
+}
 
 const (
 	// ClusterStateChangeReasonCodeInternalError is a ClusterStateChangeReasonCode enum value
@@ -12086,6 +12147,20 @@ const (
 	ClusterStateChangeReasonCodeAllStepsCompleted = "ALL_STEPS_COMPLETED"
 )
 
+// ClusterStateChangeReasonCode_Values returns all elements of the ClusterStateChangeReasonCode enum
+func ClusterStateChangeReasonCode_Values() []string {
+	return []string{
+		ClusterStateChangeReasonCodeInternalError,
+		ClusterStateChangeReasonCodeValidationError,
+		ClusterStateChangeReasonCodeInstanceFailure,
+		ClusterStateChangeReasonCodeInstanceFleetTimeout,
+		ClusterStateChangeReasonCodeBootstrapFailure,
+		ClusterStateChangeReasonCodeUserRequest,
+		ClusterStateChangeReasonCodeStepFailure,
+		ClusterStateChangeReasonCodeAllStepsCompleted,
+	}
+}
+
 const (
 	// ComparisonOperatorGreaterThanOrEqual is a ComparisonOperator enum value
 	ComparisonOperatorGreaterThanOrEqual = "GREATER_THAN_OR_EQUAL"
@@ -12100,6 +12175,16 @@ const (
 	ComparisonOperatorLessThanOrEqual = "LESS_THAN_OR_EQUAL"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorGreaterThanOrEqual,
+		ComparisonOperatorGreaterThan,
+		ComparisonOperatorLessThan,
+		ComparisonOperatorLessThanOrEqual,
+	}
+}
+
 const (
 	// ComputeLimitsUnitTypeInstanceFleetUnits is a ComputeLimitsUnitType enum value
 	ComputeLimitsUnitTypeInstanceFleetUnits = "InstanceFleetUnits"
@@ -12111,6 +12196,15 @@ const (
 	ComputeLimitsUnitTypeVcpu = "VCPU"
 )
 
+// ComputeLimitsUnitType_Values returns all elements of the ComputeLimitsUnitType enum
+func ComputeLimitsUnitType_Values() []string {
+	return []string{
+		ComputeLimitsUnitTypeInstanceFleetUnits,
+		ComputeLimitsUnitTypeInstances,
+		ComputeLimitsUnitTypeVcpu,
+	}
+}
+
 const (
 	// InstanceCollectionTypeInstanceFleet is a InstanceCollectionType enum value
 	InstanceCollectionTypeInstanceFleet = "INSTANCE_FLEET"
@@ -12118,6 +12212,14 @@ const (
 	// InstanceCollectionTypeInstanceGroup is a InstanceCollectionType enum value
 	InstanceCollectionTypeInstanceGroup = "INSTANCE_GROUP"
 )
+
+// InstanceCollectionType_Values returns all elements of the InstanceCollectionType enum
+func InstanceCollectionType_Values() []string {
+	return []string{
+		InstanceCollectionTypeInstanceFleet,
+		InstanceCollectionTypeInstanceGroup,
+	}
+}
 
 const (
 	// InstanceFleetStateProvisioning is a InstanceFleetState enum value
@@ -12142,6 +12244,19 @@ const (
 	InstanceFleetStateTerminated = "TERMINATED"
 )
 
+// InstanceFleetState_Values returns all elements of the InstanceFleetState enum
+func InstanceFleetState_Values() []string {
+	return []string{
+		InstanceFleetStateProvisioning,
+		InstanceFleetStateBootstrapping,
+		InstanceFleetStateRunning,
+		InstanceFleetStateResizing,
+		InstanceFleetStateSuspended,
+		InstanceFleetStateTerminating,
+		InstanceFleetStateTerminated,
+	}
+}
+
 const (
 	// InstanceFleetStateChangeReasonCodeInternalError is a InstanceFleetStateChangeReasonCode enum value
 	InstanceFleetStateChangeReasonCodeInternalError = "INTERNAL_ERROR"
@@ -12156,6 +12271,16 @@ const (
 	InstanceFleetStateChangeReasonCodeClusterTerminated = "CLUSTER_TERMINATED"
 )
 
+// InstanceFleetStateChangeReasonCode_Values returns all elements of the InstanceFleetStateChangeReasonCode enum
+func InstanceFleetStateChangeReasonCode_Values() []string {
+	return []string{
+		InstanceFleetStateChangeReasonCodeInternalError,
+		InstanceFleetStateChangeReasonCodeValidationError,
+		InstanceFleetStateChangeReasonCodeInstanceFailure,
+		InstanceFleetStateChangeReasonCodeClusterTerminated,
+	}
+}
+
 const (
 	// InstanceFleetTypeMaster is a InstanceFleetType enum value
 	InstanceFleetTypeMaster = "MASTER"
@@ -12166,6 +12291,15 @@ const (
 	// InstanceFleetTypeTask is a InstanceFleetType enum value
 	InstanceFleetTypeTask = "TASK"
 )
+
+// InstanceFleetType_Values returns all elements of the InstanceFleetType enum
+func InstanceFleetType_Values() []string {
+	return []string{
+		InstanceFleetTypeMaster,
+		InstanceFleetTypeCore,
+		InstanceFleetTypeTask,
+	}
+}
 
 const (
 	// InstanceGroupStateProvisioning is a InstanceGroupState enum value
@@ -12202,6 +12336,23 @@ const (
 	InstanceGroupStateEnded = "ENDED"
 )
 
+// InstanceGroupState_Values returns all elements of the InstanceGroupState enum
+func InstanceGroupState_Values() []string {
+	return []string{
+		InstanceGroupStateProvisioning,
+		InstanceGroupStateBootstrapping,
+		InstanceGroupStateRunning,
+		InstanceGroupStateReconfiguring,
+		InstanceGroupStateResizing,
+		InstanceGroupStateSuspended,
+		InstanceGroupStateTerminating,
+		InstanceGroupStateTerminated,
+		InstanceGroupStateArrested,
+		InstanceGroupStateShuttingDown,
+		InstanceGroupStateEnded,
+	}
+}
+
 const (
 	// InstanceGroupStateChangeReasonCodeInternalError is a InstanceGroupStateChangeReasonCode enum value
 	InstanceGroupStateChangeReasonCodeInternalError = "INTERNAL_ERROR"
@@ -12216,6 +12367,16 @@ const (
 	InstanceGroupStateChangeReasonCodeClusterTerminated = "CLUSTER_TERMINATED"
 )
 
+// InstanceGroupStateChangeReasonCode_Values returns all elements of the InstanceGroupStateChangeReasonCode enum
+func InstanceGroupStateChangeReasonCode_Values() []string {
+	return []string{
+		InstanceGroupStateChangeReasonCodeInternalError,
+		InstanceGroupStateChangeReasonCodeValidationError,
+		InstanceGroupStateChangeReasonCodeInstanceFailure,
+		InstanceGroupStateChangeReasonCodeClusterTerminated,
+	}
+}
+
 const (
 	// InstanceGroupTypeMaster is a InstanceGroupType enum value
 	InstanceGroupTypeMaster = "MASTER"
@@ -12227,6 +12388,15 @@ const (
 	InstanceGroupTypeTask = "TASK"
 )
 
+// InstanceGroupType_Values returns all elements of the InstanceGroupType enum
+func InstanceGroupType_Values() []string {
+	return []string{
+		InstanceGroupTypeMaster,
+		InstanceGroupTypeCore,
+		InstanceGroupTypeTask,
+	}
+}
+
 const (
 	// InstanceRoleTypeMaster is a InstanceRoleType enum value
 	InstanceRoleTypeMaster = "MASTER"
@@ -12237,6 +12407,15 @@ const (
 	// InstanceRoleTypeTask is a InstanceRoleType enum value
 	InstanceRoleTypeTask = "TASK"
 )
+
+// InstanceRoleType_Values returns all elements of the InstanceRoleType enum
+func InstanceRoleType_Values() []string {
+	return []string{
+		InstanceRoleTypeMaster,
+		InstanceRoleTypeCore,
+		InstanceRoleTypeTask,
+	}
+}
 
 const (
 	// InstanceStateAwaitingFulfillment is a InstanceState enum value
@@ -12255,6 +12434,17 @@ const (
 	InstanceStateTerminated = "TERMINATED"
 )
 
+// InstanceState_Values returns all elements of the InstanceState enum
+func InstanceState_Values() []string {
+	return []string{
+		InstanceStateAwaitingFulfillment,
+		InstanceStateProvisioning,
+		InstanceStateBootstrapping,
+		InstanceStateRunning,
+		InstanceStateTerminated,
+	}
+}
+
 const (
 	// InstanceStateChangeReasonCodeInternalError is a InstanceStateChangeReasonCode enum value
 	InstanceStateChangeReasonCodeInternalError = "INTERNAL_ERROR"
@@ -12271,6 +12461,17 @@ const (
 	// InstanceStateChangeReasonCodeClusterTerminated is a InstanceStateChangeReasonCode enum value
 	InstanceStateChangeReasonCodeClusterTerminated = "CLUSTER_TERMINATED"
 )
+
+// InstanceStateChangeReasonCode_Values returns all elements of the InstanceStateChangeReasonCode enum
+func InstanceStateChangeReasonCode_Values() []string {
+	return []string{
+		InstanceStateChangeReasonCodeInternalError,
+		InstanceStateChangeReasonCodeValidationError,
+		InstanceStateChangeReasonCodeInstanceFailure,
+		InstanceStateChangeReasonCodeBootstrapFailure,
+		InstanceStateChangeReasonCodeClusterTerminated,
+	}
+}
 
 // The type of instance.
 const (
@@ -12299,6 +12500,20 @@ const (
 	JobFlowExecutionStateFailed = "FAILED"
 )
 
+// JobFlowExecutionState_Values returns all elements of the JobFlowExecutionState enum
+func JobFlowExecutionState_Values() []string {
+	return []string{
+		JobFlowExecutionStateStarting,
+		JobFlowExecutionStateBootstrapping,
+		JobFlowExecutionStateRunning,
+		JobFlowExecutionStateWaiting,
+		JobFlowExecutionStateShuttingDown,
+		JobFlowExecutionStateTerminated,
+		JobFlowExecutionStateCompleted,
+		JobFlowExecutionStateFailed,
+	}
+}
+
 const (
 	// MarketTypeOnDemand is a MarketType enum value
 	MarketTypeOnDemand = "ON_DEMAND"
@@ -12307,10 +12522,25 @@ const (
 	MarketTypeSpot = "SPOT"
 )
 
+// MarketType_Values returns all elements of the MarketType enum
+func MarketType_Values() []string {
+	return []string{
+		MarketTypeOnDemand,
+		MarketTypeSpot,
+	}
+}
+
 const (
 	// OnDemandProvisioningAllocationStrategyLowestPrice is a OnDemandProvisioningAllocationStrategy enum value
 	OnDemandProvisioningAllocationStrategyLowestPrice = "lowest-price"
 )
+
+// OnDemandProvisioningAllocationStrategy_Values returns all elements of the OnDemandProvisioningAllocationStrategy enum
+func OnDemandProvisioningAllocationStrategy_Values() []string {
+	return []string{
+		OnDemandProvisioningAllocationStrategyLowestPrice,
+	}
+}
 
 const (
 	// RepoUpgradeOnBootSecurity is a RepoUpgradeOnBoot enum value
@@ -12320,6 +12550,14 @@ const (
 	RepoUpgradeOnBootNone = "NONE"
 )
 
+// RepoUpgradeOnBoot_Values returns all elements of the RepoUpgradeOnBoot enum
+func RepoUpgradeOnBoot_Values() []string {
+	return []string{
+		RepoUpgradeOnBootSecurity,
+		RepoUpgradeOnBootNone,
+	}
+}
+
 const (
 	// ScaleDownBehaviorTerminateAtInstanceHour is a ScaleDownBehavior enum value
 	ScaleDownBehaviorTerminateAtInstanceHour = "TERMINATE_AT_INSTANCE_HOUR"
@@ -12328,10 +12566,25 @@ const (
 	ScaleDownBehaviorTerminateAtTaskCompletion = "TERMINATE_AT_TASK_COMPLETION"
 )
 
+// ScaleDownBehavior_Values returns all elements of the ScaleDownBehavior enum
+func ScaleDownBehavior_Values() []string {
+	return []string{
+		ScaleDownBehaviorTerminateAtInstanceHour,
+		ScaleDownBehaviorTerminateAtTaskCompletion,
+	}
+}
+
 const (
 	// SpotProvisioningAllocationStrategyCapacityOptimized is a SpotProvisioningAllocationStrategy enum value
 	SpotProvisioningAllocationStrategyCapacityOptimized = "capacity-optimized"
 )
+
+// SpotProvisioningAllocationStrategy_Values returns all elements of the SpotProvisioningAllocationStrategy enum
+func SpotProvisioningAllocationStrategy_Values() []string {
+	return []string{
+		SpotProvisioningAllocationStrategyCapacityOptimized,
+	}
+}
 
 const (
 	// SpotProvisioningTimeoutActionSwitchToOnDemand is a SpotProvisioningTimeoutAction enum value
@@ -12340,6 +12593,14 @@ const (
 	// SpotProvisioningTimeoutActionTerminateCluster is a SpotProvisioningTimeoutAction enum value
 	SpotProvisioningTimeoutActionTerminateCluster = "TERMINATE_CLUSTER"
 )
+
+// SpotProvisioningTimeoutAction_Values returns all elements of the SpotProvisioningTimeoutAction enum
+func SpotProvisioningTimeoutAction_Values() []string {
+	return []string{
+		SpotProvisioningTimeoutActionSwitchToOnDemand,
+		SpotProvisioningTimeoutActionTerminateCluster,
+	}
+}
 
 const (
 	// StatisticSampleCount is a Statistic enum value
@@ -12358,6 +12619,17 @@ const (
 	StatisticMaximum = "MAXIMUM"
 )
 
+// Statistic_Values returns all elements of the Statistic enum
+func Statistic_Values() []string {
+	return []string{
+		StatisticSampleCount,
+		StatisticAverage,
+		StatisticSum,
+		StatisticMinimum,
+		StatisticMaximum,
+	}
+}
+
 const (
 	// StepCancellationOptionSendInterrupt is a StepCancellationOption enum value
 	StepCancellationOptionSendInterrupt = "SEND_INTERRUPT"
@@ -12365,6 +12637,14 @@ const (
 	// StepCancellationOptionTerminateProcess is a StepCancellationOption enum value
 	StepCancellationOptionTerminateProcess = "TERMINATE_PROCESS"
 )
+
+// StepCancellationOption_Values returns all elements of the StepCancellationOption enum
+func StepCancellationOption_Values() []string {
+	return []string{
+		StepCancellationOptionSendInterrupt,
+		StepCancellationOptionTerminateProcess,
+	}
+}
 
 const (
 	// StepExecutionStatePending is a StepExecutionState enum value
@@ -12389,6 +12669,19 @@ const (
 	StepExecutionStateInterrupted = "INTERRUPTED"
 )
 
+// StepExecutionState_Values returns all elements of the StepExecutionState enum
+func StepExecutionState_Values() []string {
+	return []string{
+		StepExecutionStatePending,
+		StepExecutionStateRunning,
+		StepExecutionStateContinue,
+		StepExecutionStateCompleted,
+		StepExecutionStateCancelled,
+		StepExecutionStateFailed,
+		StepExecutionStateInterrupted,
+	}
+}
+
 const (
 	// StepStatePending is a StepState enum value
 	StepStatePending = "PENDING"
@@ -12412,10 +12705,30 @@ const (
 	StepStateInterrupted = "INTERRUPTED"
 )
 
+// StepState_Values returns all elements of the StepState enum
+func StepState_Values() []string {
+	return []string{
+		StepStatePending,
+		StepStateCancelPending,
+		StepStateRunning,
+		StepStateCompleted,
+		StepStateCancelled,
+		StepStateFailed,
+		StepStateInterrupted,
+	}
+}
+
 const (
 	// StepStateChangeReasonCodeNone is a StepStateChangeReasonCode enum value
 	StepStateChangeReasonCodeNone = "NONE"
 )
+
+// StepStateChangeReasonCode_Values returns all elements of the StepStateChangeReasonCode enum
+func StepStateChangeReasonCode_Values() []string {
+	return []string{
+		StepStateChangeReasonCodeNone,
+	}
+}
 
 const (
 	// UnitNone is a Unit enum value
@@ -12499,3 +12812,36 @@ const (
 	// UnitCountPerSecond is a Unit enum value
 	UnitCountPerSecond = "COUNT_PER_SECOND"
 )
+
+// Unit_Values returns all elements of the Unit enum
+func Unit_Values() []string {
+	return []string{
+		UnitNone,
+		UnitSeconds,
+		UnitMicroSeconds,
+		UnitMilliSeconds,
+		UnitBytes,
+		UnitKiloBytes,
+		UnitMegaBytes,
+		UnitGigaBytes,
+		UnitTeraBytes,
+		UnitBits,
+		UnitKiloBits,
+		UnitMegaBits,
+		UnitGigaBits,
+		UnitTeraBits,
+		UnitPercent,
+		UnitCount,
+		UnitBytesPerSecond,
+		UnitKiloBytesPerSecond,
+		UnitMegaBytesPerSecond,
+		UnitGigaBytesPerSecond,
+		UnitTeraBytesPerSecond,
+		UnitBitsPerSecond,
+		UnitKiloBitsPerSecond,
+		UnitMegaBitsPerSecond,
+		UnitGigaBitsPerSecond,
+		UnitTeraBitsPerSecond,
+		UnitCountPerSecond,
+	}
+}

--- a/service/eventbridge/api.go
+++ b/service/eventbridge/api.go
@@ -8084,6 +8084,14 @@ const (
 	AssignPublicIpDisabled = "DISABLED"
 )
 
+// AssignPublicIp_Values returns all elements of the AssignPublicIp enum
+func AssignPublicIp_Values() []string {
+	return []string{
+		AssignPublicIpEnabled,
+		AssignPublicIpDisabled,
+	}
+}
+
 const (
 	// EventSourceStatePending is a EventSourceState enum value
 	EventSourceStatePending = "PENDING"
@@ -8095,6 +8103,15 @@ const (
 	EventSourceStateDeleted = "DELETED"
 )
 
+// EventSourceState_Values returns all elements of the EventSourceState enum
+func EventSourceState_Values() []string {
+	return []string{
+		EventSourceStatePending,
+		EventSourceStateActive,
+		EventSourceStateDeleted,
+	}
+}
+
 const (
 	// LaunchTypeEc2 is a LaunchType enum value
 	LaunchTypeEc2 = "EC2"
@@ -8103,6 +8120,14 @@ const (
 	LaunchTypeFargate = "FARGATE"
 )
 
+// LaunchType_Values returns all elements of the LaunchType enum
+func LaunchType_Values() []string {
+	return []string{
+		LaunchTypeEc2,
+		LaunchTypeFargate,
+	}
+}
+
 const (
 	// RuleStateEnabled is a RuleState enum value
 	RuleStateEnabled = "ENABLED"
@@ -8110,3 +8135,11 @@ const (
 	// RuleStateDisabled is a RuleState enum value
 	RuleStateDisabled = "DISABLED"
 )
+
+// RuleState_Values returns all elements of the RuleState enum
+func RuleState_Values() []string {
+	return []string{
+		RuleStateEnabled,
+		RuleStateDisabled,
+	}
+}

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -8230,6 +8230,17 @@ const (
 	CompressionFormatHadoopSnappy = "HADOOP_SNAPPY"
 )
 
+// CompressionFormat_Values returns all elements of the CompressionFormat enum
+func CompressionFormat_Values() []string {
+	return []string{
+		CompressionFormatUncompressed,
+		CompressionFormatGzip,
+		CompressionFormatZip,
+		CompressionFormatSnappy,
+		CompressionFormatHadoopSnappy,
+	}
+}
+
 const (
 	// ContentEncodingNone is a ContentEncoding enum value
 	ContentEncodingNone = "NONE"
@@ -8237,6 +8248,14 @@ const (
 	// ContentEncodingGzip is a ContentEncoding enum value
 	ContentEncodingGzip = "GZIP"
 )
+
+// ContentEncoding_Values returns all elements of the ContentEncoding enum
+func ContentEncoding_Values() []string {
+	return []string{
+		ContentEncodingNone,
+		ContentEncodingGzip,
+	}
+}
 
 const (
 	// DeliveryStreamEncryptionStatusEnabled is a DeliveryStreamEncryptionStatus enum value
@@ -8257,6 +8276,18 @@ const (
 	// DeliveryStreamEncryptionStatusDisablingFailed is a DeliveryStreamEncryptionStatus enum value
 	DeliveryStreamEncryptionStatusDisablingFailed = "DISABLING_FAILED"
 )
+
+// DeliveryStreamEncryptionStatus_Values returns all elements of the DeliveryStreamEncryptionStatus enum
+func DeliveryStreamEncryptionStatus_Values() []string {
+	return []string{
+		DeliveryStreamEncryptionStatusEnabled,
+		DeliveryStreamEncryptionStatusEnabling,
+		DeliveryStreamEncryptionStatusEnablingFailed,
+		DeliveryStreamEncryptionStatusDisabled,
+		DeliveryStreamEncryptionStatusDisabling,
+		DeliveryStreamEncryptionStatusDisablingFailed,
+	}
+}
 
 const (
 	// DeliveryStreamFailureTypeRetireKmsGrantFailed is a DeliveryStreamFailureType enum value
@@ -8305,6 +8336,27 @@ const (
 	DeliveryStreamFailureTypeUnknownError = "UNKNOWN_ERROR"
 )
 
+// DeliveryStreamFailureType_Values returns all elements of the DeliveryStreamFailureType enum
+func DeliveryStreamFailureType_Values() []string {
+	return []string{
+		DeliveryStreamFailureTypeRetireKmsGrantFailed,
+		DeliveryStreamFailureTypeCreateKmsGrantFailed,
+		DeliveryStreamFailureTypeKmsAccessDenied,
+		DeliveryStreamFailureTypeDisabledKmsKey,
+		DeliveryStreamFailureTypeInvalidKmsKey,
+		DeliveryStreamFailureTypeKmsKeyNotFound,
+		DeliveryStreamFailureTypeKmsOptInRequired,
+		DeliveryStreamFailureTypeCreateEniFailed,
+		DeliveryStreamFailureTypeDeleteEniFailed,
+		DeliveryStreamFailureTypeSubnetNotFound,
+		DeliveryStreamFailureTypeSecurityGroupNotFound,
+		DeliveryStreamFailureTypeEniAccessDenied,
+		DeliveryStreamFailureTypeSubnetAccessDenied,
+		DeliveryStreamFailureTypeSecurityGroupAccessDenied,
+		DeliveryStreamFailureTypeUnknownError,
+	}
+}
+
 const (
 	// DeliveryStreamStatusCreating is a DeliveryStreamStatus enum value
 	DeliveryStreamStatusCreating = "CREATING"
@@ -8322,6 +8374,17 @@ const (
 	DeliveryStreamStatusActive = "ACTIVE"
 )
 
+// DeliveryStreamStatus_Values returns all elements of the DeliveryStreamStatus enum
+func DeliveryStreamStatus_Values() []string {
+	return []string{
+		DeliveryStreamStatusCreating,
+		DeliveryStreamStatusCreatingFailed,
+		DeliveryStreamStatusDeleting,
+		DeliveryStreamStatusDeletingFailed,
+		DeliveryStreamStatusActive,
+	}
+}
+
 const (
 	// DeliveryStreamTypeDirectPut is a DeliveryStreamType enum value
 	DeliveryStreamTypeDirectPut = "DirectPut"
@@ -8329,6 +8392,14 @@ const (
 	// DeliveryStreamTypeKinesisStreamAsSource is a DeliveryStreamType enum value
 	DeliveryStreamTypeKinesisStreamAsSource = "KinesisStreamAsSource"
 )
+
+// DeliveryStreamType_Values returns all elements of the DeliveryStreamType enum
+func DeliveryStreamType_Values() []string {
+	return []string{
+		DeliveryStreamTypeDirectPut,
+		DeliveryStreamTypeKinesisStreamAsSource,
+	}
+}
 
 const (
 	// ElasticsearchIndexRotationPeriodNoRotation is a ElasticsearchIndexRotationPeriod enum value
@@ -8347,6 +8418,17 @@ const (
 	ElasticsearchIndexRotationPeriodOneMonth = "OneMonth"
 )
 
+// ElasticsearchIndexRotationPeriod_Values returns all elements of the ElasticsearchIndexRotationPeriod enum
+func ElasticsearchIndexRotationPeriod_Values() []string {
+	return []string{
+		ElasticsearchIndexRotationPeriodNoRotation,
+		ElasticsearchIndexRotationPeriodOneHour,
+		ElasticsearchIndexRotationPeriodOneDay,
+		ElasticsearchIndexRotationPeriodOneWeek,
+		ElasticsearchIndexRotationPeriodOneMonth,
+	}
+}
+
 const (
 	// ElasticsearchS3BackupModeFailedDocumentsOnly is a ElasticsearchS3BackupMode enum value
 	ElasticsearchS3BackupModeFailedDocumentsOnly = "FailedDocumentsOnly"
@@ -8354,6 +8436,14 @@ const (
 	// ElasticsearchS3BackupModeAllDocuments is a ElasticsearchS3BackupMode enum value
 	ElasticsearchS3BackupModeAllDocuments = "AllDocuments"
 )
+
+// ElasticsearchS3BackupMode_Values returns all elements of the ElasticsearchS3BackupMode enum
+func ElasticsearchS3BackupMode_Values() []string {
+	return []string{
+		ElasticsearchS3BackupModeFailedDocumentsOnly,
+		ElasticsearchS3BackupModeAllDocuments,
+	}
+}
 
 const (
 	// HECEndpointTypeRaw is a HECEndpointType enum value
@@ -8363,6 +8453,14 @@ const (
 	HECEndpointTypeEvent = "Event"
 )
 
+// HECEndpointType_Values returns all elements of the HECEndpointType enum
+func HECEndpointType_Values() []string {
+	return []string{
+		HECEndpointTypeRaw,
+		HECEndpointTypeEvent,
+	}
+}
+
 const (
 	// HttpEndpointS3BackupModeFailedDataOnly is a HttpEndpointS3BackupMode enum value
 	HttpEndpointS3BackupModeFailedDataOnly = "FailedDataOnly"
@@ -8370,6 +8468,14 @@ const (
 	// HttpEndpointS3BackupModeAllData is a HttpEndpointS3BackupMode enum value
 	HttpEndpointS3BackupModeAllData = "AllData"
 )
+
+// HttpEndpointS3BackupMode_Values returns all elements of the HttpEndpointS3BackupMode enum
+func HttpEndpointS3BackupMode_Values() []string {
+	return []string{
+		HttpEndpointS3BackupModeFailedDataOnly,
+		HttpEndpointS3BackupModeAllData,
+	}
+}
 
 const (
 	// KeyTypeAwsOwnedCmk is a KeyType enum value
@@ -8379,10 +8485,25 @@ const (
 	KeyTypeCustomerManagedCmk = "CUSTOMER_MANAGED_CMK"
 )
 
+// KeyType_Values returns all elements of the KeyType enum
+func KeyType_Values() []string {
+	return []string{
+		KeyTypeAwsOwnedCmk,
+		KeyTypeCustomerManagedCmk,
+	}
+}
+
 const (
 	// NoEncryptionConfigNoEncryption is a NoEncryptionConfig enum value
 	NoEncryptionConfigNoEncryption = "NoEncryption"
 )
+
+// NoEncryptionConfig_Values returns all elements of the NoEncryptionConfig enum
+func NoEncryptionConfig_Values() []string {
+	return []string{
+		NoEncryptionConfigNoEncryption,
+	}
+}
 
 const (
 	// OrcCompressionNone is a OrcCompression enum value
@@ -8395,6 +8516,15 @@ const (
 	OrcCompressionSnappy = "SNAPPY"
 )
 
+// OrcCompression_Values returns all elements of the OrcCompression enum
+func OrcCompression_Values() []string {
+	return []string{
+		OrcCompressionNone,
+		OrcCompressionZlib,
+		OrcCompressionSnappy,
+	}
+}
+
 const (
 	// OrcFormatVersionV011 is a OrcFormatVersion enum value
 	OrcFormatVersionV011 = "V0_11"
@@ -8402,6 +8532,14 @@ const (
 	// OrcFormatVersionV012 is a OrcFormatVersion enum value
 	OrcFormatVersionV012 = "V0_12"
 )
+
+// OrcFormatVersion_Values returns all elements of the OrcFormatVersion enum
+func OrcFormatVersion_Values() []string {
+	return []string{
+		OrcFormatVersionV011,
+		OrcFormatVersionV012,
+	}
+}
 
 const (
 	// ParquetCompressionUncompressed is a ParquetCompression enum value
@@ -8414,6 +8552,15 @@ const (
 	ParquetCompressionSnappy = "SNAPPY"
 )
 
+// ParquetCompression_Values returns all elements of the ParquetCompression enum
+func ParquetCompression_Values() []string {
+	return []string{
+		ParquetCompressionUncompressed,
+		ParquetCompressionGzip,
+		ParquetCompressionSnappy,
+	}
+}
+
 const (
 	// ParquetWriterVersionV1 is a ParquetWriterVersion enum value
 	ParquetWriterVersionV1 = "V1"
@@ -8421,6 +8568,14 @@ const (
 	// ParquetWriterVersionV2 is a ParquetWriterVersion enum value
 	ParquetWriterVersionV2 = "V2"
 )
+
+// ParquetWriterVersion_Values returns all elements of the ParquetWriterVersion enum
+func ParquetWriterVersion_Values() []string {
+	return []string{
+		ParquetWriterVersionV1,
+		ParquetWriterVersionV2,
+	}
+}
 
 const (
 	// ProcessorParameterNameLambdaArn is a ProcessorParameterName enum value
@@ -8439,10 +8594,28 @@ const (
 	ProcessorParameterNameBufferIntervalInSeconds = "BufferIntervalInSeconds"
 )
 
+// ProcessorParameterName_Values returns all elements of the ProcessorParameterName enum
+func ProcessorParameterName_Values() []string {
+	return []string{
+		ProcessorParameterNameLambdaArn,
+		ProcessorParameterNameNumberOfRetries,
+		ProcessorParameterNameRoleArn,
+		ProcessorParameterNameBufferSizeInMbs,
+		ProcessorParameterNameBufferIntervalInSeconds,
+	}
+}
+
 const (
 	// ProcessorTypeLambda is a ProcessorType enum value
 	ProcessorTypeLambda = "Lambda"
 )
+
+// ProcessorType_Values returns all elements of the ProcessorType enum
+func ProcessorType_Values() []string {
+	return []string{
+		ProcessorTypeLambda,
+	}
+}
 
 const (
 	// RedshiftS3BackupModeDisabled is a RedshiftS3BackupMode enum value
@@ -8452,6 +8625,14 @@ const (
 	RedshiftS3BackupModeEnabled = "Enabled"
 )
 
+// RedshiftS3BackupMode_Values returns all elements of the RedshiftS3BackupMode enum
+func RedshiftS3BackupMode_Values() []string {
+	return []string{
+		RedshiftS3BackupModeDisabled,
+		RedshiftS3BackupModeEnabled,
+	}
+}
+
 const (
 	// S3BackupModeDisabled is a S3BackupMode enum value
 	S3BackupModeDisabled = "Disabled"
@@ -8460,6 +8641,14 @@ const (
 	S3BackupModeEnabled = "Enabled"
 )
 
+// S3BackupMode_Values returns all elements of the S3BackupMode enum
+func S3BackupMode_Values() []string {
+	return []string{
+		S3BackupModeDisabled,
+		S3BackupModeEnabled,
+	}
+}
+
 const (
 	// SplunkS3BackupModeFailedEventsOnly is a SplunkS3BackupMode enum value
 	SplunkS3BackupModeFailedEventsOnly = "FailedEventsOnly"
@@ -8467,3 +8656,11 @@ const (
 	// SplunkS3BackupModeAllEvents is a SplunkS3BackupMode enum value
 	SplunkS3BackupModeAllEvents = "AllEvents"
 )
+
+// SplunkS3BackupMode_Values returns all elements of the SplunkS3BackupMode enum
+func SplunkS3BackupMode_Values() []string {
+	return []string{
+		SplunkS3BackupModeFailedEventsOnly,
+		SplunkS3BackupModeAllEvents,
+	}
+}

--- a/service/fms/api.go
+++ b/service/fms/api.go
@@ -6713,6 +6713,17 @@ const (
 	AccountRoleStatusDeleted = "DELETED"
 )
 
+// AccountRoleStatus_Values returns all elements of the AccountRoleStatus enum
+func AccountRoleStatus_Values() []string {
+	return []string{
+		AccountRoleStatusReady,
+		AccountRoleStatusCreating,
+		AccountRoleStatusPendingDeletion,
+		AccountRoleStatusDeleting,
+		AccountRoleStatusDeleted,
+	}
+}
+
 const (
 	// CustomerPolicyScopeIdTypeAccount is a CustomerPolicyScopeIdType enum value
 	CustomerPolicyScopeIdTypeAccount = "ACCOUNT"
@@ -6720,6 +6731,14 @@ const (
 	// CustomerPolicyScopeIdTypeOrgUnit is a CustomerPolicyScopeIdType enum value
 	CustomerPolicyScopeIdTypeOrgUnit = "ORG_UNIT"
 )
+
+// CustomerPolicyScopeIdType_Values returns all elements of the CustomerPolicyScopeIdType enum
+func CustomerPolicyScopeIdType_Values() []string {
+	return []string{
+		CustomerPolicyScopeIdTypeAccount,
+		CustomerPolicyScopeIdTypeOrgUnit,
+	}
+}
 
 const (
 	// DependentServiceNameAwsconfig is a DependentServiceName enum value
@@ -6735,6 +6754,16 @@ const (
 	DependentServiceNameAwsvpc = "AWSVPC"
 )
 
+// DependentServiceName_Values returns all elements of the DependentServiceName enum
+func DependentServiceName_Values() []string {
+	return []string{
+		DependentServiceNameAwsconfig,
+		DependentServiceNameAwswaf,
+		DependentServiceNameAwsshieldAdvanced,
+		DependentServiceNameAwsvpc,
+	}
+}
+
 const (
 	// PolicyComplianceStatusTypeCompliant is a PolicyComplianceStatusType enum value
 	PolicyComplianceStatusTypeCompliant = "COMPLIANT"
@@ -6743,6 +6772,14 @@ const (
 	PolicyComplianceStatusTypeNonCompliant = "NON_COMPLIANT"
 )
 
+// PolicyComplianceStatusType_Values returns all elements of the PolicyComplianceStatusType enum
+func PolicyComplianceStatusType_Values() []string {
+	return []string{
+		PolicyComplianceStatusTypeCompliant,
+		PolicyComplianceStatusTypeNonCompliant,
+	}
+}
+
 const (
 	// RemediationActionTypeRemove is a RemediationActionType enum value
 	RemediationActionTypeRemove = "REMOVE"
@@ -6750,6 +6787,14 @@ const (
 	// RemediationActionTypeModify is a RemediationActionType enum value
 	RemediationActionTypeModify = "MODIFY"
 )
+
+// RemediationActionType_Values returns all elements of the RemediationActionType enum
+func RemediationActionType_Values() []string {
+	return []string{
+		RemediationActionTypeRemove,
+		RemediationActionTypeModify,
+	}
+}
 
 const (
 	// SecurityServiceTypeWaf is a SecurityServiceType enum value
@@ -6770,6 +6815,18 @@ const (
 	// SecurityServiceTypeSecurityGroupsUsageAudit is a SecurityServiceType enum value
 	SecurityServiceTypeSecurityGroupsUsageAudit = "SECURITY_GROUPS_USAGE_AUDIT"
 )
+
+// SecurityServiceType_Values returns all elements of the SecurityServiceType enum
+func SecurityServiceType_Values() []string {
+	return []string{
+		SecurityServiceTypeWaf,
+		SecurityServiceTypeWafv2,
+		SecurityServiceTypeShieldAdvanced,
+		SecurityServiceTypeSecurityGroupsCommon,
+		SecurityServiceTypeSecurityGroupsContentAudit,
+		SecurityServiceTypeSecurityGroupsUsageAudit,
+	}
+}
 
 const (
 	// ViolationReasonWebAclMissingRuleGroup is a ViolationReason enum value
@@ -6799,3 +6856,18 @@ const (
 	// ViolationReasonSecurityGroupRedundant is a ViolationReason enum value
 	ViolationReasonSecurityGroupRedundant = "SECURITY_GROUP_REDUNDANT"
 )
+
+// ViolationReason_Values returns all elements of the ViolationReason enum
+func ViolationReason_Values() []string {
+	return []string{
+		ViolationReasonWebAclMissingRuleGroup,
+		ViolationReasonResourceMissingWebAcl,
+		ViolationReasonResourceIncorrectWebAcl,
+		ViolationReasonResourceMissingShieldProtection,
+		ViolationReasonResourceMissingWebAclOrShieldProtection,
+		ViolationReasonResourceMissingSecurityGroup,
+		ViolationReasonResourceViolatesAuditSecurityGroup,
+		ViolationReasonSecurityGroupUnused,
+		ViolationReasonSecurityGroupRedundant,
+	}
+}

--- a/service/forecastservice/api.go
+++ b/service/forecastservice/api.go
@@ -9287,6 +9287,16 @@ const (
 	AttributeTypeTimestamp = "timestamp"
 )
 
+// AttributeType_Values returns all elements of the AttributeType enum
+func AttributeType_Values() []string {
+	return []string{
+		AttributeTypeString,
+		AttributeTypeInteger,
+		AttributeTypeFloat,
+		AttributeTypeTimestamp,
+	}
+}
+
 const (
 	// DatasetTypeTargetTimeSeries is a DatasetType enum value
 	DatasetTypeTargetTimeSeries = "TARGET_TIME_SERIES"
@@ -9297,6 +9307,15 @@ const (
 	// DatasetTypeItemMetadata is a DatasetType enum value
 	DatasetTypeItemMetadata = "ITEM_METADATA"
 )
+
+// DatasetType_Values returns all elements of the DatasetType enum
+func DatasetType_Values() []string {
+	return []string{
+		DatasetTypeTargetTimeSeries,
+		DatasetTypeRelatedTimeSeries,
+		DatasetTypeItemMetadata,
+	}
+}
 
 const (
 	// DomainRetail is a Domain enum value
@@ -9321,6 +9340,19 @@ const (
 	DomainMetrics = "METRICS"
 )
 
+// Domain_Values returns all elements of the Domain enum
+func Domain_Values() []string {
+	return []string{
+		DomainRetail,
+		DomainCustom,
+		DomainInventoryPlanning,
+		DomainEc2Capacity,
+		DomainWorkForce,
+		DomainWebTraffic,
+		DomainMetrics,
+	}
+}
+
 const (
 	// EvaluationTypeSummary is a EvaluationType enum value
 	EvaluationTypeSummary = "SUMMARY"
@@ -9329,10 +9361,25 @@ const (
 	EvaluationTypeComputed = "COMPUTED"
 )
 
+// EvaluationType_Values returns all elements of the EvaluationType enum
+func EvaluationType_Values() []string {
+	return []string{
+		EvaluationTypeSummary,
+		EvaluationTypeComputed,
+	}
+}
+
 const (
 	// FeaturizationMethodNameFilling is a FeaturizationMethodName enum value
 	FeaturizationMethodNameFilling = "filling"
 )
+
+// FeaturizationMethodName_Values returns all elements of the FeaturizationMethodName enum
+func FeaturizationMethodName_Values() []string {
+	return []string{
+		FeaturizationMethodNameFilling,
+	}
+}
 
 const (
 	// FilterConditionStringIs is a FilterConditionString enum value
@@ -9341,6 +9388,14 @@ const (
 	// FilterConditionStringIsNot is a FilterConditionString enum value
 	FilterConditionStringIsNot = "IS_NOT"
 )
+
+// FilterConditionString_Values returns all elements of the FilterConditionString enum
+func FilterConditionString_Values() []string {
+	return []string{
+		FilterConditionStringIs,
+		FilterConditionStringIsNot,
+	}
+}
 
 const (
 	// ScalingTypeAuto is a ScalingType enum value
@@ -9355,3 +9410,13 @@ const (
 	// ScalingTypeReverseLogarithmic is a ScalingType enum value
 	ScalingTypeReverseLogarithmic = "ReverseLogarithmic"
 )
+
+// ScalingType_Values returns all elements of the ScalingType enum
+func ScalingType_Values() []string {
+	return []string{
+		ScalingTypeAuto,
+		ScalingTypeLinear,
+		ScalingTypeLogarithmic,
+		ScalingTypeReverseLogarithmic,
+	}
+}

--- a/service/frauddetector/api.go
+++ b/service/frauddetector/api.go
@@ -11970,6 +11970,15 @@ const (
 	DataSourceExternalModelScore = "EXTERNAL_MODEL_SCORE"
 )
 
+// DataSource_Values returns all elements of the DataSource enum
+func DataSource_Values() []string {
+	return []string{
+		DataSourceEvent,
+		DataSourceModelScore,
+		DataSourceExternalModelScore,
+	}
+}
+
 const (
 	// DataTypeString is a DataType enum value
 	DataTypeString = "STRING"
@@ -11984,6 +11993,16 @@ const (
 	DataTypeBoolean = "BOOLEAN"
 )
 
+// DataType_Values returns all elements of the DataType enum
+func DataType_Values() []string {
+	return []string{
+		DataTypeString,
+		DataTypeInteger,
+		DataTypeFloat,
+		DataTypeBoolean,
+	}
+}
+
 const (
 	// DetectorVersionStatusDraft is a DetectorVersionStatus enum value
 	DetectorVersionStatusDraft = "DRAFT"
@@ -11995,10 +12014,26 @@ const (
 	DetectorVersionStatusInactive = "INACTIVE"
 )
 
+// DetectorVersionStatus_Values returns all elements of the DetectorVersionStatus enum
+func DetectorVersionStatus_Values() []string {
+	return []string{
+		DetectorVersionStatusDraft,
+		DetectorVersionStatusActive,
+		DetectorVersionStatusInactive,
+	}
+}
+
 const (
 	// LanguageDetectorpl is a Language enum value
 	LanguageDetectorpl = "DETECTORPL"
 )
+
+// Language_Values returns all elements of the Language enum
+func Language_Values() []string {
+	return []string{
+		LanguageDetectorpl,
+	}
+}
 
 const (
 	// ModelEndpointStatusAssociated is a ModelEndpointStatus enum value
@@ -12008,6 +12043,14 @@ const (
 	ModelEndpointStatusDissociated = "DISSOCIATED"
 )
 
+// ModelEndpointStatus_Values returns all elements of the ModelEndpointStatus enum
+func ModelEndpointStatus_Values() []string {
+	return []string{
+		ModelEndpointStatusAssociated,
+		ModelEndpointStatusDissociated,
+	}
+}
+
 const (
 	// ModelInputDataFormatTextCsv is a ModelInputDataFormat enum value
 	ModelInputDataFormatTextCsv = "TEXT_CSV"
@@ -12015,6 +12058,14 @@ const (
 	// ModelInputDataFormatApplicationJson is a ModelInputDataFormat enum value
 	ModelInputDataFormatApplicationJson = "APPLICATION_JSON"
 )
+
+// ModelInputDataFormat_Values returns all elements of the ModelInputDataFormat enum
+func ModelInputDataFormat_Values() []string {
+	return []string{
+		ModelInputDataFormatTextCsv,
+		ModelInputDataFormatApplicationJson,
+	}
+}
 
 const (
 	// ModelOutputDataFormatTextCsv is a ModelOutputDataFormat enum value
@@ -12024,15 +12075,37 @@ const (
 	ModelOutputDataFormatApplicationJsonlines = "APPLICATION_JSONLINES"
 )
 
+// ModelOutputDataFormat_Values returns all elements of the ModelOutputDataFormat enum
+func ModelOutputDataFormat_Values() []string {
+	return []string{
+		ModelOutputDataFormatTextCsv,
+		ModelOutputDataFormatApplicationJsonlines,
+	}
+}
+
 const (
 	// ModelSourceSagemaker is a ModelSource enum value
 	ModelSourceSagemaker = "SAGEMAKER"
 )
 
+// ModelSource_Values returns all elements of the ModelSource enum
+func ModelSource_Values() []string {
+	return []string{
+		ModelSourceSagemaker,
+	}
+}
+
 const (
 	// ModelTypeEnumOnlineFraudInsights is a ModelTypeEnum enum value
 	ModelTypeEnumOnlineFraudInsights = "ONLINE_FRAUD_INSIGHTS"
 )
+
+// ModelTypeEnum_Values returns all elements of the ModelTypeEnum enum
+func ModelTypeEnum_Values() []string {
+	return []string{
+		ModelTypeEnumOnlineFraudInsights,
+	}
+}
 
 const (
 	// ModelVersionStatusActive is a ModelVersionStatus enum value
@@ -12042,6 +12115,14 @@ const (
 	ModelVersionStatusInactive = "INACTIVE"
 )
 
+// ModelVersionStatus_Values returns all elements of the ModelVersionStatus enum
+func ModelVersionStatus_Values() []string {
+	return []string{
+		ModelVersionStatusActive,
+		ModelVersionStatusInactive,
+	}
+}
+
 const (
 	// RuleExecutionModeAllMatched is a RuleExecutionMode enum value
 	RuleExecutionModeAllMatched = "ALL_MATCHED"
@@ -12050,7 +12131,22 @@ const (
 	RuleExecutionModeFirstMatched = "FIRST_MATCHED"
 )
 
+// RuleExecutionMode_Values returns all elements of the RuleExecutionMode enum
+func RuleExecutionMode_Values() []string {
+	return []string{
+		RuleExecutionModeAllMatched,
+		RuleExecutionModeFirstMatched,
+	}
+}
+
 const (
 	// TrainingDataSourceEnumExternalEvents is a TrainingDataSourceEnum enum value
 	TrainingDataSourceEnumExternalEvents = "EXTERNAL_EVENTS"
 )
+
+// TrainingDataSourceEnum_Values returns all elements of the TrainingDataSourceEnum enum
+func TrainingDataSourceEnum_Values() []string {
+	return []string{
+		TrainingDataSourceEnumExternalEvents,
+	}
+}

--- a/service/fsx/api.go
+++ b/service/fsx/api.go
@@ -7277,6 +7277,16 @@ const (
 	ActiveDirectoryErrorTypeInvalidDomainStage = "INVALID_DOMAIN_STAGE"
 )
 
+// ActiveDirectoryErrorType_Values returns all elements of the ActiveDirectoryErrorType enum
+func ActiveDirectoryErrorType_Values() []string {
+	return []string{
+		ActiveDirectoryErrorTypeDomainNotFound,
+		ActiveDirectoryErrorTypeIncompatibleDomainMode,
+		ActiveDirectoryErrorTypeWrongVpc,
+		ActiveDirectoryErrorTypeInvalidDomainStage,
+	}
+}
+
 // Describes the type of administrative action, as follows:
 //
 //    * FILE_SYSTEM_UPDATE - A file system update administrative action initiated
@@ -7298,6 +7308,14 @@ const (
 	AdministrativeActionTypeStorageOptimization = "STORAGE_OPTIMIZATION"
 )
 
+// AdministrativeActionType_Values returns all elements of the AdministrativeActionType enum
+func AdministrativeActionType_Values() []string {
+	return []string{
+		AdministrativeActionTypeFileSystemUpdate,
+		AdministrativeActionTypeStorageOptimization,
+	}
+}
+
 const (
 	// AutoImportPolicyTypeNone is a AutoImportPolicyType enum value
 	AutoImportPolicyTypeNone = "NONE"
@@ -7308,6 +7326,15 @@ const (
 	// AutoImportPolicyTypeNewChanged is a AutoImportPolicyType enum value
 	AutoImportPolicyTypeNewChanged = "NEW_CHANGED"
 )
+
+// AutoImportPolicyType_Values returns all elements of the AutoImportPolicyType enum
+func AutoImportPolicyType_Values() []string {
+	return []string{
+		AutoImportPolicyTypeNone,
+		AutoImportPolicyTypeNew,
+		AutoImportPolicyTypeNewChanged,
+	}
+}
 
 // The lifecycle status of the backup.
 const (
@@ -7324,6 +7351,16 @@ const (
 	BackupLifecycleFailed = "FAILED"
 )
 
+// BackupLifecycle_Values returns all elements of the BackupLifecycle enum
+func BackupLifecycle_Values() []string {
+	return []string{
+		BackupLifecycleAvailable,
+		BackupLifecycleCreating,
+		BackupLifecycleDeleted,
+		BackupLifecycleFailed,
+	}
+}
+
 // The type of the backup.
 const (
 	// BackupTypeAutomatic is a BackupType enum value
@@ -7332,6 +7369,14 @@ const (
 	// BackupTypeUserInitiated is a BackupType enum value
 	BackupTypeUserInitiated = "USER_INITIATED"
 )
+
+// BackupType_Values returns all elements of the BackupType enum
+func BackupType_Values() []string {
+	return []string{
+		BackupTypeAutomatic,
+		BackupTypeUserInitiated,
+	}
+}
 
 const (
 	// DataRepositoryLifecycleCreating is a DataRepositoryLifecycle enum value
@@ -7350,6 +7395,17 @@ const (
 	DataRepositoryLifecycleDeleting = "DELETING"
 )
 
+// DataRepositoryLifecycle_Values returns all elements of the DataRepositoryLifecycle enum
+func DataRepositoryLifecycle_Values() []string {
+	return []string{
+		DataRepositoryLifecycleCreating,
+		DataRepositoryLifecycleAvailable,
+		DataRepositoryLifecycleMisconfigured,
+		DataRepositoryLifecycleUpdating,
+		DataRepositoryLifecycleDeleting,
+	}
+}
+
 const (
 	// DataRepositoryTaskFilterNameFileSystemId is a DataRepositoryTaskFilterName enum value
 	DataRepositoryTaskFilterNameFileSystemId = "file-system-id"
@@ -7357,6 +7413,14 @@ const (
 	// DataRepositoryTaskFilterNameTaskLifecycle is a DataRepositoryTaskFilterName enum value
 	DataRepositoryTaskFilterNameTaskLifecycle = "task-lifecycle"
 )
+
+// DataRepositoryTaskFilterName_Values returns all elements of the DataRepositoryTaskFilterName enum
+func DataRepositoryTaskFilterName_Values() []string {
+	return []string{
+		DataRepositoryTaskFilterNameFileSystemId,
+		DataRepositoryTaskFilterNameTaskLifecycle,
+	}
+}
 
 const (
 	// DataRepositoryTaskLifecyclePending is a DataRepositoryTaskLifecycle enum value
@@ -7378,10 +7442,29 @@ const (
 	DataRepositoryTaskLifecycleCanceling = "CANCELING"
 )
 
+// DataRepositoryTaskLifecycle_Values returns all elements of the DataRepositoryTaskLifecycle enum
+func DataRepositoryTaskLifecycle_Values() []string {
+	return []string{
+		DataRepositoryTaskLifecyclePending,
+		DataRepositoryTaskLifecycleExecuting,
+		DataRepositoryTaskLifecycleFailed,
+		DataRepositoryTaskLifecycleSucceeded,
+		DataRepositoryTaskLifecycleCanceled,
+		DataRepositoryTaskLifecycleCanceling,
+	}
+}
+
 const (
 	// DataRepositoryTaskTypeExportToRepository is a DataRepositoryTaskType enum value
 	DataRepositoryTaskTypeExportToRepository = "EXPORT_TO_REPOSITORY"
 )
+
+// DataRepositoryTaskType_Values returns all elements of the DataRepositoryTaskType enum
+func DataRepositoryTaskType_Values() []string {
+	return []string{
+		DataRepositoryTaskTypeExportToRepository,
+	}
+}
 
 // The lifecycle status of the file system.
 const (
@@ -7404,6 +7487,18 @@ const (
 	FileSystemLifecycleUpdating = "UPDATING"
 )
 
+// FileSystemLifecycle_Values returns all elements of the FileSystemLifecycle enum
+func FileSystemLifecycle_Values() []string {
+	return []string{
+		FileSystemLifecycleAvailable,
+		FileSystemLifecycleCreating,
+		FileSystemLifecycleFailed,
+		FileSystemLifecycleDeleting,
+		FileSystemLifecycleMisconfigured,
+		FileSystemLifecycleUpdating,
+	}
+}
+
 // An enumeration specifying the currently ongoing maintenance operation.
 const (
 	// FileSystemMaintenanceOperationPatching is a FileSystemMaintenanceOperation enum value
@@ -7413,6 +7508,14 @@ const (
 	FileSystemMaintenanceOperationBackingUp = "BACKING_UP"
 )
 
+// FileSystemMaintenanceOperation_Values returns all elements of the FileSystemMaintenanceOperation enum
+func FileSystemMaintenanceOperation_Values() []string {
+	return []string{
+		FileSystemMaintenanceOperationPatching,
+		FileSystemMaintenanceOperationBackingUp,
+	}
+}
+
 // The type of file system.
 const (
 	// FileSystemTypeWindows is a FileSystemType enum value
@@ -7421,6 +7524,14 @@ const (
 	// FileSystemTypeLustre is a FileSystemType enum value
 	FileSystemTypeLustre = "LUSTRE"
 )
+
+// FileSystemType_Values returns all elements of the FileSystemType enum
+func FileSystemType_Values() []string {
+	return []string{
+		FileSystemTypeWindows,
+		FileSystemTypeLustre,
+	}
+}
 
 // The name for a filter.
 const (
@@ -7434,6 +7545,15 @@ const (
 	FilterNameFileSystemType = "file-system-type"
 )
 
+// FilterName_Values returns all elements of the FilterName enum
+func FilterName_Values() []string {
+	return []string{
+		FilterNameFileSystemId,
+		FilterNameBackupType,
+		FilterNameFileSystemType,
+	}
+}
+
 const (
 	// LustreDeploymentTypeScratch1 is a LustreDeploymentType enum value
 	LustreDeploymentTypeScratch1 = "SCRATCH_1"
@@ -7445,15 +7565,38 @@ const (
 	LustreDeploymentTypePersistent1 = "PERSISTENT_1"
 )
 
+// LustreDeploymentType_Values returns all elements of the LustreDeploymentType enum
+func LustreDeploymentType_Values() []string {
+	return []string{
+		LustreDeploymentTypeScratch1,
+		LustreDeploymentTypeScratch2,
+		LustreDeploymentTypePersistent1,
+	}
+}
+
 const (
 	// ReportFormatReportCsv20191124 is a ReportFormat enum value
 	ReportFormatReportCsv20191124 = "REPORT_CSV_20191124"
 )
 
+// ReportFormat_Values returns all elements of the ReportFormat enum
+func ReportFormat_Values() []string {
+	return []string{
+		ReportFormatReportCsv20191124,
+	}
+}
+
 const (
 	// ReportScopeFailedFilesOnly is a ReportScope enum value
 	ReportScopeFailedFilesOnly = "FAILED_FILES_ONLY"
 )
+
+// ReportScope_Values returns all elements of the ReportScope enum
+func ReportScope_Values() []string {
+	return []string{
+		ReportScopeFailedFilesOnly,
+	}
+}
 
 // The types of limits on your service utilization. Limits include file system
 // count, total throughput capacity, total storage, and total user-initiated
@@ -7473,6 +7616,16 @@ const (
 	ServiceLimitTotalUserInitiatedBackups = "TOTAL_USER_INITIATED_BACKUPS"
 )
 
+// ServiceLimit_Values returns all elements of the ServiceLimit enum
+func ServiceLimit_Values() []string {
+	return []string{
+		ServiceLimitFileSystemCount,
+		ServiceLimitTotalThroughputCapacity,
+		ServiceLimitTotalStorage,
+		ServiceLimitTotalUserInitiatedBackups,
+	}
+}
+
 const (
 	// StatusFailed is a Status enum value
 	StatusFailed = "FAILED"
@@ -7490,6 +7643,17 @@ const (
 	StatusUpdatedOptimizing = "UPDATED_OPTIMIZING"
 )
 
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusFailed,
+		StatusInProgress,
+		StatusPending,
+		StatusCompleted,
+		StatusUpdatedOptimizing,
+	}
+}
+
 // The storage type for your Amazon FSx file system.
 const (
 	// StorageTypeSsd is a StorageType enum value
@@ -7498,6 +7662,14 @@ const (
 	// StorageTypeHdd is a StorageType enum value
 	StorageTypeHdd = "HDD"
 )
+
+// StorageType_Values returns all elements of the StorageType enum
+func StorageType_Values() []string {
+	return []string{
+		StorageTypeSsd,
+		StorageTypeHdd,
+	}
+}
 
 const (
 	// WindowsDeploymentTypeMultiAz1 is a WindowsDeploymentType enum value
@@ -7509,3 +7681,12 @@ const (
 	// WindowsDeploymentTypeSingleAz2 is a WindowsDeploymentType enum value
 	WindowsDeploymentTypeSingleAz2 = "SINGLE_AZ_2"
 )
+
+// WindowsDeploymentType_Values returns all elements of the WindowsDeploymentType enum
+func WindowsDeploymentType_Values() []string {
+	return []string{
+		WindowsDeploymentTypeMultiAz1,
+		WindowsDeploymentTypeSingleAz1,
+		WindowsDeploymentTypeSingleAz2,
+	}
+}

--- a/service/gamelift/api.go
+++ b/service/gamelift/api.go
@@ -26088,6 +26088,14 @@ const (
 	AcceptanceTypeReject = "REJECT"
 )
 
+// AcceptanceType_Values returns all elements of the AcceptanceType enum
+func AcceptanceType_Values() []string {
+	return []string{
+		AcceptanceTypeAccept,
+		AcceptanceTypeReject,
+	}
+}
+
 const (
 	// BackfillModeAutomatic is a BackfillMode enum value
 	BackfillModeAutomatic = "AUTOMATIC"
@@ -26096,6 +26104,14 @@ const (
 	BackfillModeManual = "MANUAL"
 )
 
+// BackfillMode_Values returns all elements of the BackfillMode enum
+func BackfillMode_Values() []string {
+	return []string{
+		BackfillModeAutomatic,
+		BackfillModeManual,
+	}
+}
+
 const (
 	// BalancingStrategySpotOnly is a BalancingStrategy enum value
 	BalancingStrategySpotOnly = "SPOT_ONLY"
@@ -26103,6 +26119,14 @@ const (
 	// BalancingStrategySpotPreferred is a BalancingStrategy enum value
 	BalancingStrategySpotPreferred = "SPOT_PREFERRED"
 )
+
+// BalancingStrategy_Values returns all elements of the BalancingStrategy enum
+func BalancingStrategy_Values() []string {
+	return []string{
+		BalancingStrategySpotOnly,
+		BalancingStrategySpotPreferred,
+	}
+}
 
 const (
 	// BuildStatusInitialized is a BuildStatus enum value
@@ -26115,6 +26139,15 @@ const (
 	BuildStatusFailed = "FAILED"
 )
 
+// BuildStatus_Values returns all elements of the BuildStatus enum
+func BuildStatus_Values() []string {
+	return []string{
+		BuildStatusInitialized,
+		BuildStatusReady,
+		BuildStatusFailed,
+	}
+}
+
 const (
 	// CertificateTypeDisabled is a CertificateType enum value
 	CertificateTypeDisabled = "DISABLED"
@@ -26122,6 +26155,14 @@ const (
 	// CertificateTypeGenerated is a CertificateType enum value
 	CertificateTypeGenerated = "GENERATED"
 )
+
+// CertificateType_Values returns all elements of the CertificateType enum
+func CertificateType_Values() []string {
+	return []string{
+		CertificateTypeDisabled,
+		CertificateTypeGenerated,
+	}
+}
 
 const (
 	// ComparisonOperatorTypeGreaterThanOrEqualToThreshold is a ComparisonOperatorType enum value
@@ -26136,6 +26177,16 @@ const (
 	// ComparisonOperatorTypeLessThanOrEqualToThreshold is a ComparisonOperatorType enum value
 	ComparisonOperatorTypeLessThanOrEqualToThreshold = "LessThanOrEqualToThreshold"
 )
+
+// ComparisonOperatorType_Values returns all elements of the ComparisonOperatorType enum
+func ComparisonOperatorType_Values() []string {
+	return []string{
+		ComparisonOperatorTypeGreaterThanOrEqualToThreshold,
+		ComparisonOperatorTypeGreaterThanThreshold,
+		ComparisonOperatorTypeLessThanThreshold,
+		ComparisonOperatorTypeLessThanOrEqualToThreshold,
+	}
+}
 
 const (
 	// EC2InstanceTypeT2Micro is a EC2InstanceType enum value
@@ -26313,6 +26364,70 @@ const (
 	EC2InstanceTypeM524xlarge = "m5.24xlarge"
 )
 
+// EC2InstanceType_Values returns all elements of the EC2InstanceType enum
+func EC2InstanceType_Values() []string {
+	return []string{
+		EC2InstanceTypeT2Micro,
+		EC2InstanceTypeT2Small,
+		EC2InstanceTypeT2Medium,
+		EC2InstanceTypeT2Large,
+		EC2InstanceTypeC3Large,
+		EC2InstanceTypeC3Xlarge,
+		EC2InstanceTypeC32xlarge,
+		EC2InstanceTypeC34xlarge,
+		EC2InstanceTypeC38xlarge,
+		EC2InstanceTypeC4Large,
+		EC2InstanceTypeC4Xlarge,
+		EC2InstanceTypeC42xlarge,
+		EC2InstanceTypeC44xlarge,
+		EC2InstanceTypeC48xlarge,
+		EC2InstanceTypeC5Large,
+		EC2InstanceTypeC5Xlarge,
+		EC2InstanceTypeC52xlarge,
+		EC2InstanceTypeC54xlarge,
+		EC2InstanceTypeC59xlarge,
+		EC2InstanceTypeC512xlarge,
+		EC2InstanceTypeC518xlarge,
+		EC2InstanceTypeC524xlarge,
+		EC2InstanceTypeR3Large,
+		EC2InstanceTypeR3Xlarge,
+		EC2InstanceTypeR32xlarge,
+		EC2InstanceTypeR34xlarge,
+		EC2InstanceTypeR38xlarge,
+		EC2InstanceTypeR4Large,
+		EC2InstanceTypeR4Xlarge,
+		EC2InstanceTypeR42xlarge,
+		EC2InstanceTypeR44xlarge,
+		EC2InstanceTypeR48xlarge,
+		EC2InstanceTypeR416xlarge,
+		EC2InstanceTypeR5Large,
+		EC2InstanceTypeR5Xlarge,
+		EC2InstanceTypeR52xlarge,
+		EC2InstanceTypeR54xlarge,
+		EC2InstanceTypeR58xlarge,
+		EC2InstanceTypeR512xlarge,
+		EC2InstanceTypeR516xlarge,
+		EC2InstanceTypeR524xlarge,
+		EC2InstanceTypeM3Medium,
+		EC2InstanceTypeM3Large,
+		EC2InstanceTypeM3Xlarge,
+		EC2InstanceTypeM32xlarge,
+		EC2InstanceTypeM4Large,
+		EC2InstanceTypeM4Xlarge,
+		EC2InstanceTypeM42xlarge,
+		EC2InstanceTypeM44xlarge,
+		EC2InstanceTypeM410xlarge,
+		EC2InstanceTypeM5Large,
+		EC2InstanceTypeM5Xlarge,
+		EC2InstanceTypeM52xlarge,
+		EC2InstanceTypeM54xlarge,
+		EC2InstanceTypeM58xlarge,
+		EC2InstanceTypeM512xlarge,
+		EC2InstanceTypeM516xlarge,
+		EC2InstanceTypeM524xlarge,
+	}
+}
+
 const (
 	// EventCodeGenericEvent is a EventCode enum value
 	EventCodeGenericEvent = "GENERIC_EVENT"
@@ -26414,10 +26529,56 @@ const (
 	EventCodeInstanceInterrupted = "INSTANCE_INTERRUPTED"
 )
 
+// EventCode_Values returns all elements of the EventCode enum
+func EventCode_Values() []string {
+	return []string{
+		EventCodeGenericEvent,
+		EventCodeFleetCreated,
+		EventCodeFleetDeleted,
+		EventCodeFleetScalingEvent,
+		EventCodeFleetStateDownloading,
+		EventCodeFleetStateValidating,
+		EventCodeFleetStateBuilding,
+		EventCodeFleetStateActivating,
+		EventCodeFleetStateActive,
+		EventCodeFleetStateError,
+		EventCodeFleetInitializationFailed,
+		EventCodeFleetBinaryDownloadFailed,
+		EventCodeFleetValidationLaunchPathNotFound,
+		EventCodeFleetValidationExecutableRuntimeFailure,
+		EventCodeFleetValidationTimedOut,
+		EventCodeFleetActivationFailed,
+		EventCodeFleetActivationFailedNoInstances,
+		EventCodeFleetNewGameSessionProtectionPolicyUpdated,
+		EventCodeServerProcessInvalidPath,
+		EventCodeServerProcessSdkInitializationTimeout,
+		EventCodeServerProcessProcessReadyTimeout,
+		EventCodeServerProcessCrashed,
+		EventCodeServerProcessTerminatedUnhealthy,
+		EventCodeServerProcessForceTerminated,
+		EventCodeServerProcessProcessExitTimeout,
+		EventCodeGameSessionActivationTimeout,
+		EventCodeFleetCreationExtractingBuild,
+		EventCodeFleetCreationRunningInstaller,
+		EventCodeFleetCreationValidatingRuntimeConfig,
+		EventCodeFleetVpcPeeringSucceeded,
+		EventCodeFleetVpcPeeringFailed,
+		EventCodeFleetVpcPeeringDeleted,
+		EventCodeInstanceInterrupted,
+	}
+}
+
 const (
 	// FleetActionAutoScaling is a FleetAction enum value
 	FleetActionAutoScaling = "AUTO_SCALING"
 )
+
+// FleetAction_Values returns all elements of the FleetAction enum
+func FleetAction_Values() []string {
+	return []string{
+		FleetActionAutoScaling,
+	}
+}
 
 const (
 	// FleetStatusNew is a FleetStatus enum value
@@ -26448,6 +26609,21 @@ const (
 	FleetStatusTerminated = "TERMINATED"
 )
 
+// FleetStatus_Values returns all elements of the FleetStatus enum
+func FleetStatus_Values() []string {
+	return []string{
+		FleetStatusNew,
+		FleetStatusDownloading,
+		FleetStatusValidating,
+		FleetStatusBuilding,
+		FleetStatusActivating,
+		FleetStatusActive,
+		FleetStatusDeleting,
+		FleetStatusError,
+		FleetStatusTerminated,
+	}
+}
+
 const (
 	// FleetTypeOnDemand is a FleetType enum value
 	FleetTypeOnDemand = "ON_DEMAND"
@@ -26456,15 +26632,37 @@ const (
 	FleetTypeSpot = "SPOT"
 )
 
+// FleetType_Values returns all elements of the FleetType enum
+func FleetType_Values() []string {
+	return []string{
+		FleetTypeOnDemand,
+		FleetTypeSpot,
+	}
+}
+
 const (
 	// GameServerClaimStatusClaimed is a GameServerClaimStatus enum value
 	GameServerClaimStatusClaimed = "CLAIMED"
 )
 
+// GameServerClaimStatus_Values returns all elements of the GameServerClaimStatus enum
+func GameServerClaimStatus_Values() []string {
+	return []string{
+		GameServerClaimStatusClaimed,
+	}
+}
+
 const (
 	// GameServerGroupActionReplaceInstanceTypes is a GameServerGroupAction enum value
 	GameServerGroupActionReplaceInstanceTypes = "REPLACE_INSTANCE_TYPES"
 )
+
+// GameServerGroupAction_Values returns all elements of the GameServerGroupAction enum
+func GameServerGroupAction_Values() []string {
+	return []string{
+		GameServerGroupActionReplaceInstanceTypes,
+	}
+}
 
 const (
 	// GameServerGroupDeleteOptionSafeDelete is a GameServerGroupDeleteOption enum value
@@ -26476,6 +26674,15 @@ const (
 	// GameServerGroupDeleteOptionRetain is a GameServerGroupDeleteOption enum value
 	GameServerGroupDeleteOptionRetain = "RETAIN"
 )
+
+// GameServerGroupDeleteOption_Values returns all elements of the GameServerGroupDeleteOption enum
+func GameServerGroupDeleteOption_Values() []string {
+	return []string{
+		GameServerGroupDeleteOptionSafeDelete,
+		GameServerGroupDeleteOptionForceDelete,
+		GameServerGroupDeleteOptionRetain,
+	}
+}
 
 const (
 	// GameServerGroupInstanceTypeC4Large is a GameServerGroupInstanceType enum value
@@ -26599,6 +26806,52 @@ const (
 	GameServerGroupInstanceTypeM524xlarge = "m5.24xlarge"
 )
 
+// GameServerGroupInstanceType_Values returns all elements of the GameServerGroupInstanceType enum
+func GameServerGroupInstanceType_Values() []string {
+	return []string{
+		GameServerGroupInstanceTypeC4Large,
+		GameServerGroupInstanceTypeC4Xlarge,
+		GameServerGroupInstanceTypeC42xlarge,
+		GameServerGroupInstanceTypeC44xlarge,
+		GameServerGroupInstanceTypeC48xlarge,
+		GameServerGroupInstanceTypeC5Large,
+		GameServerGroupInstanceTypeC5Xlarge,
+		GameServerGroupInstanceTypeC52xlarge,
+		GameServerGroupInstanceTypeC54xlarge,
+		GameServerGroupInstanceTypeC59xlarge,
+		GameServerGroupInstanceTypeC512xlarge,
+		GameServerGroupInstanceTypeC518xlarge,
+		GameServerGroupInstanceTypeC524xlarge,
+		GameServerGroupInstanceTypeR4Large,
+		GameServerGroupInstanceTypeR4Xlarge,
+		GameServerGroupInstanceTypeR42xlarge,
+		GameServerGroupInstanceTypeR44xlarge,
+		GameServerGroupInstanceTypeR48xlarge,
+		GameServerGroupInstanceTypeR416xlarge,
+		GameServerGroupInstanceTypeR5Large,
+		GameServerGroupInstanceTypeR5Xlarge,
+		GameServerGroupInstanceTypeR52xlarge,
+		GameServerGroupInstanceTypeR54xlarge,
+		GameServerGroupInstanceTypeR58xlarge,
+		GameServerGroupInstanceTypeR512xlarge,
+		GameServerGroupInstanceTypeR516xlarge,
+		GameServerGroupInstanceTypeR524xlarge,
+		GameServerGroupInstanceTypeM4Large,
+		GameServerGroupInstanceTypeM4Xlarge,
+		GameServerGroupInstanceTypeM42xlarge,
+		GameServerGroupInstanceTypeM44xlarge,
+		GameServerGroupInstanceTypeM410xlarge,
+		GameServerGroupInstanceTypeM5Large,
+		GameServerGroupInstanceTypeM5Xlarge,
+		GameServerGroupInstanceTypeM52xlarge,
+		GameServerGroupInstanceTypeM54xlarge,
+		GameServerGroupInstanceTypeM58xlarge,
+		GameServerGroupInstanceTypeM512xlarge,
+		GameServerGroupInstanceTypeM516xlarge,
+		GameServerGroupInstanceTypeM524xlarge,
+	}
+}
+
 const (
 	// GameServerGroupStatusNew is a GameServerGroupStatus enum value
 	GameServerGroupStatusNew = "NEW"
@@ -26622,10 +26875,30 @@ const (
 	GameServerGroupStatusError = "ERROR"
 )
 
+// GameServerGroupStatus_Values returns all elements of the GameServerGroupStatus enum
+func GameServerGroupStatus_Values() []string {
+	return []string{
+		GameServerGroupStatusNew,
+		GameServerGroupStatusActivating,
+		GameServerGroupStatusActive,
+		GameServerGroupStatusDeleteScheduled,
+		GameServerGroupStatusDeleting,
+		GameServerGroupStatusDeleted,
+		GameServerGroupStatusError,
+	}
+}
+
 const (
 	// GameServerHealthCheckHealthy is a GameServerHealthCheck enum value
 	GameServerHealthCheckHealthy = "HEALTHY"
 )
+
+// GameServerHealthCheck_Values returns all elements of the GameServerHealthCheck enum
+func GameServerHealthCheck_Values() []string {
+	return []string{
+		GameServerHealthCheckHealthy,
+	}
+}
 
 const (
 	// GameServerProtectionPolicyNoProtection is a GameServerProtectionPolicy enum value
@@ -26635,6 +26908,14 @@ const (
 	GameServerProtectionPolicyFullProtection = "FULL_PROTECTION"
 )
 
+// GameServerProtectionPolicy_Values returns all elements of the GameServerProtectionPolicy enum
+func GameServerProtectionPolicy_Values() []string {
+	return []string{
+		GameServerProtectionPolicyNoProtection,
+		GameServerProtectionPolicyFullProtection,
+	}
+}
+
 const (
 	// GameServerUtilizationStatusAvailable is a GameServerUtilizationStatus enum value
 	GameServerUtilizationStatusAvailable = "AVAILABLE"
@@ -26642,6 +26923,14 @@ const (
 	// GameServerUtilizationStatusUtilized is a GameServerUtilizationStatus enum value
 	GameServerUtilizationStatusUtilized = "UTILIZED"
 )
+
+// GameServerUtilizationStatus_Values returns all elements of the GameServerUtilizationStatus enum
+func GameServerUtilizationStatus_Values() []string {
+	return []string{
+		GameServerUtilizationStatusAvailable,
+		GameServerUtilizationStatusUtilized,
+	}
+}
 
 const (
 	// GameSessionPlacementStatePending is a GameSessionPlacementState enum value
@@ -26660,6 +26949,17 @@ const (
 	GameSessionPlacementStateFailed = "FAILED"
 )
 
+// GameSessionPlacementState_Values returns all elements of the GameSessionPlacementState enum
+func GameSessionPlacementState_Values() []string {
+	return []string{
+		GameSessionPlacementStatePending,
+		GameSessionPlacementStateFulfilled,
+		GameSessionPlacementStateCancelled,
+		GameSessionPlacementStateTimedOut,
+		GameSessionPlacementStateFailed,
+	}
+}
+
 const (
 	// GameSessionStatusActive is a GameSessionStatus enum value
 	GameSessionStatusActive = "ACTIVE"
@@ -26677,10 +26977,28 @@ const (
 	GameSessionStatusError = "ERROR"
 )
 
+// GameSessionStatus_Values returns all elements of the GameSessionStatus enum
+func GameSessionStatus_Values() []string {
+	return []string{
+		GameSessionStatusActive,
+		GameSessionStatusActivating,
+		GameSessionStatusTerminated,
+		GameSessionStatusTerminating,
+		GameSessionStatusError,
+	}
+}
+
 const (
 	// GameSessionStatusReasonInterrupted is a GameSessionStatusReason enum value
 	GameSessionStatusReasonInterrupted = "INTERRUPTED"
 )
+
+// GameSessionStatusReason_Values returns all elements of the GameSessionStatusReason enum
+func GameSessionStatusReason_Values() []string {
+	return []string{
+		GameSessionStatusReasonInterrupted,
+	}
+}
 
 const (
 	// InstanceStatusPending is a InstanceStatus enum value
@@ -26693,6 +27011,15 @@ const (
 	InstanceStatusTerminating = "TERMINATING"
 )
 
+// InstanceStatus_Values returns all elements of the InstanceStatus enum
+func InstanceStatus_Values() []string {
+	return []string{
+		InstanceStatusPending,
+		InstanceStatusActive,
+		InstanceStatusTerminating,
+	}
+}
+
 const (
 	// IpProtocolTcp is a IpProtocol enum value
 	IpProtocolTcp = "TCP"
@@ -26700,6 +27027,14 @@ const (
 	// IpProtocolUdp is a IpProtocol enum value
 	IpProtocolUdp = "UDP"
 )
+
+// IpProtocol_Values returns all elements of the IpProtocol enum
+func IpProtocol_Values() []string {
+	return []string{
+		IpProtocolTcp,
+		IpProtocolUdp,
+	}
+}
 
 const (
 	// MatchmakingConfigurationStatusCancelled is a MatchmakingConfigurationStatus enum value
@@ -26726,6 +27061,20 @@ const (
 	// MatchmakingConfigurationStatusTimedOut is a MatchmakingConfigurationStatus enum value
 	MatchmakingConfigurationStatusTimedOut = "TIMED_OUT"
 )
+
+// MatchmakingConfigurationStatus_Values returns all elements of the MatchmakingConfigurationStatus enum
+func MatchmakingConfigurationStatus_Values() []string {
+	return []string{
+		MatchmakingConfigurationStatusCancelled,
+		MatchmakingConfigurationStatusCompleted,
+		MatchmakingConfigurationStatusFailed,
+		MatchmakingConfigurationStatusPlacing,
+		MatchmakingConfigurationStatusQueued,
+		MatchmakingConfigurationStatusRequiresAcceptance,
+		MatchmakingConfigurationStatusSearching,
+		MatchmakingConfigurationStatusTimedOut,
+	}
+}
 
 const (
 	// MetricNameActivatingGameSessions is a MetricName enum value
@@ -26762,6 +27111,23 @@ const (
 	MetricNameWaitTime = "WaitTime"
 )
 
+// MetricName_Values returns all elements of the MetricName enum
+func MetricName_Values() []string {
+	return []string{
+		MetricNameActivatingGameSessions,
+		MetricNameActiveGameSessions,
+		MetricNameActiveInstances,
+		MetricNameAvailableGameSessions,
+		MetricNameAvailablePlayerSessions,
+		MetricNameCurrentPlayerSessions,
+		MetricNameIdleInstances,
+		MetricNamePercentAvailableGameSessions,
+		MetricNamePercentIdleInstances,
+		MetricNameQueueDepth,
+		MetricNameWaitTime,
+	}
+}
+
 const (
 	// OperatingSystemWindows2012 is a OperatingSystem enum value
 	OperatingSystemWindows2012 = "WINDOWS_2012"
@@ -26773,6 +27139,15 @@ const (
 	OperatingSystemAmazonLinux2 = "AMAZON_LINUX_2"
 )
 
+// OperatingSystem_Values returns all elements of the OperatingSystem enum
+func OperatingSystem_Values() []string {
+	return []string{
+		OperatingSystemWindows2012,
+		OperatingSystemAmazonLinux,
+		OperatingSystemAmazonLinux2,
+	}
+}
+
 const (
 	// PlayerSessionCreationPolicyAcceptAll is a PlayerSessionCreationPolicy enum value
 	PlayerSessionCreationPolicyAcceptAll = "ACCEPT_ALL"
@@ -26780,6 +27155,14 @@ const (
 	// PlayerSessionCreationPolicyDenyAll is a PlayerSessionCreationPolicy enum value
 	PlayerSessionCreationPolicyDenyAll = "DENY_ALL"
 )
+
+// PlayerSessionCreationPolicy_Values returns all elements of the PlayerSessionCreationPolicy enum
+func PlayerSessionCreationPolicy_Values() []string {
+	return []string{
+		PlayerSessionCreationPolicyAcceptAll,
+		PlayerSessionCreationPolicyDenyAll,
+	}
+}
 
 const (
 	// PlayerSessionStatusReserved is a PlayerSessionStatus enum value
@@ -26795,6 +27178,16 @@ const (
 	PlayerSessionStatusTimedout = "TIMEDOUT"
 )
 
+// PlayerSessionStatus_Values returns all elements of the PlayerSessionStatus enum
+func PlayerSessionStatus_Values() []string {
+	return []string{
+		PlayerSessionStatusReserved,
+		PlayerSessionStatusActive,
+		PlayerSessionStatusCompleted,
+		PlayerSessionStatusTimedout,
+	}
+}
+
 const (
 	// PolicyTypeRuleBased is a PolicyType enum value
 	PolicyTypeRuleBased = "RuleBased"
@@ -26802,6 +27195,14 @@ const (
 	// PolicyTypeTargetBased is a PolicyType enum value
 	PolicyTypeTargetBased = "TargetBased"
 )
+
+// PolicyType_Values returns all elements of the PolicyType enum
+func PolicyType_Values() []string {
+	return []string{
+		PolicyTypeRuleBased,
+		PolicyTypeTargetBased,
+	}
+}
 
 const (
 	// ProtectionPolicyNoProtection is a ProtectionPolicy enum value
@@ -26811,6 +27212,14 @@ const (
 	ProtectionPolicyFullProtection = "FullProtection"
 )
 
+// ProtectionPolicy_Values returns all elements of the ProtectionPolicy enum
+func ProtectionPolicy_Values() []string {
+	return []string{
+		ProtectionPolicyNoProtection,
+		ProtectionPolicyFullProtection,
+	}
+}
+
 const (
 	// RoutingStrategyTypeSimple is a RoutingStrategyType enum value
 	RoutingStrategyTypeSimple = "SIMPLE"
@@ -26818,6 +27227,14 @@ const (
 	// RoutingStrategyTypeTerminal is a RoutingStrategyType enum value
 	RoutingStrategyTypeTerminal = "TERMINAL"
 )
+
+// RoutingStrategyType_Values returns all elements of the RoutingStrategyType enum
+func RoutingStrategyType_Values() []string {
+	return []string{
+		RoutingStrategyTypeSimple,
+		RoutingStrategyTypeTerminal,
+	}
+}
 
 const (
 	// ScalingAdjustmentTypeChangeInCapacity is a ScalingAdjustmentType enum value
@@ -26829,6 +27246,15 @@ const (
 	// ScalingAdjustmentTypePercentChangeInCapacity is a ScalingAdjustmentType enum value
 	ScalingAdjustmentTypePercentChangeInCapacity = "PercentChangeInCapacity"
 )
+
+// ScalingAdjustmentType_Values returns all elements of the ScalingAdjustmentType enum
+func ScalingAdjustmentType_Values() []string {
+	return []string{
+		ScalingAdjustmentTypeChangeInCapacity,
+		ScalingAdjustmentTypeExactCapacity,
+		ScalingAdjustmentTypePercentChangeInCapacity,
+	}
+}
 
 const (
 	// ScalingStatusTypeActive is a ScalingStatusType enum value
@@ -26853,6 +27279,19 @@ const (
 	ScalingStatusTypeError = "ERROR"
 )
 
+// ScalingStatusType_Values returns all elements of the ScalingStatusType enum
+func ScalingStatusType_Values() []string {
+	return []string{
+		ScalingStatusTypeActive,
+		ScalingStatusTypeUpdateRequested,
+		ScalingStatusTypeUpdating,
+		ScalingStatusTypeDeleteRequested,
+		ScalingStatusTypeDeleting,
+		ScalingStatusTypeDeleted,
+		ScalingStatusTypeError,
+	}
+}
+
 const (
 	// SortOrderAscending is a SortOrder enum value
 	SortOrderAscending = "ASCENDING"
@@ -26860,3 +27299,11 @@ const (
 	// SortOrderDescending is a SortOrder enum value
 	SortOrderDescending = "DESCENDING"
 )
+
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderAscending,
+		SortOrderDescending,
+	}
+}

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -8986,6 +8986,15 @@ const (
 	ActionCodeSelect = "Select"
 )
 
+// ActionCode_Values returns all elements of the ActionCode enum
+func ActionCode_Values() []string {
+	return []string{
+		ActionCodeArchiveRetrieval,
+		ActionCodeInventoryRetrieval,
+		ActionCodeSelect,
+	}
+}
+
 const (
 	// CannedACLPrivate is a CannedACL enum value
 	CannedACLPrivate = "private"
@@ -9009,6 +9018,19 @@ const (
 	CannedACLBucketOwnerFullControl = "bucket-owner-full-control"
 )
 
+// CannedACL_Values returns all elements of the CannedACL enum
+func CannedACL_Values() []string {
+	return []string{
+		CannedACLPrivate,
+		CannedACLPublicRead,
+		CannedACLPublicReadWrite,
+		CannedACLAwsExecRead,
+		CannedACLAuthenticatedRead,
+		CannedACLBucketOwnerRead,
+		CannedACLBucketOwnerFullControl,
+	}
+}
+
 const (
 	// EncryptionTypeAwsKms is a EncryptionType enum value
 	EncryptionTypeAwsKms = "aws:kms"
@@ -9017,10 +9039,25 @@ const (
 	EncryptionTypeAes256 = "AES256"
 )
 
+// EncryptionType_Values returns all elements of the EncryptionType enum
+func EncryptionType_Values() []string {
+	return []string{
+		EncryptionTypeAwsKms,
+		EncryptionTypeAes256,
+	}
+}
+
 const (
 	// ExpressionTypeSql is a ExpressionType enum value
 	ExpressionTypeSql = "SQL"
 )
+
+// ExpressionType_Values returns all elements of the ExpressionType enum
+func ExpressionType_Values() []string {
+	return []string{
+		ExpressionTypeSql,
+	}
+}
 
 const (
 	// FileHeaderInfoUse is a FileHeaderInfo enum value
@@ -9032,6 +9069,15 @@ const (
 	// FileHeaderInfoNone is a FileHeaderInfo enum value
 	FileHeaderInfoNone = "NONE"
 )
+
+// FileHeaderInfo_Values returns all elements of the FileHeaderInfo enum
+func FileHeaderInfo_Values() []string {
+	return []string{
+		FileHeaderInfoUse,
+		FileHeaderInfoIgnore,
+		FileHeaderInfoNone,
+	}
+}
 
 const (
 	// PermissionFullControl is a Permission enum value
@@ -9050,6 +9096,17 @@ const (
 	PermissionReadAcp = "READ_ACP"
 )
 
+// Permission_Values returns all elements of the Permission enum
+func Permission_Values() []string {
+	return []string{
+		PermissionFullControl,
+		PermissionWrite,
+		PermissionWriteAcp,
+		PermissionRead,
+		PermissionReadAcp,
+	}
+}
+
 const (
 	// QuoteFieldsAlways is a QuoteFields enum value
 	QuoteFieldsAlways = "ALWAYS"
@@ -9057,6 +9114,14 @@ const (
 	// QuoteFieldsAsneeded is a QuoteFields enum value
 	QuoteFieldsAsneeded = "ASNEEDED"
 )
+
+// QuoteFields_Values returns all elements of the QuoteFields enum
+func QuoteFields_Values() []string {
+	return []string{
+		QuoteFieldsAlways,
+		QuoteFieldsAsneeded,
+	}
+}
 
 const (
 	// StatusCodeInProgress is a StatusCode enum value
@@ -9069,6 +9134,15 @@ const (
 	StatusCodeFailed = "Failed"
 )
 
+// StatusCode_Values returns all elements of the StatusCode enum
+func StatusCode_Values() []string {
+	return []string{
+		StatusCodeInProgress,
+		StatusCodeSucceeded,
+		StatusCodeFailed,
+	}
+}
+
 const (
 	// StorageClassStandard is a StorageClass enum value
 	StorageClassStandard = "STANDARD"
@@ -9080,6 +9154,15 @@ const (
 	StorageClassStandardIa = "STANDARD_IA"
 )
 
+// StorageClass_Values returns all elements of the StorageClass enum
+func StorageClass_Values() []string {
+	return []string{
+		StorageClassStandard,
+		StorageClassReducedRedundancy,
+		StorageClassStandardIa,
+	}
+}
+
 const (
 	// TypeAmazonCustomerByEmail is a Type enum value
 	TypeAmazonCustomerByEmail = "AmazonCustomerByEmail"
@@ -9090,3 +9173,12 @@ const (
 	// TypeGroup is a Type enum value
 	TypeGroup = "Group"
 )
+
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypeAmazonCustomerByEmail,
+		TypeCanonicalUser,
+		TypeGroup,
+	}
+}

--- a/service/globalaccelerator/api.go
+++ b/service/globalaccelerator/api.go
@@ -6179,6 +6179,14 @@ const (
 	AcceleratorStatusInProgress = "IN_PROGRESS"
 )
 
+// AcceleratorStatus_Values returns all elements of the AcceleratorStatus enum
+func AcceleratorStatus_Values() []string {
+	return []string{
+		AcceleratorStatusDeployed,
+		AcceleratorStatusInProgress,
+	}
+}
+
 const (
 	// ByoipCidrStatePendingProvisioning is a ByoipCidrState enum value
 	ByoipCidrStatePendingProvisioning = "PENDING_PROVISIONING"
@@ -6214,6 +6222,23 @@ const (
 	ByoipCidrStateFailedDeprovision = "FAILED_DEPROVISION"
 )
 
+// ByoipCidrState_Values returns all elements of the ByoipCidrState enum
+func ByoipCidrState_Values() []string {
+	return []string{
+		ByoipCidrStatePendingProvisioning,
+		ByoipCidrStateReady,
+		ByoipCidrStatePendingAdvertising,
+		ByoipCidrStateAdvertising,
+		ByoipCidrStatePendingWithdrawing,
+		ByoipCidrStatePendingDeprovisioning,
+		ByoipCidrStateDeprovisioned,
+		ByoipCidrStateFailedProvision,
+		ByoipCidrStateFailedAdvertising,
+		ByoipCidrStateFailedWithdraw,
+		ByoipCidrStateFailedDeprovision,
+	}
+}
+
 const (
 	// ClientAffinityNone is a ClientAffinity enum value
 	ClientAffinityNone = "NONE"
@@ -6221,6 +6246,14 @@ const (
 	// ClientAffinitySourceIp is a ClientAffinity enum value
 	ClientAffinitySourceIp = "SOURCE_IP"
 )
+
+// ClientAffinity_Values returns all elements of the ClientAffinity enum
+func ClientAffinity_Values() []string {
+	return []string{
+		ClientAffinityNone,
+		ClientAffinitySourceIp,
+	}
+}
 
 const (
 	// HealthCheckProtocolTcp is a HealthCheckProtocol enum value
@@ -6233,6 +6266,15 @@ const (
 	HealthCheckProtocolHttps = "HTTPS"
 )
 
+// HealthCheckProtocol_Values returns all elements of the HealthCheckProtocol enum
+func HealthCheckProtocol_Values() []string {
+	return []string{
+		HealthCheckProtocolTcp,
+		HealthCheckProtocolHttp,
+		HealthCheckProtocolHttps,
+	}
+}
+
 const (
 	// HealthStateInitial is a HealthState enum value
 	HealthStateInitial = "INITIAL"
@@ -6244,10 +6286,26 @@ const (
 	HealthStateUnhealthy = "UNHEALTHY"
 )
 
+// HealthState_Values returns all elements of the HealthState enum
+func HealthState_Values() []string {
+	return []string{
+		HealthStateInitial,
+		HealthStateHealthy,
+		HealthStateUnhealthy,
+	}
+}
+
 const (
 	// IpAddressTypeIpv4 is a IpAddressType enum value
 	IpAddressTypeIpv4 = "IPV4"
 )
+
+// IpAddressType_Values returns all elements of the IpAddressType enum
+func IpAddressType_Values() []string {
+	return []string{
+		IpAddressTypeIpv4,
+	}
+}
 
 const (
 	// ProtocolTcp is a Protocol enum value
@@ -6256,3 +6314,11 @@ const (
 	// ProtocolUdp is a Protocol enum value
 	ProtocolUdp = "UDP"
 )
+
+// Protocol_Values returns all elements of the Protocol enum
+func Protocol_Values() []string {
+	return []string{
+		ProtocolTcp,
+		ProtocolUdp,
+	}
+}

--- a/service/glue/api.go
+++ b/service/glue/api.go
@@ -37388,6 +37388,14 @@ const (
 	CatalogEncryptionModeSseKms = "SSE-KMS"
 )
 
+// CatalogEncryptionMode_Values returns all elements of the CatalogEncryptionMode enum
+func CatalogEncryptionMode_Values() []string {
+	return []string{
+		CatalogEncryptionModeDisabled,
+		CatalogEncryptionModeSseKms,
+	}
+}
+
 const (
 	// CloudWatchEncryptionModeDisabled is a CloudWatchEncryptionMode enum value
 	CloudWatchEncryptionModeDisabled = "DISABLED"
@@ -37395,6 +37403,14 @@ const (
 	// CloudWatchEncryptionModeSseKms is a CloudWatchEncryptionMode enum value
 	CloudWatchEncryptionModeSseKms = "SSE-KMS"
 )
+
+// CloudWatchEncryptionMode_Values returns all elements of the CloudWatchEncryptionMode enum
+func CloudWatchEncryptionMode_Values() []string {
+	return []string{
+		CloudWatchEncryptionModeDisabled,
+		CloudWatchEncryptionModeSseKms,
+	}
+}
 
 const (
 	// ColumnStatisticsTypeBoolean is a ColumnStatisticsType enum value
@@ -37419,6 +37435,19 @@ const (
 	ColumnStatisticsTypeBinary = "BINARY"
 )
 
+// ColumnStatisticsType_Values returns all elements of the ColumnStatisticsType enum
+func ColumnStatisticsType_Values() []string {
+	return []string{
+		ColumnStatisticsTypeBoolean,
+		ColumnStatisticsTypeDate,
+		ColumnStatisticsTypeDecimal,
+		ColumnStatisticsTypeDouble,
+		ColumnStatisticsTypeLong,
+		ColumnStatisticsTypeString,
+		ColumnStatisticsTypeBinary,
+	}
+}
+
 const (
 	// ComparatorEquals is a Comparator enum value
 	ComparatorEquals = "EQUALS"
@@ -37435,6 +37464,17 @@ const (
 	// ComparatorLessThanEquals is a Comparator enum value
 	ComparatorLessThanEquals = "LESS_THAN_EQUALS"
 )
+
+// Comparator_Values returns all elements of the Comparator enum
+func Comparator_Values() []string {
+	return []string{
+		ComparatorEquals,
+		ComparatorGreaterThan,
+		ComparatorLessThan,
+		ComparatorGreaterThanEquals,
+		ComparatorLessThanEquals,
+	}
+}
 
 const (
 	// ConnectionPropertyKeyHost is a ConnectionPropertyKey enum value
@@ -37501,6 +37541,33 @@ const (
 	ConnectionPropertyKeyKafkaSkipCustomCertValidation = "KAFKA_SKIP_CUSTOM_CERT_VALIDATION"
 )
 
+// ConnectionPropertyKey_Values returns all elements of the ConnectionPropertyKey enum
+func ConnectionPropertyKey_Values() []string {
+	return []string{
+		ConnectionPropertyKeyHost,
+		ConnectionPropertyKeyPort,
+		ConnectionPropertyKeyUsername,
+		ConnectionPropertyKeyPassword,
+		ConnectionPropertyKeyEncryptedPassword,
+		ConnectionPropertyKeyJdbcDriverJarUri,
+		ConnectionPropertyKeyJdbcDriverClassName,
+		ConnectionPropertyKeyJdbcEngine,
+		ConnectionPropertyKeyJdbcEngineVersion,
+		ConnectionPropertyKeyConfigFiles,
+		ConnectionPropertyKeyInstanceId,
+		ConnectionPropertyKeyJdbcConnectionUrl,
+		ConnectionPropertyKeyJdbcEnforceSsl,
+		ConnectionPropertyKeyCustomJdbcCert,
+		ConnectionPropertyKeySkipCustomJdbcCertValidation,
+		ConnectionPropertyKeyCustomJdbcCertString,
+		ConnectionPropertyKeyConnectionUrl,
+		ConnectionPropertyKeyKafkaBootstrapServers,
+		ConnectionPropertyKeyKafkaSslEnabled,
+		ConnectionPropertyKeyKafkaCustomCert,
+		ConnectionPropertyKeyKafkaSkipCustomCertValidation,
+	}
+}
+
 const (
 	// ConnectionTypeJdbc is a ConnectionType enum value
 	ConnectionTypeJdbc = "JDBC"
@@ -37517,6 +37584,17 @@ const (
 	// ConnectionTypeNetwork is a ConnectionType enum value
 	ConnectionTypeNetwork = "NETWORK"
 )
+
+// ConnectionType_Values returns all elements of the ConnectionType enum
+func ConnectionType_Values() []string {
+	return []string{
+		ConnectionTypeJdbc,
+		ConnectionTypeSftp,
+		ConnectionTypeMongodb,
+		ConnectionTypeKafka,
+		ConnectionTypeNetwork,
+	}
+}
 
 const (
 	// CrawlStateRunning is a CrawlState enum value
@@ -37535,6 +37613,17 @@ const (
 	CrawlStateFailed = "FAILED"
 )
 
+// CrawlState_Values returns all elements of the CrawlState enum
+func CrawlState_Values() []string {
+	return []string{
+		CrawlStateRunning,
+		CrawlStateCancelling,
+		CrawlStateCancelled,
+		CrawlStateSucceeded,
+		CrawlStateFailed,
+	}
+}
+
 const (
 	// CrawlerStateReady is a CrawlerState enum value
 	CrawlerStateReady = "READY"
@@ -37545,6 +37634,15 @@ const (
 	// CrawlerStateStopping is a CrawlerState enum value
 	CrawlerStateStopping = "STOPPING"
 )
+
+// CrawlerState_Values returns all elements of the CrawlerState enum
+func CrawlerState_Values() []string {
+	return []string{
+		CrawlerStateReady,
+		CrawlerStateRunning,
+		CrawlerStateStopping,
+	}
+}
 
 const (
 	// CsvHeaderOptionUnknown is a CsvHeaderOption enum value
@@ -37557,6 +37655,15 @@ const (
 	CsvHeaderOptionAbsent = "ABSENT"
 )
 
+// CsvHeaderOption_Values returns all elements of the CsvHeaderOption enum
+func CsvHeaderOption_Values() []string {
+	return []string{
+		CsvHeaderOptionUnknown,
+		CsvHeaderOptionPresent,
+		CsvHeaderOptionAbsent,
+	}
+}
+
 const (
 	// DeleteBehaviorLog is a DeleteBehavior enum value
 	DeleteBehaviorLog = "LOG"
@@ -37568,6 +37675,15 @@ const (
 	DeleteBehaviorDeprecateInDatabase = "DEPRECATE_IN_DATABASE"
 )
 
+// DeleteBehavior_Values returns all elements of the DeleteBehavior enum
+func DeleteBehavior_Values() []string {
+	return []string{
+		DeleteBehaviorLog,
+		DeleteBehaviorDeleteFromDatabase,
+		DeleteBehaviorDeprecateInDatabase,
+	}
+}
+
 const (
 	// EnableHybridValuesTrue is a EnableHybridValues enum value
 	EnableHybridValuesTrue = "TRUE"
@@ -37575,6 +37691,14 @@ const (
 	// EnableHybridValuesFalse is a EnableHybridValues enum value
 	EnableHybridValuesFalse = "FALSE"
 )
+
+// EnableHybridValues_Values returns all elements of the EnableHybridValues enum
+func EnableHybridValues_Values() []string {
+	return []string{
+		EnableHybridValuesTrue,
+		EnableHybridValuesFalse,
+	}
+}
 
 const (
 	// ExistConditionMustExist is a ExistCondition enum value
@@ -37587,6 +37711,15 @@ const (
 	ExistConditionNone = "NONE"
 )
 
+// ExistCondition_Values returns all elements of the ExistCondition enum
+func ExistCondition_Values() []string {
+	return []string{
+		ExistConditionMustExist,
+		ExistConditionNotExist,
+		ExistConditionNone,
+	}
+}
+
 const (
 	// JobBookmarksEncryptionModeDisabled is a JobBookmarksEncryptionMode enum value
 	JobBookmarksEncryptionModeDisabled = "DISABLED"
@@ -37594,6 +37727,14 @@ const (
 	// JobBookmarksEncryptionModeCseKms is a JobBookmarksEncryptionMode enum value
 	JobBookmarksEncryptionModeCseKms = "CSE-KMS"
 )
+
+// JobBookmarksEncryptionMode_Values returns all elements of the JobBookmarksEncryptionMode enum
+func JobBookmarksEncryptionMode_Values() []string {
+	return []string{
+		JobBookmarksEncryptionModeDisabled,
+		JobBookmarksEncryptionModeCseKms,
+	}
+}
 
 const (
 	// JobRunStateStarting is a JobRunState enum value
@@ -37618,6 +37759,19 @@ const (
 	JobRunStateTimeout = "TIMEOUT"
 )
 
+// JobRunState_Values returns all elements of the JobRunState enum
+func JobRunState_Values() []string {
+	return []string{
+		JobRunStateStarting,
+		JobRunStateRunning,
+		JobRunStateStopping,
+		JobRunStateStopped,
+		JobRunStateSucceeded,
+		JobRunStateFailed,
+		JobRunStateTimeout,
+	}
+}
+
 const (
 	// LanguagePython is a Language enum value
 	LanguagePython = "PYTHON"
@@ -37625,6 +37779,14 @@ const (
 	// LanguageScala is a Language enum value
 	LanguageScala = "SCALA"
 )
+
+// Language_Values returns all elements of the Language enum
+func Language_Values() []string {
+	return []string{
+		LanguagePython,
+		LanguageScala,
+	}
+}
 
 const (
 	// LastCrawlStatusSucceeded is a LastCrawlStatus enum value
@@ -37637,6 +37799,15 @@ const (
 	LastCrawlStatusFailed = "FAILED"
 )
 
+// LastCrawlStatus_Values returns all elements of the LastCrawlStatus enum
+func LastCrawlStatus_Values() []string {
+	return []string{
+		LastCrawlStatusSucceeded,
+		LastCrawlStatusCancelled,
+		LastCrawlStatusFailed,
+	}
+}
+
 const (
 	// LogicalAnd is a Logical enum value
 	LogicalAnd = "AND"
@@ -37645,10 +37816,25 @@ const (
 	LogicalAny = "ANY"
 )
 
+// Logical_Values returns all elements of the Logical enum
+func Logical_Values() []string {
+	return []string{
+		LogicalAnd,
+		LogicalAny,
+	}
+}
+
 const (
 	// LogicalOperatorEquals is a LogicalOperator enum value
 	LogicalOperatorEquals = "EQUALS"
 )
+
+// LogicalOperator_Values returns all elements of the LogicalOperator enum
+func LogicalOperator_Values() []string {
+	return []string{
+		LogicalOperatorEquals,
+	}
+}
 
 const (
 	// NodeTypeCrawler is a NodeType enum value
@@ -37660,6 +37846,15 @@ const (
 	// NodeTypeTrigger is a NodeType enum value
 	NodeTypeTrigger = "TRIGGER"
 )
+
+// NodeType_Values returns all elements of the NodeType enum
+func NodeType_Values() []string {
+	return []string{
+		NodeTypeCrawler,
+		NodeTypeJob,
+		NodeTypeTrigger,
+	}
+}
 
 const (
 	// PermissionAll is a Permission enum value
@@ -37690,6 +37885,21 @@ const (
 	PermissionDataLocationAccess = "DATA_LOCATION_ACCESS"
 )
 
+// Permission_Values returns all elements of the Permission enum
+func Permission_Values() []string {
+	return []string{
+		PermissionAll,
+		PermissionSelect,
+		PermissionAlter,
+		PermissionDrop,
+		PermissionDelete,
+		PermissionInsert,
+		PermissionCreateDatabase,
+		PermissionCreateTable,
+		PermissionDataLocationAccess,
+	}
+}
+
 const (
 	// PrincipalTypeUser is a PrincipalType enum value
 	PrincipalTypeUser = "USER"
@@ -37701,6 +37911,15 @@ const (
 	PrincipalTypeGroup = "GROUP"
 )
 
+// PrincipalType_Values returns all elements of the PrincipalType enum
+func PrincipalType_Values() []string {
+	return []string{
+		PrincipalTypeUser,
+		PrincipalTypeRole,
+		PrincipalTypeGroup,
+	}
+}
+
 const (
 	// ResourceShareTypeForeign is a ResourceShareType enum value
 	ResourceShareTypeForeign = "FOREIGN"
@@ -37708,6 +37927,14 @@ const (
 	// ResourceShareTypeAll is a ResourceShareType enum value
 	ResourceShareTypeAll = "ALL"
 )
+
+// ResourceShareType_Values returns all elements of the ResourceShareType enum
+func ResourceShareType_Values() []string {
+	return []string{
+		ResourceShareTypeForeign,
+		ResourceShareTypeAll,
+	}
+}
 
 const (
 	// ResourceTypeJar is a ResourceType enum value
@@ -37720,6 +37947,15 @@ const (
 	ResourceTypeArchive = "ARCHIVE"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeJar,
+		ResourceTypeFile,
+		ResourceTypeArchive,
+	}
+}
+
 const (
 	// S3EncryptionModeDisabled is a S3EncryptionMode enum value
 	S3EncryptionModeDisabled = "DISABLED"
@@ -37730,6 +37966,15 @@ const (
 	// S3EncryptionModeSseS3 is a S3EncryptionMode enum value
 	S3EncryptionModeSseS3 = "SSE-S3"
 )
+
+// S3EncryptionMode_Values returns all elements of the S3EncryptionMode enum
+func S3EncryptionMode_Values() []string {
+	return []string{
+		S3EncryptionModeDisabled,
+		S3EncryptionModeSseKms,
+		S3EncryptionModeSseS3,
+	}
+}
 
 const (
 	// ScheduleStateScheduled is a ScheduleState enum value
@@ -37742,6 +37987,15 @@ const (
 	ScheduleStateTransitioning = "TRANSITIONING"
 )
 
+// ScheduleState_Values returns all elements of the ScheduleState enum
+func ScheduleState_Values() []string {
+	return []string{
+		ScheduleStateScheduled,
+		ScheduleStateNotScheduled,
+		ScheduleStateTransitioning,
+	}
+}
+
 const (
 	// SortAsc is a Sort enum value
 	SortAsc = "ASC"
@@ -37750,6 +38004,14 @@ const (
 	SortDesc = "DESC"
 )
 
+// Sort_Values returns all elements of the Sort enum
+func Sort_Values() []string {
+	return []string{
+		SortAsc,
+		SortDesc,
+	}
+}
+
 const (
 	// SortDirectionTypeDescending is a SortDirectionType enum value
 	SortDirectionTypeDescending = "DESCENDING"
@@ -37757,6 +38019,14 @@ const (
 	// SortDirectionTypeAscending is a SortDirectionType enum value
 	SortDirectionTypeAscending = "ASCENDING"
 )
+
+// SortDirectionType_Values returns all elements of the SortDirectionType enum
+func SortDirectionType_Values() []string {
+	return []string{
+		SortDirectionTypeDescending,
+		SortDirectionTypeAscending,
+	}
+}
 
 const (
 	// TaskRunSortColumnTypeTaskRunType is a TaskRunSortColumnType enum value
@@ -37768,6 +38038,15 @@ const (
 	// TaskRunSortColumnTypeStarted is a TaskRunSortColumnType enum value
 	TaskRunSortColumnTypeStarted = "STARTED"
 )
+
+// TaskRunSortColumnType_Values returns all elements of the TaskRunSortColumnType enum
+func TaskRunSortColumnType_Values() []string {
+	return []string{
+		TaskRunSortColumnTypeTaskRunType,
+		TaskRunSortColumnTypeStatus,
+		TaskRunSortColumnTypeStarted,
+	}
+}
 
 const (
 	// TaskStatusTypeStarting is a TaskStatusType enum value
@@ -37792,6 +38071,19 @@ const (
 	TaskStatusTypeTimeout = "TIMEOUT"
 )
 
+// TaskStatusType_Values returns all elements of the TaskStatusType enum
+func TaskStatusType_Values() []string {
+	return []string{
+		TaskStatusTypeStarting,
+		TaskStatusTypeRunning,
+		TaskStatusTypeStopping,
+		TaskStatusTypeStopped,
+		TaskStatusTypeSucceeded,
+		TaskStatusTypeFailed,
+		TaskStatusTypeTimeout,
+	}
+}
+
 const (
 	// TaskTypeEvaluation is a TaskType enum value
 	TaskTypeEvaluation = "EVALUATION"
@@ -37808,6 +38100,17 @@ const (
 	// TaskTypeFindMatches is a TaskType enum value
 	TaskTypeFindMatches = "FIND_MATCHES"
 )
+
+// TaskType_Values returns all elements of the TaskType enum
+func TaskType_Values() []string {
+	return []string{
+		TaskTypeEvaluation,
+		TaskTypeLabelingSetGeneration,
+		TaskTypeImportLabels,
+		TaskTypeExportLabels,
+		TaskTypeFindMatches,
+	}
+}
 
 const (
 	// TransformSortColumnTypeName is a TransformSortColumnType enum value
@@ -37826,6 +38129,17 @@ const (
 	TransformSortColumnTypeLastModified = "LAST_MODIFIED"
 )
 
+// TransformSortColumnType_Values returns all elements of the TransformSortColumnType enum
+func TransformSortColumnType_Values() []string {
+	return []string{
+		TransformSortColumnTypeName,
+		TransformSortColumnTypeTransformType,
+		TransformSortColumnTypeStatus,
+		TransformSortColumnTypeCreated,
+		TransformSortColumnTypeLastModified,
+	}
+}
+
 const (
 	// TransformStatusTypeNotReady is a TransformStatusType enum value
 	TransformStatusTypeNotReady = "NOT_READY"
@@ -37837,10 +38151,26 @@ const (
 	TransformStatusTypeDeleting = "DELETING"
 )
 
+// TransformStatusType_Values returns all elements of the TransformStatusType enum
+func TransformStatusType_Values() []string {
+	return []string{
+		TransformStatusTypeNotReady,
+		TransformStatusTypeReady,
+		TransformStatusTypeDeleting,
+	}
+}
+
 const (
 	// TransformTypeFindMatches is a TransformType enum value
 	TransformTypeFindMatches = "FIND_MATCHES"
 )
+
+// TransformType_Values returns all elements of the TransformType enum
+func TransformType_Values() []string {
+	return []string{
+		TransformTypeFindMatches,
+	}
+}
 
 const (
 	// TriggerStateCreating is a TriggerState enum value
@@ -37868,6 +38198,20 @@ const (
 	TriggerStateUpdating = "UPDATING"
 )
 
+// TriggerState_Values returns all elements of the TriggerState enum
+func TriggerState_Values() []string {
+	return []string{
+		TriggerStateCreating,
+		TriggerStateCreated,
+		TriggerStateActivating,
+		TriggerStateActivated,
+		TriggerStateDeactivating,
+		TriggerStateDeactivated,
+		TriggerStateDeleting,
+		TriggerStateUpdating,
+	}
+}
+
 const (
 	// TriggerTypeScheduled is a TriggerType enum value
 	TriggerTypeScheduled = "SCHEDULED"
@@ -37879,6 +38223,15 @@ const (
 	TriggerTypeOnDemand = "ON_DEMAND"
 )
 
+// TriggerType_Values returns all elements of the TriggerType enum
+func TriggerType_Values() []string {
+	return []string{
+		TriggerTypeScheduled,
+		TriggerTypeConditional,
+		TriggerTypeOnDemand,
+	}
+}
+
 const (
 	// UpdateBehaviorLog is a UpdateBehavior enum value
 	UpdateBehaviorLog = "LOG"
@@ -37886,6 +38239,14 @@ const (
 	// UpdateBehaviorUpdateInDatabase is a UpdateBehavior enum value
 	UpdateBehaviorUpdateInDatabase = "UPDATE_IN_DATABASE"
 )
+
+// UpdateBehavior_Values returns all elements of the UpdateBehavior enum
+func UpdateBehavior_Values() []string {
+	return []string{
+		UpdateBehaviorLog,
+		UpdateBehaviorUpdateInDatabase,
+	}
+}
 
 const (
 	// WorkerTypeStandard is a WorkerType enum value
@@ -37897,6 +38258,15 @@ const (
 	// WorkerTypeG2x is a WorkerType enum value
 	WorkerTypeG2x = "G.2X"
 )
+
+// WorkerType_Values returns all elements of the WorkerType enum
+func WorkerType_Values() []string {
+	return []string{
+		WorkerTypeStandard,
+		WorkerTypeG1x,
+		WorkerTypeG2x,
+	}
+}
 
 const (
 	// WorkflowRunStatusRunning is a WorkflowRunStatus enum value
@@ -37914,3 +38284,13 @@ const (
 	// WorkflowRunStatusError is a WorkflowRunStatus enum value
 	WorkflowRunStatusError = "ERROR"
 )
+
+// WorkflowRunStatus_Values returns all elements of the WorkflowRunStatus enum
+func WorkflowRunStatus_Values() []string {
+	return []string{
+		WorkflowRunStatusRunning,
+		WorkflowRunStatusCompleted,
+		WorkflowRunStatusStopping,
+		WorkflowRunStatusStopped,
+	}
+}

--- a/service/glue/api.go
+++ b/service/glue/api.go
@@ -38292,5 +38292,6 @@ func WorkflowRunStatus_Values() []string {
 		WorkflowRunStatusCompleted,
 		WorkflowRunStatusStopping,
 		WorkflowRunStatusStopped,
+		WorkflowRunStatusError,
 	}
 }

--- a/service/greengrass/api.go
+++ b/service/greengrass/api.go
@@ -17704,6 +17704,18 @@ const (
 	BulkDeploymentStatusFailed = "Failed"
 )
 
+// BulkDeploymentStatus_Values returns all elements of the BulkDeploymentStatus enum
+func BulkDeploymentStatus_Values() []string {
+	return []string{
+		BulkDeploymentStatusInitializing,
+		BulkDeploymentStatusRunning,
+		BulkDeploymentStatusCompleted,
+		BulkDeploymentStatusStopping,
+		BulkDeploymentStatusStopped,
+		BulkDeploymentStatusFailed,
+	}
+}
+
 // The type of deployment. When used for ''CreateDeployment'', only ''NewDeployment''
 // and ''Redeployment'' are valid.
 const (
@@ -17720,6 +17732,16 @@ const (
 	DeploymentTypeForceResetDeployment = "ForceResetDeployment"
 )
 
+// DeploymentType_Values returns all elements of the DeploymentType enum
+func DeploymentType_Values() []string {
+	return []string{
+		DeploymentTypeNewDeployment,
+		DeploymentTypeRedeployment,
+		DeploymentTypeResetDeployment,
+		DeploymentTypeForceResetDeployment,
+	}
+}
+
 const (
 	// EncodingTypeBinary is a EncodingType enum value
 	EncodingTypeBinary = "binary"
@@ -17727,6 +17749,14 @@ const (
 	// EncodingTypeJson is a EncodingType enum value
 	EncodingTypeJson = "json"
 )
+
+// EncodingType_Values returns all elements of the EncodingType enum
+func EncodingType_Values() []string {
+	return []string{
+		EncodingTypeBinary,
+		EncodingTypeJson,
+	}
+}
 
 // Specifies whether the Lambda function runs in a Greengrass container (default)
 // or without containerization. Unless your scenario requires that you run without
@@ -17741,6 +17771,14 @@ const (
 	FunctionIsolationModeNoContainer = "NoContainer"
 )
 
+// FunctionIsolationMode_Values returns all elements of the FunctionIsolationMode enum
+func FunctionIsolationMode_Values() []string {
+	return []string{
+		FunctionIsolationModeGreengrassContainer,
+		FunctionIsolationModeNoContainer,
+	}
+}
+
 const (
 	// LoggerComponentGreengrassSystem is a LoggerComponent enum value
 	LoggerComponentGreengrassSystem = "GreengrassSystem"
@@ -17748,6 +17786,14 @@ const (
 	// LoggerComponentLambda is a LoggerComponent enum value
 	LoggerComponentLambda = "Lambda"
 )
+
+// LoggerComponent_Values returns all elements of the LoggerComponent enum
+func LoggerComponent_Values() []string {
+	return []string{
+		LoggerComponentGreengrassSystem,
+		LoggerComponentLambda,
+	}
+}
 
 const (
 	// LoggerLevelDebug is a LoggerLevel enum value
@@ -17766,6 +17812,17 @@ const (
 	LoggerLevelFatal = "FATAL"
 )
 
+// LoggerLevel_Values returns all elements of the LoggerLevel enum
+func LoggerLevel_Values() []string {
+	return []string{
+		LoggerLevelDebug,
+		LoggerLevelInfo,
+		LoggerLevelWarn,
+		LoggerLevelError,
+		LoggerLevelFatal,
+	}
+}
+
 const (
 	// LoggerTypeFileSystem is a LoggerType enum value
 	LoggerTypeFileSystem = "FileSystem"
@@ -17773,6 +17830,14 @@ const (
 	// LoggerTypeAwscloudWatch is a LoggerType enum value
 	LoggerTypeAwscloudWatch = "AWSCloudWatch"
 )
+
+// LoggerType_Values returns all elements of the LoggerType enum
+func LoggerType_Values() []string {
+	return []string{
+		LoggerTypeFileSystem,
+		LoggerTypeAwscloudWatch,
+	}
+}
 
 // The type of permission a function has to access a resource.
 const (
@@ -17783,6 +17848,14 @@ const (
 	PermissionRw = "rw"
 )
 
+// Permission_Values returns all elements of the Permission enum
+func Permission_Values() []string {
+	return []string{
+		PermissionRo,
+		PermissionRw,
+	}
+}
+
 // The piece of software on the Greengrass core that will be updated.
 const (
 	// SoftwareToUpdateCore is a SoftwareToUpdate enum value
@@ -17791,6 +17864,14 @@ const (
 	// SoftwareToUpdateOtaAgent is a SoftwareToUpdate enum value
 	SoftwareToUpdateOtaAgent = "ota_agent"
 )
+
+// SoftwareToUpdate_Values returns all elements of the SoftwareToUpdate enum
+func SoftwareToUpdate_Values() []string {
+	return []string{
+		SoftwareToUpdateCore,
+		SoftwareToUpdateOtaAgent,
+	}
+}
 
 // The minimum level of log statements that should be logged by the OTA Agent
 // during an update.
@@ -17820,6 +17901,20 @@ const (
 	UpdateAgentLogLevelFatal = "FATAL"
 )
 
+// UpdateAgentLogLevel_Values returns all elements of the UpdateAgentLogLevel enum
+func UpdateAgentLogLevel_Values() []string {
+	return []string{
+		UpdateAgentLogLevelNone,
+		UpdateAgentLogLevelTrace,
+		UpdateAgentLogLevelDebug,
+		UpdateAgentLogLevelVerbose,
+		UpdateAgentLogLevelInfo,
+		UpdateAgentLogLevelWarn,
+		UpdateAgentLogLevelError,
+		UpdateAgentLogLevelFatal,
+	}
+}
+
 // The architecture of the cores which are the targets of an update.
 const (
 	// UpdateTargetsArchitectureArmv6l is a UpdateTargetsArchitecture enum value
@@ -17835,6 +17930,16 @@ const (
 	UpdateTargetsArchitectureAarch64 = "aarch64"
 )
 
+// UpdateTargetsArchitecture_Values returns all elements of the UpdateTargetsArchitecture enum
+func UpdateTargetsArchitecture_Values() []string {
+	return []string{
+		UpdateTargetsArchitectureArmv6l,
+		UpdateTargetsArchitectureArmv7l,
+		UpdateTargetsArchitectureX8664,
+		UpdateTargetsArchitectureAarch64,
+	}
+}
+
 // The operating system of the cores which are the targets of an update.
 const (
 	// UpdateTargetsOperatingSystemUbuntu is a UpdateTargetsOperatingSystem enum value
@@ -17849,3 +17954,13 @@ const (
 	// UpdateTargetsOperatingSystemOpenwrt is a UpdateTargetsOperatingSystem enum value
 	UpdateTargetsOperatingSystemOpenwrt = "openwrt"
 )
+
+// UpdateTargetsOperatingSystem_Values returns all elements of the UpdateTargetsOperatingSystem enum
+func UpdateTargetsOperatingSystem_Values() []string {
+	return []string{
+		UpdateTargetsOperatingSystemUbuntu,
+		UpdateTargetsOperatingSystemRaspbian,
+		UpdateTargetsOperatingSystemAmazonLinux,
+		UpdateTargetsOperatingSystemOpenwrt,
+	}
+}

--- a/service/groundstation/api.go
+++ b/service/groundstation/api.go
@@ -6914,6 +6914,14 @@ const (
 	AngleUnitsRadian = "RADIAN"
 )
 
+// AngleUnits_Values returns all elements of the AngleUnits enum
+func AngleUnits_Values() []string {
+	return []string{
+		AngleUnitsDegreeAngle,
+		AngleUnitsRadian,
+	}
+}
+
 const (
 	// BandwidthUnitsGhz is a BandwidthUnits enum value
 	BandwidthUnitsGhz = "GHz"
@@ -6924,6 +6932,15 @@ const (
 	// BandwidthUnitsKHz is a BandwidthUnits enum value
 	BandwidthUnitsKHz = "kHz"
 )
+
+// BandwidthUnits_Values returns all elements of the BandwidthUnits enum
+func BandwidthUnits_Values() []string {
+	return []string{
+		BandwidthUnitsGhz,
+		BandwidthUnitsMhz,
+		BandwidthUnitsKHz,
+	}
+}
 
 const (
 	// ConfigCapabilityTypeAntennaDownlink is a ConfigCapabilityType enum value
@@ -6944,6 +6961,18 @@ const (
 	// ConfigCapabilityTypeUplinkEcho is a ConfigCapabilityType enum value
 	ConfigCapabilityTypeUplinkEcho = "uplink-echo"
 )
+
+// ConfigCapabilityType_Values returns all elements of the ConfigCapabilityType enum
+func ConfigCapabilityType_Values() []string {
+	return []string{
+		ConfigCapabilityTypeAntennaDownlink,
+		ConfigCapabilityTypeAntennaDownlinkDemodDecode,
+		ConfigCapabilityTypeAntennaUplink,
+		ConfigCapabilityTypeDataflowEndpoint,
+		ConfigCapabilityTypeTracking,
+		ConfigCapabilityTypeUplinkEcho,
+	}
+}
 
 const (
 	// ContactStatusAvailable is a ContactStatus enum value
@@ -6983,6 +7012,24 @@ const (
 	ContactStatusScheduling = "SCHEDULING"
 )
 
+// ContactStatus_Values returns all elements of the ContactStatus enum
+func ContactStatus_Values() []string {
+	return []string{
+		ContactStatusAvailable,
+		ContactStatusAwsCancelled,
+		ContactStatusCancelled,
+		ContactStatusCancelling,
+		ContactStatusCompleted,
+		ContactStatusFailed,
+		ContactStatusFailedToSchedule,
+		ContactStatusPass,
+		ContactStatusPostpass,
+		ContactStatusPrepass,
+		ContactStatusScheduled,
+		ContactStatusScheduling,
+	}
+}
+
 const (
 	// CriticalityPreferred is a Criticality enum value
 	CriticalityPreferred = "PREFERRED"
@@ -6994,10 +7041,26 @@ const (
 	CriticalityRequired = "REQUIRED"
 )
 
+// Criticality_Values returns all elements of the Criticality enum
+func Criticality_Values() []string {
+	return []string{
+		CriticalityPreferred,
+		CriticalityRemoved,
+		CriticalityRequired,
+	}
+}
+
 const (
 	// EirpUnitsDBw is a EirpUnits enum value
 	EirpUnitsDBw = "dBW"
 )
+
+// EirpUnits_Values returns all elements of the EirpUnits enum
+func EirpUnits_Values() []string {
+	return []string{
+		EirpUnitsDBw,
+	}
+}
 
 const (
 	// EndpointStatusCreated is a EndpointStatus enum value
@@ -7016,6 +7079,17 @@ const (
 	EndpointStatusFailed = "failed"
 )
 
+// EndpointStatus_Values returns all elements of the EndpointStatus enum
+func EndpointStatus_Values() []string {
+	return []string{
+		EndpointStatusCreated,
+		EndpointStatusCreating,
+		EndpointStatusDeleted,
+		EndpointStatusDeleting,
+		EndpointStatusFailed,
+	}
+}
+
 const (
 	// FrequencyUnitsGhz is a FrequencyUnits enum value
 	FrequencyUnitsGhz = "GHz"
@@ -7027,6 +7101,15 @@ const (
 	FrequencyUnitsKHz = "kHz"
 )
 
+// FrequencyUnits_Values returns all elements of the FrequencyUnits enum
+func FrequencyUnits_Values() []string {
+	return []string{
+		FrequencyUnitsGhz,
+		FrequencyUnitsMhz,
+		FrequencyUnitsKHz,
+	}
+}
+
 const (
 	// PolarizationLeftHand is a Polarization enum value
 	PolarizationLeftHand = "LEFT_HAND"
@@ -7037,3 +7120,12 @@ const (
 	// PolarizationRightHand is a Polarization enum value
 	PolarizationRightHand = "RIGHT_HAND"
 )
+
+// Polarization_Values returns all elements of the Polarization enum
+func Polarization_Values() []string {
+	return []string{
+		PolarizationLeftHand,
+		PolarizationNone,
+		PolarizationRightHand,
+	}
+}

--- a/service/guardduty/api.go
+++ b/service/guardduty/api.go
@@ -14299,6 +14299,14 @@ const (
 	AdminStatusDisableInProgress = "DISABLE_IN_PROGRESS"
 )
 
+// AdminStatus_Values returns all elements of the AdminStatus enum
+func AdminStatus_Values() []string {
+	return []string{
+		AdminStatusEnabled,
+		AdminStatusDisableInProgress,
+	}
+}
+
 const (
 	// DataSourceFlowLogs is a DataSource enum value
 	DataSourceFlowLogs = "FLOW_LOGS"
@@ -14313,6 +14321,16 @@ const (
 	DataSourceS3Logs = "S3_LOGS"
 )
 
+// DataSource_Values returns all elements of the DataSource enum
+func DataSource_Values() []string {
+	return []string{
+		DataSourceFlowLogs,
+		DataSourceCloudTrail,
+		DataSourceDnsLogs,
+		DataSourceS3Logs,
+	}
+}
+
 const (
 	// DataSourceStatusEnabled is a DataSourceStatus enum value
 	DataSourceStatusEnabled = "ENABLED"
@@ -14321,10 +14339,25 @@ const (
 	DataSourceStatusDisabled = "DISABLED"
 )
 
+// DataSourceStatus_Values returns all elements of the DataSourceStatus enum
+func DataSourceStatus_Values() []string {
+	return []string{
+		DataSourceStatusEnabled,
+		DataSourceStatusDisabled,
+	}
+}
+
 const (
 	// DestinationTypeS3 is a DestinationType enum value
 	DestinationTypeS3 = "S3"
 )
+
+// DestinationType_Values returns all elements of the DestinationType enum
+func DestinationType_Values() []string {
+	return []string{
+		DestinationTypeS3,
+	}
+}
 
 const (
 	// DetectorStatusEnabled is a DetectorStatus enum value
@@ -14334,6 +14367,14 @@ const (
 	DetectorStatusDisabled = "DISABLED"
 )
 
+// DetectorStatus_Values returns all elements of the DetectorStatus enum
+func DetectorStatus_Values() []string {
+	return []string{
+		DetectorStatusEnabled,
+		DetectorStatusDisabled,
+	}
+}
+
 const (
 	// FeedbackUseful is a Feedback enum value
 	FeedbackUseful = "USEFUL"
@@ -14342,6 +14383,14 @@ const (
 	FeedbackNotUseful = "NOT_USEFUL"
 )
 
+// Feedback_Values returns all elements of the Feedback enum
+func Feedback_Values() []string {
+	return []string{
+		FeedbackUseful,
+		FeedbackNotUseful,
+	}
+}
+
 const (
 	// FilterActionNoop is a FilterAction enum value
 	FilterActionNoop = "NOOP"
@@ -14349,6 +14398,14 @@ const (
 	// FilterActionArchive is a FilterAction enum value
 	FilterActionArchive = "ARCHIVE"
 )
+
+// FilterAction_Values returns all elements of the FilterAction enum
+func FilterAction_Values() []string {
+	return []string{
+		FilterActionNoop,
+		FilterActionArchive,
+	}
+}
 
 const (
 	// FindingPublishingFrequencyFifteenMinutes is a FindingPublishingFrequency enum value
@@ -14361,10 +14418,26 @@ const (
 	FindingPublishingFrequencySixHours = "SIX_HOURS"
 )
 
+// FindingPublishingFrequency_Values returns all elements of the FindingPublishingFrequency enum
+func FindingPublishingFrequency_Values() []string {
+	return []string{
+		FindingPublishingFrequencyFifteenMinutes,
+		FindingPublishingFrequencyOneHour,
+		FindingPublishingFrequencySixHours,
+	}
+}
+
 const (
 	// FindingStatisticTypeCountBySeverity is a FindingStatisticType enum value
 	FindingStatisticTypeCountBySeverity = "COUNT_BY_SEVERITY"
 )
+
+// FindingStatisticType_Values returns all elements of the FindingStatisticType enum
+func FindingStatisticType_Values() []string {
+	return []string{
+		FindingStatisticTypeCountBySeverity,
+	}
+}
 
 const (
 	// IpSetFormatTxt is a IpSetFormat enum value
@@ -14385,6 +14458,18 @@ const (
 	// IpSetFormatFireEye is a IpSetFormat enum value
 	IpSetFormatFireEye = "FIRE_EYE"
 )
+
+// IpSetFormat_Values returns all elements of the IpSetFormat enum
+func IpSetFormat_Values() []string {
+	return []string{
+		IpSetFormatTxt,
+		IpSetFormatStix,
+		IpSetFormatOtxCsv,
+		IpSetFormatAlienVault,
+		IpSetFormatProofPoint,
+		IpSetFormatFireEye,
+	}
+}
 
 const (
 	// IpSetStatusInactive is a IpSetStatus enum value
@@ -14409,6 +14494,19 @@ const (
 	IpSetStatusDeleted = "DELETED"
 )
 
+// IpSetStatus_Values returns all elements of the IpSetStatus enum
+func IpSetStatus_Values() []string {
+	return []string{
+		IpSetStatusInactive,
+		IpSetStatusActivating,
+		IpSetStatusActive,
+		IpSetStatusDeactivating,
+		IpSetStatusError,
+		IpSetStatusDeletePending,
+		IpSetStatusDeleted,
+	}
+}
+
 const (
 	// OrderByAsc is a OrderBy enum value
 	OrderByAsc = "ASC"
@@ -14416,6 +14514,14 @@ const (
 	// OrderByDesc is a OrderBy enum value
 	OrderByDesc = "DESC"
 )
+
+// OrderBy_Values returns all elements of the OrderBy enum
+func OrderBy_Values() []string {
+	return []string{
+		OrderByAsc,
+		OrderByDesc,
+	}
+}
 
 const (
 	// PublishingStatusPendingVerification is a PublishingStatus enum value
@@ -14430,6 +14536,16 @@ const (
 	// PublishingStatusStopped is a PublishingStatus enum value
 	PublishingStatusStopped = "STOPPED"
 )
+
+// PublishingStatus_Values returns all elements of the PublishingStatus enum
+func PublishingStatus_Values() []string {
+	return []string{
+		PublishingStatusPendingVerification,
+		PublishingStatusPublishing,
+		PublishingStatusUnableToPublishFixDestinationProperty,
+		PublishingStatusStopped,
+	}
+}
 
 const (
 	// ThreatIntelSetFormatTxt is a ThreatIntelSetFormat enum value
@@ -14450,6 +14566,18 @@ const (
 	// ThreatIntelSetFormatFireEye is a ThreatIntelSetFormat enum value
 	ThreatIntelSetFormatFireEye = "FIRE_EYE"
 )
+
+// ThreatIntelSetFormat_Values returns all elements of the ThreatIntelSetFormat enum
+func ThreatIntelSetFormat_Values() []string {
+	return []string{
+		ThreatIntelSetFormatTxt,
+		ThreatIntelSetFormatStix,
+		ThreatIntelSetFormatOtxCsv,
+		ThreatIntelSetFormatAlienVault,
+		ThreatIntelSetFormatProofPoint,
+		ThreatIntelSetFormatFireEye,
+	}
+}
 
 const (
 	// ThreatIntelSetStatusInactive is a ThreatIntelSetStatus enum value
@@ -14474,6 +14602,19 @@ const (
 	ThreatIntelSetStatusDeleted = "DELETED"
 )
 
+// ThreatIntelSetStatus_Values returns all elements of the ThreatIntelSetStatus enum
+func ThreatIntelSetStatus_Values() []string {
+	return []string{
+		ThreatIntelSetStatusInactive,
+		ThreatIntelSetStatusActivating,
+		ThreatIntelSetStatusActive,
+		ThreatIntelSetStatusDeactivating,
+		ThreatIntelSetStatusError,
+		ThreatIntelSetStatusDeletePending,
+		ThreatIntelSetStatusDeleted,
+	}
+}
+
 const (
 	// UsageStatisticTypeSumByAccount is a UsageStatisticType enum value
 	UsageStatisticTypeSumByAccount = "SUM_BY_ACCOUNT"
@@ -14487,3 +14628,13 @@ const (
 	// UsageStatisticTypeTopResources is a UsageStatisticType enum value
 	UsageStatisticTypeTopResources = "TOP_RESOURCES"
 )
+
+// UsageStatisticType_Values returns all elements of the UsageStatisticType enum
+func UsageStatisticType_Values() []string {
+	return []string{
+		UsageStatisticTypeSumByAccount,
+		UsageStatisticTypeSumByDataSource,
+		UsageStatisticTypeSumByResource,
+		UsageStatisticTypeTopResources,
+	}
+}

--- a/service/health/api.go
+++ b/service/health/api.go
@@ -4368,10 +4368,26 @@ const (
 	EntityStatusCodeUnknown = "UNKNOWN"
 )
 
+// EntityStatusCode_Values returns all elements of the EntityStatusCode enum
+func EntityStatusCode_Values() []string {
+	return []string{
+		EntityStatusCodeImpaired,
+		EntityStatusCodeUnimpaired,
+		EntityStatusCodeUnknown,
+	}
+}
+
 const (
 	// EventAggregateFieldEventTypeCategory is a EventAggregateField enum value
 	EventAggregateFieldEventTypeCategory = "eventTypeCategory"
 )
+
+// EventAggregateField_Values returns all elements of the EventAggregateField enum
+func EventAggregateField_Values() []string {
+	return []string{
+		EventAggregateFieldEventTypeCategory,
+	}
+}
 
 const (
 	// EventScopeCodePublic is a EventScopeCode enum value
@@ -4384,6 +4400,15 @@ const (
 	EventScopeCodeNone = "NONE"
 )
 
+// EventScopeCode_Values returns all elements of the EventScopeCode enum
+func EventScopeCode_Values() []string {
+	return []string{
+		EventScopeCodePublic,
+		EventScopeCodeAccountSpecific,
+		EventScopeCodeNone,
+	}
+}
+
 const (
 	// EventStatusCodeOpen is a EventStatusCode enum value
 	EventStatusCodeOpen = "open"
@@ -4394,6 +4419,15 @@ const (
 	// EventStatusCodeUpcoming is a EventStatusCode enum value
 	EventStatusCodeUpcoming = "upcoming"
 )
+
+// EventStatusCode_Values returns all elements of the EventStatusCode enum
+func EventStatusCode_Values() []string {
+	return []string{
+		EventStatusCodeOpen,
+		EventStatusCodeClosed,
+		EventStatusCodeUpcoming,
+	}
+}
 
 const (
 	// EventTypeCategoryIssue is a EventTypeCategory enum value
@@ -4408,3 +4442,13 @@ const (
 	// EventTypeCategoryInvestigation is a EventTypeCategory enum value
 	EventTypeCategoryInvestigation = "investigation"
 )
+
+// EventTypeCategory_Values returns all elements of the EventTypeCategory enum
+func EventTypeCategory_Values() []string {
+	return []string{
+		EventTypeCategoryIssue,
+		EventTypeCategoryAccountNotification,
+		EventTypeCategoryScheduledChange,
+		EventTypeCategoryInvestigation,
+	}
+}

--- a/service/honeycode/api.go
+++ b/service/honeycode/api.go
@@ -1314,3 +1314,20 @@ const (
 	// FormatRowlink is a Format enum value
 	FormatRowlink = "ROWLINK"
 )
+
+// Format_Values returns all elements of the Format enum
+func Format_Values() []string {
+	return []string{
+		FormatAuto,
+		FormatNumber,
+		FormatCurrency,
+		FormatDate,
+		FormatTime,
+		FormatDateTime,
+		FormatPercentage,
+		FormatText,
+		FormatAccounting,
+		FormatContact,
+		FormatRowlink,
+	}
+}

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -33274,6 +33274,14 @@ const (
 	AccessAdvisorUsageGranularityTypeActionLevel = "ACTION_LEVEL"
 )
 
+// AccessAdvisorUsageGranularityType_Values returns all elements of the AccessAdvisorUsageGranularityType enum
+func AccessAdvisorUsageGranularityType_Values() []string {
+	return []string{
+		AccessAdvisorUsageGranularityTypeServiceLevel,
+		AccessAdvisorUsageGranularityTypeActionLevel,
+	}
+}
+
 const (
 	// AssignmentStatusTypeAssigned is a AssignmentStatusType enum value
 	AssignmentStatusTypeAssigned = "Assigned"
@@ -33284,6 +33292,15 @@ const (
 	// AssignmentStatusTypeAny is a AssignmentStatusType enum value
 	AssignmentStatusTypeAny = "Any"
 )
+
+// AssignmentStatusType_Values returns all elements of the AssignmentStatusType enum
+func AssignmentStatusType_Values() []string {
+	return []string{
+		AssignmentStatusTypeAssigned,
+		AssignmentStatusTypeUnassigned,
+		AssignmentStatusTypeAny,
+	}
+}
 
 const (
 	// ContextKeyTypeEnumString is a ContextKeyTypeEnum enum value
@@ -33323,6 +33340,24 @@ const (
 	ContextKeyTypeEnumDateList = "dateList"
 )
 
+// ContextKeyTypeEnum_Values returns all elements of the ContextKeyTypeEnum enum
+func ContextKeyTypeEnum_Values() []string {
+	return []string{
+		ContextKeyTypeEnumString,
+		ContextKeyTypeEnumStringList,
+		ContextKeyTypeEnumNumeric,
+		ContextKeyTypeEnumNumericList,
+		ContextKeyTypeEnumBoolean,
+		ContextKeyTypeEnumBooleanList,
+		ContextKeyTypeEnumIp,
+		ContextKeyTypeEnumIpList,
+		ContextKeyTypeEnumBinary,
+		ContextKeyTypeEnumBinaryList,
+		ContextKeyTypeEnumDate,
+		ContextKeyTypeEnumDateList,
+	}
+}
+
 const (
 	// DeletionTaskStatusTypeSucceeded is a DeletionTaskStatusType enum value
 	DeletionTaskStatusTypeSucceeded = "SUCCEEDED"
@@ -33337,6 +33372,16 @@ const (
 	DeletionTaskStatusTypeNotStarted = "NOT_STARTED"
 )
 
+// DeletionTaskStatusType_Values returns all elements of the DeletionTaskStatusType enum
+func DeletionTaskStatusType_Values() []string {
+	return []string{
+		DeletionTaskStatusTypeSucceeded,
+		DeletionTaskStatusTypeInProgress,
+		DeletionTaskStatusTypeFailed,
+		DeletionTaskStatusTypeNotStarted,
+	}
+}
+
 const (
 	// EncodingTypeSsh is a EncodingType enum value
 	EncodingTypeSsh = "SSH"
@@ -33344,6 +33389,14 @@ const (
 	// EncodingTypePem is a EncodingType enum value
 	EncodingTypePem = "PEM"
 )
+
+// EncodingType_Values returns all elements of the EncodingType enum
+func EncodingType_Values() []string {
+	return []string{
+		EncodingTypeSsh,
+		EncodingTypePem,
+	}
+}
 
 const (
 	// EntityTypeUser is a EntityType enum value
@@ -33362,6 +33415,17 @@ const (
 	EntityTypeAwsmanagedPolicy = "AWSManagedPolicy"
 )
 
+// EntityType_Values returns all elements of the EntityType enum
+func EntityType_Values() []string {
+	return []string{
+		EntityTypeUser,
+		EntityTypeRole,
+		EntityTypeGroup,
+		EntityTypeLocalManagedPolicy,
+		EntityTypeAwsmanagedPolicy,
+	}
+}
+
 const (
 	// GlobalEndpointTokenVersionV1token is a GlobalEndpointTokenVersion enum value
 	GlobalEndpointTokenVersionV1token = "v1Token"
@@ -33369,6 +33433,14 @@ const (
 	// GlobalEndpointTokenVersionV2token is a GlobalEndpointTokenVersion enum value
 	GlobalEndpointTokenVersionV2token = "v2Token"
 )
+
+// GlobalEndpointTokenVersion_Values returns all elements of the GlobalEndpointTokenVersion enum
+func GlobalEndpointTokenVersion_Values() []string {
+	return []string{
+		GlobalEndpointTokenVersionV1token,
+		GlobalEndpointTokenVersionV2token,
+	}
+}
 
 const (
 	// JobStatusTypeInProgress is a JobStatusType enum value
@@ -33381,10 +33453,26 @@ const (
 	JobStatusTypeFailed = "FAILED"
 )
 
+// JobStatusType_Values returns all elements of the JobStatusType enum
+func JobStatusType_Values() []string {
+	return []string{
+		JobStatusTypeInProgress,
+		JobStatusTypeCompleted,
+		JobStatusTypeFailed,
+	}
+}
+
 const (
 	// PermissionsBoundaryAttachmentTypePermissionsBoundaryPolicy is a PermissionsBoundaryAttachmentType enum value
 	PermissionsBoundaryAttachmentTypePermissionsBoundaryPolicy = "PermissionsBoundaryPolicy"
 )
+
+// PermissionsBoundaryAttachmentType_Values returns all elements of the PermissionsBoundaryAttachmentType enum
+func PermissionsBoundaryAttachmentType_Values() []string {
+	return []string{
+		PermissionsBoundaryAttachmentTypePermissionsBoundaryPolicy,
+	}
+}
 
 const (
 	// PolicyEvaluationDecisionTypeAllowed is a PolicyEvaluationDecisionType enum value
@@ -33397,6 +33485,15 @@ const (
 	PolicyEvaluationDecisionTypeImplicitDeny = "implicitDeny"
 )
 
+// PolicyEvaluationDecisionType_Values returns all elements of the PolicyEvaluationDecisionType enum
+func PolicyEvaluationDecisionType_Values() []string {
+	return []string{
+		PolicyEvaluationDecisionTypeAllowed,
+		PolicyEvaluationDecisionTypeExplicitDeny,
+		PolicyEvaluationDecisionTypeImplicitDeny,
+	}
+}
+
 const (
 	// PolicyOwnerEntityTypeUser is a PolicyOwnerEntityType enum value
 	PolicyOwnerEntityTypeUser = "USER"
@@ -33408,6 +33505,15 @@ const (
 	PolicyOwnerEntityTypeGroup = "GROUP"
 )
 
+// PolicyOwnerEntityType_Values returns all elements of the PolicyOwnerEntityType enum
+func PolicyOwnerEntityType_Values() []string {
+	return []string{
+		PolicyOwnerEntityTypeUser,
+		PolicyOwnerEntityTypeRole,
+		PolicyOwnerEntityTypeGroup,
+	}
+}
+
 const (
 	// PolicyScopeTypeAll is a PolicyScopeType enum value
 	PolicyScopeTypeAll = "All"
@@ -33418,6 +33524,15 @@ const (
 	// PolicyScopeTypeLocal is a PolicyScopeType enum value
 	PolicyScopeTypeLocal = "Local"
 )
+
+// PolicyScopeType_Values returns all elements of the PolicyScopeType enum
+func PolicyScopeType_Values() []string {
+	return []string{
+		PolicyScopeTypeAll,
+		PolicyScopeTypeAws,
+		PolicyScopeTypeLocal,
+	}
+}
 
 const (
 	// PolicySourceTypeUser is a PolicySourceType enum value
@@ -33442,6 +33557,19 @@ const (
 	PolicySourceTypeNone = "none"
 )
 
+// PolicySourceType_Values returns all elements of the PolicySourceType enum
+func PolicySourceType_Values() []string {
+	return []string{
+		PolicySourceTypeUser,
+		PolicySourceTypeGroup,
+		PolicySourceTypeRole,
+		PolicySourceTypeAwsManaged,
+		PolicySourceTypeUserManaged,
+		PolicySourceTypeResource,
+		PolicySourceTypeNone,
+	}
+}
+
 const (
 	// PolicyTypeInline is a PolicyType enum value
 	PolicyTypeInline = "INLINE"
@@ -33449,6 +33577,14 @@ const (
 	// PolicyTypeManaged is a PolicyType enum value
 	PolicyTypeManaged = "MANAGED"
 )
+
+// PolicyType_Values returns all elements of the PolicyType enum
+func PolicyType_Values() []string {
+	return []string{
+		PolicyTypeInline,
+		PolicyTypeManaged,
+	}
+}
 
 // The policy usage type that indicates whether the policy is used as a permissions
 // policy or as the permissions boundary for an entity.
@@ -33464,10 +33600,25 @@ const (
 	PolicyUsageTypePermissionsBoundary = "PermissionsBoundary"
 )
 
+// PolicyUsageType_Values returns all elements of the PolicyUsageType enum
+func PolicyUsageType_Values() []string {
+	return []string{
+		PolicyUsageTypePermissionsPolicy,
+		PolicyUsageTypePermissionsBoundary,
+	}
+}
+
 const (
 	// ReportFormatTypeTextCsv is a ReportFormatType enum value
 	ReportFormatTypeTextCsv = "text/csv"
 )
+
+// ReportFormatType_Values returns all elements of the ReportFormatType enum
+func ReportFormatType_Values() []string {
+	return []string{
+		ReportFormatTypeTextCsv,
+	}
+}
 
 const (
 	// ReportStateTypeStarted is a ReportStateType enum value
@@ -33479,6 +33630,15 @@ const (
 	// ReportStateTypeComplete is a ReportStateType enum value
 	ReportStateTypeComplete = "COMPLETE"
 )
+
+// ReportStateType_Values returns all elements of the ReportStateType enum
+func ReportStateType_Values() []string {
+	return []string{
+		ReportStateTypeStarted,
+		ReportStateTypeInprogress,
+		ReportStateTypeComplete,
+	}
+}
 
 const (
 	// SortKeyTypeServiceNamespaceAscending is a SortKeyType enum value
@@ -33494,6 +33654,16 @@ const (
 	SortKeyTypeLastAuthenticatedTimeDescending = "LAST_AUTHENTICATED_TIME_DESCENDING"
 )
 
+// SortKeyType_Values returns all elements of the SortKeyType enum
+func SortKeyType_Values() []string {
+	return []string{
+		SortKeyTypeServiceNamespaceAscending,
+		SortKeyTypeServiceNamespaceDescending,
+		SortKeyTypeLastAuthenticatedTimeAscending,
+		SortKeyTypeLastAuthenticatedTimeDescending,
+	}
+}
+
 const (
 	// StatusTypeActive is a StatusType enum value
 	StatusTypeActive = "Active"
@@ -33501,6 +33671,14 @@ const (
 	// StatusTypeInactive is a StatusType enum value
 	StatusTypeInactive = "Inactive"
 )
+
+// StatusType_Values returns all elements of the StatusType enum
+func StatusType_Values() []string {
+	return []string{
+		StatusTypeActive,
+		StatusTypeInactive,
+	}
+}
 
 const (
 	// SummaryKeyTypeUsers is a SummaryKeyType enum value
@@ -33581,3 +33759,35 @@ const (
 	// SummaryKeyTypeGlobalEndpointTokenVersion is a SummaryKeyType enum value
 	SummaryKeyTypeGlobalEndpointTokenVersion = "GlobalEndpointTokenVersion"
 )
+
+// SummaryKeyType_Values returns all elements of the SummaryKeyType enum
+func SummaryKeyType_Values() []string {
+	return []string{
+		SummaryKeyTypeUsers,
+		SummaryKeyTypeUsersQuota,
+		SummaryKeyTypeGroups,
+		SummaryKeyTypeGroupsQuota,
+		SummaryKeyTypeServerCertificates,
+		SummaryKeyTypeServerCertificatesQuota,
+		SummaryKeyTypeUserPolicySizeQuota,
+		SummaryKeyTypeGroupPolicySizeQuota,
+		SummaryKeyTypeGroupsPerUserQuota,
+		SummaryKeyTypeSigningCertificatesPerUserQuota,
+		SummaryKeyTypeAccessKeysPerUserQuota,
+		SummaryKeyTypeMfadevices,
+		SummaryKeyTypeMfadevicesInUse,
+		SummaryKeyTypeAccountMfaenabled,
+		SummaryKeyTypeAccountAccessKeysPresent,
+		SummaryKeyTypeAccountSigningCertificatesPresent,
+		SummaryKeyTypeAttachedPoliciesPerGroupQuota,
+		SummaryKeyTypeAttachedPoliciesPerRoleQuota,
+		SummaryKeyTypeAttachedPoliciesPerUserQuota,
+		SummaryKeyTypePolicies,
+		SummaryKeyTypePoliciesQuota,
+		SummaryKeyTypePolicySizeQuota,
+		SummaryKeyTypePolicyVersionsInUse,
+		SummaryKeyTypePolicyVersionsInUseQuota,
+		SummaryKeyTypeVersionsPerPolicyQuota,
+		SummaryKeyTypeGlobalEndpointTokenVersion,
+	}
+}

--- a/service/imagebuilder/api.go
+++ b/service/imagebuilder/api.go
@@ -12678,6 +12678,13 @@ const (
 	ComponentFormatShell = "SHELL"
 )
 
+// ComponentFormat_Values returns all elements of the ComponentFormat enum
+func ComponentFormat_Values() []string {
+	return []string{
+		ComponentFormatShell,
+	}
+}
+
 const (
 	// ComponentTypeBuild is a ComponentType enum value
 	ComponentTypeBuild = "BUILD"
@@ -12685,6 +12692,14 @@ const (
 	// ComponentTypeTest is a ComponentType enum value
 	ComponentTypeTest = "TEST"
 )
+
+// ComponentType_Values returns all elements of the ComponentType enum
+func ComponentType_Values() []string {
+	return []string{
+		ComponentTypeBuild,
+		ComponentTypeTest,
+	}
+}
 
 const (
 	// EbsVolumeTypeStandard is a EbsVolumeType enum value
@@ -12702,6 +12717,17 @@ const (
 	// EbsVolumeTypeSt1 is a EbsVolumeType enum value
 	EbsVolumeTypeSt1 = "st1"
 )
+
+// EbsVolumeType_Values returns all elements of the EbsVolumeType enum
+func EbsVolumeType_Values() []string {
+	return []string{
+		EbsVolumeTypeStandard,
+		EbsVolumeTypeIo1,
+		EbsVolumeTypeGp2,
+		EbsVolumeTypeSc1,
+		EbsVolumeTypeSt1,
+	}
+}
 
 const (
 	// ImageStatusPending is a ImageStatus enum value
@@ -12738,6 +12764,23 @@ const (
 	ImageStatusDeleted = "DELETED"
 )
 
+// ImageStatus_Values returns all elements of the ImageStatus enum
+func ImageStatus_Values() []string {
+	return []string{
+		ImageStatusPending,
+		ImageStatusCreating,
+		ImageStatusBuilding,
+		ImageStatusTesting,
+		ImageStatusDistributing,
+		ImageStatusIntegrating,
+		ImageStatusAvailable,
+		ImageStatusCancelled,
+		ImageStatusFailed,
+		ImageStatusDeprecated,
+		ImageStatusDeleted,
+	}
+}
+
 const (
 	// OwnershipSelf is a Ownership enum value
 	OwnershipSelf = "Self"
@@ -12749,6 +12792,15 @@ const (
 	OwnershipAmazon = "Amazon"
 )
 
+// Ownership_Values returns all elements of the Ownership enum
+func Ownership_Values() []string {
+	return []string{
+		OwnershipSelf,
+		OwnershipShared,
+		OwnershipAmazon,
+	}
+}
+
 const (
 	// PipelineExecutionStartConditionExpressionMatchOnly is a PipelineExecutionStartCondition enum value
 	PipelineExecutionStartConditionExpressionMatchOnly = "EXPRESSION_MATCH_ONLY"
@@ -12756,6 +12808,14 @@ const (
 	// PipelineExecutionStartConditionExpressionMatchAndDependencyUpdatesAvailable is a PipelineExecutionStartCondition enum value
 	PipelineExecutionStartConditionExpressionMatchAndDependencyUpdatesAvailable = "EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE"
 )
+
+// PipelineExecutionStartCondition_Values returns all elements of the PipelineExecutionStartCondition enum
+func PipelineExecutionStartCondition_Values() []string {
+	return []string{
+		PipelineExecutionStartConditionExpressionMatchOnly,
+		PipelineExecutionStartConditionExpressionMatchAndDependencyUpdatesAvailable,
+	}
+}
 
 const (
 	// PipelineStatusDisabled is a PipelineStatus enum value
@@ -12765,6 +12825,14 @@ const (
 	PipelineStatusEnabled = "ENABLED"
 )
 
+// PipelineStatus_Values returns all elements of the PipelineStatus enum
+func PipelineStatus_Values() []string {
+	return []string{
+		PipelineStatusDisabled,
+		PipelineStatusEnabled,
+	}
+}
+
 const (
 	// PlatformWindows is a Platform enum value
 	PlatformWindows = "Windows"
@@ -12772,3 +12840,11 @@ const (
 	// PlatformLinux is a Platform enum value
 	PlatformLinux = "Linux"
 )
+
+// Platform_Values returns all elements of the Platform enum
+func Platform_Values() []string {
+	return []string{
+		PlatformWindows,
+		PlatformLinux,
+	}
+}

--- a/service/inspector/api.go
+++ b/service/inspector/api.go
@@ -10339,6 +10339,20 @@ const (
 	AccessDeniedErrorCodeAccessDeniedToIamRole = "ACCESS_DENIED_TO_IAM_ROLE"
 )
 
+// AccessDeniedErrorCode_Values returns all elements of the AccessDeniedErrorCode enum
+func AccessDeniedErrorCode_Values() []string {
+	return []string{
+		AccessDeniedErrorCodeAccessDeniedToAssessmentTarget,
+		AccessDeniedErrorCodeAccessDeniedToAssessmentTemplate,
+		AccessDeniedErrorCodeAccessDeniedToAssessmentRun,
+		AccessDeniedErrorCodeAccessDeniedToFinding,
+		AccessDeniedErrorCodeAccessDeniedToResourceGroup,
+		AccessDeniedErrorCodeAccessDeniedToRulesPackage,
+		AccessDeniedErrorCodeAccessDeniedToSnsTopic,
+		AccessDeniedErrorCodeAccessDeniedToIamRole,
+	}
+}
+
 const (
 	// AgentHealthHealthy is a AgentHealth enum value
 	AgentHealthHealthy = "HEALTHY"
@@ -10349,6 +10363,15 @@ const (
 	// AgentHealthUnknown is a AgentHealth enum value
 	AgentHealthUnknown = "UNKNOWN"
 )
+
+// AgentHealth_Values returns all elements of the AgentHealth enum
+func AgentHealth_Values() []string {
+	return []string{
+		AgentHealthHealthy,
+		AgentHealthUnhealthy,
+		AgentHealthUnknown,
+	}
+}
 
 const (
 	// AgentHealthCodeIdle is a AgentHealthCode enum value
@@ -10370,6 +10393,18 @@ const (
 	AgentHealthCodeUnknown = "UNKNOWN"
 )
 
+// AgentHealthCode_Values returns all elements of the AgentHealthCode enum
+func AgentHealthCode_Values() []string {
+	return []string{
+		AgentHealthCodeIdle,
+		AgentHealthCodeRunning,
+		AgentHealthCodeShutdown,
+		AgentHealthCodeUnhealthy,
+		AgentHealthCodeThrottled,
+		AgentHealthCodeUnknown,
+	}
+}
+
 const (
 	// AssessmentRunNotificationSnsStatusCodeSuccess is a AssessmentRunNotificationSnsStatusCode enum value
 	AssessmentRunNotificationSnsStatusCodeSuccess = "SUCCESS"
@@ -10383,6 +10418,16 @@ const (
 	// AssessmentRunNotificationSnsStatusCodeInternalError is a AssessmentRunNotificationSnsStatusCode enum value
 	AssessmentRunNotificationSnsStatusCodeInternalError = "INTERNAL_ERROR"
 )
+
+// AssessmentRunNotificationSnsStatusCode_Values returns all elements of the AssessmentRunNotificationSnsStatusCode enum
+func AssessmentRunNotificationSnsStatusCode_Values() []string {
+	return []string{
+		AssessmentRunNotificationSnsStatusCodeSuccess,
+		AssessmentRunNotificationSnsStatusCodeTopicDoesNotExist,
+		AssessmentRunNotificationSnsStatusCodeAccessDenied,
+		AssessmentRunNotificationSnsStatusCodeInternalError,
+	}
+}
 
 const (
 	// AssessmentRunStateCreated is a AssessmentRunState enum value
@@ -10425,10 +10470,36 @@ const (
 	AssessmentRunStateCanceled = "CANCELED"
 )
 
+// AssessmentRunState_Values returns all elements of the AssessmentRunState enum
+func AssessmentRunState_Values() []string {
+	return []string{
+		AssessmentRunStateCreated,
+		AssessmentRunStateStartDataCollectionPending,
+		AssessmentRunStateStartDataCollectionInProgress,
+		AssessmentRunStateCollectingData,
+		AssessmentRunStateStopDataCollectionPending,
+		AssessmentRunStateDataCollected,
+		AssessmentRunStateStartEvaluatingRulesPending,
+		AssessmentRunStateEvaluatingRules,
+		AssessmentRunStateFailed,
+		AssessmentRunStateError,
+		AssessmentRunStateCompleted,
+		AssessmentRunStateCompletedWithErrors,
+		AssessmentRunStateCanceled,
+	}
+}
+
 const (
 	// AssetTypeEc2Instance is a AssetType enum value
 	AssetTypeEc2Instance = "ec2-instance"
 )
+
+// AssetType_Values returns all elements of the AssetType enum
+func AssetType_Values() []string {
+	return []string{
+		AssetTypeEc2Instance,
+	}
+}
 
 const (
 	// EventAssessmentRunStarted is a Event enum value
@@ -10446,6 +10517,17 @@ const (
 	// EventOther is a Event enum value
 	EventOther = "OTHER"
 )
+
+// Event_Values returns all elements of the Event enum
+func Event_Values() []string {
+	return []string{
+		EventAssessmentRunStarted,
+		EventAssessmentRunCompleted,
+		EventAssessmentRunStateChanged,
+		EventFindingReported,
+		EventOther,
+	}
+}
 
 const (
 	// FailedItemErrorCodeInvalidArn is a FailedItemErrorCode enum value
@@ -10467,6 +10549,18 @@ const (
 	FailedItemErrorCodeInternalError = "INTERNAL_ERROR"
 )
 
+// FailedItemErrorCode_Values returns all elements of the FailedItemErrorCode enum
+func FailedItemErrorCode_Values() []string {
+	return []string{
+		FailedItemErrorCodeInvalidArn,
+		FailedItemErrorCodeDuplicateArn,
+		FailedItemErrorCodeItemDoesNotExist,
+		FailedItemErrorCodeAccessDenied,
+		FailedItemErrorCodeLimitExceeded,
+		FailedItemErrorCodeInternalError,
+	}
+}
+
 const (
 	// InvalidCrossAccountRoleErrorCodeRoleDoesNotExistOrInvalidTrustRelationship is a InvalidCrossAccountRoleErrorCode enum value
 	InvalidCrossAccountRoleErrorCodeRoleDoesNotExistOrInvalidTrustRelationship = "ROLE_DOES_NOT_EXIST_OR_INVALID_TRUST_RELATIONSHIP"
@@ -10474,6 +10568,14 @@ const (
 	// InvalidCrossAccountRoleErrorCodeRoleDoesNotHaveCorrectPolicy is a InvalidCrossAccountRoleErrorCode enum value
 	InvalidCrossAccountRoleErrorCodeRoleDoesNotHaveCorrectPolicy = "ROLE_DOES_NOT_HAVE_CORRECT_POLICY"
 )
+
+// InvalidCrossAccountRoleErrorCode_Values returns all elements of the InvalidCrossAccountRoleErrorCode enum
+func InvalidCrossAccountRoleErrorCode_Values() []string {
+	return []string{
+		InvalidCrossAccountRoleErrorCodeRoleDoesNotExistOrInvalidTrustRelationship,
+		InvalidCrossAccountRoleErrorCodeRoleDoesNotHaveCorrectPolicy,
+	}
+}
 
 const (
 	// InvalidInputErrorCodeInvalidAssessmentTargetArn is a InvalidInputErrorCode enum value
@@ -10639,6 +10741,66 @@ const (
 	InvalidInputErrorCodeInvalidNumberOfSeverities = "INVALID_NUMBER_OF_SEVERITIES"
 )
 
+// InvalidInputErrorCode_Values returns all elements of the InvalidInputErrorCode enum
+func InvalidInputErrorCode_Values() []string {
+	return []string{
+		InvalidInputErrorCodeInvalidAssessmentTargetArn,
+		InvalidInputErrorCodeInvalidAssessmentTemplateArn,
+		InvalidInputErrorCodeInvalidAssessmentRunArn,
+		InvalidInputErrorCodeInvalidFindingArn,
+		InvalidInputErrorCodeInvalidResourceGroupArn,
+		InvalidInputErrorCodeInvalidRulesPackageArn,
+		InvalidInputErrorCodeInvalidResourceArn,
+		InvalidInputErrorCodeInvalidSnsTopicArn,
+		InvalidInputErrorCodeInvalidIamRoleArn,
+		InvalidInputErrorCodeInvalidAssessmentTargetName,
+		InvalidInputErrorCodeInvalidAssessmentTargetNamePattern,
+		InvalidInputErrorCodeInvalidAssessmentTemplateName,
+		InvalidInputErrorCodeInvalidAssessmentTemplateNamePattern,
+		InvalidInputErrorCodeInvalidAssessmentTemplateDuration,
+		InvalidInputErrorCodeInvalidAssessmentTemplateDurationRange,
+		InvalidInputErrorCodeInvalidAssessmentRunDurationRange,
+		InvalidInputErrorCodeInvalidAssessmentRunStartTimeRange,
+		InvalidInputErrorCodeInvalidAssessmentRunCompletionTimeRange,
+		InvalidInputErrorCodeInvalidAssessmentRunStateChangeTimeRange,
+		InvalidInputErrorCodeInvalidAssessmentRunState,
+		InvalidInputErrorCodeInvalidTag,
+		InvalidInputErrorCodeInvalidTagKey,
+		InvalidInputErrorCodeInvalidTagValue,
+		InvalidInputErrorCodeInvalidResourceGroupTagKey,
+		InvalidInputErrorCodeInvalidResourceGroupTagValue,
+		InvalidInputErrorCodeInvalidAttribute,
+		InvalidInputErrorCodeInvalidUserAttribute,
+		InvalidInputErrorCodeInvalidUserAttributeKey,
+		InvalidInputErrorCodeInvalidUserAttributeValue,
+		InvalidInputErrorCodeInvalidPaginationToken,
+		InvalidInputErrorCodeInvalidMaxResults,
+		InvalidInputErrorCodeInvalidAgentId,
+		InvalidInputErrorCodeInvalidAutoScalingGroup,
+		InvalidInputErrorCodeInvalidRuleName,
+		InvalidInputErrorCodeInvalidSeverity,
+		InvalidInputErrorCodeInvalidLocale,
+		InvalidInputErrorCodeInvalidEvent,
+		InvalidInputErrorCodeAssessmentTargetNameAlreadyTaken,
+		InvalidInputErrorCodeAssessmentTemplateNameAlreadyTaken,
+		InvalidInputErrorCodeInvalidNumberOfAssessmentTargetArns,
+		InvalidInputErrorCodeInvalidNumberOfAssessmentTemplateArns,
+		InvalidInputErrorCodeInvalidNumberOfAssessmentRunArns,
+		InvalidInputErrorCodeInvalidNumberOfFindingArns,
+		InvalidInputErrorCodeInvalidNumberOfResourceGroupArns,
+		InvalidInputErrorCodeInvalidNumberOfRulesPackageArns,
+		InvalidInputErrorCodeInvalidNumberOfAssessmentRunStates,
+		InvalidInputErrorCodeInvalidNumberOfTags,
+		InvalidInputErrorCodeInvalidNumberOfResourceGroupTags,
+		InvalidInputErrorCodeInvalidNumberOfAttributes,
+		InvalidInputErrorCodeInvalidNumberOfUserAttributes,
+		InvalidInputErrorCodeInvalidNumberOfAgentIds,
+		InvalidInputErrorCodeInvalidNumberOfAutoScalingGroups,
+		InvalidInputErrorCodeInvalidNumberOfRuleNames,
+		InvalidInputErrorCodeInvalidNumberOfSeverities,
+	}
+}
+
 const (
 	// LimitExceededErrorCodeAssessmentTargetLimitExceeded is a LimitExceededErrorCode enum value
 	LimitExceededErrorCodeAssessmentTargetLimitExceeded = "ASSESSMENT_TARGET_LIMIT_EXCEEDED"
@@ -10656,10 +10818,28 @@ const (
 	LimitExceededErrorCodeEventSubscriptionLimitExceeded = "EVENT_SUBSCRIPTION_LIMIT_EXCEEDED"
 )
 
+// LimitExceededErrorCode_Values returns all elements of the LimitExceededErrorCode enum
+func LimitExceededErrorCode_Values() []string {
+	return []string{
+		LimitExceededErrorCodeAssessmentTargetLimitExceeded,
+		LimitExceededErrorCodeAssessmentTemplateLimitExceeded,
+		LimitExceededErrorCodeAssessmentRunLimitExceeded,
+		LimitExceededErrorCodeResourceGroupLimitExceeded,
+		LimitExceededErrorCodeEventSubscriptionLimitExceeded,
+	}
+}
+
 const (
 	// LocaleEnUs is a Locale enum value
 	LocaleEnUs = "EN_US"
 )
+
+// Locale_Values returns all elements of the Locale enum
+func Locale_Values() []string {
+	return []string{
+		LocaleEnUs,
+	}
+}
 
 const (
 	// NoSuchEntityErrorCodeAssessmentTargetDoesNotExist is a NoSuchEntityErrorCode enum value
@@ -10687,6 +10867,20 @@ const (
 	NoSuchEntityErrorCodeIamRoleDoesNotExist = "IAM_ROLE_DOES_NOT_EXIST"
 )
 
+// NoSuchEntityErrorCode_Values returns all elements of the NoSuchEntityErrorCode enum
+func NoSuchEntityErrorCode_Values() []string {
+	return []string{
+		NoSuchEntityErrorCodeAssessmentTargetDoesNotExist,
+		NoSuchEntityErrorCodeAssessmentTemplateDoesNotExist,
+		NoSuchEntityErrorCodeAssessmentRunDoesNotExist,
+		NoSuchEntityErrorCodeFindingDoesNotExist,
+		NoSuchEntityErrorCodeResourceGroupDoesNotExist,
+		NoSuchEntityErrorCodeRulesPackageDoesNotExist,
+		NoSuchEntityErrorCodeSnsTopicDoesNotExist,
+		NoSuchEntityErrorCodeIamRoleDoesNotExist,
+	}
+}
+
 const (
 	// PreviewStatusWorkInProgress is a PreviewStatus enum value
 	PreviewStatusWorkInProgress = "WORK_IN_PROGRESS"
@@ -10695,6 +10889,14 @@ const (
 	PreviewStatusCompleted = "COMPLETED"
 )
 
+// PreviewStatus_Values returns all elements of the PreviewStatus enum
+func PreviewStatus_Values() []string {
+	return []string{
+		PreviewStatusWorkInProgress,
+		PreviewStatusCompleted,
+	}
+}
+
 const (
 	// ReportFileFormatHtml is a ReportFileFormat enum value
 	ReportFileFormatHtml = "HTML"
@@ -10702,6 +10904,14 @@ const (
 	// ReportFileFormatPdf is a ReportFileFormat enum value
 	ReportFileFormatPdf = "PDF"
 )
+
+// ReportFileFormat_Values returns all elements of the ReportFileFormat enum
+func ReportFileFormat_Values() []string {
+	return []string{
+		ReportFileFormatHtml,
+		ReportFileFormatPdf,
+	}
+}
 
 const (
 	// ReportStatusWorkInProgress is a ReportStatus enum value
@@ -10714,6 +10924,15 @@ const (
 	ReportStatusCompleted = "COMPLETED"
 )
 
+// ReportStatus_Values returns all elements of the ReportStatus enum
+func ReportStatus_Values() []string {
+	return []string{
+		ReportStatusWorkInProgress,
+		ReportStatusFailed,
+		ReportStatusCompleted,
+	}
+}
+
 const (
 	// ReportTypeFinding is a ReportType enum value
 	ReportTypeFinding = "FINDING"
@@ -10722,6 +10941,14 @@ const (
 	ReportTypeFull = "FULL"
 )
 
+// ReportType_Values returns all elements of the ReportType enum
+func ReportType_Values() []string {
+	return []string{
+		ReportTypeFinding,
+		ReportTypeFull,
+	}
+}
+
 const (
 	// ScopeTypeInstanceId is a ScopeType enum value
 	ScopeTypeInstanceId = "INSTANCE_ID"
@@ -10729,6 +10956,14 @@ const (
 	// ScopeTypeRulesPackageArn is a ScopeType enum value
 	ScopeTypeRulesPackageArn = "RULES_PACKAGE_ARN"
 )
+
+// ScopeType_Values returns all elements of the ScopeType enum
+func ScopeType_Values() []string {
+	return []string{
+		ScopeTypeInstanceId,
+		ScopeTypeRulesPackageArn,
+	}
+}
 
 const (
 	// SeverityLow is a Severity enum value
@@ -10747,6 +10982,17 @@ const (
 	SeverityUndefined = "Undefined"
 )
 
+// Severity_Values returns all elements of the Severity enum
+func Severity_Values() []string {
+	return []string{
+		SeverityLow,
+		SeverityMedium,
+		SeverityHigh,
+		SeverityInformational,
+		SeverityUndefined,
+	}
+}
+
 const (
 	// StopActionStartEvaluation is a StopAction enum value
 	StopActionStartEvaluation = "START_EVALUATION"
@@ -10754,3 +11000,11 @@ const (
 	// StopActionSkipEvaluation is a StopAction enum value
 	StopActionSkipEvaluation = "SKIP_EVALUATION"
 )
+
+// StopAction_Values returns all elements of the StopAction enum
+func StopAction_Values() []string {
+	return []string{
+		StopActionStartEvaluation,
+		StopActionSkipEvaluation,
+	}
+}

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -49752,6 +49752,13 @@ const (
 	AbortActionCancel = "CANCEL"
 )
 
+// AbortAction_Values returns all elements of the AbortAction enum
+func AbortAction_Values() []string {
+	return []string{
+		AbortActionCancel,
+	}
+}
+
 const (
 	// ActionTypePublish is a ActionType enum value
 	ActionTypePublish = "PUBLISH"
@@ -49766,11 +49773,28 @@ const (
 	ActionTypeConnect = "CONNECT"
 )
 
+// ActionType_Values returns all elements of the ActionType enum
+func ActionType_Values() []string {
+	return []string{
+		ActionTypePublish,
+		ActionTypeSubscribe,
+		ActionTypeReceive,
+		ActionTypeConnect,
+	}
+}
+
 // The type of alert target: one of "SNS".
 const (
 	// AlertTargetTypeSns is a AlertTargetType enum value
 	AlertTargetTypeSns = "SNS"
 )
+
+// AlertTargetType_Values returns all elements of the AlertTargetType enum
+func AlertTargetType_Values() []string {
+	return []string{
+		AlertTargetTypeSns,
+	}
+}
 
 const (
 	// AuditCheckRunStatusInProgress is a AuditCheckRunStatus enum value
@@ -49792,6 +49816,18 @@ const (
 	AuditCheckRunStatusFailed = "FAILED"
 )
 
+// AuditCheckRunStatus_Values returns all elements of the AuditCheckRunStatus enum
+func AuditCheckRunStatus_Values() []string {
+	return []string{
+		AuditCheckRunStatusInProgress,
+		AuditCheckRunStatusWaitingForDataCollection,
+		AuditCheckRunStatusCanceled,
+		AuditCheckRunStatusCompletedCompliant,
+		AuditCheckRunStatusCompletedNonCompliant,
+		AuditCheckRunStatusFailed,
+	}
+}
+
 const (
 	// AuditFindingSeverityCritical is a AuditFindingSeverity enum value
 	AuditFindingSeverityCritical = "CRITICAL"
@@ -49806,6 +49842,16 @@ const (
 	AuditFindingSeverityLow = "LOW"
 )
 
+// AuditFindingSeverity_Values returns all elements of the AuditFindingSeverity enum
+func AuditFindingSeverity_Values() []string {
+	return []string{
+		AuditFindingSeverityCritical,
+		AuditFindingSeverityHigh,
+		AuditFindingSeverityMedium,
+		AuditFindingSeverityLow,
+	}
+}
+
 const (
 	// AuditFrequencyDaily is a AuditFrequency enum value
 	AuditFrequencyDaily = "DAILY"
@@ -49819,6 +49865,16 @@ const (
 	// AuditFrequencyMonthly is a AuditFrequency enum value
 	AuditFrequencyMonthly = "MONTHLY"
 )
+
+// AuditFrequency_Values returns all elements of the AuditFrequency enum
+func AuditFrequency_Values() []string {
+	return []string{
+		AuditFrequencyDaily,
+		AuditFrequencyWeekly,
+		AuditFrequencyBiweekly,
+		AuditFrequencyMonthly,
+	}
+}
 
 const (
 	// AuditMitigationActionsExecutionStatusInProgress is a AuditMitigationActionsExecutionStatus enum value
@@ -49840,6 +49896,18 @@ const (
 	AuditMitigationActionsExecutionStatusPending = "PENDING"
 )
 
+// AuditMitigationActionsExecutionStatus_Values returns all elements of the AuditMitigationActionsExecutionStatus enum
+func AuditMitigationActionsExecutionStatus_Values() []string {
+	return []string{
+		AuditMitigationActionsExecutionStatusInProgress,
+		AuditMitigationActionsExecutionStatusCompleted,
+		AuditMitigationActionsExecutionStatusFailed,
+		AuditMitigationActionsExecutionStatusCanceled,
+		AuditMitigationActionsExecutionStatusSkipped,
+		AuditMitigationActionsExecutionStatusPending,
+	}
+}
+
 const (
 	// AuditMitigationActionsTaskStatusInProgress is a AuditMitigationActionsTaskStatus enum value
 	AuditMitigationActionsTaskStatusInProgress = "IN_PROGRESS"
@@ -49854,10 +49922,27 @@ const (
 	AuditMitigationActionsTaskStatusCanceled = "CANCELED"
 )
 
+// AuditMitigationActionsTaskStatus_Values returns all elements of the AuditMitigationActionsTaskStatus enum
+func AuditMitigationActionsTaskStatus_Values() []string {
+	return []string{
+		AuditMitigationActionsTaskStatusInProgress,
+		AuditMitigationActionsTaskStatusCompleted,
+		AuditMitigationActionsTaskStatusFailed,
+		AuditMitigationActionsTaskStatusCanceled,
+	}
+}
+
 const (
 	// AuditNotificationTypeSns is a AuditNotificationType enum value
 	AuditNotificationTypeSns = "SNS"
 )
+
+// AuditNotificationType_Values returns all elements of the AuditNotificationType enum
+func AuditNotificationType_Values() []string {
+	return []string{
+		AuditNotificationTypeSns,
+	}
+}
 
 const (
 	// AuditTaskStatusInProgress is a AuditTaskStatus enum value
@@ -49873,6 +49958,16 @@ const (
 	AuditTaskStatusCanceled = "CANCELED"
 )
 
+// AuditTaskStatus_Values returns all elements of the AuditTaskStatus enum
+func AuditTaskStatus_Values() []string {
+	return []string{
+		AuditTaskStatusInProgress,
+		AuditTaskStatusCompleted,
+		AuditTaskStatusFailed,
+		AuditTaskStatusCanceled,
+	}
+}
+
 const (
 	// AuditTaskTypeOnDemandAuditTask is a AuditTaskType enum value
 	AuditTaskTypeOnDemandAuditTask = "ON_DEMAND_AUDIT_TASK"
@@ -49880,6 +49975,14 @@ const (
 	// AuditTaskTypeScheduledAuditTask is a AuditTaskType enum value
 	AuditTaskTypeScheduledAuditTask = "SCHEDULED_AUDIT_TASK"
 )
+
+// AuditTaskType_Values returns all elements of the AuditTaskType enum
+func AuditTaskType_Values() []string {
+	return []string{
+		AuditTaskTypeOnDemandAuditTask,
+		AuditTaskTypeScheduledAuditTask,
+	}
+}
 
 const (
 	// AuthDecisionAllowed is a AuthDecision enum value
@@ -49892,6 +49995,15 @@ const (
 	AuthDecisionImplicitDeny = "IMPLICIT_DENY"
 )
 
+// AuthDecision_Values returns all elements of the AuthDecision enum
+func AuthDecision_Values() []string {
+	return []string{
+		AuthDecisionAllowed,
+		AuthDecisionExplicitDeny,
+		AuthDecisionImplicitDeny,
+	}
+}
+
 const (
 	// AuthorizerStatusActive is a AuthorizerStatus enum value
 	AuthorizerStatusActive = "ACTIVE"
@@ -49899,6 +50011,14 @@ const (
 	// AuthorizerStatusInactive is a AuthorizerStatus enum value
 	AuthorizerStatusInactive = "INACTIVE"
 )
+
+// AuthorizerStatus_Values returns all elements of the AuthorizerStatus enum
+func AuthorizerStatus_Values() []string {
+	return []string{
+		AuthorizerStatusActive,
+		AuthorizerStatusInactive,
+	}
+}
 
 const (
 	// AutoRegistrationStatusEnable is a AutoRegistrationStatus enum value
@@ -49908,10 +50028,25 @@ const (
 	AutoRegistrationStatusDisable = "DISABLE"
 )
 
+// AutoRegistrationStatus_Values returns all elements of the AutoRegistrationStatus enum
+func AutoRegistrationStatus_Values() []string {
+	return []string{
+		AutoRegistrationStatusEnable,
+		AutoRegistrationStatusDisable,
+	}
+}
+
 const (
 	// AwsJobAbortCriteriaAbortActionCancel is a AwsJobAbortCriteriaAbortAction enum value
 	AwsJobAbortCriteriaAbortActionCancel = "CANCEL"
 )
+
+// AwsJobAbortCriteriaAbortAction_Values returns all elements of the AwsJobAbortCriteriaAbortAction enum
+func AwsJobAbortCriteriaAbortAction_Values() []string {
+	return []string{
+		AwsJobAbortCriteriaAbortActionCancel,
+	}
+}
 
 const (
 	// AwsJobAbortCriteriaFailureTypeFailed is a AwsJobAbortCriteriaFailureType enum value
@@ -49927,6 +50062,16 @@ const (
 	AwsJobAbortCriteriaFailureTypeAll = "ALL"
 )
 
+// AwsJobAbortCriteriaFailureType_Values returns all elements of the AwsJobAbortCriteriaFailureType enum
+func AwsJobAbortCriteriaFailureType_Values() []string {
+	return []string{
+		AwsJobAbortCriteriaFailureTypeFailed,
+		AwsJobAbortCriteriaFailureTypeRejected,
+		AwsJobAbortCriteriaFailureTypeTimedOut,
+		AwsJobAbortCriteriaFailureTypeAll,
+	}
+}
+
 const (
 	// CACertificateStatusActive is a CACertificateStatus enum value
 	CACertificateStatusActive = "ACTIVE"
@@ -49935,10 +50080,25 @@ const (
 	CACertificateStatusInactive = "INACTIVE"
 )
 
+// CACertificateStatus_Values returns all elements of the CACertificateStatus enum
+func CACertificateStatus_Values() []string {
+	return []string{
+		CACertificateStatusActive,
+		CACertificateStatusInactive,
+	}
+}
+
 const (
 	// CACertificateUpdateActionDeactivate is a CACertificateUpdateAction enum value
 	CACertificateUpdateActionDeactivate = "DEACTIVATE"
 )
+
+// CACertificateUpdateAction_Values returns all elements of the CACertificateUpdateAction enum
+func CACertificateUpdateAction_Values() []string {
+	return []string{
+		CACertificateUpdateActionDeactivate,
+	}
+}
 
 const (
 	// CannedAccessControlListPrivate is a CannedAccessControlList enum value
@@ -49966,6 +50126,20 @@ const (
 	CannedAccessControlListLogDeliveryWrite = "log-delivery-write"
 )
 
+// CannedAccessControlList_Values returns all elements of the CannedAccessControlList enum
+func CannedAccessControlList_Values() []string {
+	return []string{
+		CannedAccessControlListPrivate,
+		CannedAccessControlListPublicRead,
+		CannedAccessControlListPublicReadWrite,
+		CannedAccessControlListAwsExecRead,
+		CannedAccessControlListAuthenticatedRead,
+		CannedAccessControlListBucketOwnerRead,
+		CannedAccessControlListBucketOwnerFullControl,
+		CannedAccessControlListLogDeliveryWrite,
+	}
+}
+
 const (
 	// CertificateModeDefault is a CertificateMode enum value
 	CertificateModeDefault = "DEFAULT"
@@ -49973,6 +50147,14 @@ const (
 	// CertificateModeSniOnly is a CertificateMode enum value
 	CertificateModeSniOnly = "SNI_ONLY"
 )
+
+// CertificateMode_Values returns all elements of the CertificateMode enum
+func CertificateMode_Values() []string {
+	return []string{
+		CertificateModeDefault,
+		CertificateModeSniOnly,
+	}
+}
 
 const (
 	// CertificateStatusActive is a CertificateStatus enum value
@@ -49993,6 +50175,18 @@ const (
 	// CertificateStatusPendingActivation is a CertificateStatus enum value
 	CertificateStatusPendingActivation = "PENDING_ACTIVATION"
 )
+
+// CertificateStatus_Values returns all elements of the CertificateStatus enum
+func CertificateStatus_Values() []string {
+	return []string{
+		CertificateStatusActive,
+		CertificateStatusInactive,
+		CertificateStatusRevoked,
+		CertificateStatusPendingTransfer,
+		CertificateStatusRegisterInactive,
+		CertificateStatusPendingActivation,
+	}
+}
 
 const (
 	// ComparisonOperatorLessThan is a ComparisonOperator enum value
@@ -50020,6 +50214,20 @@ const (
 	ComparisonOperatorNotInPortSet = "not-in-port-set"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorLessThan,
+		ComparisonOperatorLessThanEquals,
+		ComparisonOperatorGreaterThan,
+		ComparisonOperatorGreaterThanEquals,
+		ComparisonOperatorInCidrSet,
+		ComparisonOperatorNotInCidrSet,
+		ComparisonOperatorInPortSet,
+		ComparisonOperatorNotInPortSet,
+	}
+}
+
 const (
 	// DayOfWeekSun is a DayOfWeek enum value
 	DayOfWeekSun = "SUN"
@@ -50043,15 +50251,42 @@ const (
 	DayOfWeekSat = "SAT"
 )
 
+// DayOfWeek_Values returns all elements of the DayOfWeek enum
+func DayOfWeek_Values() []string {
+	return []string{
+		DayOfWeekSun,
+		DayOfWeekMon,
+		DayOfWeekTue,
+		DayOfWeekWed,
+		DayOfWeekThu,
+		DayOfWeekFri,
+		DayOfWeekSat,
+	}
+}
+
 const (
 	// DeviceCertificateUpdateActionDeactivate is a DeviceCertificateUpdateAction enum value
 	DeviceCertificateUpdateActionDeactivate = "DEACTIVATE"
 )
 
+// DeviceCertificateUpdateAction_Values returns all elements of the DeviceCertificateUpdateAction enum
+func DeviceCertificateUpdateAction_Values() []string {
+	return []string{
+		DeviceCertificateUpdateActionDeactivate,
+	}
+}
+
 const (
 	// DimensionTypeTopicFilter is a DimensionType enum value
 	DimensionTypeTopicFilter = "TOPIC_FILTER"
 )
+
+// DimensionType_Values returns all elements of the DimensionType enum
+func DimensionType_Values() []string {
+	return []string{
+		DimensionTypeTopicFilter,
+	}
+}
 
 const (
 	// DimensionValueOperatorIn is a DimensionValueOperator enum value
@@ -50061,6 +50296,14 @@ const (
 	DimensionValueOperatorNotIn = "NOT_IN"
 )
 
+// DimensionValueOperator_Values returns all elements of the DimensionValueOperator enum
+func DimensionValueOperator_Values() []string {
+	return []string{
+		DimensionValueOperatorIn,
+		DimensionValueOperatorNotIn,
+	}
+}
+
 const (
 	// DomainConfigurationStatusEnabled is a DomainConfigurationStatus enum value
 	DomainConfigurationStatusEnabled = "ENABLED"
@@ -50068,6 +50311,14 @@ const (
 	// DomainConfigurationStatusDisabled is a DomainConfigurationStatus enum value
 	DomainConfigurationStatusDisabled = "DISABLED"
 )
+
+// DomainConfigurationStatus_Values returns all elements of the DomainConfigurationStatus enum
+func DomainConfigurationStatus_Values() []string {
+	return []string{
+		DomainConfigurationStatusEnabled,
+		DomainConfigurationStatusDisabled,
+	}
+}
 
 const (
 	// DomainTypeEndpoint is a DomainType enum value
@@ -50080,6 +50331,15 @@ const (
 	DomainTypeCustomerManaged = "CUSTOMER_MANAGED"
 )
 
+// DomainType_Values returns all elements of the DomainType enum
+func DomainType_Values() []string {
+	return []string{
+		DomainTypeEndpoint,
+		DomainTypeAwsManaged,
+		DomainTypeCustomerManaged,
+	}
+}
+
 const (
 	// DynamicGroupStatusActive is a DynamicGroupStatus enum value
 	DynamicGroupStatusActive = "ACTIVE"
@@ -50091,6 +50351,15 @@ const (
 	DynamicGroupStatusRebuilding = "REBUILDING"
 )
 
+// DynamicGroupStatus_Values returns all elements of the DynamicGroupStatus enum
+func DynamicGroupStatus_Values() []string {
+	return []string{
+		DynamicGroupStatusActive,
+		DynamicGroupStatusBuilding,
+		DynamicGroupStatusRebuilding,
+	}
+}
+
 const (
 	// DynamoKeyTypeString is a DynamoKeyType enum value
 	DynamoKeyTypeString = "STRING"
@@ -50098,6 +50367,14 @@ const (
 	// DynamoKeyTypeNumber is a DynamoKeyType enum value
 	DynamoKeyTypeNumber = "NUMBER"
 )
+
+// DynamoKeyType_Values returns all elements of the DynamoKeyType enum
+func DynamoKeyType_Values() []string {
+	return []string{
+		DynamoKeyTypeString,
+		DynamoKeyTypeNumber,
+	}
+}
 
 const (
 	// EventTypeThing is a EventType enum value
@@ -50134,6 +50411,23 @@ const (
 	EventTypeCaCertificate = "CA_CERTIFICATE"
 )
 
+// EventType_Values returns all elements of the EventType enum
+func EventType_Values() []string {
+	return []string{
+		EventTypeThing,
+		EventTypeThingGroup,
+		EventTypeThingType,
+		EventTypeThingGroupMembership,
+		EventTypeThingGroupHierarchy,
+		EventTypeThingTypeAssociation,
+		EventTypeJob,
+		EventTypeJobExecution,
+		EventTypePolicy,
+		EventTypeCertificate,
+		EventTypeCaCertificate,
+	}
+}
+
 const (
 	// FieldTypeNumber is a FieldType enum value
 	FieldTypeNumber = "Number"
@@ -50145,6 +50439,15 @@ const (
 	FieldTypeBoolean = "Boolean"
 )
 
+// FieldType_Values returns all elements of the FieldType enum
+func FieldType_Values() []string {
+	return []string{
+		FieldTypeNumber,
+		FieldTypeString,
+		FieldTypeBoolean,
+	}
+}
+
 const (
 	// IndexStatusActive is a IndexStatus enum value
 	IndexStatusActive = "ACTIVE"
@@ -50155,6 +50458,15 @@ const (
 	// IndexStatusRebuilding is a IndexStatus enum value
 	IndexStatusRebuilding = "REBUILDING"
 )
+
+// IndexStatus_Values returns all elements of the IndexStatus enum
+func IndexStatus_Values() []string {
+	return []string{
+		IndexStatusActive,
+		IndexStatusBuilding,
+		IndexStatusRebuilding,
+	}
+}
 
 const (
 	// JobExecutionFailureTypeFailed is a JobExecutionFailureType enum value
@@ -50169,6 +50481,16 @@ const (
 	// JobExecutionFailureTypeAll is a JobExecutionFailureType enum value
 	JobExecutionFailureTypeAll = "ALL"
 )
+
+// JobExecutionFailureType_Values returns all elements of the JobExecutionFailureType enum
+func JobExecutionFailureType_Values() []string {
+	return []string{
+		JobExecutionFailureTypeFailed,
+		JobExecutionFailureTypeRejected,
+		JobExecutionFailureTypeTimedOut,
+		JobExecutionFailureTypeAll,
+	}
+}
 
 const (
 	// JobExecutionStatusQueued is a JobExecutionStatus enum value
@@ -50196,6 +50518,20 @@ const (
 	JobExecutionStatusCanceled = "CANCELED"
 )
 
+// JobExecutionStatus_Values returns all elements of the JobExecutionStatus enum
+func JobExecutionStatus_Values() []string {
+	return []string{
+		JobExecutionStatusQueued,
+		JobExecutionStatusInProgress,
+		JobExecutionStatusSucceeded,
+		JobExecutionStatusFailed,
+		JobExecutionStatusTimedOut,
+		JobExecutionStatusRejected,
+		JobExecutionStatusRemoved,
+		JobExecutionStatusCanceled,
+	}
+}
+
 const (
 	// JobStatusInProgress is a JobStatus enum value
 	JobStatusInProgress = "IN_PROGRESS"
@@ -50209,6 +50545,16 @@ const (
 	// JobStatusDeletionInProgress is a JobStatus enum value
 	JobStatusDeletionInProgress = "DELETION_IN_PROGRESS"
 )
+
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusInProgress,
+		JobStatusCanceled,
+		JobStatusCompleted,
+		JobStatusDeletionInProgress,
+	}
+}
 
 const (
 	// LogLevelDebug is a LogLevel enum value
@@ -50227,6 +50573,17 @@ const (
 	LogLevelDisabled = "DISABLED"
 )
 
+// LogLevel_Values returns all elements of the LogLevel enum
+func LogLevel_Values() []string {
+	return []string{
+		LogLevelDebug,
+		LogLevelInfo,
+		LogLevelError,
+		LogLevelWarn,
+		LogLevelDisabled,
+	}
+}
+
 const (
 	// LogTargetTypeDefault is a LogTargetType enum value
 	LogTargetTypeDefault = "DEFAULT"
@@ -50235,6 +50592,14 @@ const (
 	LogTargetTypeThingGroup = "THING_GROUP"
 )
 
+// LogTargetType_Values returns all elements of the LogTargetType enum
+func LogTargetType_Values() []string {
+	return []string{
+		LogTargetTypeDefault,
+		LogTargetTypeThingGroup,
+	}
+}
+
 const (
 	// MessageFormatRaw is a MessageFormat enum value
 	MessageFormatRaw = "RAW"
@@ -50242,6 +50607,14 @@ const (
 	// MessageFormatJson is a MessageFormat enum value
 	MessageFormatJson = "JSON"
 )
+
+// MessageFormat_Values returns all elements of the MessageFormat enum
+func MessageFormat_Values() []string {
+	return []string{
+		MessageFormatRaw,
+		MessageFormatJson,
+	}
+}
 
 const (
 	// MitigationActionTypeUpdateDeviceCertificate is a MitigationActionType enum value
@@ -50263,6 +50636,18 @@ const (
 	MitigationActionTypePublishFindingToSns = "PUBLISH_FINDING_TO_SNS"
 )
 
+// MitigationActionType_Values returns all elements of the MitigationActionType enum
+func MitigationActionType_Values() []string {
+	return []string{
+		MitigationActionTypeUpdateDeviceCertificate,
+		MitigationActionTypeUpdateCaCertificate,
+		MitigationActionTypeAddThingsToThingGroup,
+		MitigationActionTypeReplaceDefaultPolicyVersion,
+		MitigationActionTypeEnableIotLogging,
+		MitigationActionTypePublishFindingToSns,
+	}
+}
+
 const (
 	// OTAUpdateStatusCreatePending is a OTAUpdateStatus enum value
 	OTAUpdateStatusCreatePending = "CREATE_PENDING"
@@ -50277,10 +50662,27 @@ const (
 	OTAUpdateStatusCreateFailed = "CREATE_FAILED"
 )
 
+// OTAUpdateStatus_Values returns all elements of the OTAUpdateStatus enum
+func OTAUpdateStatus_Values() []string {
+	return []string{
+		OTAUpdateStatusCreatePending,
+		OTAUpdateStatusCreateInProgress,
+		OTAUpdateStatusCreateComplete,
+		OTAUpdateStatusCreateFailed,
+	}
+}
+
 const (
 	// PolicyTemplateNameBlankPolicy is a PolicyTemplateName enum value
 	PolicyTemplateNameBlankPolicy = "BLANK_POLICY"
 )
+
+// PolicyTemplateName_Values returns all elements of the PolicyTemplateName enum
+func PolicyTemplateName_Values() []string {
+	return []string{
+		PolicyTemplateNameBlankPolicy,
+	}
+}
 
 const (
 	// ProtocolMqtt is a Protocol enum value
@@ -50290,6 +50692,14 @@ const (
 	ProtocolHttp = "HTTP"
 )
 
+// Protocol_Values returns all elements of the Protocol enum
+func Protocol_Values() []string {
+	return []string{
+		ProtocolMqtt,
+		ProtocolHttp,
+	}
+}
+
 const (
 	// ReportTypeErrors is a ReportType enum value
 	ReportTypeErrors = "ERRORS"
@@ -50297,6 +50707,14 @@ const (
 	// ReportTypeResults is a ReportType enum value
 	ReportTypeResults = "RESULTS"
 )
+
+// ReportType_Values returns all elements of the ReportType enum
+func ReportType_Values() []string {
+	return []string{
+		ReportTypeErrors,
+		ReportTypeResults,
+	}
+}
 
 const (
 	// ResourceTypeDeviceCertificate is a ResourceType enum value
@@ -50324,6 +50742,20 @@ const (
 	ResourceTypeIamRole = "IAM_ROLE"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeDeviceCertificate,
+		ResourceTypeCaCertificate,
+		ResourceTypeIotPolicy,
+		ResourceTypeCognitoIdentityPool,
+		ResourceTypeClientId,
+		ResourceTypeAccountSettings,
+		ResourceTypeRoleAlias,
+		ResourceTypeIamRole,
+	}
+}
+
 const (
 	// ServerCertificateStatusInvalid is a ServerCertificateStatus enum value
 	ServerCertificateStatusInvalid = "INVALID"
@@ -50331,6 +50763,14 @@ const (
 	// ServerCertificateStatusValid is a ServerCertificateStatus enum value
 	ServerCertificateStatusValid = "VALID"
 )
+
+// ServerCertificateStatus_Values returns all elements of the ServerCertificateStatus enum
+func ServerCertificateStatus_Values() []string {
+	return []string{
+		ServerCertificateStatusInvalid,
+		ServerCertificateStatusValid,
+	}
+}
 
 const (
 	// ServiceTypeData is a ServiceType enum value
@@ -50342,6 +50782,15 @@ const (
 	// ServiceTypeJobs is a ServiceType enum value
 	ServiceTypeJobs = "JOBS"
 )
+
+// ServiceType_Values returns all elements of the ServiceType enum
+func ServiceType_Values() []string {
+	return []string{
+		ServiceTypeData,
+		ServiceTypeCredentialProvider,
+		ServiceTypeJobs,
+	}
+}
 
 const (
 	// StatusInProgress is a Status enum value
@@ -50360,6 +50809,17 @@ const (
 	StatusCancelling = "Cancelling"
 )
 
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusInProgress,
+		StatusCompleted,
+		StatusFailed,
+		StatusCancelled,
+		StatusCancelling,
+	}
+}
+
 const (
 	// TargetSelectionContinuous is a TargetSelection enum value
 	TargetSelectionContinuous = "CONTINUOUS"
@@ -50367,6 +50827,14 @@ const (
 	// TargetSelectionSnapshot is a TargetSelection enum value
 	TargetSelectionSnapshot = "SNAPSHOT"
 )
+
+// TargetSelection_Values returns all elements of the TargetSelection enum
+func TargetSelection_Values() []string {
+	return []string{
+		TargetSelectionContinuous,
+		TargetSelectionSnapshot,
+	}
+}
 
 const (
 	// ThingConnectivityIndexingModeOff is a ThingConnectivityIndexingMode enum value
@@ -50376,6 +50844,14 @@ const (
 	ThingConnectivityIndexingModeStatus = "STATUS"
 )
 
+// ThingConnectivityIndexingMode_Values returns all elements of the ThingConnectivityIndexingMode enum
+func ThingConnectivityIndexingMode_Values() []string {
+	return []string{
+		ThingConnectivityIndexingModeOff,
+		ThingConnectivityIndexingModeStatus,
+	}
+}
+
 const (
 	// ThingGroupIndexingModeOff is a ThingGroupIndexingMode enum value
 	ThingGroupIndexingModeOff = "OFF"
@@ -50383,6 +50859,14 @@ const (
 	// ThingGroupIndexingModeOn is a ThingGroupIndexingMode enum value
 	ThingGroupIndexingModeOn = "ON"
 )
+
+// ThingGroupIndexingMode_Values returns all elements of the ThingGroupIndexingMode enum
+func ThingGroupIndexingMode_Values() []string {
+	return []string{
+		ThingGroupIndexingModeOff,
+		ThingGroupIndexingModeOn,
+	}
+}
 
 const (
 	// ThingIndexingModeOff is a ThingIndexingMode enum value
@@ -50394,6 +50878,15 @@ const (
 	// ThingIndexingModeRegistryAndShadow is a ThingIndexingMode enum value
 	ThingIndexingModeRegistryAndShadow = "REGISTRY_AND_SHADOW"
 )
+
+// ThingIndexingMode_Values returns all elements of the ThingIndexingMode enum
+func ThingIndexingMode_Values() []string {
+	return []string{
+		ThingIndexingModeOff,
+		ThingIndexingModeRegistry,
+		ThingIndexingModeRegistryAndShadow,
+	}
+}
 
 const (
 	// TopicRuleDestinationStatusEnabled is a TopicRuleDestinationStatus enum value
@@ -50409,6 +50902,16 @@ const (
 	TopicRuleDestinationStatusError = "ERROR"
 )
 
+// TopicRuleDestinationStatus_Values returns all elements of the TopicRuleDestinationStatus enum
+func TopicRuleDestinationStatus_Values() []string {
+	return []string{
+		TopicRuleDestinationStatusEnabled,
+		TopicRuleDestinationStatusInProgress,
+		TopicRuleDestinationStatusDisabled,
+		TopicRuleDestinationStatusError,
+	}
+}
+
 const (
 	// ViolationEventTypeInAlarm is a ViolationEventType enum value
 	ViolationEventTypeInAlarm = "in-alarm"
@@ -50419,3 +50922,12 @@ const (
 	// ViolationEventTypeAlarmInvalidated is a ViolationEventType enum value
 	ViolationEventTypeAlarmInvalidated = "alarm-invalidated"
 )
+
+// ViolationEventType_Values returns all elements of the ViolationEventType enum
+func ViolationEventType_Values() []string {
+	return []string{
+		ViolationEventTypeInAlarm,
+		ViolationEventTypeAlarmCleared,
+		ViolationEventTypeAlarmInvalidated,
+	}
+}

--- a/service/iotanalytics/api.go
+++ b/service/iotanalytics/api.go
@@ -10521,6 +10521,15 @@ const (
 	ChannelStatusDeleting = "DELETING"
 )
 
+// ChannelStatus_Values returns all elements of the ChannelStatus enum
+func ChannelStatus_Values() []string {
+	return []string{
+		ChannelStatusCreating,
+		ChannelStatusActive,
+		ChannelStatusDeleting,
+	}
+}
+
 const (
 	// ComputeTypeAcu1 is a ComputeType enum value
 	ComputeTypeAcu1 = "ACU_1"
@@ -10529,6 +10538,14 @@ const (
 	ComputeTypeAcu2 = "ACU_2"
 )
 
+// ComputeType_Values returns all elements of the ComputeType enum
+func ComputeType_Values() []string {
+	return []string{
+		ComputeTypeAcu1,
+		ComputeTypeAcu2,
+	}
+}
+
 const (
 	// DatasetActionTypeQuery is a DatasetActionType enum value
 	DatasetActionTypeQuery = "QUERY"
@@ -10536,6 +10553,14 @@ const (
 	// DatasetActionTypeContainer is a DatasetActionType enum value
 	DatasetActionTypeContainer = "CONTAINER"
 )
+
+// DatasetActionType_Values returns all elements of the DatasetActionType enum
+func DatasetActionType_Values() []string {
+	return []string{
+		DatasetActionTypeQuery,
+		DatasetActionTypeContainer,
+	}
+}
 
 const (
 	// DatasetContentStateCreating is a DatasetContentState enum value
@@ -10548,6 +10573,15 @@ const (
 	DatasetContentStateFailed = "FAILED"
 )
 
+// DatasetContentState_Values returns all elements of the DatasetContentState enum
+func DatasetContentState_Values() []string {
+	return []string{
+		DatasetContentStateCreating,
+		DatasetContentStateSucceeded,
+		DatasetContentStateFailed,
+	}
+}
+
 const (
 	// DatasetStatusCreating is a DatasetStatus enum value
 	DatasetStatusCreating = "CREATING"
@@ -10558,6 +10592,15 @@ const (
 	// DatasetStatusDeleting is a DatasetStatus enum value
 	DatasetStatusDeleting = "DELETING"
 )
+
+// DatasetStatus_Values returns all elements of the DatasetStatus enum
+func DatasetStatus_Values() []string {
+	return []string{
+		DatasetStatusCreating,
+		DatasetStatusActive,
+		DatasetStatusDeleting,
+	}
+}
 
 const (
 	// DatastoreStatusCreating is a DatastoreStatus enum value
@@ -10570,10 +10613,26 @@ const (
 	DatastoreStatusDeleting = "DELETING"
 )
 
+// DatastoreStatus_Values returns all elements of the DatastoreStatus enum
+func DatastoreStatus_Values() []string {
+	return []string{
+		DatastoreStatusCreating,
+		DatastoreStatusActive,
+		DatastoreStatusDeleting,
+	}
+}
+
 const (
 	// LoggingLevelError is a LoggingLevel enum value
 	LoggingLevelError = "ERROR"
 )
+
+// LoggingLevel_Values returns all elements of the LoggingLevel enum
+func LoggingLevel_Values() []string {
+	return []string{
+		LoggingLevelError,
+	}
+}
 
 const (
 	// ReprocessingStatusRunning is a ReprocessingStatus enum value
@@ -10588,3 +10647,13 @@ const (
 	// ReprocessingStatusFailed is a ReprocessingStatus enum value
 	ReprocessingStatusFailed = "FAILED"
 )
+
+// ReprocessingStatus_Values returns all elements of the ReprocessingStatus enum
+func ReprocessingStatus_Values() []string {
+	return []string{
+		ReprocessingStatusRunning,
+		ReprocessingStatusSucceeded,
+		ReprocessingStatusCancelled,
+		ReprocessingStatusFailed,
+	}
+}

--- a/service/iotevents/api.go
+++ b/service/iotevents/api.go
@@ -6010,6 +6010,19 @@ const (
 	DetectorModelVersionStatusFailed = "FAILED"
 )
 
+// DetectorModelVersionStatus_Values returns all elements of the DetectorModelVersionStatus enum
+func DetectorModelVersionStatus_Values() []string {
+	return []string{
+		DetectorModelVersionStatusActive,
+		DetectorModelVersionStatusActivating,
+		DetectorModelVersionStatusInactive,
+		DetectorModelVersionStatusDeprecated,
+		DetectorModelVersionStatusDraft,
+		DetectorModelVersionStatusPaused,
+		DetectorModelVersionStatusFailed,
+	}
+}
+
 const (
 	// EvaluationMethodBatch is a EvaluationMethod enum value
 	EvaluationMethodBatch = "BATCH"
@@ -6017,6 +6030,14 @@ const (
 	// EvaluationMethodSerial is a EvaluationMethod enum value
 	EvaluationMethodSerial = "SERIAL"
 )
+
+// EvaluationMethod_Values returns all elements of the EvaluationMethod enum
+func EvaluationMethod_Values() []string {
+	return []string{
+		EvaluationMethodBatch,
+		EvaluationMethodSerial,
+	}
+}
 
 const (
 	// InputStatusCreating is a InputStatus enum value
@@ -6032,6 +6053,16 @@ const (
 	InputStatusDeleting = "DELETING"
 )
 
+// InputStatus_Values returns all elements of the InputStatus enum
+func InputStatus_Values() []string {
+	return []string{
+		InputStatusCreating,
+		InputStatusUpdating,
+		InputStatusActive,
+		InputStatusDeleting,
+	}
+}
+
 const (
 	// LoggingLevelError is a LoggingLevel enum value
 	LoggingLevelError = "ERROR"
@@ -6043,6 +6074,15 @@ const (
 	LoggingLevelDebug = "DEBUG"
 )
 
+// LoggingLevel_Values returns all elements of the LoggingLevel enum
+func LoggingLevel_Values() []string {
+	return []string{
+		LoggingLevelError,
+		LoggingLevelInfo,
+		LoggingLevelDebug,
+	}
+}
+
 const (
 	// PayloadTypeString is a PayloadType enum value
 	PayloadTypeString = "STRING"
@@ -6050,3 +6090,11 @@ const (
 	// PayloadTypeJson is a PayloadType enum value
 	PayloadTypeJson = "JSON"
 )
+
+// PayloadType_Values returns all elements of the PayloadType enum
+func PayloadType_Values() []string {
+	return []string{
+		PayloadTypeString,
+		PayloadTypeJson,
+	}
+}

--- a/service/ioteventsdata/api.go
+++ b/service/ioteventsdata/api.go
@@ -1761,3 +1761,14 @@ const (
 	// ErrorCodeThrottlingException is a ErrorCode enum value
 	ErrorCodeThrottlingException = "ThrottlingException"
 )
+
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeResourceNotFoundException,
+		ErrorCodeInvalidRequestException,
+		ErrorCodeInternalFailureException,
+		ErrorCodeServiceUnavailableException,
+		ErrorCodeThrottlingException,
+	}
+}

--- a/service/iotjobsdataplane/api.go
+++ b/service/iotjobsdataplane/api.go
@@ -1499,3 +1499,17 @@ const (
 	// JobExecutionStatusCanceled is a JobExecutionStatus enum value
 	JobExecutionStatusCanceled = "CANCELED"
 )
+
+// JobExecutionStatus_Values returns all elements of the JobExecutionStatus enum
+func JobExecutionStatus_Values() []string {
+	return []string{
+		JobExecutionStatusQueued,
+		JobExecutionStatusInProgress,
+		JobExecutionStatusSucceeded,
+		JobExecutionStatusFailed,
+		JobExecutionStatusTimedOut,
+		JobExecutionStatusRejected,
+		JobExecutionStatusRemoved,
+		JobExecutionStatusCanceled,
+	}
+}

--- a/service/iotsecuretunneling/api.go
+++ b/service/iotsecuretunneling/api.go
@@ -1684,6 +1684,14 @@ const (
 	ConnectionStatusDisconnected = "DISCONNECTED"
 )
 
+// ConnectionStatus_Values returns all elements of the ConnectionStatus enum
+func ConnectionStatus_Values() []string {
+	return []string{
+		ConnectionStatusConnected,
+		ConnectionStatusDisconnected,
+	}
+}
+
 const (
 	// TunnelStatusOpen is a TunnelStatus enum value
 	TunnelStatusOpen = "OPEN"
@@ -1691,3 +1699,11 @@ const (
 	// TunnelStatusClosed is a TunnelStatus enum value
 	TunnelStatusClosed = "CLOSED"
 )
+
+// TunnelStatus_Values returns all elements of the TunnelStatus enum
+func TunnelStatus_Values() []string {
+	return []string{
+		TunnelStatusOpen,
+		TunnelStatusClosed,
+	}
+}

--- a/service/iotsitewise/api.go
+++ b/service/iotsitewise/api.go
@@ -15962,10 +15962,29 @@ const (
 	AggregateTypeStandardDeviation = "STANDARD_DEVIATION"
 )
 
+// AggregateType_Values returns all elements of the AggregateType enum
+func AggregateType_Values() []string {
+	return []string{
+		AggregateTypeAverage,
+		AggregateTypeCount,
+		AggregateTypeMaximum,
+		AggregateTypeMinimum,
+		AggregateTypeSum,
+		AggregateTypeStandardDeviation,
+	}
+}
+
 const (
 	// AssetErrorCodeInternalFailure is a AssetErrorCode enum value
 	AssetErrorCodeInternalFailure = "INTERNAL_FAILURE"
 )
+
+// AssetErrorCode_Values returns all elements of the AssetErrorCode enum
+func AssetErrorCode_Values() []string {
+	return []string{
+		AssetErrorCodeInternalFailure,
+	}
+}
 
 const (
 	// AssetModelStateCreating is a AssetModelState enum value
@@ -15987,6 +16006,18 @@ const (
 	AssetModelStateFailed = "FAILED"
 )
 
+// AssetModelState_Values returns all elements of the AssetModelState enum
+func AssetModelState_Values() []string {
+	return []string{
+		AssetModelStateCreating,
+		AssetModelStateActive,
+		AssetModelStateUpdating,
+		AssetModelStatePropagating,
+		AssetModelStateDeleting,
+		AssetModelStateFailed,
+	}
+}
+
 const (
 	// AssetStateCreating is a AssetState enum value
 	AssetStateCreating = "CREATING"
@@ -16003,6 +16034,17 @@ const (
 	// AssetStateFailed is a AssetState enum value
 	AssetStateFailed = "FAILED"
 )
+
+// AssetState_Values returns all elements of the AssetState enum
+func AssetState_Values() []string {
+	return []string{
+		AssetStateCreating,
+		AssetStateActive,
+		AssetStateUpdating,
+		AssetStateDeleting,
+		AssetStateFailed,
+	}
+}
 
 const (
 	// BatchPutAssetPropertyValueErrorCodeResourceNotFoundException is a BatchPutAssetPropertyValueErrorCode enum value
@@ -16033,6 +16075,21 @@ const (
 	BatchPutAssetPropertyValueErrorCodeAccessDeniedException = "AccessDeniedException"
 )
 
+// BatchPutAssetPropertyValueErrorCode_Values returns all elements of the BatchPutAssetPropertyValueErrorCode enum
+func BatchPutAssetPropertyValueErrorCode_Values() []string {
+	return []string{
+		BatchPutAssetPropertyValueErrorCodeResourceNotFoundException,
+		BatchPutAssetPropertyValueErrorCodeInvalidRequestException,
+		BatchPutAssetPropertyValueErrorCodeInternalFailureException,
+		BatchPutAssetPropertyValueErrorCodeServiceUnavailableException,
+		BatchPutAssetPropertyValueErrorCodeThrottlingException,
+		BatchPutAssetPropertyValueErrorCodeLimitExceededException,
+		BatchPutAssetPropertyValueErrorCodeConflictingOperationException,
+		BatchPutAssetPropertyValueErrorCodeTimestampOutOfRangeException,
+		BatchPutAssetPropertyValueErrorCodeAccessDeniedException,
+	}
+}
+
 const (
 	// CapabilitySyncStatusInSync is a CapabilitySyncStatus enum value
 	CapabilitySyncStatusInSync = "IN_SYNC"
@@ -16044,6 +16101,15 @@ const (
 	CapabilitySyncStatusSyncFailed = "SYNC_FAILED"
 )
 
+// CapabilitySyncStatus_Values returns all elements of the CapabilitySyncStatus enum
+func CapabilitySyncStatus_Values() []string {
+	return []string{
+		CapabilitySyncStatusInSync,
+		CapabilitySyncStatusOutOfSync,
+		CapabilitySyncStatusSyncFailed,
+	}
+}
+
 const (
 	// ErrorCodeValidationError is a ErrorCode enum value
 	ErrorCodeValidationError = "VALIDATION_ERROR"
@@ -16051,6 +16117,14 @@ const (
 	// ErrorCodeInternalFailure is a ErrorCode enum value
 	ErrorCodeInternalFailure = "INTERNAL_FAILURE"
 )
+
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeValidationError,
+		ErrorCodeInternalFailure,
+	}
+}
 
 const (
 	// IdentityTypeUser is a IdentityType enum value
@@ -16060,10 +16134,25 @@ const (
 	IdentityTypeGroup = "GROUP"
 )
 
+// IdentityType_Values returns all elements of the IdentityType enum
+func IdentityType_Values() []string {
+	return []string{
+		IdentityTypeUser,
+		IdentityTypeGroup,
+	}
+}
+
 const (
 	// ImageFileTypePng is a ImageFileType enum value
 	ImageFileTypePng = "PNG"
 )
+
+// ImageFileType_Values returns all elements of the ImageFileType enum
+func ImageFileType_Values() []string {
+	return []string{
+		ImageFileTypePng,
+	}
+}
 
 const (
 	// ListAssetsFilterAll is a ListAssetsFilter enum value
@@ -16072,6 +16161,14 @@ const (
 	// ListAssetsFilterTopLevel is a ListAssetsFilter enum value
 	ListAssetsFilterTopLevel = "TOP_LEVEL"
 )
+
+// ListAssetsFilter_Values returns all elements of the ListAssetsFilter enum
+func ListAssetsFilter_Values() []string {
+	return []string{
+		ListAssetsFilterAll,
+		ListAssetsFilterTopLevel,
+	}
+}
 
 const (
 	// LoggingLevelError is a LoggingLevel enum value
@@ -16084,10 +16181,26 @@ const (
 	LoggingLevelOff = "OFF"
 )
 
+// LoggingLevel_Values returns all elements of the LoggingLevel enum
+func LoggingLevel_Values() []string {
+	return []string{
+		LoggingLevelError,
+		LoggingLevelInfo,
+		LoggingLevelOff,
+	}
+}
+
 const (
 	// MonitorErrorCodeInternalFailure is a MonitorErrorCode enum value
 	MonitorErrorCodeInternalFailure = "INTERNAL_FAILURE"
 )
+
+// MonitorErrorCode_Values returns all elements of the MonitorErrorCode enum
+func MonitorErrorCode_Values() []string {
+	return []string{
+		MonitorErrorCodeInternalFailure,
+	}
+}
 
 const (
 	// PermissionAdministrator is a Permission enum value
@@ -16096,6 +16209,14 @@ const (
 	// PermissionViewer is a Permission enum value
 	PermissionViewer = "VIEWER"
 )
+
+// Permission_Values returns all elements of the Permission enum
+func Permission_Values() []string {
+	return []string{
+		PermissionAdministrator,
+		PermissionViewer,
+	}
+}
 
 const (
 	// PortalStateCreating is a PortalState enum value
@@ -16114,6 +16235,17 @@ const (
 	PortalStateFailed = "FAILED"
 )
 
+// PortalState_Values returns all elements of the PortalState enum
+func PortalState_Values() []string {
+	return []string{
+		PortalStateCreating,
+		PortalStateUpdating,
+		PortalStateDeleting,
+		PortalStateActive,
+		PortalStateFailed,
+	}
+}
+
 const (
 	// PropertyDataTypeString is a PropertyDataType enum value
 	PropertyDataTypeString = "STRING"
@@ -16128,6 +16260,16 @@ const (
 	PropertyDataTypeBoolean = "BOOLEAN"
 )
 
+// PropertyDataType_Values returns all elements of the PropertyDataType enum
+func PropertyDataType_Values() []string {
+	return []string{
+		PropertyDataTypeString,
+		PropertyDataTypeInteger,
+		PropertyDataTypeDouble,
+		PropertyDataTypeBoolean,
+	}
+}
+
 const (
 	// PropertyNotificationStateEnabled is a PropertyNotificationState enum value
 	PropertyNotificationStateEnabled = "ENABLED"
@@ -16135,6 +16277,14 @@ const (
 	// PropertyNotificationStateDisabled is a PropertyNotificationState enum value
 	PropertyNotificationStateDisabled = "DISABLED"
 )
+
+// PropertyNotificationState_Values returns all elements of the PropertyNotificationState enum
+func PropertyNotificationState_Values() []string {
+	return []string{
+		PropertyNotificationStateEnabled,
+		PropertyNotificationStateDisabled,
+	}
+}
 
 const (
 	// QualityGood is a Quality enum value
@@ -16147,6 +16297,15 @@ const (
 	QualityUncertain = "UNCERTAIN"
 )
 
+// Quality_Values returns all elements of the Quality enum
+func Quality_Values() []string {
+	return []string{
+		QualityGood,
+		QualityBad,
+		QualityUncertain,
+	}
+}
+
 const (
 	// ResourceTypePortal is a ResourceType enum value
 	ResourceTypePortal = "PORTAL"
@@ -16155,6 +16314,14 @@ const (
 	ResourceTypeProject = "PROJECT"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypePortal,
+		ResourceTypeProject,
+	}
+}
+
 const (
 	// TimeOrderingAscending is a TimeOrdering enum value
 	TimeOrderingAscending = "ASCENDING"
@@ -16162,3 +16329,11 @@ const (
 	// TimeOrderingDescending is a TimeOrdering enum value
 	TimeOrderingDescending = "DESCENDING"
 )
+
+// TimeOrdering_Values returns all elements of the TimeOrdering enum
+func TimeOrdering_Values() []string {
+	return []string{
+		TimeOrderingAscending,
+		TimeOrderingDescending,
+	}
+}

--- a/service/iotthingsgraph/api.go
+++ b/service/iotthingsgraph/api.go
@@ -7900,6 +7900,13 @@ const (
 	DefinitionLanguageGraphql = "GRAPHQL"
 )
 
+// DefinitionLanguage_Values returns all elements of the DefinitionLanguage enum
+func DefinitionLanguage_Values() []string {
+	return []string{
+		DefinitionLanguageGraphql,
+	}
+}
+
 const (
 	// DeploymentTargetGreengrass is a DeploymentTarget enum value
 	DeploymentTargetGreengrass = "GREENGRASS"
@@ -7907,6 +7914,14 @@ const (
 	// DeploymentTargetCloud is a DeploymentTarget enum value
 	DeploymentTargetCloud = "CLOUD"
 )
+
+// DeploymentTarget_Values returns all elements of the DeploymentTarget enum
+func DeploymentTarget_Values() []string {
+	return []string{
+		DeploymentTargetGreengrass,
+		DeploymentTargetCloud,
+	}
+}
 
 const (
 	// EntityFilterNameName is a EntityFilterName enum value
@@ -7921,6 +7936,16 @@ const (
 	// EntityFilterNameReferencedEntityId is a EntityFilterName enum value
 	EntityFilterNameReferencedEntityId = "REFERENCED_ENTITY_ID"
 )
+
+// EntityFilterName_Values returns all elements of the EntityFilterName enum
+func EntityFilterName_Values() []string {
+	return []string{
+		EntityFilterNameName,
+		EntityFilterNameNamespace,
+		EntityFilterNameSemanticTypePath,
+		EntityFilterNameReferencedEntityId,
+	}
+}
 
 const (
 	// EntityTypeDevice is a EntityType enum value
@@ -7953,6 +7978,22 @@ const (
 	// EntityTypeEnum is a EntityType enum value
 	EntityTypeEnum = "ENUM"
 )
+
+// EntityType_Values returns all elements of the EntityType enum
+func EntityType_Values() []string {
+	return []string{
+		EntityTypeDevice,
+		EntityTypeService,
+		EntityTypeDeviceModel,
+		EntityTypeCapability,
+		EntityTypeState,
+		EntityTypeAction,
+		EntityTypeEvent,
+		EntityTypeProperty,
+		EntityTypeMapping,
+		EntityTypeEnum,
+	}
+}
 
 const (
 	// FlowExecutionEventTypeExecutionStarted is a FlowExecutionEventType enum value
@@ -8007,6 +8048,29 @@ const (
 	FlowExecutionEventTypeAcknowledgeTaskMessage = "ACKNOWLEDGE_TASK_MESSAGE"
 )
 
+// FlowExecutionEventType_Values returns all elements of the FlowExecutionEventType enum
+func FlowExecutionEventType_Values() []string {
+	return []string{
+		FlowExecutionEventTypeExecutionStarted,
+		FlowExecutionEventTypeExecutionFailed,
+		FlowExecutionEventTypeExecutionAborted,
+		FlowExecutionEventTypeExecutionSucceeded,
+		FlowExecutionEventTypeStepStarted,
+		FlowExecutionEventTypeStepFailed,
+		FlowExecutionEventTypeStepSucceeded,
+		FlowExecutionEventTypeActivityScheduled,
+		FlowExecutionEventTypeActivityStarted,
+		FlowExecutionEventTypeActivityFailed,
+		FlowExecutionEventTypeActivitySucceeded,
+		FlowExecutionEventTypeStartFlowExecutionTask,
+		FlowExecutionEventTypeScheduleNextReadyStepsTask,
+		FlowExecutionEventTypeThingActionTask,
+		FlowExecutionEventTypeThingActionTaskFailed,
+		FlowExecutionEventTypeThingActionTaskSucceeded,
+		FlowExecutionEventTypeAcknowledgeTaskMessage,
+	}
+}
+
 const (
 	// FlowExecutionStatusRunning is a FlowExecutionStatus enum value
 	FlowExecutionStatusRunning = "RUNNING"
@@ -8021,10 +8085,27 @@ const (
 	FlowExecutionStatusFailed = "FAILED"
 )
 
+// FlowExecutionStatus_Values returns all elements of the FlowExecutionStatus enum
+func FlowExecutionStatus_Values() []string {
+	return []string{
+		FlowExecutionStatusRunning,
+		FlowExecutionStatusAborted,
+		FlowExecutionStatusSucceeded,
+		FlowExecutionStatusFailed,
+	}
+}
+
 const (
 	// FlowTemplateFilterNameDeviceModelId is a FlowTemplateFilterName enum value
 	FlowTemplateFilterNameDeviceModelId = "DEVICE_MODEL_ID"
 )
+
+// FlowTemplateFilterName_Values returns all elements of the FlowTemplateFilterName enum
+func FlowTemplateFilterName_Values() []string {
+	return []string{
+		FlowTemplateFilterNameDeviceModelId,
+	}
+}
 
 const (
 	// NamespaceDeletionStatusInProgress is a NamespaceDeletionStatus enum value
@@ -8037,10 +8118,26 @@ const (
 	NamespaceDeletionStatusFailed = "FAILED"
 )
 
+// NamespaceDeletionStatus_Values returns all elements of the NamespaceDeletionStatus enum
+func NamespaceDeletionStatus_Values() []string {
+	return []string{
+		NamespaceDeletionStatusInProgress,
+		NamespaceDeletionStatusSucceeded,
+		NamespaceDeletionStatusFailed,
+	}
+}
+
 const (
 	// NamespaceDeletionStatusErrorCodesValidationFailed is a NamespaceDeletionStatusErrorCodes enum value
 	NamespaceDeletionStatusErrorCodesValidationFailed = "VALIDATION_FAILED"
 )
+
+// NamespaceDeletionStatusErrorCodes_Values returns all elements of the NamespaceDeletionStatusErrorCodes enum
+func NamespaceDeletionStatusErrorCodes_Values() []string {
+	return []string{
+		NamespaceDeletionStatusErrorCodesValidationFailed,
+	}
+}
 
 const (
 	// SystemInstanceDeploymentStatusNotDeployed is a SystemInstanceDeploymentStatus enum value
@@ -8068,6 +8165,20 @@ const (
 	SystemInstanceDeploymentStatusDeletedInTarget = "DELETED_IN_TARGET"
 )
 
+// SystemInstanceDeploymentStatus_Values returns all elements of the SystemInstanceDeploymentStatus enum
+func SystemInstanceDeploymentStatus_Values() []string {
+	return []string{
+		SystemInstanceDeploymentStatusNotDeployed,
+		SystemInstanceDeploymentStatusBootstrap,
+		SystemInstanceDeploymentStatusDeployInProgress,
+		SystemInstanceDeploymentStatusDeployedInTarget,
+		SystemInstanceDeploymentStatusUndeployInProgress,
+		SystemInstanceDeploymentStatusFailed,
+		SystemInstanceDeploymentStatusPendingDelete,
+		SystemInstanceDeploymentStatusDeletedInTarget,
+	}
+}
+
 const (
 	// SystemInstanceFilterNameSystemTemplateId is a SystemInstanceFilterName enum value
 	SystemInstanceFilterNameSystemTemplateId = "SYSTEM_TEMPLATE_ID"
@@ -8079,10 +8190,26 @@ const (
 	SystemInstanceFilterNameGreengrassGroupName = "GREENGRASS_GROUP_NAME"
 )
 
+// SystemInstanceFilterName_Values returns all elements of the SystemInstanceFilterName enum
+func SystemInstanceFilterName_Values() []string {
+	return []string{
+		SystemInstanceFilterNameSystemTemplateId,
+		SystemInstanceFilterNameStatus,
+		SystemInstanceFilterNameGreengrassGroupName,
+	}
+}
+
 const (
 	// SystemTemplateFilterNameFlowTemplateId is a SystemTemplateFilterName enum value
 	SystemTemplateFilterNameFlowTemplateId = "FLOW_TEMPLATE_ID"
 )
+
+// SystemTemplateFilterName_Values returns all elements of the SystemTemplateFilterName enum
+func SystemTemplateFilterName_Values() []string {
+	return []string{
+		SystemTemplateFilterNameFlowTemplateId,
+	}
+}
 
 const (
 	// UploadStatusInProgress is a UploadStatus enum value
@@ -8094,3 +8221,12 @@ const (
 	// UploadStatusFailed is a UploadStatus enum value
 	UploadStatusFailed = "FAILED"
 )
+
+// UploadStatus_Values returns all elements of the UploadStatus enum
+func UploadStatus_Values() []string {
+	return []string{
+		UploadStatusInProgress,
+		UploadStatusSucceeded,
+		UploadStatusFailed,
+	}
+}

--- a/service/ivs/api.go
+++ b/service/ivs/api.go
@@ -4091,6 +4091,14 @@ const (
 	ChannelLatencyModeLow = "LOW"
 )
 
+// ChannelLatencyMode_Values returns all elements of the ChannelLatencyMode enum
+func ChannelLatencyMode_Values() []string {
+	return []string{
+		ChannelLatencyModeNormal,
+		ChannelLatencyModeLow,
+	}
+}
+
 const (
 	// ChannelTypeBasic is a ChannelType enum value
 	ChannelTypeBasic = "BASIC"
@@ -4098,6 +4106,14 @@ const (
 	// ChannelTypeStandard is a ChannelType enum value
 	ChannelTypeStandard = "STANDARD"
 )
+
+// ChannelType_Values returns all elements of the ChannelType enum
+func ChannelType_Values() []string {
+	return []string{
+		ChannelTypeBasic,
+		ChannelTypeStandard,
+	}
+}
 
 const (
 	// StreamHealthHealthy is a StreamHealth enum value
@@ -4110,6 +4126,15 @@ const (
 	StreamHealthUnknown = "UNKNOWN"
 )
 
+// StreamHealth_Values returns all elements of the StreamHealth enum
+func StreamHealth_Values() []string {
+	return []string{
+		StreamHealthHealthy,
+		StreamHealthStarving,
+		StreamHealthUnknown,
+	}
+}
+
 const (
 	// StreamStateLive is a StreamState enum value
 	StreamStateLive = "LIVE"
@@ -4117,3 +4142,11 @@ const (
 	// StreamStateOffline is a StreamState enum value
 	StreamStateOffline = "OFFLINE"
 )
+
+// StreamState_Values returns all elements of the StreamState enum
+func StreamState_Values() []string {
+	return []string{
+		StreamStateLive,
+		StreamStateOffline,
+	}
+}

--- a/service/kafka/api.go
+++ b/service/kafka/api.go
@@ -7210,6 +7210,13 @@ const (
 	BrokerAZDistributionDefault = "DEFAULT"
 )
 
+// BrokerAZDistribution_Values returns all elements of the BrokerAZDistribution enum
+func BrokerAZDistribution_Values() []string {
+	return []string{
+		BrokerAZDistributionDefault,
+	}
+}
+
 // Client-broker encryption in transit setting.
 const (
 	// ClientBrokerTls is a ClientBroker enum value
@@ -7221,6 +7228,15 @@ const (
 	// ClientBrokerPlaintext is a ClientBroker enum value
 	ClientBrokerPlaintext = "PLAINTEXT"
 )
+
+// ClientBroker_Values returns all elements of the ClientBroker enum
+func ClientBroker_Values() []string {
+	return []string{
+		ClientBrokerTls,
+		ClientBrokerTlsPlaintext,
+		ClientBrokerPlaintext,
+	}
+}
 
 // The state of a Kafka cluster.
 const (
@@ -7240,6 +7256,17 @@ const (
 	ClusterStateFailed = "FAILED"
 )
 
+// ClusterState_Values returns all elements of the ClusterState enum
+func ClusterState_Values() []string {
+	return []string{
+		ClusterStateActive,
+		ClusterStateCreating,
+		ClusterStateUpdating,
+		ClusterStateDeleting,
+		ClusterStateFailed,
+	}
+}
+
 // Specifies which metrics are gathered for the MSK cluster. This property has
 // three possible values: DEFAULT, PER_BROKER, and PER_TOPIC_PER_BROKER. For
 // a list of the metrics associated with each of these three levels of monitoring,
@@ -7255,6 +7282,15 @@ const (
 	EnhancedMonitoringPerTopicPerBroker = "PER_TOPIC_PER_BROKER"
 )
 
+// EnhancedMonitoring_Values returns all elements of the EnhancedMonitoring enum
+func EnhancedMonitoring_Values() []string {
+	return []string{
+		EnhancedMonitoringDefault,
+		EnhancedMonitoringPerBroker,
+		EnhancedMonitoringPerTopicPerBroker,
+	}
+}
+
 // The status of a Kafka version.
 const (
 	// KafkaVersionStatusActive is a KafkaVersionStatus enum value
@@ -7264,8 +7300,23 @@ const (
 	KafkaVersionStatusDeprecated = "DEPRECATED"
 )
 
+// KafkaVersionStatus_Values returns all elements of the KafkaVersionStatus enum
+func KafkaVersionStatus_Values() []string {
+	return []string{
+		KafkaVersionStatusActive,
+		KafkaVersionStatusDeprecated,
+	}
+}
+
 // The broker or Zookeeper node.
 const (
 	// NodeTypeBroker is a NodeType enum value
 	NodeTypeBroker = "BROKER"
 )
+
+// NodeType_Values returns all elements of the NodeType enum
+func NodeType_Values() []string {
+	return []string{
+		NodeTypeBroker,
+	}
+}

--- a/service/kendra/api.go
+++ b/service/kendra/api.go
@@ -10141,6 +10141,13 @@ const (
 	AdditionalResultAttributeValueTypeTextWithHighlightsValue = "TEXT_WITH_HIGHLIGHTS_VALUE"
 )
 
+// AdditionalResultAttributeValueType_Values returns all elements of the AdditionalResultAttributeValueType enum
+func AdditionalResultAttributeValueType_Values() []string {
+	return []string{
+		AdditionalResultAttributeValueTypeTextWithHighlightsValue,
+	}
+}
+
 const (
 	// ContentTypePdf is a ContentType enum value
 	ContentTypePdf = "PDF"
@@ -10158,6 +10165,17 @@ const (
 	ContentTypePpt = "PPT"
 )
 
+// ContentType_Values returns all elements of the ContentType enum
+func ContentType_Values() []string {
+	return []string{
+		ContentTypePdf,
+		ContentTypeHtml,
+		ContentTypeMsWord,
+		ContentTypePlainText,
+		ContentTypePpt,
+	}
+}
+
 const (
 	// DataSourceStatusCreating is a DataSourceStatus enum value
 	DataSourceStatusCreating = "CREATING"
@@ -10174,6 +10192,17 @@ const (
 	// DataSourceStatusActive is a DataSourceStatus enum value
 	DataSourceStatusActive = "ACTIVE"
 )
+
+// DataSourceStatus_Values returns all elements of the DataSourceStatus enum
+func DataSourceStatus_Values() []string {
+	return []string{
+		DataSourceStatusCreating,
+		DataSourceStatusDeleting,
+		DataSourceStatusFailed,
+		DataSourceStatusUpdating,
+		DataSourceStatusActive,
+	}
+}
 
 const (
 	// DataSourceSyncJobStatusFailed is a DataSourceSyncJobStatus enum value
@@ -10198,6 +10227,19 @@ const (
 	DataSourceSyncJobStatusSyncingIndexing = "SYNCING_INDEXING"
 )
 
+// DataSourceSyncJobStatus_Values returns all elements of the DataSourceSyncJobStatus enum
+func DataSourceSyncJobStatus_Values() []string {
+	return []string{
+		DataSourceSyncJobStatusFailed,
+		DataSourceSyncJobStatusSucceeded,
+		DataSourceSyncJobStatusSyncing,
+		DataSourceSyncJobStatusIncomplete,
+		DataSourceSyncJobStatusStopping,
+		DataSourceSyncJobStatusAborted,
+		DataSourceSyncJobStatusSyncingIndexing,
+	}
+}
+
 const (
 	// DataSourceTypeS3 is a DataSourceType enum value
 	DataSourceTypeS3 = "S3"
@@ -10218,6 +10260,18 @@ const (
 	DataSourceTypeServicenow = "SERVICENOW"
 )
 
+// DataSourceType_Values returns all elements of the DataSourceType enum
+func DataSourceType_Values() []string {
+	return []string{
+		DataSourceTypeS3,
+		DataSourceTypeSharepoint,
+		DataSourceTypeDatabase,
+		DataSourceTypeSalesforce,
+		DataSourceTypeOnedrive,
+		DataSourceTypeServicenow,
+	}
+}
+
 const (
 	// DatabaseEngineTypeRdsAuroraMysql is a DatabaseEngineType enum value
 	DatabaseEngineTypeRdsAuroraMysql = "RDS_AURORA_MYSQL"
@@ -10231,6 +10285,16 @@ const (
 	// DatabaseEngineTypeRdsPostgresql is a DatabaseEngineType enum value
 	DatabaseEngineTypeRdsPostgresql = "RDS_POSTGRESQL"
 )
+
+// DatabaseEngineType_Values returns all elements of the DatabaseEngineType enum
+func DatabaseEngineType_Values() []string {
+	return []string{
+		DatabaseEngineTypeRdsAuroraMysql,
+		DatabaseEngineTypeRdsAuroraPostgresql,
+		DatabaseEngineTypeRdsMysql,
+		DatabaseEngineTypeRdsPostgresql,
+	}
+}
 
 const (
 	// DocumentAttributeValueTypeStringValue is a DocumentAttributeValueType enum value
@@ -10246,6 +10310,16 @@ const (
 	DocumentAttributeValueTypeDateValue = "DATE_VALUE"
 )
 
+// DocumentAttributeValueType_Values returns all elements of the DocumentAttributeValueType enum
+func DocumentAttributeValueType_Values() []string {
+	return []string{
+		DocumentAttributeValueTypeStringValue,
+		DocumentAttributeValueTypeStringListValue,
+		DocumentAttributeValueTypeLongValue,
+		DocumentAttributeValueTypeDateValue,
+	}
+}
+
 const (
 	// ErrorCodeInternalError is a ErrorCode enum value
 	ErrorCodeInternalError = "InternalError"
@@ -10253,6 +10327,14 @@ const (
 	// ErrorCodeInvalidRequest is a ErrorCode enum value
 	ErrorCodeInvalidRequest = "InvalidRequest"
 )
+
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeInternalError,
+		ErrorCodeInvalidRequest,
+	}
+}
 
 const (
 	// FaqStatusCreating is a FaqStatus enum value
@@ -10271,6 +10353,17 @@ const (
 	FaqStatusFailed = "FAILED"
 )
 
+// FaqStatus_Values returns all elements of the FaqStatus enum
+func FaqStatus_Values() []string {
+	return []string{
+		FaqStatusCreating,
+		FaqStatusUpdating,
+		FaqStatusActive,
+		FaqStatusDeleting,
+		FaqStatusFailed,
+	}
+}
+
 const (
 	// IndexEditionDeveloperEdition is a IndexEdition enum value
 	IndexEditionDeveloperEdition = "DEVELOPER_EDITION"
@@ -10278,6 +10371,14 @@ const (
 	// IndexEditionEnterpriseEdition is a IndexEdition enum value
 	IndexEditionEnterpriseEdition = "ENTERPRISE_EDITION"
 )
+
+// IndexEdition_Values returns all elements of the IndexEdition enum
+func IndexEdition_Values() []string {
+	return []string{
+		IndexEditionDeveloperEdition,
+		IndexEditionEnterpriseEdition,
+	}
+}
 
 const (
 	// IndexStatusCreating is a IndexStatus enum value
@@ -10299,6 +10400,18 @@ const (
 	IndexStatusSystemUpdating = "SYSTEM_UPDATING"
 )
 
+// IndexStatus_Values returns all elements of the IndexStatus enum
+func IndexStatus_Values() []string {
+	return []string{
+		IndexStatusCreating,
+		IndexStatusActive,
+		IndexStatusDeleting,
+		IndexStatusFailed,
+		IndexStatusUpdating,
+		IndexStatusSystemUpdating,
+	}
+}
+
 const (
 	// OrderAscending is a Order enum value
 	OrderAscending = "ASCENDING"
@@ -10306,6 +10419,14 @@ const (
 	// OrderDescending is a Order enum value
 	OrderDescending = "DESCENDING"
 )
+
+// Order_Values returns all elements of the Order enum
+func Order_Values() []string {
+	return []string{
+		OrderAscending,
+		OrderDescending,
+	}
+}
 
 const (
 	// PrincipalTypeUser is a PrincipalType enum value
@@ -10315,6 +10436,14 @@ const (
 	PrincipalTypeGroup = "GROUP"
 )
 
+// PrincipalType_Values returns all elements of the PrincipalType enum
+func PrincipalType_Values() []string {
+	return []string{
+		PrincipalTypeUser,
+		PrincipalTypeGroup,
+	}
+}
+
 const (
 	// QueryIdentifiersEnclosingOptionDoubleQuotes is a QueryIdentifiersEnclosingOption enum value
 	QueryIdentifiersEnclosingOptionDoubleQuotes = "DOUBLE_QUOTES"
@@ -10322,6 +10451,14 @@ const (
 	// QueryIdentifiersEnclosingOptionNone is a QueryIdentifiersEnclosingOption enum value
 	QueryIdentifiersEnclosingOptionNone = "NONE"
 )
+
+// QueryIdentifiersEnclosingOption_Values returns all elements of the QueryIdentifiersEnclosingOption enum
+func QueryIdentifiersEnclosingOption_Values() []string {
+	return []string{
+		QueryIdentifiersEnclosingOptionDoubleQuotes,
+		QueryIdentifiersEnclosingOptionNone,
+	}
+}
 
 const (
 	// QueryResultTypeDocument is a QueryResultType enum value
@@ -10334,6 +10471,15 @@ const (
 	QueryResultTypeAnswer = "ANSWER"
 )
 
+// QueryResultType_Values returns all elements of the QueryResultType enum
+func QueryResultType_Values() []string {
+	return []string{
+		QueryResultTypeDocument,
+		QueryResultTypeQuestionAnswer,
+		QueryResultTypeAnswer,
+	}
+}
+
 const (
 	// ReadAccessTypeAllow is a ReadAccessType enum value
 	ReadAccessTypeAllow = "ALLOW"
@@ -10341,6 +10487,14 @@ const (
 	// ReadAccessTypeDeny is a ReadAccessType enum value
 	ReadAccessTypeDeny = "DENY"
 )
+
+// ReadAccessType_Values returns all elements of the ReadAccessType enum
+func ReadAccessType_Values() []string {
+	return []string{
+		ReadAccessTypeAllow,
+		ReadAccessTypeDeny,
+	}
+}
 
 const (
 	// RelevanceTypeRelevant is a RelevanceType enum value
@@ -10350,6 +10504,14 @@ const (
 	RelevanceTypeNotRelevant = "NOT_RELEVANT"
 )
 
+// RelevanceType_Values returns all elements of the RelevanceType enum
+func RelevanceType_Values() []string {
+	return []string{
+		RelevanceTypeRelevant,
+		RelevanceTypeNotRelevant,
+	}
+}
+
 const (
 	// SalesforceChatterFeedIncludeFilterTypeActiveUser is a SalesforceChatterFeedIncludeFilterType enum value
 	SalesforceChatterFeedIncludeFilterTypeActiveUser = "ACTIVE_USER"
@@ -10357,6 +10519,14 @@ const (
 	// SalesforceChatterFeedIncludeFilterTypeStandardUser is a SalesforceChatterFeedIncludeFilterType enum value
 	SalesforceChatterFeedIncludeFilterTypeStandardUser = "STANDARD_USER"
 )
+
+// SalesforceChatterFeedIncludeFilterType_Values returns all elements of the SalesforceChatterFeedIncludeFilterType enum
+func SalesforceChatterFeedIncludeFilterType_Values() []string {
+	return []string{
+		SalesforceChatterFeedIncludeFilterTypeActiveUser,
+		SalesforceChatterFeedIncludeFilterTypeStandardUser,
+	}
+}
 
 const (
 	// SalesforceKnowledgeArticleStateDraft is a SalesforceKnowledgeArticleState enum value
@@ -10368,6 +10538,15 @@ const (
 	// SalesforceKnowledgeArticleStateArchived is a SalesforceKnowledgeArticleState enum value
 	SalesforceKnowledgeArticleStateArchived = "ARCHIVED"
 )
+
+// SalesforceKnowledgeArticleState_Values returns all elements of the SalesforceKnowledgeArticleState enum
+func SalesforceKnowledgeArticleState_Values() []string {
+	return []string{
+		SalesforceKnowledgeArticleStateDraft,
+		SalesforceKnowledgeArticleStatePublished,
+		SalesforceKnowledgeArticleStateArchived,
+	}
+}
 
 const (
 	// SalesforceStandardObjectNameAccount is a SalesforceStandardObjectName enum value
@@ -10422,6 +10601,29 @@ const (
 	SalesforceStandardObjectNameUser = "USER"
 )
 
+// SalesforceStandardObjectName_Values returns all elements of the SalesforceStandardObjectName enum
+func SalesforceStandardObjectName_Values() []string {
+	return []string{
+		SalesforceStandardObjectNameAccount,
+		SalesforceStandardObjectNameCampaign,
+		SalesforceStandardObjectNameCase,
+		SalesforceStandardObjectNameContact,
+		SalesforceStandardObjectNameContract,
+		SalesforceStandardObjectNameDocument,
+		SalesforceStandardObjectNameGroup,
+		SalesforceStandardObjectNameIdea,
+		SalesforceStandardObjectNameLead,
+		SalesforceStandardObjectNameOpportunity,
+		SalesforceStandardObjectNamePartner,
+		SalesforceStandardObjectNamePricebook,
+		SalesforceStandardObjectNameProduct,
+		SalesforceStandardObjectNameProfile,
+		SalesforceStandardObjectNameSolution,
+		SalesforceStandardObjectNameTask,
+		SalesforceStandardObjectNameUser,
+	}
+}
+
 const (
 	// ServiceNowBuildVersionTypeLondon is a ServiceNowBuildVersionType enum value
 	ServiceNowBuildVersionTypeLondon = "LONDON"
@@ -10430,10 +10632,25 @@ const (
 	ServiceNowBuildVersionTypeOthers = "OTHERS"
 )
 
+// ServiceNowBuildVersionType_Values returns all elements of the ServiceNowBuildVersionType enum
+func ServiceNowBuildVersionType_Values() []string {
+	return []string{
+		ServiceNowBuildVersionTypeLondon,
+		ServiceNowBuildVersionTypeOthers,
+	}
+}
+
 const (
 	// SharePointVersionSharepointOnline is a SharePointVersion enum value
 	SharePointVersionSharepointOnline = "SHAREPOINT_ONLINE"
 )
+
+// SharePointVersion_Values returns all elements of the SharePointVersion enum
+func SharePointVersion_Values() []string {
+	return []string{
+		SharePointVersionSharepointOnline,
+	}
+}
 
 const (
 	// SortOrderDesc is a SortOrder enum value
@@ -10442,3 +10659,11 @@ const (
 	// SortOrderAsc is a SortOrder enum value
 	SortOrderAsc = "ASC"
 )
+
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderDesc,
+		SortOrderAsc,
+	}
+}

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -8594,6 +8594,15 @@ const (
 	ConsumerStatusActive = "ACTIVE"
 )
 
+// ConsumerStatus_Values returns all elements of the ConsumerStatus enum
+func ConsumerStatus_Values() []string {
+	return []string{
+		ConsumerStatusCreating,
+		ConsumerStatusDeleting,
+		ConsumerStatusActive,
+	}
+}
+
 const (
 	// EncryptionTypeNone is a EncryptionType enum value
 	EncryptionTypeNone = "NONE"
@@ -8601,6 +8610,14 @@ const (
 	// EncryptionTypeKms is a EncryptionType enum value
 	EncryptionTypeKms = "KMS"
 )
+
+// EncryptionType_Values returns all elements of the EncryptionType enum
+func EncryptionType_Values() []string {
+	return []string{
+		EncryptionTypeNone,
+		EncryptionTypeKms,
+	}
+}
 
 const (
 	// MetricsNameIncomingBytes is a MetricsName enum value
@@ -8628,10 +8645,31 @@ const (
 	MetricsNameAll = "ALL"
 )
 
+// MetricsName_Values returns all elements of the MetricsName enum
+func MetricsName_Values() []string {
+	return []string{
+		MetricsNameIncomingBytes,
+		MetricsNameIncomingRecords,
+		MetricsNameOutgoingBytes,
+		MetricsNameOutgoingRecords,
+		MetricsNameWriteProvisionedThroughputExceeded,
+		MetricsNameReadProvisionedThroughputExceeded,
+		MetricsNameIteratorAgeMilliseconds,
+		MetricsNameAll,
+	}
+}
+
 const (
 	// ScalingTypeUniformScaling is a ScalingType enum value
 	ScalingTypeUniformScaling = "UNIFORM_SCALING"
 )
+
+// ScalingType_Values returns all elements of the ScalingType enum
+func ScalingType_Values() []string {
+	return []string{
+		ScalingTypeUniformScaling,
+	}
+}
 
 const (
 	// ShardIteratorTypeAtSequenceNumber is a ShardIteratorType enum value
@@ -8650,6 +8688,17 @@ const (
 	ShardIteratorTypeAtTimestamp = "AT_TIMESTAMP"
 )
 
+// ShardIteratorType_Values returns all elements of the ShardIteratorType enum
+func ShardIteratorType_Values() []string {
+	return []string{
+		ShardIteratorTypeAtSequenceNumber,
+		ShardIteratorTypeAfterSequenceNumber,
+		ShardIteratorTypeTrimHorizon,
+		ShardIteratorTypeLatest,
+		ShardIteratorTypeAtTimestamp,
+	}
+}
+
 const (
 	// StreamStatusCreating is a StreamStatus enum value
 	StreamStatusCreating = "CREATING"
@@ -8663,3 +8712,13 @@ const (
 	// StreamStatusUpdating is a StreamStatus enum value
 	StreamStatusUpdating = "UPDATING"
 )
+
+// StreamStatus_Values returns all elements of the StreamStatus enum
+func StreamStatus_Values() []string {
+	return []string{
+		StreamStatusCreating,
+		StreamStatusDeleting,
+		StreamStatusActive,
+		StreamStatusUpdating,
+	}
+}

--- a/service/kinesisanalytics/api.go
+++ b/service/kinesisanalytics/api.go
@@ -8195,6 +8195,18 @@ const (
 	ApplicationStatusUpdating = "UPDATING"
 )
 
+// ApplicationStatus_Values returns all elements of the ApplicationStatus enum
+func ApplicationStatus_Values() []string {
+	return []string{
+		ApplicationStatusDeleting,
+		ApplicationStatusStarting,
+		ApplicationStatusStopping,
+		ApplicationStatusReady,
+		ApplicationStatusRunning,
+		ApplicationStatusUpdating,
+	}
+}
+
 const (
 	// InputStartingPositionNow is a InputStartingPosition enum value
 	InputStartingPositionNow = "NOW"
@@ -8206,6 +8218,15 @@ const (
 	InputStartingPositionLastStoppedPoint = "LAST_STOPPED_POINT"
 )
 
+// InputStartingPosition_Values returns all elements of the InputStartingPosition enum
+func InputStartingPosition_Values() []string {
+	return []string{
+		InputStartingPositionNow,
+		InputStartingPositionTrimHorizon,
+		InputStartingPositionLastStoppedPoint,
+	}
+}
+
 const (
 	// RecordFormatTypeJson is a RecordFormatType enum value
 	RecordFormatTypeJson = "JSON"
@@ -8213,3 +8234,11 @@ const (
 	// RecordFormatTypeCsv is a RecordFormatType enum value
 	RecordFormatTypeCsv = "CSV"
 )
+
+// RecordFormatType_Values returns all elements of the RecordFormatType enum
+func RecordFormatType_Values() []string {
+	return []string{
+		RecordFormatTypeJson,
+		RecordFormatTypeCsv,
+	}
+}

--- a/service/kinesisanalyticsv2/api.go
+++ b/service/kinesisanalyticsv2/api.go
@@ -11739,6 +11739,15 @@ const (
 	ApplicationRestoreTypeRestoreFromCustomSnapshot = "RESTORE_FROM_CUSTOM_SNAPSHOT"
 )
 
+// ApplicationRestoreType_Values returns all elements of the ApplicationRestoreType enum
+func ApplicationRestoreType_Values() []string {
+	return []string{
+		ApplicationRestoreTypeSkipRestoreFromSnapshot,
+		ApplicationRestoreTypeRestoreFromLatestSnapshot,
+		ApplicationRestoreTypeRestoreFromCustomSnapshot,
+	}
+}
+
 const (
 	// ApplicationStatusDeleting is a ApplicationStatus enum value
 	ApplicationStatusDeleting = "DELETING"
@@ -11759,6 +11768,18 @@ const (
 	ApplicationStatusUpdating = "UPDATING"
 )
 
+// ApplicationStatus_Values returns all elements of the ApplicationStatus enum
+func ApplicationStatus_Values() []string {
+	return []string{
+		ApplicationStatusDeleting,
+		ApplicationStatusStarting,
+		ApplicationStatusStopping,
+		ApplicationStatusReady,
+		ApplicationStatusRunning,
+		ApplicationStatusUpdating,
+	}
+}
+
 const (
 	// CodeContentTypePlaintext is a CodeContentType enum value
 	CodeContentTypePlaintext = "PLAINTEXT"
@@ -11767,6 +11788,14 @@ const (
 	CodeContentTypeZipfile = "ZIPFILE"
 )
 
+// CodeContentType_Values returns all elements of the CodeContentType enum
+func CodeContentType_Values() []string {
+	return []string{
+		CodeContentTypePlaintext,
+		CodeContentTypeZipfile,
+	}
+}
+
 const (
 	// ConfigurationTypeDefault is a ConfigurationType enum value
 	ConfigurationTypeDefault = "DEFAULT"
@@ -11774,6 +11803,14 @@ const (
 	// ConfigurationTypeCustom is a ConfigurationType enum value
 	ConfigurationTypeCustom = "CUSTOM"
 )
+
+// ConfigurationType_Values returns all elements of the ConfigurationType enum
+func ConfigurationType_Values() []string {
+	return []string{
+		ConfigurationTypeDefault,
+		ConfigurationTypeCustom,
+	}
+}
 
 const (
 	// InputStartingPositionNow is a InputStartingPosition enum value
@@ -11785,6 +11822,15 @@ const (
 	// InputStartingPositionLastStoppedPoint is a InputStartingPosition enum value
 	InputStartingPositionLastStoppedPoint = "LAST_STOPPED_POINT"
 )
+
+// InputStartingPosition_Values returns all elements of the InputStartingPosition enum
+func InputStartingPosition_Values() []string {
+	return []string{
+		InputStartingPositionNow,
+		InputStartingPositionTrimHorizon,
+		InputStartingPositionLastStoppedPoint,
+	}
+}
 
 const (
 	// LogLevelInfo is a LogLevel enum value
@@ -11800,6 +11846,16 @@ const (
 	LogLevelDebug = "DEBUG"
 )
 
+// LogLevel_Values returns all elements of the LogLevel enum
+func LogLevel_Values() []string {
+	return []string{
+		LogLevelInfo,
+		LogLevelWarn,
+		LogLevelError,
+		LogLevelDebug,
+	}
+}
+
 const (
 	// MetricsLevelApplication is a MetricsLevel enum value
 	MetricsLevelApplication = "APPLICATION"
@@ -11814,6 +11870,16 @@ const (
 	MetricsLevelParallelism = "PARALLELISM"
 )
 
+// MetricsLevel_Values returns all elements of the MetricsLevel enum
+func MetricsLevel_Values() []string {
+	return []string{
+		MetricsLevelApplication,
+		MetricsLevelTask,
+		MetricsLevelOperator,
+		MetricsLevelParallelism,
+	}
+}
+
 const (
 	// RecordFormatTypeJson is a RecordFormatType enum value
 	RecordFormatTypeJson = "JSON"
@@ -11821,6 +11887,14 @@ const (
 	// RecordFormatTypeCsv is a RecordFormatType enum value
 	RecordFormatTypeCsv = "CSV"
 )
+
+// RecordFormatType_Values returns all elements of the RecordFormatType enum
+func RecordFormatType_Values() []string {
+	return []string{
+		RecordFormatTypeJson,
+		RecordFormatTypeCsv,
+	}
+}
 
 const (
 	// RuntimeEnvironmentSql10 is a RuntimeEnvironment enum value
@@ -11832,6 +11906,15 @@ const (
 	// RuntimeEnvironmentFlink18 is a RuntimeEnvironment enum value
 	RuntimeEnvironmentFlink18 = "FLINK-1_8"
 )
+
+// RuntimeEnvironment_Values returns all elements of the RuntimeEnvironment enum
+func RuntimeEnvironment_Values() []string {
+	return []string{
+		RuntimeEnvironmentSql10,
+		RuntimeEnvironmentFlink16,
+		RuntimeEnvironmentFlink18,
+	}
+}
 
 const (
 	// SnapshotStatusCreating is a SnapshotStatus enum value
@@ -11846,3 +11929,13 @@ const (
 	// SnapshotStatusFailed is a SnapshotStatus enum value
 	SnapshotStatusFailed = "FAILED"
 )
+
+// SnapshotStatus_Values returns all elements of the SnapshotStatus enum
+func SnapshotStatus_Values() []string {
+	return []string{
+		SnapshotStatusCreating,
+		SnapshotStatusReady,
+		SnapshotStatusDeleting,
+		SnapshotStatusFailed,
+	}
+}

--- a/service/kinesisvideo/api.go
+++ b/service/kinesisvideo/api.go
@@ -4941,6 +4941,19 @@ const (
 	APINameGetClip = "GET_CLIP"
 )
 
+// APIName_Values returns all elements of the APIName enum
+func APIName_Values() []string {
+	return []string{
+		APINamePutMedia,
+		APINameGetMedia,
+		APINameListFragments,
+		APINameGetMediaForFragmentList,
+		APINameGetHlsStreamingSessionUrl,
+		APINameGetDashStreamingSessionUrl,
+		APINameGetClip,
+	}
+}
+
 const (
 	// ChannelProtocolWss is a ChannelProtocol enum value
 	ChannelProtocolWss = "WSS"
@@ -4948,6 +4961,14 @@ const (
 	// ChannelProtocolHttps is a ChannelProtocol enum value
 	ChannelProtocolHttps = "HTTPS"
 )
+
+// ChannelProtocol_Values returns all elements of the ChannelProtocol enum
+func ChannelProtocol_Values() []string {
+	return []string{
+		ChannelProtocolWss,
+		ChannelProtocolHttps,
+	}
+}
 
 const (
 	// ChannelRoleMaster is a ChannelRole enum value
@@ -4957,15 +4978,37 @@ const (
 	ChannelRoleViewer = "VIEWER"
 )
 
+// ChannelRole_Values returns all elements of the ChannelRole enum
+func ChannelRole_Values() []string {
+	return []string{
+		ChannelRoleMaster,
+		ChannelRoleViewer,
+	}
+}
+
 const (
 	// ChannelTypeSingleMaster is a ChannelType enum value
 	ChannelTypeSingleMaster = "SINGLE_MASTER"
 )
 
+// ChannelType_Values returns all elements of the ChannelType enum
+func ChannelType_Values() []string {
+	return []string{
+		ChannelTypeSingleMaster,
+	}
+}
+
 const (
 	// ComparisonOperatorBeginsWith is a ComparisonOperator enum value
 	ComparisonOperatorBeginsWith = "BEGINS_WITH"
 )
+
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorBeginsWith,
+	}
+}
 
 const (
 	// StatusCreating is a Status enum value
@@ -4981,6 +5024,16 @@ const (
 	StatusDeleting = "DELETING"
 )
 
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusCreating,
+		StatusActive,
+		StatusUpdating,
+		StatusDeleting,
+	}
+}
+
 const (
 	// UpdateDataRetentionOperationIncreaseDataRetention is a UpdateDataRetentionOperation enum value
 	UpdateDataRetentionOperationIncreaseDataRetention = "INCREASE_DATA_RETENTION"
@@ -4988,3 +5041,11 @@ const (
 	// UpdateDataRetentionOperationDecreaseDataRetention is a UpdateDataRetentionOperation enum value
 	UpdateDataRetentionOperationDecreaseDataRetention = "DECREASE_DATA_RETENTION"
 )
+
+// UpdateDataRetentionOperation_Values returns all elements of the UpdateDataRetentionOperation enum
+func UpdateDataRetentionOperation_Values() []string {
+	return []string{
+		UpdateDataRetentionOperationIncreaseDataRetention,
+		UpdateDataRetentionOperationDecreaseDataRetention,
+	}
+}

--- a/service/kinesisvideoarchivedmedia/api.go
+++ b/service/kinesisvideoarchivedmedia/api.go
@@ -2907,6 +2907,14 @@ const (
 	ClipFragmentSelectorTypeServerTimestamp = "SERVER_TIMESTAMP"
 )
 
+// ClipFragmentSelectorType_Values returns all elements of the ClipFragmentSelectorType enum
+func ClipFragmentSelectorType_Values() []string {
+	return []string{
+		ClipFragmentSelectorTypeProducerTimestamp,
+		ClipFragmentSelectorTypeServerTimestamp,
+	}
+}
+
 const (
 	// ContainerFormatFragmentedMp4 is a ContainerFormat enum value
 	ContainerFormatFragmentedMp4 = "FRAGMENTED_MP4"
@@ -2914,6 +2922,14 @@ const (
 	// ContainerFormatMpegTs is a ContainerFormat enum value
 	ContainerFormatMpegTs = "MPEG_TS"
 )
+
+// ContainerFormat_Values returns all elements of the ContainerFormat enum
+func ContainerFormat_Values() []string {
+	return []string{
+		ContainerFormatFragmentedMp4,
+		ContainerFormatMpegTs,
+	}
+}
 
 const (
 	// DASHDisplayFragmentNumberAlways is a DASHDisplayFragmentNumber enum value
@@ -2923,6 +2939,14 @@ const (
 	DASHDisplayFragmentNumberNever = "NEVER"
 )
 
+// DASHDisplayFragmentNumber_Values returns all elements of the DASHDisplayFragmentNumber enum
+func DASHDisplayFragmentNumber_Values() []string {
+	return []string{
+		DASHDisplayFragmentNumberAlways,
+		DASHDisplayFragmentNumberNever,
+	}
+}
+
 const (
 	// DASHDisplayFragmentTimestampAlways is a DASHDisplayFragmentTimestamp enum value
 	DASHDisplayFragmentTimestampAlways = "ALWAYS"
@@ -2931,6 +2955,14 @@ const (
 	DASHDisplayFragmentTimestampNever = "NEVER"
 )
 
+// DASHDisplayFragmentTimestamp_Values returns all elements of the DASHDisplayFragmentTimestamp enum
+func DASHDisplayFragmentTimestamp_Values() []string {
+	return []string{
+		DASHDisplayFragmentTimestampAlways,
+		DASHDisplayFragmentTimestampNever,
+	}
+}
+
 const (
 	// DASHFragmentSelectorTypeProducerTimestamp is a DASHFragmentSelectorType enum value
 	DASHFragmentSelectorTypeProducerTimestamp = "PRODUCER_TIMESTAMP"
@@ -2938,6 +2970,14 @@ const (
 	// DASHFragmentSelectorTypeServerTimestamp is a DASHFragmentSelectorType enum value
 	DASHFragmentSelectorTypeServerTimestamp = "SERVER_TIMESTAMP"
 )
+
+// DASHFragmentSelectorType_Values returns all elements of the DASHFragmentSelectorType enum
+func DASHFragmentSelectorType_Values() []string {
+	return []string{
+		DASHFragmentSelectorTypeProducerTimestamp,
+		DASHFragmentSelectorTypeServerTimestamp,
+	}
+}
 
 const (
 	// DASHPlaybackModeLive is a DASHPlaybackMode enum value
@@ -2950,6 +2990,15 @@ const (
 	DASHPlaybackModeOnDemand = "ON_DEMAND"
 )
 
+// DASHPlaybackMode_Values returns all elements of the DASHPlaybackMode enum
+func DASHPlaybackMode_Values() []string {
+	return []string{
+		DASHPlaybackModeLive,
+		DASHPlaybackModeLiveReplay,
+		DASHPlaybackModeOnDemand,
+	}
+}
+
 const (
 	// FragmentSelectorTypeProducerTimestamp is a FragmentSelectorType enum value
 	FragmentSelectorTypeProducerTimestamp = "PRODUCER_TIMESTAMP"
@@ -2957,6 +3006,14 @@ const (
 	// FragmentSelectorTypeServerTimestamp is a FragmentSelectorType enum value
 	FragmentSelectorTypeServerTimestamp = "SERVER_TIMESTAMP"
 )
+
+// FragmentSelectorType_Values returns all elements of the FragmentSelectorType enum
+func FragmentSelectorType_Values() []string {
+	return []string{
+		FragmentSelectorTypeProducerTimestamp,
+		FragmentSelectorTypeServerTimestamp,
+	}
+}
 
 const (
 	// HLSDiscontinuityModeAlways is a HLSDiscontinuityMode enum value
@@ -2969,6 +3026,15 @@ const (
 	HLSDiscontinuityModeOnDiscontinuity = "ON_DISCONTINUITY"
 )
 
+// HLSDiscontinuityMode_Values returns all elements of the HLSDiscontinuityMode enum
+func HLSDiscontinuityMode_Values() []string {
+	return []string{
+		HLSDiscontinuityModeAlways,
+		HLSDiscontinuityModeNever,
+		HLSDiscontinuityModeOnDiscontinuity,
+	}
+}
+
 const (
 	// HLSDisplayFragmentTimestampAlways is a HLSDisplayFragmentTimestamp enum value
 	HLSDisplayFragmentTimestampAlways = "ALWAYS"
@@ -2977,6 +3043,14 @@ const (
 	HLSDisplayFragmentTimestampNever = "NEVER"
 )
 
+// HLSDisplayFragmentTimestamp_Values returns all elements of the HLSDisplayFragmentTimestamp enum
+func HLSDisplayFragmentTimestamp_Values() []string {
+	return []string{
+		HLSDisplayFragmentTimestampAlways,
+		HLSDisplayFragmentTimestampNever,
+	}
+}
+
 const (
 	// HLSFragmentSelectorTypeProducerTimestamp is a HLSFragmentSelectorType enum value
 	HLSFragmentSelectorTypeProducerTimestamp = "PRODUCER_TIMESTAMP"
@@ -2984,6 +3058,14 @@ const (
 	// HLSFragmentSelectorTypeServerTimestamp is a HLSFragmentSelectorType enum value
 	HLSFragmentSelectorTypeServerTimestamp = "SERVER_TIMESTAMP"
 )
+
+// HLSFragmentSelectorType_Values returns all elements of the HLSFragmentSelectorType enum
+func HLSFragmentSelectorType_Values() []string {
+	return []string{
+		HLSFragmentSelectorTypeProducerTimestamp,
+		HLSFragmentSelectorTypeServerTimestamp,
+	}
+}
 
 const (
 	// HLSPlaybackModeLive is a HLSPlaybackMode enum value
@@ -2995,3 +3077,12 @@ const (
 	// HLSPlaybackModeOnDemand is a HLSPlaybackMode enum value
 	HLSPlaybackModeOnDemand = "ON_DEMAND"
 )
+
+// HLSPlaybackMode_Values returns all elements of the HLSPlaybackMode enum
+func HLSPlaybackMode_Values() []string {
+	return []string{
+		HLSPlaybackModeLive,
+		HLSPlaybackModeLiveReplay,
+		HLSPlaybackModeOnDemand,
+	}
+}

--- a/service/kinesisvideomedia/api.go
+++ b/service/kinesisvideomedia/api.go
@@ -766,3 +766,15 @@ const (
 	// StartSelectorTypeContinuationToken is a StartSelectorType enum value
 	StartSelectorTypeContinuationToken = "CONTINUATION_TOKEN"
 )
+
+// StartSelectorType_Values returns all elements of the StartSelectorType enum
+func StartSelectorType_Values() []string {
+	return []string{
+		StartSelectorTypeFragmentNumber,
+		StartSelectorTypeServerTimestamp,
+		StartSelectorTypeProducerTimestamp,
+		StartSelectorTypeNow,
+		StartSelectorTypeEarliest,
+		StartSelectorTypeContinuationToken,
+	}
+}

--- a/service/kinesisvideosignalingchannels/api.go
+++ b/service/kinesisvideosignalingchannels/api.go
@@ -811,3 +811,10 @@ const (
 	// ServiceTurn is a Service enum value
 	ServiceTurn = "TURN"
 )
+
+// Service_Values returns all elements of the Service enum
+func Service_Values() []string {
+	return []string{
+		ServiceTurn,
+	}
+}

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -14540,6 +14540,15 @@ const (
 	AlgorithmSpecRsaesOaepSha256 = "RSAES_OAEP_SHA_256"
 )
 
+// AlgorithmSpec_Values returns all elements of the AlgorithmSpec enum
+func AlgorithmSpec_Values() []string {
+	return []string{
+		AlgorithmSpecRsaesPkcs1V15,
+		AlgorithmSpecRsaesOaepSha1,
+		AlgorithmSpecRsaesOaepSha256,
+	}
+}
+
 const (
 	// ConnectionErrorCodeTypeInvalidCredentials is a ConnectionErrorCodeType enum value
 	ConnectionErrorCodeTypeInvalidCredentials = "INVALID_CREDENTIALS"
@@ -14569,6 +14578,21 @@ const (
 	ConnectionErrorCodeTypeSubnetNotFound = "SUBNET_NOT_FOUND"
 )
 
+// ConnectionErrorCodeType_Values returns all elements of the ConnectionErrorCodeType enum
+func ConnectionErrorCodeType_Values() []string {
+	return []string{
+		ConnectionErrorCodeTypeInvalidCredentials,
+		ConnectionErrorCodeTypeClusterNotFound,
+		ConnectionErrorCodeTypeNetworkErrors,
+		ConnectionErrorCodeTypeInternalError,
+		ConnectionErrorCodeTypeInsufficientCloudhsmHsms,
+		ConnectionErrorCodeTypeUserLockedOut,
+		ConnectionErrorCodeTypeUserNotFound,
+		ConnectionErrorCodeTypeUserLoggedIn,
+		ConnectionErrorCodeTypeSubnetNotFound,
+	}
+}
+
 const (
 	// ConnectionStateTypeConnected is a ConnectionStateType enum value
 	ConnectionStateTypeConnected = "CONNECTED"
@@ -14585,6 +14609,17 @@ const (
 	// ConnectionStateTypeDisconnecting is a ConnectionStateType enum value
 	ConnectionStateTypeDisconnecting = "DISCONNECTING"
 )
+
+// ConnectionStateType_Values returns all elements of the ConnectionStateType enum
+func ConnectionStateType_Values() []string {
+	return []string{
+		ConnectionStateTypeConnected,
+		ConnectionStateTypeConnecting,
+		ConnectionStateTypeFailed,
+		ConnectionStateTypeDisconnected,
+		ConnectionStateTypeDisconnecting,
+	}
+}
 
 const (
 	// CustomerMasterKeySpecRsa2048 is a CustomerMasterKeySpec enum value
@@ -14612,6 +14647,20 @@ const (
 	CustomerMasterKeySpecSymmetricDefault = "SYMMETRIC_DEFAULT"
 )
 
+// CustomerMasterKeySpec_Values returns all elements of the CustomerMasterKeySpec enum
+func CustomerMasterKeySpec_Values() []string {
+	return []string{
+		CustomerMasterKeySpecRsa2048,
+		CustomerMasterKeySpecRsa3072,
+		CustomerMasterKeySpecRsa4096,
+		CustomerMasterKeySpecEccNistP256,
+		CustomerMasterKeySpecEccNistP384,
+		CustomerMasterKeySpecEccNistP521,
+		CustomerMasterKeySpecEccSecgP256k1,
+		CustomerMasterKeySpecSymmetricDefault,
+	}
+}
+
 const (
 	// DataKeyPairSpecRsa2048 is a DataKeyPairSpec enum value
 	DataKeyPairSpecRsa2048 = "RSA_2048"
@@ -14635,6 +14684,19 @@ const (
 	DataKeyPairSpecEccSecgP256k1 = "ECC_SECG_P256K1"
 )
 
+// DataKeyPairSpec_Values returns all elements of the DataKeyPairSpec enum
+func DataKeyPairSpec_Values() []string {
+	return []string{
+		DataKeyPairSpecRsa2048,
+		DataKeyPairSpecRsa3072,
+		DataKeyPairSpecRsa4096,
+		DataKeyPairSpecEccNistP256,
+		DataKeyPairSpecEccNistP384,
+		DataKeyPairSpecEccNistP521,
+		DataKeyPairSpecEccSecgP256k1,
+	}
+}
+
 const (
 	// DataKeySpecAes256 is a DataKeySpec enum value
 	DataKeySpecAes256 = "AES_256"
@@ -14642,6 +14704,14 @@ const (
 	// DataKeySpecAes128 is a DataKeySpec enum value
 	DataKeySpecAes128 = "AES_128"
 )
+
+// DataKeySpec_Values returns all elements of the DataKeySpec enum
+func DataKeySpec_Values() []string {
+	return []string{
+		DataKeySpecAes256,
+		DataKeySpecAes128,
+	}
+}
 
 const (
 	// EncryptionAlgorithmSpecSymmetricDefault is a EncryptionAlgorithmSpec enum value
@@ -14654,6 +14724,15 @@ const (
 	EncryptionAlgorithmSpecRsaesOaepSha256 = "RSAES_OAEP_SHA_256"
 )
 
+// EncryptionAlgorithmSpec_Values returns all elements of the EncryptionAlgorithmSpec enum
+func EncryptionAlgorithmSpec_Values() []string {
+	return []string{
+		EncryptionAlgorithmSpecSymmetricDefault,
+		EncryptionAlgorithmSpecRsaesOaepSha1,
+		EncryptionAlgorithmSpecRsaesOaepSha256,
+	}
+}
+
 const (
 	// ExpirationModelTypeKeyMaterialExpires is a ExpirationModelType enum value
 	ExpirationModelTypeKeyMaterialExpires = "KEY_MATERIAL_EXPIRES"
@@ -14661,6 +14740,14 @@ const (
 	// ExpirationModelTypeKeyMaterialDoesNotExpire is a ExpirationModelType enum value
 	ExpirationModelTypeKeyMaterialDoesNotExpire = "KEY_MATERIAL_DOES_NOT_EXPIRE"
 )
+
+// ExpirationModelType_Values returns all elements of the ExpirationModelType enum
+func ExpirationModelType_Values() []string {
+	return []string{
+		ExpirationModelTypeKeyMaterialExpires,
+		ExpirationModelTypeKeyMaterialDoesNotExpire,
+	}
+}
 
 const (
 	// GrantOperationDecrypt is a GrantOperation enum value
@@ -14706,6 +14793,26 @@ const (
 	GrantOperationGenerateDataKeyPairWithoutPlaintext = "GenerateDataKeyPairWithoutPlaintext"
 )
 
+// GrantOperation_Values returns all elements of the GrantOperation enum
+func GrantOperation_Values() []string {
+	return []string{
+		GrantOperationDecrypt,
+		GrantOperationEncrypt,
+		GrantOperationGenerateDataKey,
+		GrantOperationGenerateDataKeyWithoutPlaintext,
+		GrantOperationReEncryptFrom,
+		GrantOperationReEncryptTo,
+		GrantOperationSign,
+		GrantOperationVerify,
+		GrantOperationGetPublicKey,
+		GrantOperationCreateGrant,
+		GrantOperationRetireGrant,
+		GrantOperationDescribeKey,
+		GrantOperationGenerateDataKeyPair,
+		GrantOperationGenerateDataKeyPairWithoutPlaintext,
+	}
+}
+
 const (
 	// KeyManagerTypeAws is a KeyManagerType enum value
 	KeyManagerTypeAws = "AWS"
@@ -14713,6 +14820,14 @@ const (
 	// KeyManagerTypeCustomer is a KeyManagerType enum value
 	KeyManagerTypeCustomer = "CUSTOMER"
 )
+
+// KeyManagerType_Values returns all elements of the KeyManagerType enum
+func KeyManagerType_Values() []string {
+	return []string{
+		KeyManagerTypeAws,
+		KeyManagerTypeCustomer,
+	}
+}
 
 const (
 	// KeyStateEnabled is a KeyState enum value
@@ -14731,6 +14846,17 @@ const (
 	KeyStateUnavailable = "Unavailable"
 )
 
+// KeyState_Values returns all elements of the KeyState enum
+func KeyState_Values() []string {
+	return []string{
+		KeyStateEnabled,
+		KeyStateDisabled,
+		KeyStatePendingDeletion,
+		KeyStatePendingImport,
+		KeyStateUnavailable,
+	}
+}
+
 const (
 	// KeyUsageTypeSignVerify is a KeyUsageType enum value
 	KeyUsageTypeSignVerify = "SIGN_VERIFY"
@@ -14739,6 +14865,14 @@ const (
 	KeyUsageTypeEncryptDecrypt = "ENCRYPT_DECRYPT"
 )
 
+// KeyUsageType_Values returns all elements of the KeyUsageType enum
+func KeyUsageType_Values() []string {
+	return []string{
+		KeyUsageTypeSignVerify,
+		KeyUsageTypeEncryptDecrypt,
+	}
+}
+
 const (
 	// MessageTypeRaw is a MessageType enum value
 	MessageTypeRaw = "RAW"
@@ -14746,6 +14880,14 @@ const (
 	// MessageTypeDigest is a MessageType enum value
 	MessageTypeDigest = "DIGEST"
 )
+
+// MessageType_Values returns all elements of the MessageType enum
+func MessageType_Values() []string {
+	return []string{
+		MessageTypeRaw,
+		MessageTypeDigest,
+	}
+}
 
 const (
 	// OriginTypeAwsKms is a OriginType enum value
@@ -14757,6 +14899,15 @@ const (
 	// OriginTypeAwsCloudhsm is a OriginType enum value
 	OriginTypeAwsCloudhsm = "AWS_CLOUDHSM"
 )
+
+// OriginType_Values returns all elements of the OriginType enum
+func OriginType_Values() []string {
+	return []string{
+		OriginTypeAwsKms,
+		OriginTypeExternal,
+		OriginTypeAwsCloudhsm,
+	}
+}
 
 const (
 	// SigningAlgorithmSpecRsassaPssSha256 is a SigningAlgorithmSpec enum value
@@ -14787,7 +14938,29 @@ const (
 	SigningAlgorithmSpecEcdsaSha512 = "ECDSA_SHA_512"
 )
 
+// SigningAlgorithmSpec_Values returns all elements of the SigningAlgorithmSpec enum
+func SigningAlgorithmSpec_Values() []string {
+	return []string{
+		SigningAlgorithmSpecRsassaPssSha256,
+		SigningAlgorithmSpecRsassaPssSha384,
+		SigningAlgorithmSpecRsassaPssSha512,
+		SigningAlgorithmSpecRsassaPkcs1V15Sha256,
+		SigningAlgorithmSpecRsassaPkcs1V15Sha384,
+		SigningAlgorithmSpecRsassaPkcs1V15Sha512,
+		SigningAlgorithmSpecEcdsaSha256,
+		SigningAlgorithmSpecEcdsaSha384,
+		SigningAlgorithmSpecEcdsaSha512,
+	}
+}
+
 const (
 	// WrappingKeySpecRsa2048 is a WrappingKeySpec enum value
 	WrappingKeySpecRsa2048 = "RSA_2048"
 )
+
+// WrappingKeySpec_Values returns all elements of the WrappingKeySpec enum
+func WrappingKeySpec_Values() []string {
+	return []string{
+		WrappingKeySpecRsa2048,
+	}
+}

--- a/service/lakeformation/api.go
+++ b/service/lakeformation/api.go
@@ -3782,6 +3782,23 @@ const (
 	ComparisonOperatorBetween = "BETWEEN"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorEq,
+		ComparisonOperatorNe,
+		ComparisonOperatorLe,
+		ComparisonOperatorLt,
+		ComparisonOperatorGe,
+		ComparisonOperatorGt,
+		ComparisonOperatorContains,
+		ComparisonOperatorNotContains,
+		ComparisonOperatorBeginsWith,
+		ComparisonOperatorIn,
+		ComparisonOperatorBetween,
+	}
+}
+
 const (
 	// DataLakeResourceTypeCatalog is a DataLakeResourceType enum value
 	DataLakeResourceTypeCatalog = "CATALOG"
@@ -3796,6 +3813,16 @@ const (
 	DataLakeResourceTypeDataLocation = "DATA_LOCATION"
 )
 
+// DataLakeResourceType_Values returns all elements of the DataLakeResourceType enum
+func DataLakeResourceType_Values() []string {
+	return []string{
+		DataLakeResourceTypeCatalog,
+		DataLakeResourceTypeDatabase,
+		DataLakeResourceTypeTable,
+		DataLakeResourceTypeDataLocation,
+	}
+}
+
 const (
 	// FieldNameStringResourceArn is a FieldNameString enum value
 	FieldNameStringResourceArn = "RESOURCE_ARN"
@@ -3806,6 +3833,15 @@ const (
 	// FieldNameStringLastModified is a FieldNameString enum value
 	FieldNameStringLastModified = "LAST_MODIFIED"
 )
+
+// FieldNameString_Values returns all elements of the FieldNameString enum
+func FieldNameString_Values() []string {
+	return []string{
+		FieldNameStringResourceArn,
+		FieldNameStringRoleArn,
+		FieldNameStringLastModified,
+	}
+}
 
 const (
 	// PermissionAll is a Permission enum value
@@ -3838,3 +3874,19 @@ const (
 	// PermissionDataLocationAccess is a Permission enum value
 	PermissionDataLocationAccess = "DATA_LOCATION_ACCESS"
 )
+
+// Permission_Values returns all elements of the Permission enum
+func Permission_Values() []string {
+	return []string{
+		PermissionAll,
+		PermissionSelect,
+		PermissionAlter,
+		PermissionDrop,
+		PermissionDelete,
+		PermissionInsert,
+		PermissionDescribe,
+		PermissionCreateDatabase,
+		PermissionCreateTable,
+		PermissionDataLocationAccess,
+	}
+}

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -14165,10 +14165,26 @@ const (
 	EventSourcePositionAtTimestamp = "AT_TIMESTAMP"
 )
 
+// EventSourcePosition_Values returns all elements of the EventSourcePosition enum
+func EventSourcePosition_Values() []string {
+	return []string{
+		EventSourcePositionTrimHorizon,
+		EventSourcePositionLatest,
+		EventSourcePositionAtTimestamp,
+	}
+}
+
 const (
 	// FunctionVersionAll is a FunctionVersion enum value
 	FunctionVersionAll = "ALL"
 )
+
+// FunctionVersion_Values returns all elements of the FunctionVersion enum
+func FunctionVersion_Values() []string {
+	return []string{
+		FunctionVersionAll,
+	}
+}
 
 const (
 	// InvocationTypeEvent is a InvocationType enum value
@@ -14181,6 +14197,15 @@ const (
 	InvocationTypeDryRun = "DryRun"
 )
 
+// InvocationType_Values returns all elements of the InvocationType enum
+func InvocationType_Values() []string {
+	return []string{
+		InvocationTypeEvent,
+		InvocationTypeRequestResponse,
+		InvocationTypeDryRun,
+	}
+}
+
 const (
 	// LastUpdateStatusSuccessful is a LastUpdateStatus enum value
 	LastUpdateStatusSuccessful = "Successful"
@@ -14191,6 +14216,15 @@ const (
 	// LastUpdateStatusInProgress is a LastUpdateStatus enum value
 	LastUpdateStatusInProgress = "InProgress"
 )
+
+// LastUpdateStatus_Values returns all elements of the LastUpdateStatus enum
+func LastUpdateStatus_Values() []string {
+	return []string{
+		LastUpdateStatusSuccessful,
+		LastUpdateStatusFailed,
+		LastUpdateStatusInProgress,
+	}
+}
 
 const (
 	// LastUpdateStatusReasonCodeEniLimitExceeded is a LastUpdateStatusReasonCode enum value
@@ -14215,6 +14249,19 @@ const (
 	LastUpdateStatusReasonCodeInvalidSecurityGroup = "InvalidSecurityGroup"
 )
 
+// LastUpdateStatusReasonCode_Values returns all elements of the LastUpdateStatusReasonCode enum
+func LastUpdateStatusReasonCode_Values() []string {
+	return []string{
+		LastUpdateStatusReasonCodeEniLimitExceeded,
+		LastUpdateStatusReasonCodeInsufficientRolePermissions,
+		LastUpdateStatusReasonCodeInvalidConfiguration,
+		LastUpdateStatusReasonCodeInternalError,
+		LastUpdateStatusReasonCodeSubnetOutOfIpaddresses,
+		LastUpdateStatusReasonCodeInvalidSubnet,
+		LastUpdateStatusReasonCodeInvalidSecurityGroup,
+	}
+}
+
 const (
 	// LogTypeNone is a LogType enum value
 	LogTypeNone = "None"
@@ -14222,6 +14269,14 @@ const (
 	// LogTypeTail is a LogType enum value
 	LogTypeTail = "Tail"
 )
+
+// LogType_Values returns all elements of the LogType enum
+func LogType_Values() []string {
+	return []string{
+		LogTypeNone,
+		LogTypeTail,
+	}
+}
 
 const (
 	// ProvisionedConcurrencyStatusEnumInProgress is a ProvisionedConcurrencyStatusEnum enum value
@@ -14233,6 +14288,15 @@ const (
 	// ProvisionedConcurrencyStatusEnumFailed is a ProvisionedConcurrencyStatusEnum enum value
 	ProvisionedConcurrencyStatusEnumFailed = "FAILED"
 )
+
+// ProvisionedConcurrencyStatusEnum_Values returns all elements of the ProvisionedConcurrencyStatusEnum enum
+func ProvisionedConcurrencyStatusEnum_Values() []string {
+	return []string{
+		ProvisionedConcurrencyStatusEnumInProgress,
+		ProvisionedConcurrencyStatusEnumReady,
+		ProvisionedConcurrencyStatusEnumFailed,
+	}
+}
 
 const (
 	// RuntimeNodejs is a Runtime enum value
@@ -14299,6 +14363,33 @@ const (
 	RuntimeProvided = "provided"
 )
 
+// Runtime_Values returns all elements of the Runtime enum
+func Runtime_Values() []string {
+	return []string{
+		RuntimeNodejs,
+		RuntimeNodejs43,
+		RuntimeNodejs610,
+		RuntimeNodejs810,
+		RuntimeNodejs10X,
+		RuntimeNodejs12X,
+		RuntimeJava8,
+		RuntimeJava11,
+		RuntimePython27,
+		RuntimePython36,
+		RuntimePython37,
+		RuntimePython38,
+		RuntimeDotnetcore10,
+		RuntimeDotnetcore20,
+		RuntimeDotnetcore21,
+		RuntimeDotnetcore31,
+		RuntimeNodejs43Edge,
+		RuntimeGo1X,
+		RuntimeRuby25,
+		RuntimeRuby27,
+		RuntimeProvided,
+	}
+}
+
 const (
 	// StatePending is a State enum value
 	StatePending = "Pending"
@@ -14312,6 +14403,16 @@ const (
 	// StateFailed is a State enum value
 	StateFailed = "Failed"
 )
+
+// State_Values returns all elements of the State enum
+func State_Values() []string {
+	return []string{
+		StatePending,
+		StateActive,
+		StateInactive,
+		StateFailed,
+	}
+}
 
 const (
 	// StateReasonCodeIdle is a StateReasonCode enum value
@@ -14345,6 +14446,22 @@ const (
 	StateReasonCodeInvalidSecurityGroup = "InvalidSecurityGroup"
 )
 
+// StateReasonCode_Values returns all elements of the StateReasonCode enum
+func StateReasonCode_Values() []string {
+	return []string{
+		StateReasonCodeIdle,
+		StateReasonCodeCreating,
+		StateReasonCodeRestoring,
+		StateReasonCodeEniLimitExceeded,
+		StateReasonCodeInsufficientRolePermissions,
+		StateReasonCodeInvalidConfiguration,
+		StateReasonCodeInternalError,
+		StateReasonCodeSubnetOutOfIpaddresses,
+		StateReasonCodeInvalidSubnet,
+		StateReasonCodeInvalidSecurityGroup,
+	}
+}
+
 const (
 	// ThrottleReasonConcurrentInvocationLimitExceeded is a ThrottleReason enum value
 	ThrottleReasonConcurrentInvocationLimitExceeded = "ConcurrentInvocationLimitExceeded"
@@ -14362,6 +14479,17 @@ const (
 	ThrottleReasonCallerRateLimitExceeded = "CallerRateLimitExceeded"
 )
 
+// ThrottleReason_Values returns all elements of the ThrottleReason enum
+func ThrottleReason_Values() []string {
+	return []string{
+		ThrottleReasonConcurrentInvocationLimitExceeded,
+		ThrottleReasonFunctionInvocationRateLimitExceeded,
+		ThrottleReasonReservedFunctionConcurrentInvocationLimitExceeded,
+		ThrottleReasonReservedFunctionInvocationRateLimitExceeded,
+		ThrottleReasonCallerRateLimitExceeded,
+	}
+}
+
 const (
 	// TracingModeActive is a TracingMode enum value
 	TracingModeActive = "Active"
@@ -14369,3 +14497,11 @@ const (
 	// TracingModePassThrough is a TracingMode enum value
 	TracingModePassThrough = "PassThrough"
 )
+
+// TracingMode_Values returns all elements of the TracingMode enum
+func TracingMode_Values() []string {
+	return []string{
+		TracingModeActive,
+		TracingModePassThrough,
+	}
+}

--- a/service/lexmodelbuildingservice/api.go
+++ b/service/lexmodelbuildingservice/api.go
@@ -12583,6 +12583,15 @@ const (
 	ChannelStatusFailed = "FAILED"
 )
 
+// ChannelStatus_Values returns all elements of the ChannelStatus enum
+func ChannelStatus_Values() []string {
+	return []string{
+		ChannelStatusInProgress,
+		ChannelStatusCreated,
+		ChannelStatusFailed,
+	}
+}
+
 const (
 	// ChannelTypeFacebook is a ChannelType enum value
 	ChannelTypeFacebook = "Facebook"
@@ -12597,6 +12606,16 @@ const (
 	ChannelTypeKik = "Kik"
 )
 
+// ChannelType_Values returns all elements of the ChannelType enum
+func ChannelType_Values() []string {
+	return []string{
+		ChannelTypeFacebook,
+		ChannelTypeSlack,
+		ChannelTypeTwilioSms,
+		ChannelTypeKik,
+	}
+}
+
 const (
 	// ContentTypePlainText is a ContentType enum value
 	ContentTypePlainText = "PlainText"
@@ -12608,6 +12627,15 @@ const (
 	ContentTypeCustomPayload = "CustomPayload"
 )
 
+// ContentType_Values returns all elements of the ContentType enum
+func ContentType_Values() []string {
+	return []string{
+		ContentTypePlainText,
+		ContentTypeSsml,
+		ContentTypeCustomPayload,
+	}
+}
+
 const (
 	// DestinationCloudwatchLogs is a Destination enum value
 	DestinationCloudwatchLogs = "CLOUDWATCH_LOGS"
@@ -12615,6 +12643,14 @@ const (
 	// DestinationS3 is a Destination enum value
 	DestinationS3 = "S3"
 )
+
+// Destination_Values returns all elements of the Destination enum
+func Destination_Values() []string {
+	return []string{
+		DestinationCloudwatchLogs,
+		DestinationS3,
+	}
+}
 
 const (
 	// ExportStatusInProgress is a ExportStatus enum value
@@ -12627,6 +12663,15 @@ const (
 	ExportStatusFailed = "FAILED"
 )
 
+// ExportStatus_Values returns all elements of the ExportStatus enum
+func ExportStatus_Values() []string {
+	return []string{
+		ExportStatusInProgress,
+		ExportStatusReady,
+		ExportStatusFailed,
+	}
+}
+
 const (
 	// ExportTypeAlexaSkillsKit is a ExportType enum value
 	ExportTypeAlexaSkillsKit = "ALEXA_SKILLS_KIT"
@@ -12635,6 +12680,14 @@ const (
 	ExportTypeLex = "LEX"
 )
 
+// ExportType_Values returns all elements of the ExportType enum
+func ExportType_Values() []string {
+	return []string{
+		ExportTypeAlexaSkillsKit,
+		ExportTypeLex,
+	}
+}
+
 const (
 	// FulfillmentActivityTypeReturnIntent is a FulfillmentActivityType enum value
 	FulfillmentActivityTypeReturnIntent = "ReturnIntent"
@@ -12642,6 +12695,14 @@ const (
 	// FulfillmentActivityTypeCodeHook is a FulfillmentActivityType enum value
 	FulfillmentActivityTypeCodeHook = "CodeHook"
 )
+
+// FulfillmentActivityType_Values returns all elements of the FulfillmentActivityType enum
+func FulfillmentActivityType_Values() []string {
+	return []string{
+		FulfillmentActivityTypeReturnIntent,
+		FulfillmentActivityTypeCodeHook,
+	}
+}
 
 const (
 	// ImportStatusInProgress is a ImportStatus enum value
@@ -12654,6 +12715,15 @@ const (
 	ImportStatusFailed = "FAILED"
 )
 
+// ImportStatus_Values returns all elements of the ImportStatus enum
+func ImportStatus_Values() []string {
+	return []string{
+		ImportStatusInProgress,
+		ImportStatusComplete,
+		ImportStatusFailed,
+	}
+}
+
 const (
 	// LocaleEnUs is a Locale enum value
 	LocaleEnUs = "en-US"
@@ -12665,6 +12735,15 @@ const (
 	LocaleDeDe = "de-DE"
 )
 
+// Locale_Values returns all elements of the Locale enum
+func Locale_Values() []string {
+	return []string{
+		LocaleEnUs,
+		LocaleEnGb,
+		LocaleDeDe,
+	}
+}
+
 const (
 	// LogTypeAudio is a LogType enum value
 	LogTypeAudio = "AUDIO"
@@ -12672,6 +12751,14 @@ const (
 	// LogTypeText is a LogType enum value
 	LogTypeText = "TEXT"
 )
+
+// LogType_Values returns all elements of the LogType enum
+func LogType_Values() []string {
+	return []string{
+		LogTypeAudio,
+		LogTypeText,
+	}
+}
 
 const (
 	// MergeStrategyOverwriteLatest is a MergeStrategy enum value
@@ -12681,6 +12768,14 @@ const (
 	MergeStrategyFailOnConflict = "FAIL_ON_CONFLICT"
 )
 
+// MergeStrategy_Values returns all elements of the MergeStrategy enum
+func MergeStrategy_Values() []string {
+	return []string{
+		MergeStrategyOverwriteLatest,
+		MergeStrategyFailOnConflict,
+	}
+}
+
 const (
 	// ObfuscationSettingNone is a ObfuscationSetting enum value
 	ObfuscationSettingNone = "NONE"
@@ -12689,6 +12784,14 @@ const (
 	ObfuscationSettingDefaultObfuscation = "DEFAULT_OBFUSCATION"
 )
 
+// ObfuscationSetting_Values returns all elements of the ObfuscationSetting enum
+func ObfuscationSetting_Values() []string {
+	return []string{
+		ObfuscationSettingNone,
+		ObfuscationSettingDefaultObfuscation,
+	}
+}
+
 const (
 	// ProcessBehaviorSave is a ProcessBehavior enum value
 	ProcessBehaviorSave = "SAVE"
@@ -12696,6 +12799,14 @@ const (
 	// ProcessBehaviorBuild is a ProcessBehavior enum value
 	ProcessBehaviorBuild = "BUILD"
 )
+
+// ProcessBehavior_Values returns all elements of the ProcessBehavior enum
+func ProcessBehavior_Values() []string {
+	return []string{
+		ProcessBehaviorSave,
+		ProcessBehaviorBuild,
+	}
+}
 
 const (
 	// ReferenceTypeIntent is a ReferenceType enum value
@@ -12711,6 +12822,16 @@ const (
 	ReferenceTypeBotChannel = "BotChannel"
 )
 
+// ReferenceType_Values returns all elements of the ReferenceType enum
+func ReferenceType_Values() []string {
+	return []string{
+		ReferenceTypeIntent,
+		ReferenceTypeBot,
+		ReferenceTypeBotAlias,
+		ReferenceTypeBotChannel,
+	}
+}
+
 const (
 	// ResourceTypeBot is a ResourceType enum value
 	ResourceTypeBot = "BOT"
@@ -12722,6 +12843,15 @@ const (
 	ResourceTypeSlotType = "SLOT_TYPE"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeBot,
+		ResourceTypeIntent,
+		ResourceTypeSlotType,
+	}
+}
+
 const (
 	// SlotConstraintRequired is a SlotConstraint enum value
 	SlotConstraintRequired = "Required"
@@ -12730,6 +12860,14 @@ const (
 	SlotConstraintOptional = "Optional"
 )
 
+// SlotConstraint_Values returns all elements of the SlotConstraint enum
+func SlotConstraint_Values() []string {
+	return []string{
+		SlotConstraintRequired,
+		SlotConstraintOptional,
+	}
+}
+
 const (
 	// SlotValueSelectionStrategyOriginalValue is a SlotValueSelectionStrategy enum value
 	SlotValueSelectionStrategyOriginalValue = "ORIGINAL_VALUE"
@@ -12737,6 +12875,14 @@ const (
 	// SlotValueSelectionStrategyTopResolution is a SlotValueSelectionStrategy enum value
 	SlotValueSelectionStrategyTopResolution = "TOP_RESOLUTION"
 )
+
+// SlotValueSelectionStrategy_Values returns all elements of the SlotValueSelectionStrategy enum
+func SlotValueSelectionStrategy_Values() []string {
+	return []string{
+		SlotValueSelectionStrategyOriginalValue,
+		SlotValueSelectionStrategyTopResolution,
+	}
+}
 
 const (
 	// StatusBuilding is a Status enum value
@@ -12755,6 +12901,17 @@ const (
 	StatusNotBuilt = "NOT_BUILT"
 )
 
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusBuilding,
+		StatusReady,
+		StatusReadyBasicTesting,
+		StatusFailed,
+		StatusNotBuilt,
+	}
+}
+
 const (
 	// StatusTypeDetected is a StatusType enum value
 	StatusTypeDetected = "Detected"
@@ -12762,3 +12919,11 @@ const (
 	// StatusTypeMissed is a StatusType enum value
 	StatusTypeMissed = "Missed"
 )
+
+// StatusType_Values returns all elements of the StatusType enum
+func StatusType_Values() []string {
+	return []string{
+		StatusTypeDetected,
+		StatusTypeMissed,
+	}
+}

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -3206,10 +3206,26 @@ const (
 	ConfirmationStatusDenied = "Denied"
 )
 
+// ConfirmationStatus_Values returns all elements of the ConfirmationStatus enum
+func ConfirmationStatus_Values() []string {
+	return []string{
+		ConfirmationStatusNone,
+		ConfirmationStatusConfirmed,
+		ConfirmationStatusDenied,
+	}
+}
+
 const (
 	// ContentTypeApplicationVndAmazonawsCardGeneric is a ContentType enum value
 	ContentTypeApplicationVndAmazonawsCardGeneric = "application/vnd.amazonaws.card.generic"
 )
+
+// ContentType_Values returns all elements of the ContentType enum
+func ContentType_Values() []string {
+	return []string{
+		ContentTypeApplicationVndAmazonawsCardGeneric,
+	}
+}
 
 const (
 	// DialogActionTypeElicitIntent is a DialogActionType enum value
@@ -3227,6 +3243,17 @@ const (
 	// DialogActionTypeDelegate is a DialogActionType enum value
 	DialogActionTypeDelegate = "Delegate"
 )
+
+// DialogActionType_Values returns all elements of the DialogActionType enum
+func DialogActionType_Values() []string {
+	return []string{
+		DialogActionTypeElicitIntent,
+		DialogActionTypeConfirmIntent,
+		DialogActionTypeElicitSlot,
+		DialogActionTypeClose,
+		DialogActionTypeDelegate,
+	}
+}
 
 const (
 	// DialogStateElicitIntent is a DialogState enum value
@@ -3248,6 +3275,18 @@ const (
 	DialogStateFailed = "Failed"
 )
 
+// DialogState_Values returns all elements of the DialogState enum
+func DialogState_Values() []string {
+	return []string{
+		DialogStateElicitIntent,
+		DialogStateConfirmIntent,
+		DialogStateElicitSlot,
+		DialogStateFulfilled,
+		DialogStateReadyForFulfillment,
+		DialogStateFailed,
+	}
+}
+
 const (
 	// FulfillmentStateFulfilled is a FulfillmentState enum value
 	FulfillmentStateFulfilled = "Fulfilled"
@@ -3258,6 +3297,15 @@ const (
 	// FulfillmentStateReadyForFulfillment is a FulfillmentState enum value
 	FulfillmentStateReadyForFulfillment = "ReadyForFulfillment"
 )
+
+// FulfillmentState_Values returns all elements of the FulfillmentState enum
+func FulfillmentState_Values() []string {
+	return []string{
+		FulfillmentStateFulfilled,
+		FulfillmentStateFailed,
+		FulfillmentStateReadyForFulfillment,
+	}
+}
 
 const (
 	// MessageFormatTypePlainText is a MessageFormatType enum value
@@ -3272,3 +3320,13 @@ const (
 	// MessageFormatTypeComposite is a MessageFormatType enum value
 	MessageFormatTypeComposite = "Composite"
 )
+
+// MessageFormatType_Values returns all elements of the MessageFormatType enum
+func MessageFormatType_Values() []string {
+	return []string{
+		MessageFormatTypePlainText,
+		MessageFormatTypeCustomPayload,
+		MessageFormatTypeSsml,
+		MessageFormatTypeComposite,
+	}
+}

--- a/service/licensemanager/api.go
+++ b/service/licensemanager/api.go
@@ -4568,6 +4568,16 @@ const (
 	InventoryFilterConditionContains = "CONTAINS"
 )
 
+// InventoryFilterCondition_Values returns all elements of the InventoryFilterCondition enum
+func InventoryFilterCondition_Values() []string {
+	return []string{
+		InventoryFilterConditionEquals,
+		InventoryFilterConditionNotEquals,
+		InventoryFilterConditionBeginsWith,
+		InventoryFilterConditionContains,
+	}
+}
+
 const (
 	// LicenseConfigurationStatusAvailable is a LicenseConfigurationStatus enum value
 	LicenseConfigurationStatusAvailable = "AVAILABLE"
@@ -4575,6 +4585,14 @@ const (
 	// LicenseConfigurationStatusDisabled is a LicenseConfigurationStatus enum value
 	LicenseConfigurationStatusDisabled = "DISABLED"
 )
+
+// LicenseConfigurationStatus_Values returns all elements of the LicenseConfigurationStatus enum
+func LicenseConfigurationStatus_Values() []string {
+	return []string{
+		LicenseConfigurationStatusAvailable,
+		LicenseConfigurationStatusDisabled,
+	}
+}
 
 const (
 	// LicenseCountingTypeVCpu is a LicenseCountingType enum value
@@ -4589,6 +4607,16 @@ const (
 	// LicenseCountingTypeSocket is a LicenseCountingType enum value
 	LicenseCountingTypeSocket = "Socket"
 )
+
+// LicenseCountingType_Values returns all elements of the LicenseCountingType enum
+func LicenseCountingType_Values() []string {
+	return []string{
+		LicenseCountingTypeVCpu,
+		LicenseCountingTypeInstance,
+		LicenseCountingTypeCore,
+		LicenseCountingTypeSocket,
+	}
+}
 
 const (
 	// ResourceTypeEc2Instance is a ResourceType enum value
@@ -4606,3 +4634,14 @@ const (
 	// ResourceTypeSystemsManagerManagedInstance is a ResourceType enum value
 	ResourceTypeSystemsManagerManagedInstance = "SYSTEMS_MANAGER_MANAGED_INSTANCE"
 )
+
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeEc2Instance,
+		ResourceTypeEc2Host,
+		ResourceTypeEc2Ami,
+		ResourceTypeRds,
+		ResourceTypeSystemsManagerManagedInstance,
+	}
+}

--- a/service/lightsail/api.go
+++ b/service/lightsail/api.go
@@ -31983,10 +31983,25 @@ const (
 	AccessDirectionOutbound = "outbound"
 )
 
+// AccessDirection_Values returns all elements of the AccessDirection enum
+func AccessDirection_Values() []string {
+	return []string{
+		AccessDirectionInbound,
+		AccessDirectionOutbound,
+	}
+}
+
 const (
 	// AddOnTypeAutoSnapshot is a AddOnType enum value
 	AddOnTypeAutoSnapshot = "AutoSnapshot"
 )
+
+// AddOnType_Values returns all elements of the AddOnType enum
+func AddOnType_Values() []string {
+	return []string{
+		AddOnTypeAutoSnapshot,
+	}
+}
 
 const (
 	// AlarmStateOk is a AlarmState enum value
@@ -31998,6 +32013,15 @@ const (
 	// AlarmStateInsufficientData is a AlarmState enum value
 	AlarmStateInsufficientData = "INSUFFICIENT_DATA"
 )
+
+// AlarmState_Values returns all elements of the AlarmState enum
+func AlarmState_Values() []string {
+	return []string{
+		AlarmStateOk,
+		AlarmStateAlarm,
+		AlarmStateInsufficientData,
+	}
+}
 
 const (
 	// AutoSnapshotStatusSuccess is a AutoSnapshotStatus enum value
@@ -32013,6 +32037,16 @@ const (
 	AutoSnapshotStatusNotFound = "NotFound"
 )
 
+// AutoSnapshotStatus_Values returns all elements of the AutoSnapshotStatus enum
+func AutoSnapshotStatus_Values() []string {
+	return []string{
+		AutoSnapshotStatusSuccess,
+		AutoSnapshotStatusFailed,
+		AutoSnapshotStatusInProgress,
+		AutoSnapshotStatusNotFound,
+	}
+}
+
 const (
 	// BehaviorEnumDontCache is a BehaviorEnum enum value
 	BehaviorEnumDontCache = "dont-cache"
@@ -32021,6 +32055,14 @@ const (
 	BehaviorEnumCache = "cache"
 )
 
+// BehaviorEnum_Values returns all elements of the BehaviorEnum enum
+func BehaviorEnum_Values() []string {
+	return []string{
+		BehaviorEnumDontCache,
+		BehaviorEnumCache,
+	}
+}
+
 const (
 	// BlueprintTypeOs is a BlueprintType enum value
 	BlueprintTypeOs = "os"
@@ -32028,6 +32070,14 @@ const (
 	// BlueprintTypeApp is a BlueprintType enum value
 	BlueprintTypeApp = "app"
 )
+
+// BlueprintType_Values returns all elements of the BlueprintType enum
+func BlueprintType_Values() []string {
+	return []string{
+		BlueprintTypeOs,
+		BlueprintTypeApp,
+	}
+}
 
 const (
 	// CertificateStatusPendingValidation is a CertificateStatus enum value
@@ -32052,10 +32102,30 @@ const (
 	CertificateStatusFailed = "FAILED"
 )
 
+// CertificateStatus_Values returns all elements of the CertificateStatus enum
+func CertificateStatus_Values() []string {
+	return []string{
+		CertificateStatusPendingValidation,
+		CertificateStatusIssued,
+		CertificateStatusInactive,
+		CertificateStatusExpired,
+		CertificateStatusValidationTimedOut,
+		CertificateStatusRevoked,
+		CertificateStatusFailed,
+	}
+}
+
 const (
 	// CloudFormationStackRecordSourceTypeExportSnapshotRecord is a CloudFormationStackRecordSourceType enum value
 	CloudFormationStackRecordSourceTypeExportSnapshotRecord = "ExportSnapshotRecord"
 )
+
+// CloudFormationStackRecordSourceType_Values returns all elements of the CloudFormationStackRecordSourceType enum
+func CloudFormationStackRecordSourceType_Values() []string {
+	return []string{
+		CloudFormationStackRecordSourceTypeExportSnapshotRecord,
+	}
+}
 
 const (
 	// ComparisonOperatorGreaterThanOrEqualToThreshold is a ComparisonOperator enum value
@@ -32071,6 +32141,16 @@ const (
 	ComparisonOperatorLessThanOrEqualToThreshold = "LessThanOrEqualToThreshold"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorGreaterThanOrEqualToThreshold,
+		ComparisonOperatorGreaterThanThreshold,
+		ComparisonOperatorLessThanThreshold,
+		ComparisonOperatorLessThanOrEqualToThreshold,
+	}
+}
+
 const (
 	// ContactMethodStatusPendingVerification is a ContactMethodStatus enum value
 	ContactMethodStatusPendingVerification = "PendingVerification"
@@ -32082,10 +32162,26 @@ const (
 	ContactMethodStatusInvalid = "Invalid"
 )
 
+// ContactMethodStatus_Values returns all elements of the ContactMethodStatus enum
+func ContactMethodStatus_Values() []string {
+	return []string{
+		ContactMethodStatusPendingVerification,
+		ContactMethodStatusValid,
+		ContactMethodStatusInvalid,
+	}
+}
+
 const (
 	// ContactMethodVerificationProtocolEmail is a ContactMethodVerificationProtocol enum value
 	ContactMethodVerificationProtocolEmail = "Email"
 )
+
+// ContactMethodVerificationProtocol_Values returns all elements of the ContactMethodVerificationProtocol enum
+func ContactMethodVerificationProtocol_Values() []string {
+	return []string{
+		ContactMethodVerificationProtocolEmail,
+	}
+}
 
 const (
 	// ContactProtocolEmail is a ContactProtocol enum value
@@ -32094,6 +32190,14 @@ const (
 	// ContactProtocolSms is a ContactProtocol enum value
 	ContactProtocolSms = "SMS"
 )
+
+// ContactProtocol_Values returns all elements of the ContactProtocol enum
+func ContactProtocol_Values() []string {
+	return []string{
+		ContactProtocolEmail,
+		ContactProtocolSms,
+	}
+}
 
 const (
 	// DiskSnapshotStatePending is a DiskSnapshotState enum value
@@ -32108,6 +32212,16 @@ const (
 	// DiskSnapshotStateUnknown is a DiskSnapshotState enum value
 	DiskSnapshotStateUnknown = "unknown"
 )
+
+// DiskSnapshotState_Values returns all elements of the DiskSnapshotState enum
+func DiskSnapshotState_Values() []string {
+	return []string{
+		DiskSnapshotStatePending,
+		DiskSnapshotStateCompleted,
+		DiskSnapshotStateError,
+		DiskSnapshotStateUnknown,
+	}
+}
 
 const (
 	// DiskStatePending is a DiskState enum value
@@ -32125,6 +32239,17 @@ const (
 	// DiskStateUnknown is a DiskState enum value
 	DiskStateUnknown = "unknown"
 )
+
+// DiskState_Values returns all elements of the DiskState enum
+func DiskState_Values() []string {
+	return []string{
+		DiskStatePending,
+		DiskStateError,
+		DiskStateAvailable,
+		DiskStateInUse,
+		DiskStateUnknown,
+	}
+}
 
 const (
 	// DistributionMetricNameRequests is a DistributionMetricName enum value
@@ -32146,6 +32271,18 @@ const (
 	DistributionMetricNameHttp5xxErrorRate = "Http5xxErrorRate"
 )
 
+// DistributionMetricName_Values returns all elements of the DistributionMetricName enum
+func DistributionMetricName_Values() []string {
+	return []string{
+		DistributionMetricNameRequests,
+		DistributionMetricNameBytesDownloaded,
+		DistributionMetricNameBytesUploaded,
+		DistributionMetricNameTotalErrorRate,
+		DistributionMetricNameHttp4xxErrorRate,
+		DistributionMetricNameHttp5xxErrorRate,
+	}
+}
+
 const (
 	// ExportSnapshotRecordSourceTypeInstanceSnapshot is a ExportSnapshotRecordSourceType enum value
 	ExportSnapshotRecordSourceTypeInstanceSnapshot = "InstanceSnapshot"
@@ -32153,6 +32290,14 @@ const (
 	// ExportSnapshotRecordSourceTypeDiskSnapshot is a ExportSnapshotRecordSourceType enum value
 	ExportSnapshotRecordSourceTypeDiskSnapshot = "DiskSnapshot"
 )
+
+// ExportSnapshotRecordSourceType_Values returns all elements of the ExportSnapshotRecordSourceType enum
+func ExportSnapshotRecordSourceType_Values() []string {
+	return []string{
+		ExportSnapshotRecordSourceTypeInstanceSnapshot,
+		ExportSnapshotRecordSourceTypeDiskSnapshot,
+	}
+}
 
 const (
 	// ForwardValuesNone is a ForwardValues enum value
@@ -32164,6 +32309,15 @@ const (
 	// ForwardValuesAll is a ForwardValues enum value
 	ForwardValuesAll = "all"
 )
+
+// ForwardValues_Values returns all elements of the ForwardValues enum
+func ForwardValues_Values() []string {
+	return []string{
+		ForwardValuesNone,
+		ForwardValuesAllowList,
+		ForwardValuesAll,
+	}
+}
 
 const (
 	// HeaderEnumAccept is a HeaderEnum enum value
@@ -32212,6 +32366,27 @@ const (
 	HeaderEnumReferer = "Referer"
 )
 
+// HeaderEnum_Values returns all elements of the HeaderEnum enum
+func HeaderEnum_Values() []string {
+	return []string{
+		HeaderEnumAccept,
+		HeaderEnumAcceptCharset,
+		HeaderEnumAcceptDatetime,
+		HeaderEnumAcceptEncoding,
+		HeaderEnumAcceptLanguage,
+		HeaderEnumAuthorization,
+		HeaderEnumCloudFrontForwardedProto,
+		HeaderEnumCloudFrontIsDesktopViewer,
+		HeaderEnumCloudFrontIsMobileViewer,
+		HeaderEnumCloudFrontIsSmartTvViewer,
+		HeaderEnumCloudFrontIsTabletViewer,
+		HeaderEnumCloudFrontViewerCountry,
+		HeaderEnumHost,
+		HeaderEnumOrigin,
+		HeaderEnumReferer,
+	}
+}
+
 const (
 	// InstanceAccessProtocolSsh is a InstanceAccessProtocol enum value
 	InstanceAccessProtocolSsh = "ssh"
@@ -32219,6 +32394,14 @@ const (
 	// InstanceAccessProtocolRdp is a InstanceAccessProtocol enum value
 	InstanceAccessProtocolRdp = "rdp"
 )
+
+// InstanceAccessProtocol_Values returns all elements of the InstanceAccessProtocol enum
+func InstanceAccessProtocol_Values() []string {
+	return []string{
+		InstanceAccessProtocolSsh,
+		InstanceAccessProtocolRdp,
+	}
+}
 
 const (
 	// InstanceHealthReasonLbRegistrationInProgress is a InstanceHealthReason enum value
@@ -32255,6 +32438,23 @@ const (
 	InstanceHealthReasonInstanceIpUnusable = "Instance.IpUnusable"
 )
 
+// InstanceHealthReason_Values returns all elements of the InstanceHealthReason enum
+func InstanceHealthReason_Values() []string {
+	return []string{
+		InstanceHealthReasonLbRegistrationInProgress,
+		InstanceHealthReasonLbInitialHealthChecking,
+		InstanceHealthReasonLbInternalError,
+		InstanceHealthReasonInstanceResponseCodeMismatch,
+		InstanceHealthReasonInstanceTimeout,
+		InstanceHealthReasonInstanceFailedHealthChecks,
+		InstanceHealthReasonInstanceNotRegistered,
+		InstanceHealthReasonInstanceNotInUse,
+		InstanceHealthReasonInstanceDeregistrationInProgress,
+		InstanceHealthReasonInstanceInvalidState,
+		InstanceHealthReasonInstanceIpUnusable,
+	}
+}
+
 const (
 	// InstanceHealthStateInitial is a InstanceHealthState enum value
 	InstanceHealthStateInitial = "initial"
@@ -32274,6 +32474,18 @@ const (
 	// InstanceHealthStateUnavailable is a InstanceHealthState enum value
 	InstanceHealthStateUnavailable = "unavailable"
 )
+
+// InstanceHealthState_Values returns all elements of the InstanceHealthState enum
+func InstanceHealthState_Values() []string {
+	return []string{
+		InstanceHealthStateInitial,
+		InstanceHealthStateHealthy,
+		InstanceHealthStateUnhealthy,
+		InstanceHealthStateUnused,
+		InstanceHealthStateDraining,
+		InstanceHealthStateUnavailable,
+	}
+}
 
 const (
 	// InstanceMetricNameCpuutilization is a InstanceMetricName enum value
@@ -32301,6 +32513,20 @@ const (
 	InstanceMetricNameBurstCapacityPercentage = "BurstCapacityPercentage"
 )
 
+// InstanceMetricName_Values returns all elements of the InstanceMetricName enum
+func InstanceMetricName_Values() []string {
+	return []string{
+		InstanceMetricNameCpuutilization,
+		InstanceMetricNameNetworkIn,
+		InstanceMetricNameNetworkOut,
+		InstanceMetricNameStatusCheckFailed,
+		InstanceMetricNameStatusCheckFailedInstance,
+		InstanceMetricNameStatusCheckFailedSystem,
+		InstanceMetricNameBurstCapacityTime,
+		InstanceMetricNameBurstCapacityPercentage,
+	}
+}
+
 const (
 	// InstancePlatformLinuxUnix is a InstancePlatform enum value
 	InstancePlatformLinuxUnix = "LINUX_UNIX"
@@ -32308,6 +32534,14 @@ const (
 	// InstancePlatformWindows is a InstancePlatform enum value
 	InstancePlatformWindows = "WINDOWS"
 )
+
+// InstancePlatform_Values returns all elements of the InstancePlatform enum
+func InstancePlatform_Values() []string {
+	return []string{
+		InstancePlatformLinuxUnix,
+		InstancePlatformWindows,
+	}
+}
 
 const (
 	// InstanceSnapshotStatePending is a InstanceSnapshotState enum value
@@ -32320,6 +32554,15 @@ const (
 	InstanceSnapshotStateAvailable = "available"
 )
 
+// InstanceSnapshotState_Values returns all elements of the InstanceSnapshotState enum
+func InstanceSnapshotState_Values() []string {
+	return []string{
+		InstanceSnapshotStatePending,
+		InstanceSnapshotStateError,
+		InstanceSnapshotStateAvailable,
+	}
+}
+
 const (
 	// LoadBalancerAttributeNameHealthCheckPath is a LoadBalancerAttributeName enum value
 	LoadBalancerAttributeNameHealthCheckPath = "HealthCheckPath"
@@ -32330,6 +32573,15 @@ const (
 	// LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds is a LoadBalancerAttributeName enum value
 	LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds = "SessionStickiness_LB_CookieDurationSeconds"
 )
+
+// LoadBalancerAttributeName_Values returns all elements of the LoadBalancerAttributeName enum
+func LoadBalancerAttributeName_Values() []string {
+	return []string{
+		LoadBalancerAttributeNameHealthCheckPath,
+		LoadBalancerAttributeNameSessionStickinessEnabled,
+		LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds,
+	}
+}
 
 const (
 	// LoadBalancerMetricNameClientTlsnegotiationErrorCount is a LoadBalancerMetricName enum value
@@ -32369,6 +32621,24 @@ const (
 	LoadBalancerMetricNameRequestCount = "RequestCount"
 )
 
+// LoadBalancerMetricName_Values returns all elements of the LoadBalancerMetricName enum
+func LoadBalancerMetricName_Values() []string {
+	return []string{
+		LoadBalancerMetricNameClientTlsnegotiationErrorCount,
+		LoadBalancerMetricNameHealthyHostCount,
+		LoadBalancerMetricNameUnhealthyHostCount,
+		LoadBalancerMetricNameHttpcodeLb4xxCount,
+		LoadBalancerMetricNameHttpcodeLb5xxCount,
+		LoadBalancerMetricNameHttpcodeInstance2xxCount,
+		LoadBalancerMetricNameHttpcodeInstance3xxCount,
+		LoadBalancerMetricNameHttpcodeInstance4xxCount,
+		LoadBalancerMetricNameHttpcodeInstance5xxCount,
+		LoadBalancerMetricNameInstanceResponseTime,
+		LoadBalancerMetricNameRejectedConnectionCount,
+		LoadBalancerMetricNameRequestCount,
+	}
+}
+
 const (
 	// LoadBalancerProtocolHttpHttps is a LoadBalancerProtocol enum value
 	LoadBalancerProtocolHttpHttps = "HTTP_HTTPS"
@@ -32376,6 +32646,14 @@ const (
 	// LoadBalancerProtocolHttp is a LoadBalancerProtocol enum value
 	LoadBalancerProtocolHttp = "HTTP"
 )
+
+// LoadBalancerProtocol_Values returns all elements of the LoadBalancerProtocol enum
+func LoadBalancerProtocol_Values() []string {
+	return []string{
+		LoadBalancerProtocolHttpHttps,
+		LoadBalancerProtocolHttp,
+	}
+}
 
 const (
 	// LoadBalancerStateActive is a LoadBalancerState enum value
@@ -32394,6 +32672,17 @@ const (
 	LoadBalancerStateUnknown = "unknown"
 )
 
+// LoadBalancerState_Values returns all elements of the LoadBalancerState enum
+func LoadBalancerState_Values() []string {
+	return []string{
+		LoadBalancerStateActive,
+		LoadBalancerStateProvisioning,
+		LoadBalancerStateActiveImpaired,
+		LoadBalancerStateFailed,
+		LoadBalancerStateUnknown,
+	}
+}
+
 const (
 	// LoadBalancerTlsCertificateDomainStatusPendingValidation is a LoadBalancerTlsCertificateDomainStatus enum value
 	LoadBalancerTlsCertificateDomainStatusPendingValidation = "PENDING_VALIDATION"
@@ -32404,6 +32693,15 @@ const (
 	// LoadBalancerTlsCertificateDomainStatusSuccess is a LoadBalancerTlsCertificateDomainStatus enum value
 	LoadBalancerTlsCertificateDomainStatusSuccess = "SUCCESS"
 )
+
+// LoadBalancerTlsCertificateDomainStatus_Values returns all elements of the LoadBalancerTlsCertificateDomainStatus enum
+func LoadBalancerTlsCertificateDomainStatus_Values() []string {
+	return []string{
+		LoadBalancerTlsCertificateDomainStatusPendingValidation,
+		LoadBalancerTlsCertificateDomainStatusFailed,
+		LoadBalancerTlsCertificateDomainStatusSuccess,
+	}
+}
 
 const (
 	// LoadBalancerTlsCertificateFailureReasonNoAvailableContacts is a LoadBalancerTlsCertificateFailureReason enum value
@@ -32422,6 +32720,17 @@ const (
 	LoadBalancerTlsCertificateFailureReasonOther = "OTHER"
 )
 
+// LoadBalancerTlsCertificateFailureReason_Values returns all elements of the LoadBalancerTlsCertificateFailureReason enum
+func LoadBalancerTlsCertificateFailureReason_Values() []string {
+	return []string{
+		LoadBalancerTlsCertificateFailureReasonNoAvailableContacts,
+		LoadBalancerTlsCertificateFailureReasonAdditionalVerificationRequired,
+		LoadBalancerTlsCertificateFailureReasonDomainNotAllowed,
+		LoadBalancerTlsCertificateFailureReasonInvalidPublicDomain,
+		LoadBalancerTlsCertificateFailureReasonOther,
+	}
+}
+
 const (
 	// LoadBalancerTlsCertificateRenewalStatusPendingAutoRenewal is a LoadBalancerTlsCertificateRenewalStatus enum value
 	LoadBalancerTlsCertificateRenewalStatusPendingAutoRenewal = "PENDING_AUTO_RENEWAL"
@@ -32435,6 +32744,16 @@ const (
 	// LoadBalancerTlsCertificateRenewalStatusFailed is a LoadBalancerTlsCertificateRenewalStatus enum value
 	LoadBalancerTlsCertificateRenewalStatusFailed = "FAILED"
 )
+
+// LoadBalancerTlsCertificateRenewalStatus_Values returns all elements of the LoadBalancerTlsCertificateRenewalStatus enum
+func LoadBalancerTlsCertificateRenewalStatus_Values() []string {
+	return []string{
+		LoadBalancerTlsCertificateRenewalStatusPendingAutoRenewal,
+		LoadBalancerTlsCertificateRenewalStatusPendingValidation,
+		LoadBalancerTlsCertificateRenewalStatusSuccess,
+		LoadBalancerTlsCertificateRenewalStatusFailed,
+	}
+}
 
 const (
 	// LoadBalancerTlsCertificateRevocationReasonUnspecified is a LoadBalancerTlsCertificateRevocationReason enum value
@@ -32468,6 +32787,22 @@ const (
 	LoadBalancerTlsCertificateRevocationReasonAACompromise = "A_A_COMPROMISE"
 )
 
+// LoadBalancerTlsCertificateRevocationReason_Values returns all elements of the LoadBalancerTlsCertificateRevocationReason enum
+func LoadBalancerTlsCertificateRevocationReason_Values() []string {
+	return []string{
+		LoadBalancerTlsCertificateRevocationReasonUnspecified,
+		LoadBalancerTlsCertificateRevocationReasonKeyCompromise,
+		LoadBalancerTlsCertificateRevocationReasonCaCompromise,
+		LoadBalancerTlsCertificateRevocationReasonAffiliationChanged,
+		LoadBalancerTlsCertificateRevocationReasonSuperceded,
+		LoadBalancerTlsCertificateRevocationReasonCessationOfOperation,
+		LoadBalancerTlsCertificateRevocationReasonCertificateHold,
+		LoadBalancerTlsCertificateRevocationReasonRemoveFromCrl,
+		LoadBalancerTlsCertificateRevocationReasonPrivilegeWithdrawn,
+		LoadBalancerTlsCertificateRevocationReasonAACompromise,
+	}
+}
+
 const (
 	// LoadBalancerTlsCertificateStatusPendingValidation is a LoadBalancerTlsCertificateStatus enum value
 	LoadBalancerTlsCertificateStatusPendingValidation = "PENDING_VALIDATION"
@@ -32493,6 +32828,20 @@ const (
 	// LoadBalancerTlsCertificateStatusUnknown is a LoadBalancerTlsCertificateStatus enum value
 	LoadBalancerTlsCertificateStatusUnknown = "UNKNOWN"
 )
+
+// LoadBalancerTlsCertificateStatus_Values returns all elements of the LoadBalancerTlsCertificateStatus enum
+func LoadBalancerTlsCertificateStatus_Values() []string {
+	return []string{
+		LoadBalancerTlsCertificateStatusPendingValidation,
+		LoadBalancerTlsCertificateStatusIssued,
+		LoadBalancerTlsCertificateStatusInactive,
+		LoadBalancerTlsCertificateStatusExpired,
+		LoadBalancerTlsCertificateStatusValidationTimedOut,
+		LoadBalancerTlsCertificateStatusRevoked,
+		LoadBalancerTlsCertificateStatusFailed,
+		LoadBalancerTlsCertificateStatusUnknown,
+	}
+}
 
 const (
 	// MetricNameCpuutilization is a MetricName enum value
@@ -32571,6 +32920,37 @@ const (
 	MetricNameBurstCapacityPercentage = "BurstCapacityPercentage"
 )
 
+// MetricName_Values returns all elements of the MetricName enum
+func MetricName_Values() []string {
+	return []string{
+		MetricNameCpuutilization,
+		MetricNameNetworkIn,
+		MetricNameNetworkOut,
+		MetricNameStatusCheckFailed,
+		MetricNameStatusCheckFailedInstance,
+		MetricNameStatusCheckFailedSystem,
+		MetricNameClientTlsnegotiationErrorCount,
+		MetricNameHealthyHostCount,
+		MetricNameUnhealthyHostCount,
+		MetricNameHttpcodeLb4xxCount,
+		MetricNameHttpcodeLb5xxCount,
+		MetricNameHttpcodeInstance2xxCount,
+		MetricNameHttpcodeInstance3xxCount,
+		MetricNameHttpcodeInstance4xxCount,
+		MetricNameHttpcodeInstance5xxCount,
+		MetricNameInstanceResponseTime,
+		MetricNameRejectedConnectionCount,
+		MetricNameRequestCount,
+		MetricNameDatabaseConnections,
+		MetricNameDiskQueueDepth,
+		MetricNameFreeStorageSpace,
+		MetricNameNetworkReceiveThroughput,
+		MetricNameNetworkTransmitThroughput,
+		MetricNameBurstCapacityTime,
+		MetricNameBurstCapacityPercentage,
+	}
+}
+
 const (
 	// MetricStatisticMinimum is a MetricStatistic enum value
 	MetricStatisticMinimum = "Minimum"
@@ -32587,6 +32967,17 @@ const (
 	// MetricStatisticSampleCount is a MetricStatistic enum value
 	MetricStatisticSampleCount = "SampleCount"
 )
+
+// MetricStatistic_Values returns all elements of the MetricStatistic enum
+func MetricStatistic_Values() []string {
+	return []string{
+		MetricStatisticMinimum,
+		MetricStatisticMaximum,
+		MetricStatisticSum,
+		MetricStatisticAverage,
+		MetricStatisticSampleCount,
+	}
+}
 
 const (
 	// MetricUnitSeconds is a MetricUnit enum value
@@ -32671,6 +33062,39 @@ const (
 	MetricUnitNone = "None"
 )
 
+// MetricUnit_Values returns all elements of the MetricUnit enum
+func MetricUnit_Values() []string {
+	return []string{
+		MetricUnitSeconds,
+		MetricUnitMicroseconds,
+		MetricUnitMilliseconds,
+		MetricUnitBytes,
+		MetricUnitKilobytes,
+		MetricUnitMegabytes,
+		MetricUnitGigabytes,
+		MetricUnitTerabytes,
+		MetricUnitBits,
+		MetricUnitKilobits,
+		MetricUnitMegabits,
+		MetricUnitGigabits,
+		MetricUnitTerabits,
+		MetricUnitPercent,
+		MetricUnitCount,
+		MetricUnitBytesSecond,
+		MetricUnitKilobytesSecond,
+		MetricUnitMegabytesSecond,
+		MetricUnitGigabytesSecond,
+		MetricUnitTerabytesSecond,
+		MetricUnitBitsSecond,
+		MetricUnitKilobitsSecond,
+		MetricUnitMegabitsSecond,
+		MetricUnitGigabitsSecond,
+		MetricUnitTerabitsSecond,
+		MetricUnitCountSecond,
+		MetricUnitNone,
+	}
+}
+
 const (
 	// NetworkProtocolTcp is a NetworkProtocol enum value
 	NetworkProtocolTcp = "tcp"
@@ -32684,6 +33108,16 @@ const (
 	// NetworkProtocolIcmp is a NetworkProtocol enum value
 	NetworkProtocolIcmp = "icmp"
 )
+
+// NetworkProtocol_Values returns all elements of the NetworkProtocol enum
+func NetworkProtocol_Values() []string {
+	return []string{
+		NetworkProtocolTcp,
+		NetworkProtocolAll,
+		NetworkProtocolUdp,
+		NetworkProtocolIcmp,
+	}
+}
 
 const (
 	// OperationStatusNotStarted is a OperationStatus enum value
@@ -32701,6 +33135,17 @@ const (
 	// OperationStatusSucceeded is a OperationStatus enum value
 	OperationStatusSucceeded = "Succeeded"
 )
+
+// OperationStatus_Values returns all elements of the OperationStatus enum
+func OperationStatus_Values() []string {
+	return []string{
+		OperationStatusNotStarted,
+		OperationStatusStarted,
+		OperationStatusFailed,
+		OperationStatusCompleted,
+		OperationStatusSucceeded,
+	}
+}
 
 const (
 	// OperationTypeDeleteKnownHostKeys is a OperationType enum value
@@ -32896,6 +33341,76 @@ const (
 	OperationTypeDeleteCertificate = "DeleteCertificate"
 )
 
+// OperationType_Values returns all elements of the OperationType enum
+func OperationType_Values() []string {
+	return []string{
+		OperationTypeDeleteKnownHostKeys,
+		OperationTypeDeleteInstance,
+		OperationTypeCreateInstance,
+		OperationTypeStopInstance,
+		OperationTypeStartInstance,
+		OperationTypeRebootInstance,
+		OperationTypeOpenInstancePublicPorts,
+		OperationTypePutInstancePublicPorts,
+		OperationTypeCloseInstancePublicPorts,
+		OperationTypeAllocateStaticIp,
+		OperationTypeReleaseStaticIp,
+		OperationTypeAttachStaticIp,
+		OperationTypeDetachStaticIp,
+		OperationTypeUpdateDomainEntry,
+		OperationTypeDeleteDomainEntry,
+		OperationTypeCreateDomain,
+		OperationTypeDeleteDomain,
+		OperationTypeCreateInstanceSnapshot,
+		OperationTypeDeleteInstanceSnapshot,
+		OperationTypeCreateInstancesFromSnapshot,
+		OperationTypeCreateLoadBalancer,
+		OperationTypeDeleteLoadBalancer,
+		OperationTypeAttachInstancesToLoadBalancer,
+		OperationTypeDetachInstancesFromLoadBalancer,
+		OperationTypeUpdateLoadBalancerAttribute,
+		OperationTypeCreateLoadBalancerTlsCertificate,
+		OperationTypeDeleteLoadBalancerTlsCertificate,
+		OperationTypeAttachLoadBalancerTlsCertificate,
+		OperationTypeCreateDisk,
+		OperationTypeDeleteDisk,
+		OperationTypeAttachDisk,
+		OperationTypeDetachDisk,
+		OperationTypeCreateDiskSnapshot,
+		OperationTypeDeleteDiskSnapshot,
+		OperationTypeCreateDiskFromSnapshot,
+		OperationTypeCreateRelationalDatabase,
+		OperationTypeUpdateRelationalDatabase,
+		OperationTypeDeleteRelationalDatabase,
+		OperationTypeCreateRelationalDatabaseFromSnapshot,
+		OperationTypeCreateRelationalDatabaseSnapshot,
+		OperationTypeDeleteRelationalDatabaseSnapshot,
+		OperationTypeUpdateRelationalDatabaseParameters,
+		OperationTypeStartRelationalDatabase,
+		OperationTypeRebootRelationalDatabase,
+		OperationTypeStopRelationalDatabase,
+		OperationTypeEnableAddOn,
+		OperationTypeDisableAddOn,
+		OperationTypePutAlarm,
+		OperationTypeGetAlarms,
+		OperationTypeDeleteAlarm,
+		OperationTypeTestAlarm,
+		OperationTypeCreateContactMethod,
+		OperationTypeGetContactMethods,
+		OperationTypeSendContactMethodVerification,
+		OperationTypeDeleteContactMethod,
+		OperationTypeCreateDistribution,
+		OperationTypeUpdateDistribution,
+		OperationTypeDeleteDistribution,
+		OperationTypeResetDistributionCache,
+		OperationTypeAttachCertificateToDistribution,
+		OperationTypeDetachCertificateFromDistribution,
+		OperationTypeUpdateDistributionBundle,
+		OperationTypeCreateCertificate,
+		OperationTypeDeleteCertificate,
+	}
+}
+
 const (
 	// OriginProtocolPolicyEnumHttpOnly is a OriginProtocolPolicyEnum enum value
 	OriginProtocolPolicyEnumHttpOnly = "http-only"
@@ -32904,6 +33419,14 @@ const (
 	OriginProtocolPolicyEnumHttpsOnly = "https-only"
 )
 
+// OriginProtocolPolicyEnum_Values returns all elements of the OriginProtocolPolicyEnum enum
+func OriginProtocolPolicyEnum_Values() []string {
+	return []string{
+		OriginProtocolPolicyEnumHttpOnly,
+		OriginProtocolPolicyEnumHttpsOnly,
+	}
+}
+
 const (
 	// PortAccessTypePublic is a PortAccessType enum value
 	PortAccessTypePublic = "Public"
@@ -32911,6 +33434,14 @@ const (
 	// PortAccessTypePrivate is a PortAccessType enum value
 	PortAccessTypePrivate = "Private"
 )
+
+// PortAccessType_Values returns all elements of the PortAccessType enum
+func PortAccessType_Values() []string {
+	return []string{
+		PortAccessTypePublic,
+		PortAccessTypePrivate,
+	}
+}
 
 const (
 	// PortInfoSourceTypeDefault is a PortInfoSourceType enum value
@@ -32926,6 +33457,16 @@ const (
 	PortInfoSourceTypeClosed = "CLOSED"
 )
 
+// PortInfoSourceType_Values returns all elements of the PortInfoSourceType enum
+func PortInfoSourceType_Values() []string {
+	return []string{
+		PortInfoSourceTypeDefault,
+		PortInfoSourceTypeInstance,
+		PortInfoSourceTypeNone,
+		PortInfoSourceTypeClosed,
+	}
+}
+
 const (
 	// PortStateOpen is a PortState enum value
 	PortStateOpen = "open"
@@ -32933,6 +33474,14 @@ const (
 	// PortStateClosed is a PortState enum value
 	PortStateClosed = "closed"
 )
+
+// PortState_Values returns all elements of the PortState enum
+func PortState_Values() []string {
+	return []string{
+		PortStateOpen,
+		PortStateClosed,
+	}
+}
 
 const (
 	// RecordStateStarted is a RecordState enum value
@@ -32944,6 +33493,15 @@ const (
 	// RecordStateFailed is a RecordState enum value
 	RecordStateFailed = "Failed"
 )
+
+// RecordState_Values returns all elements of the RecordState enum
+func RecordState_Values() []string {
+	return []string{
+		RecordStateStarted,
+		RecordStateSucceeded,
+		RecordStateFailed,
+	}
+}
 
 const (
 	// RegionNameUsEast1 is a RegionName enum value
@@ -32989,10 +33547,37 @@ const (
 	RegionNameApNortheast2 = "ap-northeast-2"
 )
 
+// RegionName_Values returns all elements of the RegionName enum
+func RegionName_Values() []string {
+	return []string{
+		RegionNameUsEast1,
+		RegionNameUsEast2,
+		RegionNameUsWest1,
+		RegionNameUsWest2,
+		RegionNameEuWest1,
+		RegionNameEuWest2,
+		RegionNameEuWest3,
+		RegionNameEuCentral1,
+		RegionNameCaCentral1,
+		RegionNameApSouth1,
+		RegionNameApSoutheast1,
+		RegionNameApSoutheast2,
+		RegionNameApNortheast1,
+		RegionNameApNortheast2,
+	}
+}
+
 const (
 	// RelationalDatabaseEngineMysql is a RelationalDatabaseEngine enum value
 	RelationalDatabaseEngineMysql = "mysql"
 )
+
+// RelationalDatabaseEngine_Values returns all elements of the RelationalDatabaseEngine enum
+func RelationalDatabaseEngine_Values() []string {
+	return []string{
+		RelationalDatabaseEngineMysql,
+	}
+}
 
 const (
 	// RelationalDatabaseMetricNameCpuutilization is a RelationalDatabaseMetricName enum value
@@ -33014,6 +33599,18 @@ const (
 	RelationalDatabaseMetricNameNetworkTransmitThroughput = "NetworkTransmitThroughput"
 )
 
+// RelationalDatabaseMetricName_Values returns all elements of the RelationalDatabaseMetricName enum
+func RelationalDatabaseMetricName_Values() []string {
+	return []string{
+		RelationalDatabaseMetricNameCpuutilization,
+		RelationalDatabaseMetricNameDatabaseConnections,
+		RelationalDatabaseMetricNameDiskQueueDepth,
+		RelationalDatabaseMetricNameFreeStorageSpace,
+		RelationalDatabaseMetricNameNetworkReceiveThroughput,
+		RelationalDatabaseMetricNameNetworkTransmitThroughput,
+	}
+}
+
 const (
 	// RelationalDatabasePasswordVersionCurrent is a RelationalDatabasePasswordVersion enum value
 	RelationalDatabasePasswordVersionCurrent = "CURRENT"
@@ -33024,6 +33621,15 @@ const (
 	// RelationalDatabasePasswordVersionPending is a RelationalDatabasePasswordVersion enum value
 	RelationalDatabasePasswordVersionPending = "PENDING"
 )
+
+// RelationalDatabasePasswordVersion_Values returns all elements of the RelationalDatabasePasswordVersion enum
+func RelationalDatabasePasswordVersion_Values() []string {
+	return []string{
+		RelationalDatabasePasswordVersionCurrent,
+		RelationalDatabasePasswordVersionPrevious,
+		RelationalDatabasePasswordVersionPending,
+	}
+}
 
 const (
 	// RenewalStatusPendingAutoRenewal is a RenewalStatus enum value
@@ -33038,6 +33644,16 @@ const (
 	// RenewalStatusFailed is a RenewalStatus enum value
 	RenewalStatusFailed = "Failed"
 )
+
+// RenewalStatus_Values returns all elements of the RenewalStatus enum
+func RenewalStatus_Values() []string {
+	return []string{
+		RenewalStatusPendingAutoRenewal,
+		RenewalStatusPendingValidation,
+		RenewalStatusSuccess,
+		RenewalStatusFailed,
+	}
+}
 
 const (
 	// ResourceTypeInstance is a ResourceType enum value
@@ -33095,6 +33711,30 @@ const (
 	ResourceTypeCertificate = "Certificate"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeInstance,
+		ResourceTypeStaticIp,
+		ResourceTypeKeyPair,
+		ResourceTypeInstanceSnapshot,
+		ResourceTypeDomain,
+		ResourceTypePeeredVpc,
+		ResourceTypeLoadBalancer,
+		ResourceTypeLoadBalancerTlsCertificate,
+		ResourceTypeDisk,
+		ResourceTypeDiskSnapshot,
+		ResourceTypeRelationalDatabase,
+		ResourceTypeRelationalDatabaseSnapshot,
+		ResourceTypeExportSnapshotRecord,
+		ResourceTypeCloudFormationStackRecord,
+		ResourceTypeAlarm,
+		ResourceTypeContactMethod,
+		ResourceTypeDistribution,
+		ResourceTypeCertificate,
+	}
+}
+
 const (
 	// TreatMissingDataBreaching is a TreatMissingData enum value
 	TreatMissingDataBreaching = "breaching"
@@ -33108,3 +33748,13 @@ const (
 	// TreatMissingDataMissing is a TreatMissingData enum value
 	TreatMissingDataMissing = "missing"
 )
+
+// TreatMissingData_Values returns all elements of the TreatMissingData enum
+func TreatMissingData_Values() []string {
+	return []string{
+		TreatMissingDataBreaching,
+		TreatMissingDataNotBreaching,
+		TreatMissingDataIgnore,
+		TreatMissingDataMissing,
+	}
+}

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -9240,6 +9240,13 @@ const (
 	AlgorithmSgd = "sgd"
 )
 
+// Algorithm_Values returns all elements of the Algorithm enum
+func Algorithm_Values() []string {
+	return []string{
+		AlgorithmSgd,
+	}
+}
+
 // A list of the variables to use in searching or filtering BatchPrediction.
 //
 //    * CreatedAt - Sets the search criteria to BatchPrediction creation date.
@@ -9285,6 +9292,20 @@ const (
 	BatchPredictionFilterVariableDataUri = "DataURI"
 )
 
+// BatchPredictionFilterVariable_Values returns all elements of the BatchPredictionFilterVariable enum
+func BatchPredictionFilterVariable_Values() []string {
+	return []string{
+		BatchPredictionFilterVariableCreatedAt,
+		BatchPredictionFilterVariableLastUpdatedAt,
+		BatchPredictionFilterVariableStatus,
+		BatchPredictionFilterVariableName,
+		BatchPredictionFilterVariableIamuser,
+		BatchPredictionFilterVariableMlmodelId,
+		BatchPredictionFilterVariableDataSourceId,
+		BatchPredictionFilterVariableDataUri,
+	}
+}
+
 // A list of the variables to use in searching or filtering DataSource.
 //
 //    * CreatedAt - Sets the search criteria to DataSource creation date.
@@ -9321,6 +9342,18 @@ const (
 	DataSourceFilterVariableIamuser = "IAMUser"
 )
 
+// DataSourceFilterVariable_Values returns all elements of the DataSourceFilterVariable enum
+func DataSourceFilterVariable_Values() []string {
+	return []string{
+		DataSourceFilterVariableCreatedAt,
+		DataSourceFilterVariableLastUpdatedAt,
+		DataSourceFilterVariableStatus,
+		DataSourceFilterVariableName,
+		DataSourceFilterVariableDataLocationS3,
+		DataSourceFilterVariableIamuser,
+	}
+}
+
 // Contains the key values of
 //    DetailsMap
 // :
@@ -9339,6 +9372,14 @@ const (
 	// DetailsAttributesAlgorithm is a DetailsAttributes enum value
 	DetailsAttributesAlgorithm = "Algorithm"
 )
+
+// DetailsAttributes_Values returns all elements of the DetailsAttributes enum
+func DetailsAttributes_Values() []string {
+	return []string{
+		DetailsAttributesPredictiveModelType,
+		DetailsAttributesAlgorithm,
+	}
+}
 
 // Object status with the following possible values:
 //
@@ -9367,6 +9408,17 @@ const (
 	// EntityStatusDeleted is a EntityStatus enum value
 	EntityStatusDeleted = "DELETED"
 )
+
+// EntityStatus_Values returns all elements of the EntityStatus enum
+func EntityStatus_Values() []string {
+	return []string{
+		EntityStatusPending,
+		EntityStatusInprogress,
+		EntityStatusFailed,
+		EntityStatusCompleted,
+		EntityStatusDeleted,
+	}
+}
 
 // A list of the variables to use in searching or filtering Evaluation.
 //
@@ -9412,6 +9464,20 @@ const (
 	EvaluationFilterVariableDataUri = "DataURI"
 )
 
+// EvaluationFilterVariable_Values returns all elements of the EvaluationFilterVariable enum
+func EvaluationFilterVariable_Values() []string {
+	return []string{
+		EvaluationFilterVariableCreatedAt,
+		EvaluationFilterVariableLastUpdatedAt,
+		EvaluationFilterVariableStatus,
+		EvaluationFilterVariableName,
+		EvaluationFilterVariableIamuser,
+		EvaluationFilterVariableMlmodelId,
+		EvaluationFilterVariableDataSourceId,
+		EvaluationFilterVariableDataUri,
+	}
+}
+
 const (
 	// MLModelFilterVariableCreatedAt is a MLModelFilterVariable enum value
 	MLModelFilterVariableCreatedAt = "CreatedAt"
@@ -9444,6 +9510,22 @@ const (
 	MLModelFilterVariableTrainingDataUri = "TrainingDataURI"
 )
 
+// MLModelFilterVariable_Values returns all elements of the MLModelFilterVariable enum
+func MLModelFilterVariable_Values() []string {
+	return []string{
+		MLModelFilterVariableCreatedAt,
+		MLModelFilterVariableLastUpdatedAt,
+		MLModelFilterVariableStatus,
+		MLModelFilterVariableName,
+		MLModelFilterVariableIamuser,
+		MLModelFilterVariableTrainingDataSourceId,
+		MLModelFilterVariableRealtimeEndpointStatus,
+		MLModelFilterVariableMlmodelType,
+		MLModelFilterVariableAlgorithm,
+		MLModelFilterVariableTrainingDataUri,
+	}
+}
+
 const (
 	// MLModelTypeRegression is a MLModelType enum value
 	MLModelTypeRegression = "REGRESSION"
@@ -9454,6 +9536,15 @@ const (
 	// MLModelTypeMulticlass is a MLModelType enum value
 	MLModelTypeMulticlass = "MULTICLASS"
 )
+
+// MLModelType_Values returns all elements of the MLModelType enum
+func MLModelType_Values() []string {
+	return []string{
+		MLModelTypeRegression,
+		MLModelTypeBinary,
+		MLModelTypeMulticlass,
+	}
+}
 
 const (
 	// RealtimeEndpointStatusNone is a RealtimeEndpointStatus enum value
@@ -9469,6 +9560,16 @@ const (
 	RealtimeEndpointStatusFailed = "FAILED"
 )
 
+// RealtimeEndpointStatus_Values returns all elements of the RealtimeEndpointStatus enum
+func RealtimeEndpointStatus_Values() []string {
+	return []string{
+		RealtimeEndpointStatusNone,
+		RealtimeEndpointStatusReady,
+		RealtimeEndpointStatusUpdating,
+		RealtimeEndpointStatusFailed,
+	}
+}
+
 // The sort order specified in a listing condition. Possible values include
 // the following:
 //
@@ -9483,6 +9584,14 @@ const (
 	SortOrderDsc = "dsc"
 )
 
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderAsc,
+		SortOrderDsc,
+	}
+}
+
 const (
 	// TaggableResourceTypeBatchPrediction is a TaggableResourceType enum value
 	TaggableResourceTypeBatchPrediction = "BatchPrediction"
@@ -9496,3 +9605,13 @@ const (
 	// TaggableResourceTypeMlmodel is a TaggableResourceType enum value
 	TaggableResourceTypeMlmodel = "MLModel"
 )
+
+// TaggableResourceType_Values returns all elements of the TaggableResourceType enum
+func TaggableResourceType_Values() []string {
+	return []string{
+		TaggableResourceTypeBatchPrediction,
+		TaggableResourceTypeDataSource,
+		TaggableResourceTypeEvaluation,
+		TaggableResourceTypeMlmodel,
+	}
+}

--- a/service/macie/api.go
+++ b/service/macie/api.go
@@ -1852,6 +1852,13 @@ const (
 	S3ContinuousClassificationTypeFull = "FULL"
 )
 
+// S3ContinuousClassificationType_Values returns all elements of the S3ContinuousClassificationType enum
+func S3ContinuousClassificationType_Values() []string {
+	return []string{
+		S3ContinuousClassificationTypeFull,
+	}
+}
+
 const (
 	// S3OneTimeClassificationTypeFull is a S3OneTimeClassificationType enum value
 	S3OneTimeClassificationTypeFull = "FULL"
@@ -1859,3 +1866,11 @@ const (
 	// S3OneTimeClassificationTypeNone is a S3OneTimeClassificationType enum value
 	S3OneTimeClassificationTypeNone = "NONE"
 )
+
+// S3OneTimeClassificationType_Values returns all elements of the S3OneTimeClassificationType enum
+func S3OneTimeClassificationType_Values() []string {
+	return []string{
+		S3OneTimeClassificationTypeFull,
+		S3OneTimeClassificationTypeNone,
+	}
+}

--- a/service/macie2/api.go
+++ b/service/macie2/api.go
@@ -14046,12 +14046,27 @@ const (
 	AdminStatusDisablingInProgress = "DISABLING_IN_PROGRESS"
 )
 
+// AdminStatus_Values returns all elements of the AdminStatus enum
+func AdminStatus_Values() []string {
+	return []string{
+		AdminStatusEnabled,
+		AdminStatusDisablingInProgress,
+	}
+}
+
 // The type of currency that data for a usage metric is reported in. Possible
 // values are:
 const (
 	// CurrencyUsd is a Currency enum value
 	CurrencyUsd = "USD"
 )
+
+// Currency_Values returns all elements of the Currency enum
+func Currency_Values() []string {
+	return []string{
+		CurrencyUsd,
+	}
+}
 
 const (
 	// DayOfWeekSunday is a DayOfWeek enum value
@@ -14076,6 +14091,19 @@ const (
 	DayOfWeekSaturday = "SATURDAY"
 )
 
+// DayOfWeek_Values returns all elements of the DayOfWeek enum
+func DayOfWeek_Values() []string {
+	return []string{
+		DayOfWeekSunday,
+		DayOfWeekMonday,
+		DayOfWeekTuesday,
+		DayOfWeekWednesday,
+		DayOfWeekThursday,
+		DayOfWeekFriday,
+		DayOfWeekSaturday,
+	}
+}
+
 const (
 	// EffectivePermissionPublic is a EffectivePermission enum value
 	EffectivePermissionPublic = "PUBLIC"
@@ -14083,6 +14111,14 @@ const (
 	// EffectivePermissionNotPublic is a EffectivePermission enum value
 	EffectivePermissionNotPublic = "NOT_PUBLIC"
 )
+
+// EffectivePermission_Values returns all elements of the EffectivePermission enum
+func EffectivePermission_Values() []string {
+	return []string{
+		EffectivePermissionPublic,
+		EffectivePermissionNotPublic,
+	}
+}
 
 // The type of server-side encryption that's used to encrypt objects in the
 // S3 bucket. Valid values are:
@@ -14100,6 +14136,16 @@ const (
 	EncryptionTypeUnknown = "UNKNOWN"
 )
 
+// EncryptionType_Values returns all elements of the EncryptionType enum
+func EncryptionType_Values() []string {
+	return []string{
+		EncryptionTypeNone,
+		EncryptionTypeAes256,
+		EncryptionTypeAwsKms,
+		EncryptionTypeUnknown,
+	}
+}
+
 // The source of an error, issue, or delay. Possible values are:
 const (
 	// ErrorCodeClientError is a ErrorCode enum value
@@ -14109,12 +14155,27 @@ const (
 	ErrorCodeInternalError = "InternalError"
 )
 
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeClientError,
+		ErrorCodeInternalError,
+	}
+}
+
 // The type of action that occurred for the resource and produced the policy
 // finding:
 const (
 	// FindingActionTypeAwsApiCall is a FindingActionType enum value
 	FindingActionTypeAwsApiCall = "AWS_API_CALL"
 )
+
+// FindingActionType_Values returns all elements of the FindingActionType enum
+func FindingActionType_Values() []string {
+	return []string{
+		FindingActionTypeAwsApiCall,
+	}
+}
 
 // The category of the finding. Valid values are:
 const (
@@ -14124,6 +14185,14 @@ const (
 	// FindingCategoryPolicy is a FindingCategory enum value
 	FindingCategoryPolicy = "POLICY"
 )
+
+// FindingCategory_Values returns all elements of the FindingCategory enum
+func FindingCategory_Values() []string {
+	return []string{
+		FindingCategoryClassification,
+		FindingCategoryPolicy,
+	}
+}
 
 // The frequency with which Amazon Macie publishes updates to policy findings
 // for an account. This includes publishing updates to AWS Security Hub and
@@ -14140,6 +14209,15 @@ const (
 	FindingPublishingFrequencySixHours = "SIX_HOURS"
 )
 
+// FindingPublishingFrequency_Values returns all elements of the FindingPublishingFrequency enum
+func FindingPublishingFrequency_Values() []string {
+	return []string{
+		FindingPublishingFrequencyFifteenMinutes,
+		FindingPublishingFrequencyOneHour,
+		FindingPublishingFrequencySixHours,
+	}
+}
+
 // The grouping to sort the results by. Valid values are:
 const (
 	// FindingStatisticsSortAttributeNameGroupKey is a FindingStatisticsSortAttributeName enum value
@@ -14148,6 +14226,14 @@ const (
 	// FindingStatisticsSortAttributeNameCount is a FindingStatisticsSortAttributeName enum value
 	FindingStatisticsSortAttributeNameCount = "count"
 )
+
+// FindingStatisticsSortAttributeName_Values returns all elements of the FindingStatisticsSortAttributeName enum
+func FindingStatisticsSortAttributeName_Values() []string {
+	return []string{
+		FindingStatisticsSortAttributeNameGroupKey,
+		FindingStatisticsSortAttributeNameCount,
+	}
+}
 
 // The type of finding. Valid values are:
 const (
@@ -14182,6 +14268,22 @@ const (
 	FindingTypePolicyIamuserS3blockPublicAccessDisabled = "Policy:IAMUser/S3BlockPublicAccessDisabled"
 )
 
+// FindingType_Values returns all elements of the FindingType enum
+func FindingType_Values() []string {
+	return []string{
+		FindingTypeSensitiveDataS3objectMultiple,
+		FindingTypeSensitiveDataS3objectFinancial,
+		FindingTypeSensitiveDataS3objectPersonal,
+		FindingTypeSensitiveDataS3objectCredentials,
+		FindingTypeSensitiveDataS3objectCustomIdentifier,
+		FindingTypePolicyIamuserS3bucketPublic,
+		FindingTypePolicyIamuserS3bucketSharedExternally,
+		FindingTypePolicyIamuserS3bucketReplicatedExternally,
+		FindingTypePolicyIamuserS3bucketEncryptionDisabled,
+		FindingTypePolicyIamuserS3blockPublicAccessDisabled,
+	}
+}
+
 // The action to perform on findings that meet the filter criteria. To suppress
 // (automatically archive) findings that meet the criteria, set this value to
 // ARCHIVE. Valid values are:
@@ -14192,6 +14294,14 @@ const (
 	// FindingsFilterActionNoop is a FindingsFilterAction enum value
 	FindingsFilterActionNoop = "NOOP"
 )
+
+// FindingsFilterAction_Values returns all elements of the FindingsFilterAction enum
+func FindingsFilterAction_Values() []string {
+	return []string{
+		FindingsFilterActionArchive,
+		FindingsFilterActionNoop,
+	}
+}
 
 const (
 	// GroupByResourcesAffectedS3bucketName is a GroupBy enum value
@@ -14206,6 +14316,16 @@ const (
 	// GroupBySeverityDescription is a GroupBy enum value
 	GroupBySeverityDescription = "severity.description"
 )
+
+// GroupBy_Values returns all elements of the GroupBy enum
+func GroupBy_Values() []string {
+	return []string{
+		GroupByResourcesAffectedS3bucketName,
+		GroupByType,
+		GroupByClassificationDetailsJobId,
+		GroupBySeverityDescription,
+	}
+}
 
 // The operator to use in a condition. Valid values are:
 const (
@@ -14231,6 +14351,19 @@ const (
 	JobComparatorContains = "CONTAINS"
 )
 
+// JobComparator_Values returns all elements of the JobComparator enum
+func JobComparator_Values() []string {
+	return []string{
+		JobComparatorEq,
+		JobComparatorGt,
+		JobComparatorGte,
+		JobComparatorLt,
+		JobComparatorLte,
+		JobComparatorNe,
+		JobComparatorContains,
+	}
+}
+
 // The current status of a classification job. Possible values are:
 const (
 	// JobStatusRunning is a JobStatus enum value
@@ -14249,6 +14382,17 @@ const (
 	JobStatusIdle = "IDLE"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusRunning,
+		JobStatusPaused,
+		JobStatusCancelled,
+		JobStatusComplete,
+		JobStatusIdle,
+	}
+}
+
 // The schedule for running a classification job. Valid values are:
 const (
 	// JobTypeOneTime is a JobType enum value
@@ -14257,6 +14401,14 @@ const (
 	// JobTypeScheduled is a JobType enum value
 	JobTypeScheduled = "SCHEDULED"
 )
+
+// JobType_Values returns all elements of the JobType enum
+func JobType_Values() []string {
+	return []string{
+		JobTypeOneTime,
+		JobTypeScheduled,
+	}
+}
 
 // The property to use to filter the results. Valid values are:
 const (
@@ -14273,6 +14425,16 @@ const (
 	ListJobsFilterKeyName = "name"
 )
 
+// ListJobsFilterKey_Values returns all elements of the ListJobsFilterKey enum
+func ListJobsFilterKey_Values() []string {
+	return []string{
+		ListJobsFilterKeyJobType,
+		ListJobsFilterKeyJobStatus,
+		ListJobsFilterKeyCreatedAt,
+		ListJobsFilterKeyName,
+	}
+}
+
 // The property to sort the results by. Valid values are:
 const (
 	// ListJobsSortAttributeNameCreatedAt is a ListJobsSortAttributeName enum value
@@ -14288,6 +14450,16 @@ const (
 	ListJobsSortAttributeNameJobType = "jobType"
 )
 
+// ListJobsSortAttributeName_Values returns all elements of the ListJobsSortAttributeName enum
+func ListJobsSortAttributeName_Values() []string {
+	return []string{
+		ListJobsSortAttributeNameCreatedAt,
+		ListJobsSortAttributeNameJobStatus,
+		ListJobsSortAttributeNameName,
+		ListJobsSortAttributeNameJobType,
+	}
+}
+
 // The status of an Amazon Macie account. Valid values are:
 const (
 	// MacieStatusPaused is a MacieStatus enum value
@@ -14297,6 +14469,14 @@ const (
 	MacieStatusEnabled = "ENABLED"
 )
 
+// MacieStatus_Values returns all elements of the MacieStatus enum
+func MacieStatus_Values() []string {
+	return []string{
+		MacieStatusPaused,
+		MacieStatusEnabled,
+	}
+}
+
 const (
 	// OrderByAsc is a OrderBy enum value
 	OrderByAsc = "ASC"
@@ -14304,6 +14484,14 @@ const (
 	// OrderByDesc is a OrderBy enum value
 	OrderByDesc = "DESC"
 )
+
+// OrderBy_Values returns all elements of the OrderBy enum
+func OrderBy_Values() []string {
+	return []string{
+		OrderByAsc,
+		OrderByDesc,
+	}
+}
 
 // The current status of the relationship between an account and an associated
 // Amazon Macie master account (inviter account). Possible values are:
@@ -14339,6 +14527,22 @@ const (
 	RelationshipStatusAccountSuspended = "AccountSuspended"
 )
 
+// RelationshipStatus_Values returns all elements of the RelationshipStatus enum
+func RelationshipStatus_Values() []string {
+	return []string{
+		RelationshipStatusEnabled,
+		RelationshipStatusPaused,
+		RelationshipStatusInvited,
+		RelationshipStatusCreated,
+		RelationshipStatusRemoved,
+		RelationshipStatusResigned,
+		RelationshipStatusEmailVerificationInProgress,
+		RelationshipStatusEmailVerificationFailed,
+		RelationshipStatusRegionDisabled,
+		RelationshipStatusAccountSuspended,
+	}
+}
+
 // The property to use in a condition that determines which objects are analyzed
 // by a classification job. Valid values are:
 const (
@@ -14358,6 +14562,17 @@ const (
 	ScopeFilterKeyTag = "TAG"
 )
 
+// ScopeFilterKey_Values returns all elements of the ScopeFilterKey enum
+func ScopeFilterKey_Values() []string {
+	return []string{
+		ScopeFilterKeyBucketCreationDate,
+		ScopeFilterKeyObjectExtension,
+		ScopeFilterKeyObjectLastModifiedDate,
+		ScopeFilterKeyObjectSize,
+		ScopeFilterKeyTag,
+	}
+}
+
 // The category of sensitive data that was detected and produced the finding.
 // Possible values are:
 const (
@@ -14374,6 +14589,16 @@ const (
 	SensitiveDataItemCategoryCustomIdentifier = "CUSTOM_IDENTIFIER"
 )
 
+// SensitiveDataItemCategory_Values returns all elements of the SensitiveDataItemCategory enum
+func SensitiveDataItemCategory_Values() []string {
+	return []string{
+		SensitiveDataItemCategoryFinancialInformation,
+		SensitiveDataItemCategoryPersonalInformation,
+		SensitiveDataItemCategoryCredentials,
+		SensitiveDataItemCategoryCustomIdentifier,
+	}
+}
+
 // The textual representation of the finding's severity. Possible values are:
 const (
 	// SeverityDescriptionLow is a SeverityDescription enum value
@@ -14386,6 +14611,15 @@ const (
 	SeverityDescriptionHigh = "High"
 )
 
+// SeverityDescription_Values returns all elements of the SeverityDescription enum
+func SeverityDescription_Values() []string {
+	return []string{
+		SeverityDescriptionLow,
+		SeverityDescriptionMedium,
+		SeverityDescriptionHigh,
+	}
+}
+
 const (
 	// SharedAccessExternal is a SharedAccess enum value
 	SharedAccessExternal = "EXTERNAL"
@@ -14396,6 +14630,15 @@ const (
 	// SharedAccessNotShared is a SharedAccess enum value
 	SharedAccessNotShared = "NOT_SHARED"
 )
+
+// SharedAccess_Values returns all elements of the SharedAccess enum
+func SharedAccess_Values() []string {
+	return []string{
+		SharedAccessExternal,
+		SharedAccessInternal,
+		SharedAccessNotShared,
+	}
+}
 
 // The storage class of the S3 bucket or object. Possible values are:
 const (
@@ -14421,16 +14664,43 @@ const (
 	StorageClassGlacier = "GLACIER"
 )
 
+// StorageClass_Values returns all elements of the StorageClass enum
+func StorageClass_Values() []string {
+	return []string{
+		StorageClassStandard,
+		StorageClassReducedRedundancy,
+		StorageClassStandardIa,
+		StorageClassIntelligentTiering,
+		StorageClassDeepArchive,
+		StorageClassOnezoneIa,
+		StorageClassGlacier,
+	}
+}
+
 // The type of object to apply a tag-based condition to. Valid values are:
 const (
 	// TagTargetS3Object is a TagTarget enum value
 	TagTargetS3Object = "S3_OBJECT"
 )
 
+// TagTarget_Values returns all elements of the TagTarget enum
+func TagTarget_Values() []string {
+	return []string{
+		TagTargetS3Object,
+	}
+}
+
 const (
 	// UnitTerabytes is a Unit enum value
 	UnitTerabytes = "TERABYTES"
 )
+
+// Unit_Values returns all elements of the Unit enum
+func Unit_Values() []string {
+	return []string{
+		UnitTerabytes,
+	}
+}
 
 // The operator to use in a condition that filters the results of a query for
 // account quotas and usage data. Valid values are:
@@ -14457,6 +14727,19 @@ const (
 	UsageStatisticsFilterComparatorContains = "CONTAINS"
 )
 
+// UsageStatisticsFilterComparator_Values returns all elements of the UsageStatisticsFilterComparator enum
+func UsageStatisticsFilterComparator_Values() []string {
+	return []string{
+		UsageStatisticsFilterComparatorGt,
+		UsageStatisticsFilterComparatorGte,
+		UsageStatisticsFilterComparatorLt,
+		UsageStatisticsFilterComparatorLte,
+		UsageStatisticsFilterComparatorEq,
+		UsageStatisticsFilterComparatorNe,
+		UsageStatisticsFilterComparatorContains,
+	}
+}
+
 // The field to use in a condition that filters the results of a query for account
 // quotas and usage data. Valid values are:
 const (
@@ -14472,6 +14755,16 @@ const (
 	// UsageStatisticsFilterKeyTotal is a UsageStatisticsFilterKey enum value
 	UsageStatisticsFilterKeyTotal = "total"
 )
+
+// UsageStatisticsFilterKey_Values returns all elements of the UsageStatisticsFilterKey enum
+func UsageStatisticsFilterKey_Values() []string {
+	return []string{
+		UsageStatisticsFilterKeyAccountId,
+		UsageStatisticsFilterKeyServiceLimit,
+		UsageStatisticsFilterKeyFreeTrialStartDate,
+		UsageStatisticsFilterKeyTotal,
+	}
+}
 
 // The field to use to sort the results of a query for account quotas and usage
 // data. Valid values are:
@@ -14489,6 +14782,16 @@ const (
 	UsageStatisticsSortKeyFreeTrialStartDate = "freeTrialStartDate"
 )
 
+// UsageStatisticsSortKey_Values returns all elements of the UsageStatisticsSortKey enum
+func UsageStatisticsSortKey_Values() []string {
+	return []string{
+		UsageStatisticsSortKeyAccountId,
+		UsageStatisticsSortKeyTotal,
+		UsageStatisticsSortKeyServiceLimitValue,
+		UsageStatisticsSortKeyFreeTrialStartDate,
+	}
+}
+
 // The name of a usage metric for an account. Possible values are:
 const (
 	// UsageTypeDataInventoryEvaluation is a UsageType enum value
@@ -14497,6 +14800,14 @@ const (
 	// UsageTypeSensitiveDataDiscovery is a UsageType enum value
 	UsageTypeSensitiveDataDiscovery = "SENSITIVE_DATA_DISCOVERY"
 )
+
+// UsageType_Values returns all elements of the UsageType enum
+func UsageType_Values() []string {
+	return []string{
+		UsageTypeDataInventoryEvaluation,
+		UsageTypeSensitiveDataDiscovery,
+	}
+}
 
 // The type of entity that performed the action on the affected resource. Possible
 // values are:
@@ -14519,3 +14830,15 @@ const (
 	// UserIdentityTypeAwsservice is a UserIdentityType enum value
 	UserIdentityTypeAwsservice = "AWSService"
 )
+
+// UserIdentityType_Values returns all elements of the UserIdentityType enum
+func UserIdentityType_Values() []string {
+	return []string{
+		UserIdentityTypeAssumedRole,
+		UserIdentityTypeIamuser,
+		UserIdentityTypeFederatedUser,
+		UserIdentityTypeRoot,
+		UserIdentityTypeAwsaccount,
+		UserIdentityTypeAwsservice,
+	}
+}

--- a/service/managedblockchain/api.go
+++ b/service/managedblockchain/api.go
@@ -6715,10 +6715,25 @@ const (
 	EditionStandard = "STANDARD"
 )
 
+// Edition_Values returns all elements of the Edition enum
+func Edition_Values() []string {
+	return []string{
+		EditionStarter,
+		EditionStandard,
+	}
+}
+
 const (
 	// FrameworkHyperledgerFabric is a Framework enum value
 	FrameworkHyperledgerFabric = "HYPERLEDGER_FABRIC"
 )
+
+// Framework_Values returns all elements of the Framework enum
+func Framework_Values() []string {
+	return []string{
+		FrameworkHyperledgerFabric,
+	}
+}
 
 const (
 	// InvitationStatusPending is a InvitationStatus enum value
@@ -6736,6 +6751,17 @@ const (
 	// InvitationStatusExpired is a InvitationStatus enum value
 	InvitationStatusExpired = "EXPIRED"
 )
+
+// InvitationStatus_Values returns all elements of the InvitationStatus enum
+func InvitationStatus_Values() []string {
+	return []string{
+		InvitationStatusPending,
+		InvitationStatusAccepted,
+		InvitationStatusAccepting,
+		InvitationStatusRejected,
+		InvitationStatusExpired,
+	}
+}
 
 const (
 	// MemberStatusCreating is a MemberStatus enum value
@@ -6757,6 +6783,18 @@ const (
 	MemberStatusDeleted = "DELETED"
 )
 
+// MemberStatus_Values returns all elements of the MemberStatus enum
+func MemberStatus_Values() []string {
+	return []string{
+		MemberStatusCreating,
+		MemberStatusAvailable,
+		MemberStatusCreateFailed,
+		MemberStatusUpdating,
+		MemberStatusDeleting,
+		MemberStatusDeleted,
+	}
+}
+
 const (
 	// NetworkStatusCreating is a NetworkStatus enum value
 	NetworkStatusCreating = "CREATING"
@@ -6773,6 +6811,17 @@ const (
 	// NetworkStatusDeleted is a NetworkStatus enum value
 	NetworkStatusDeleted = "DELETED"
 )
+
+// NetworkStatus_Values returns all elements of the NetworkStatus enum
+func NetworkStatus_Values() []string {
+	return []string{
+		NetworkStatusCreating,
+		NetworkStatusAvailable,
+		NetworkStatusCreateFailed,
+		NetworkStatusDeleting,
+		NetworkStatusDeleted,
+	}
+}
 
 const (
 	// NodeStatusCreating is a NodeStatus enum value
@@ -6797,6 +6846,19 @@ const (
 	NodeStatusFailed = "FAILED"
 )
 
+// NodeStatus_Values returns all elements of the NodeStatus enum
+func NodeStatus_Values() []string {
+	return []string{
+		NodeStatusCreating,
+		NodeStatusAvailable,
+		NodeStatusCreateFailed,
+		NodeStatusUpdating,
+		NodeStatusDeleting,
+		NodeStatusDeleted,
+		NodeStatusFailed,
+	}
+}
+
 const (
 	// ProposalStatusInProgress is a ProposalStatus enum value
 	ProposalStatusInProgress = "IN_PROGRESS"
@@ -6814,6 +6876,17 @@ const (
 	ProposalStatusActionFailed = "ACTION_FAILED"
 )
 
+// ProposalStatus_Values returns all elements of the ProposalStatus enum
+func ProposalStatus_Values() []string {
+	return []string{
+		ProposalStatusInProgress,
+		ProposalStatusApproved,
+		ProposalStatusRejected,
+		ProposalStatusExpired,
+		ProposalStatusActionFailed,
+	}
+}
+
 const (
 	// ThresholdComparatorGreaterThan is a ThresholdComparator enum value
 	ThresholdComparatorGreaterThan = "GREATER_THAN"
@@ -6822,6 +6895,14 @@ const (
 	ThresholdComparatorGreaterThanOrEqualTo = "GREATER_THAN_OR_EQUAL_TO"
 )
 
+// ThresholdComparator_Values returns all elements of the ThresholdComparator enum
+func ThresholdComparator_Values() []string {
+	return []string{
+		ThresholdComparatorGreaterThan,
+		ThresholdComparatorGreaterThanOrEqualTo,
+	}
+}
+
 const (
 	// VoteValueYes is a VoteValue enum value
 	VoteValueYes = "YES"
@@ -6829,3 +6910,11 @@ const (
 	// VoteValueNo is a VoteValue enum value
 	VoteValueNo = "NO"
 )
+
+// VoteValue_Values returns all elements of the VoteValue enum
+func VoteValue_Values() []string {
+	return []string{
+		VoteValueYes,
+		VoteValueNo,
+	}
+}

--- a/service/marketplacecatalog/api.go
+++ b/service/marketplacecatalog/api.go
@@ -2443,6 +2443,17 @@ const (
 	ChangeStatusFailed = "FAILED"
 )
 
+// ChangeStatus_Values returns all elements of the ChangeStatus enum
+func ChangeStatus_Values() []string {
+	return []string{
+		ChangeStatusPreparing,
+		ChangeStatusApplying,
+		ChangeStatusSucceeded,
+		ChangeStatusCancelled,
+		ChangeStatusFailed,
+	}
+}
+
 const (
 	// SortOrderAscending is a SortOrder enum value
 	SortOrderAscending = "ASCENDING"
@@ -2450,3 +2461,11 @@ const (
 	// SortOrderDescending is a SortOrder enum value
 	SortOrderDescending = "DESCENDING"
 )
+
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderAscending,
+		SortOrderDescending,
+	}
+}

--- a/service/marketplacecommerceanalytics/api.go
+++ b/service/marketplacecommerceanalytics/api.go
@@ -735,6 +735,37 @@ const (
 	DataSetTypeUsSalesAndUseTaxRecords = "us_sales_and_use_tax_records"
 )
 
+// DataSetType_Values returns all elements of the DataSetType enum
+func DataSetType_Values() []string {
+	return []string{
+		DataSetTypeCustomerSubscriberHourlyMonthlySubscriptions,
+		DataSetTypeCustomerSubscriberAnnualSubscriptions,
+		DataSetTypeDailyBusinessUsageByInstanceType,
+		DataSetTypeDailyBusinessFees,
+		DataSetTypeDailyBusinessFreeTrialConversions,
+		DataSetTypeDailyBusinessNewInstances,
+		DataSetTypeDailyBusinessNewProductSubscribers,
+		DataSetTypeDailyBusinessCanceledProductSubscribers,
+		DataSetTypeMonthlyRevenueBillingAndRevenueData,
+		DataSetTypeMonthlyRevenueAnnualSubscriptions,
+		DataSetTypeMonthlyRevenueFieldDemonstrationUsage,
+		DataSetTypeMonthlyRevenueFlexiblePaymentSchedule,
+		DataSetTypeDisbursedAmountByProduct,
+		DataSetTypeDisbursedAmountByProductWithUncollectedFunds,
+		DataSetTypeDisbursedAmountByInstanceHours,
+		DataSetTypeDisbursedAmountByCustomerGeo,
+		DataSetTypeDisbursedAmountByAgeOfUncollectedFunds,
+		DataSetTypeDisbursedAmountByAgeOfDisbursedFunds,
+		DataSetTypeDisbursedAmountByAgeOfPastDueFunds,
+		DataSetTypeDisbursedAmountByUncollectedFundsBreakdown,
+		DataSetTypeCustomerProfileByIndustry,
+		DataSetTypeCustomerProfileByRevenue,
+		DataSetTypeCustomerProfileByGeography,
+		DataSetTypeSalesCompensationBilledRevenue,
+		DataSetTypeUsSalesAndUseTaxRecords,
+	}
+}
+
 const (
 	// SupportDataSetTypeCustomerSupportContactsData is a SupportDataSetType enum value
 	SupportDataSetTypeCustomerSupportContactsData = "customer_support_contacts_data"
@@ -742,3 +773,11 @@ const (
 	// SupportDataSetTypeTestCustomerSupportContactsData is a SupportDataSetType enum value
 	SupportDataSetTypeTestCustomerSupportContactsData = "test_customer_support_contacts_data"
 )
+
+// SupportDataSetType_Values returns all elements of the SupportDataSetType enum
+func SupportDataSetType_Values() []string {
+	return []string{
+		SupportDataSetTypeCustomerSupportContactsData,
+		SupportDataSetTypeTestCustomerSupportContactsData,
+	}
+}

--- a/service/marketplaceentitlementservice/api.go
+++ b/service/marketplaceentitlementservice/api.go
@@ -516,3 +516,11 @@ const (
 	// GetEntitlementFilterNameDimension is a GetEntitlementFilterName enum value
 	GetEntitlementFilterNameDimension = "DIMENSION"
 )
+
+// GetEntitlementFilterName_Values returns all elements of the GetEntitlementFilterName enum
+func GetEntitlementFilterName_Values() []string {
+	return []string{
+		GetEntitlementFilterNameCustomerIdentifier,
+		GetEntitlementFilterNameDimension,
+	}
+}

--- a/service/marketplacemetering/api.go
+++ b/service/marketplacemetering/api.go
@@ -1888,3 +1888,12 @@ const (
 	// UsageRecordResultStatusDuplicateRecord is a UsageRecordResultStatus enum value
 	UsageRecordResultStatusDuplicateRecord = "DuplicateRecord"
 )
+
+// UsageRecordResultStatus_Values returns all elements of the UsageRecordResultStatus enum
+func UsageRecordResultStatus_Values() []string {
+	return []string{
+		UsageRecordResultStatusSuccess,
+		UsageRecordResultStatusCustomerNotSubscribed,
+		UsageRecordResultStatusDuplicateRecord,
+	}
+}

--- a/service/mediaconnect/api.go
+++ b/service/mediaconnect/api.go
@@ -6694,6 +6694,15 @@ const (
 	AlgorithmAes256 = "aes256"
 )
 
+// Algorithm_Values returns all elements of the Algorithm enum
+func Algorithm_Values() []string {
+	return []string{
+		AlgorithmAes128,
+		AlgorithmAes192,
+		AlgorithmAes256,
+	}
+}
+
 const (
 	// EntitlementStatusEnabled is a EntitlementStatus enum value
 	EntitlementStatusEnabled = "ENABLED"
@@ -6702,6 +6711,14 @@ const (
 	EntitlementStatusDisabled = "DISABLED"
 )
 
+// EntitlementStatus_Values returns all elements of the EntitlementStatus enum
+func EntitlementStatus_Values() []string {
+	return []string{
+		EntitlementStatusEnabled,
+		EntitlementStatusDisabled,
+	}
+}
+
 const (
 	// KeyTypeSpeke is a KeyType enum value
 	KeyTypeSpeke = "speke"
@@ -6709,6 +6726,14 @@ const (
 	// KeyTypeStaticKey is a KeyType enum value
 	KeyTypeStaticKey = "static-key"
 )
+
+// KeyType_Values returns all elements of the KeyType enum
+func KeyType_Values() []string {
+	return []string{
+		KeyTypeSpeke,
+		KeyTypeStaticKey,
+	}
+}
 
 const (
 	// ProtocolZixiPush is a Protocol enum value
@@ -6727,6 +6752,17 @@ const (
 	ProtocolRist = "rist"
 )
 
+// Protocol_Values returns all elements of the Protocol enum
+func Protocol_Values() []string {
+	return []string{
+		ProtocolZixiPush,
+		ProtocolRtpFec,
+		ProtocolRtp,
+		ProtocolZixiPull,
+		ProtocolRist,
+	}
+}
+
 const (
 	// SourceTypeOwned is a SourceType enum value
 	SourceTypeOwned = "OWNED"
@@ -6735,6 +6771,14 @@ const (
 	SourceTypeEntitled = "ENTITLED"
 )
 
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeOwned,
+		SourceTypeEntitled,
+	}
+}
+
 const (
 	// StateEnabled is a State enum value
 	StateEnabled = "ENABLED"
@@ -6742,6 +6786,14 @@ const (
 	// StateDisabled is a State enum value
 	StateDisabled = "DISABLED"
 )
+
+// State_Values returns all elements of the State enum
+func State_Values() []string {
+	return []string{
+		StateEnabled,
+		StateDisabled,
+	}
+}
 
 const (
 	// StatusStandby is a Status enum value
@@ -6765,3 +6817,16 @@ const (
 	// StatusError is a Status enum value
 	StatusError = "ERROR"
 )
+
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusStandby,
+		StatusActive,
+		StatusUpdating,
+		StatusDeleting,
+		StatusStarting,
+		StatusStopping,
+		StatusError,
+	}
+}

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -19414,6 +19414,14 @@ const (
 	AacAudioDescriptionBroadcasterMixNormal = "NORMAL"
 )
 
+// AacAudioDescriptionBroadcasterMix_Values returns all elements of the AacAudioDescriptionBroadcasterMix enum
+func AacAudioDescriptionBroadcasterMix_Values() []string {
+	return []string{
+		AacAudioDescriptionBroadcasterMixBroadcasterMixedAd,
+		AacAudioDescriptionBroadcasterMixNormal,
+	}
+}
+
 // AAC Profile.
 const (
 	// AacCodecProfileLc is a AacCodecProfile enum value
@@ -19425,6 +19433,15 @@ const (
 	// AacCodecProfileHev2 is a AacCodecProfile enum value
 	AacCodecProfileHev2 = "HEV2"
 )
+
+// AacCodecProfile_Values returns all elements of the AacCodecProfile enum
+func AacCodecProfile_Values() []string {
+	return []string{
+		AacCodecProfileLc,
+		AacCodecProfileHev1,
+		AacCodecProfileHev2,
+	}
+}
 
 // Mono (Audio Description), Mono, Stereo, or 5.1 channel layout. Valid values
 // depend on rate control mode and profile. "1.0 - Audio Description (Receiver
@@ -19448,6 +19465,17 @@ const (
 	AacCodingModeCodingMode51 = "CODING_MODE_5_1"
 )
 
+// AacCodingMode_Values returns all elements of the AacCodingMode enum
+func AacCodingMode_Values() []string {
+	return []string{
+		AacCodingModeAdReceiverMix,
+		AacCodingModeCodingMode10,
+		AacCodingModeCodingMode11,
+		AacCodingModeCodingMode20,
+		AacCodingModeCodingMode51,
+	}
+}
+
 // Rate Control Mode.
 const (
 	// AacRateControlModeCbr is a AacRateControlMode enum value
@@ -19456,6 +19484,14 @@ const (
 	// AacRateControlModeVbr is a AacRateControlMode enum value
 	AacRateControlModeVbr = "VBR"
 )
+
+// AacRateControlMode_Values returns all elements of the AacRateControlMode enum
+func AacRateControlMode_Values() []string {
+	return []string{
+		AacRateControlModeCbr,
+		AacRateControlModeVbr,
+	}
+}
 
 // Enables LATM/LOAS AAC output. Note that if you use LATM/LOAS AAC in an output,
 // you must choose "No container" for the output container.
@@ -19467,6 +19503,14 @@ const (
 	AacRawFormatNone = "NONE"
 )
 
+// AacRawFormat_Values returns all elements of the AacRawFormat enum
+func AacRawFormat_Values() []string {
+	return []string{
+		AacRawFormatLatmLoas,
+		AacRawFormatNone,
+	}
+}
+
 // Use MPEG-2 AAC instead of MPEG-4 AAC audio for raw or MPEG-2 Transport Stream
 // containers.
 const (
@@ -19476,6 +19520,14 @@ const (
 	// AacSpecificationMpeg4 is a AacSpecification enum value
 	AacSpecificationMpeg4 = "MPEG4"
 )
+
+// AacSpecification_Values returns all elements of the AacSpecification enum
+func AacSpecification_Values() []string {
+	return []string{
+		AacSpecificationMpeg2,
+		AacSpecificationMpeg4,
+	}
+}
 
 // VBR Quality Level - Only used if rate_control_mode is VBR.
 const (
@@ -19491,6 +19543,16 @@ const (
 	// AacVbrQualityHigh is a AacVbrQuality enum value
 	AacVbrQualityHigh = "HIGH"
 )
+
+// AacVbrQuality_Values returns all elements of the AacVbrQuality enum
+func AacVbrQuality_Values() []string {
+	return []string{
+		AacVbrQualityLow,
+		AacVbrQualityMediumLow,
+		AacVbrQualityMediumHigh,
+		AacVbrQualityHigh,
+	}
+}
 
 // Specify the bitstream mode for the AC-3 stream that the encoder emits. For
 // more information about the AC3 bitstream mode, see ATSC A/52-2012 (Annex
@@ -19521,6 +19583,20 @@ const (
 	Ac3BitstreamModeVoiceOver = "VOICE_OVER"
 )
 
+// Ac3BitstreamMode_Values returns all elements of the Ac3BitstreamMode enum
+func Ac3BitstreamMode_Values() []string {
+	return []string{
+		Ac3BitstreamModeCompleteMain,
+		Ac3BitstreamModeCommentary,
+		Ac3BitstreamModeDialogue,
+		Ac3BitstreamModeEmergency,
+		Ac3BitstreamModeHearingImpaired,
+		Ac3BitstreamModeMusicAndEffects,
+		Ac3BitstreamModeVisuallyImpaired,
+		Ac3BitstreamModeVoiceOver,
+	}
+}
+
 // Dolby Digital coding mode. Determines number of channels.
 const (
 	// Ac3CodingModeCodingMode10 is a Ac3CodingMode enum value
@@ -19536,6 +19612,16 @@ const (
 	Ac3CodingModeCodingMode32Lfe = "CODING_MODE_3_2_LFE"
 )
 
+// Ac3CodingMode_Values returns all elements of the Ac3CodingMode enum
+func Ac3CodingMode_Values() []string {
+	return []string{
+		Ac3CodingModeCodingMode10,
+		Ac3CodingModeCodingMode11,
+		Ac3CodingModeCodingMode20,
+		Ac3CodingModeCodingMode32Lfe,
+	}
+}
+
 // If set to FILM_STANDARD, adds dynamic range compression signaling to the
 // output bitstream as defined in the Dolby Digital specification.
 const (
@@ -19545,6 +19631,14 @@ const (
 	// Ac3DynamicRangeCompressionProfileNone is a Ac3DynamicRangeCompressionProfile enum value
 	Ac3DynamicRangeCompressionProfileNone = "NONE"
 )
+
+// Ac3DynamicRangeCompressionProfile_Values returns all elements of the Ac3DynamicRangeCompressionProfile enum
+func Ac3DynamicRangeCompressionProfile_Values() []string {
+	return []string{
+		Ac3DynamicRangeCompressionProfileFilmStandard,
+		Ac3DynamicRangeCompressionProfileNone,
+	}
+}
 
 // Applies a 120Hz lowpass filter to the LFE channel prior to encoding. Only
 // valid with 3_2_LFE coding mode.
@@ -19556,6 +19650,14 @@ const (
 	Ac3LfeFilterDisabled = "DISABLED"
 )
 
+// Ac3LfeFilter_Values returns all elements of the Ac3LfeFilter enum
+func Ac3LfeFilter_Values() []string {
+	return []string{
+		Ac3LfeFilterEnabled,
+		Ac3LfeFilterDisabled,
+	}
+}
+
 // When set to FOLLOW_INPUT, encoder metadata will be sourced from the DD, DD+,
 // or DolbyE decoder that supplied this audio data. If audio was not supplied
 // from one of these streams, then the static metadata settings will be used.
@@ -19566,6 +19668,14 @@ const (
 	// Ac3MetadataControlUseConfigured is a Ac3MetadataControl enum value
 	Ac3MetadataControlUseConfigured = "USE_CONFIGURED"
 )
+
+// Ac3MetadataControl_Values returns all elements of the Ac3MetadataControl enum
+func Ac3MetadataControl_Values() []string {
+	return []string{
+		Ac3MetadataControlFollowInput,
+		Ac3MetadataControlUseConfigured,
+	}
+}
 
 // Specify whether the service runs your job with accelerated transcoding. Choose
 // DISABLED if you don't want accelerated transcoding. Choose ENABLED if you
@@ -19584,6 +19694,15 @@ const (
 	// AccelerationModePreferred is a AccelerationMode enum value
 	AccelerationModePreferred = "PREFERRED"
 )
+
+// AccelerationMode_Values returns all elements of the AccelerationMode enum
+func AccelerationMode_Values() []string {
+	return []string{
+		AccelerationModeDisabled,
+		AccelerationModeEnabled,
+		AccelerationModePreferred,
+	}
+}
 
 // Describes whether the current job is running with accelerated transcoding.
 // For jobs that have Acceleration (AccelerationMode) set to DISABLED, AccelerationStatus
@@ -19610,6 +19729,16 @@ const (
 	AccelerationStatusNotAccelerated = "NOT_ACCELERATED"
 )
 
+// AccelerationStatus_Values returns all elements of the AccelerationStatus enum
+func AccelerationStatus_Values() []string {
+	return []string{
+		AccelerationStatusNotApplicable,
+		AccelerationStatusInProgress,
+		AccelerationStatusAccelerated,
+		AccelerationStatusNotAccelerated,
+	}
+}
+
 // This setting only applies to H.264, H.265, and MPEG2 outputs. Use Insert
 // AFD signaling (AfdSignaling) to specify whether the service includes AFD
 // values in the output video data and what those values are. * Choose None
@@ -19627,6 +19756,15 @@ const (
 	AfdSignalingFixed = "FIXED"
 )
 
+// AfdSignaling_Values returns all elements of the AfdSignaling enum
+func AfdSignaling_Values() []string {
+	return []string{
+		AfdSignalingNone,
+		AfdSignalingAuto,
+		AfdSignalingFixed,
+	}
+}
+
 // Ignore this setting unless this input is a QuickTime animation with an alpha
 // channel. Use this setting to create separate Key and Fill outputs. In each
 // output, specify which part of the input MediaConvert uses. Leave this setting
@@ -19641,6 +19779,14 @@ const (
 	AlphaBehaviorRemapToLuma = "REMAP_TO_LUMA"
 )
 
+// AlphaBehavior_Values returns all elements of the AlphaBehavior enum
+func AlphaBehavior_Values() []string {
+	return []string{
+		AlphaBehaviorDiscard,
+		AlphaBehaviorRemapToLuma,
+	}
+}
+
 // Specify whether this set of input captions appears in your outputs in both
 // 608 and 708 format. If you choose Upconvert (UPCONVERT), MediaConvert includes
 // the captions data in two ways: it passes the 608 data through using the 608
@@ -19654,6 +19800,14 @@ const (
 	AncillaryConvert608To708Disabled = "DISABLED"
 )
 
+// AncillaryConvert608To708_Values returns all elements of the AncillaryConvert608To708 enum
+func AncillaryConvert608To708_Values() []string {
+	return []string{
+		AncillaryConvert608To708Upconvert,
+		AncillaryConvert608To708Disabled,
+	}
+}
+
 // By default, the service terminates any unterminated captions at the end of
 // each input. If you want the caption to continue onto your next input, disable
 // this setting.
@@ -19665,6 +19819,14 @@ const (
 	AncillaryTerminateCaptionsDisabled = "DISABLED"
 )
 
+// AncillaryTerminateCaptions_Values returns all elements of the AncillaryTerminateCaptions enum
+func AncillaryTerminateCaptions_Values() []string {
+	return []string{
+		AncillaryTerminateCaptionsEndOfInput,
+		AncillaryTerminateCaptionsDisabled,
+	}
+}
+
 // The anti-alias filter is automatically applied to all outputs. The service
 // no longer accepts the value DISABLED for AntiAlias. If you specify that in
 // your job, the service will ignore the setting.
@@ -19675,6 +19837,14 @@ const (
 	// AntiAliasEnabled is a AntiAlias enum value
 	AntiAliasEnabled = "ENABLED"
 )
+
+// AntiAlias_Values returns all elements of the AntiAlias enum
+func AntiAlias_Values() []string {
+	return []string{
+		AntiAliasDisabled,
+		AntiAliasEnabled,
+	}
+}
 
 // Type of Audio codec.
 const (
@@ -19712,6 +19882,23 @@ const (
 	AudioCodecPassthrough = "PASSTHROUGH"
 )
 
+// AudioCodec_Values returns all elements of the AudioCodec enum
+func AudioCodec_Values() []string {
+	return []string{
+		AudioCodecAac,
+		AudioCodecMp2,
+		AudioCodecMp3,
+		AudioCodecWav,
+		AudioCodecAiff,
+		AudioCodecAc3,
+		AudioCodecEac3,
+		AudioCodecEac3Atmos,
+		AudioCodecVorbis,
+		AudioCodecOpus,
+		AudioCodecPassthrough,
+	}
+}
+
 // Enable this setting on one audio selector to set it as the default for the
 // job. The service uses this default for outputs where it can't find the specified
 // input audio. If you don't set a default, those outputs have no audio.
@@ -19722,6 +19909,14 @@ const (
 	// AudioDefaultSelectionNotDefault is a AudioDefaultSelection enum value
 	AudioDefaultSelectionNotDefault = "NOT_DEFAULT"
 )
+
+// AudioDefaultSelection_Values returns all elements of the AudioDefaultSelection enum
+func AudioDefaultSelection_Values() []string {
+	return []string{
+		AudioDefaultSelectionDefault,
+		AudioDefaultSelectionNotDefault,
+	}
+}
 
 // Specify which source for language code takes precedence for this audio track.
 // When you choose Follow input (FOLLOW_INPUT), the service uses the language
@@ -19736,6 +19931,14 @@ const (
 	// AudioLanguageCodeControlUseConfigured is a AudioLanguageCodeControl enum value
 	AudioLanguageCodeControlUseConfigured = "USE_CONFIGURED"
 )
+
+// AudioLanguageCodeControl_Values returns all elements of the AudioLanguageCodeControl enum
+func AudioLanguageCodeControl_Values() []string {
+	return []string{
+		AudioLanguageCodeControlFollowInput,
+		AudioLanguageCodeControlUseConfigured,
+	}
+}
 
 // Choose one of the following audio normalization algorithms: ITU-R BS.1770-1:
 // Ungated loudness. A measurement of ungated average loudness for an entire
@@ -19761,6 +19964,16 @@ const (
 	AudioNormalizationAlgorithmItuBs17704 = "ITU_BS_1770_4"
 )
 
+// AudioNormalizationAlgorithm_Values returns all elements of the AudioNormalizationAlgorithm enum
+func AudioNormalizationAlgorithm_Values() []string {
+	return []string{
+		AudioNormalizationAlgorithmItuBs17701,
+		AudioNormalizationAlgorithmItuBs17702,
+		AudioNormalizationAlgorithmItuBs17703,
+		AudioNormalizationAlgorithmItuBs17704,
+	}
+}
+
 // When enabled the output audio is corrected using the chosen algorithm. If
 // disabled, the audio will be measured but not adjusted.
 const (
@@ -19771,6 +19984,14 @@ const (
 	AudioNormalizationAlgorithmControlMeasureOnly = "MEASURE_ONLY"
 )
 
+// AudioNormalizationAlgorithmControl_Values returns all elements of the AudioNormalizationAlgorithmControl enum
+func AudioNormalizationAlgorithmControl_Values() []string {
+	return []string{
+		AudioNormalizationAlgorithmControlCorrectAudio,
+		AudioNormalizationAlgorithmControlMeasureOnly,
+	}
+}
+
 // If set to LOG, log each output's audio track loudness to a CSV file.
 const (
 	// AudioNormalizationLoudnessLoggingLog is a AudioNormalizationLoudnessLogging enum value
@@ -19779,6 +20000,14 @@ const (
 	// AudioNormalizationLoudnessLoggingDontLog is a AudioNormalizationLoudnessLogging enum value
 	AudioNormalizationLoudnessLoggingDontLog = "DONT_LOG"
 )
+
+// AudioNormalizationLoudnessLogging_Values returns all elements of the AudioNormalizationLoudnessLogging enum
+func AudioNormalizationLoudnessLogging_Values() []string {
+	return []string{
+		AudioNormalizationLoudnessLoggingLog,
+		AudioNormalizationLoudnessLoggingDontLog,
+	}
+}
 
 // If set to TRUE_PEAK, calculate and log the TruePeak for each output's audio
 // track loudness.
@@ -19789,6 +20018,14 @@ const (
 	// AudioNormalizationPeakCalculationNone is a AudioNormalizationPeakCalculation enum value
 	AudioNormalizationPeakCalculationNone = "NONE"
 )
+
+// AudioNormalizationPeakCalculation_Values returns all elements of the AudioNormalizationPeakCalculation enum
+func AudioNormalizationPeakCalculation_Values() []string {
+	return []string{
+		AudioNormalizationPeakCalculationTruePeak,
+		AudioNormalizationPeakCalculationNone,
+	}
+}
 
 // Specifies the type of the audio selector.
 const (
@@ -19802,6 +20039,15 @@ const (
 	AudioSelectorTypeLanguageCode = "LANGUAGE_CODE"
 )
 
+// AudioSelectorType_Values returns all elements of the AudioSelectorType enum
+func AudioSelectorType_Values() []string {
+	return []string{
+		AudioSelectorTypePid,
+		AudioSelectorTypeTrack,
+		AudioSelectorTypeLanguageCode,
+	}
+}
+
 // When set to FOLLOW_INPUT, if the input contains an ISO 639 audio_type, then
 // that value is passed through to the output. If the input contains no ISO
 // 639 audio_type, the value in Audio Type is included in the output. Otherwise
@@ -19814,6 +20060,14 @@ const (
 	// AudioTypeControlUseConfigured is a AudioTypeControl enum value
 	AudioTypeControlUseConfigured = "USE_CONFIGURED"
 )
+
+// AudioTypeControl_Values returns all elements of the AudioTypeControl enum
+func AudioTypeControl_Values() []string {
+	return []string{
+		AudioTypeControlFollowInput,
+		AudioTypeControlUseConfigured,
+	}
+}
 
 // Adaptive quantization. Allows intra-frame quantizers to vary to improve visual
 // quality.
@@ -19837,6 +20091,18 @@ const (
 	Av1AdaptiveQuantizationMax = "MAX"
 )
 
+// Av1AdaptiveQuantization_Values returns all elements of the Av1AdaptiveQuantization enum
+func Av1AdaptiveQuantization_Values() []string {
+	return []string{
+		Av1AdaptiveQuantizationOff,
+		Av1AdaptiveQuantizationLow,
+		Av1AdaptiveQuantizationMedium,
+		Av1AdaptiveQuantizationHigh,
+		Av1AdaptiveQuantizationHigher,
+		Av1AdaptiveQuantizationMax,
+	}
+}
+
 // If you are using the console, use the Framerate setting to specify the frame
 // rate for this output. If you want to keep the same frame rate as the input
 // video, choose Follow source. If you want to do frame rate conversion, choose
@@ -19856,6 +20122,14 @@ const (
 	Av1FramerateControlSpecified = "SPECIFIED"
 )
 
+// Av1FramerateControl_Values returns all elements of the Av1FramerateControl enum
+func Av1FramerateControl_Values() []string {
+	return []string{
+		Av1FramerateControlInitializeFromSource,
+		Av1FramerateControlSpecified,
+	}
+}
+
 // Optional. Specify how the transcoder performs framerate conversion. The default
 // behavior is to use duplicate drop conversion.
 const (
@@ -19866,12 +20140,27 @@ const (
 	Av1FramerateConversionAlgorithmInterpolate = "INTERPOLATE"
 )
 
+// Av1FramerateConversionAlgorithm_Values returns all elements of the Av1FramerateConversionAlgorithm enum
+func Av1FramerateConversionAlgorithm_Values() []string {
+	return []string{
+		Av1FramerateConversionAlgorithmDuplicateDrop,
+		Av1FramerateConversionAlgorithmInterpolate,
+	}
+}
+
 // 'With AV1 outputs, for rate control mode, MediaConvert supports only quality-defined
 // variable bitrate (QVBR). You can''t use CBR or VBR.'
 const (
 	// Av1RateControlModeQvbr is a Av1RateControlMode enum value
 	Av1RateControlModeQvbr = "QVBR"
 )
+
+// Av1RateControlMode_Values returns all elements of the Av1RateControlMode enum
+func Av1RateControlMode_Values() []string {
+	return []string{
+		Av1RateControlModeQvbr,
+	}
+}
 
 // Adjust quantization within each frame based on spatial variation of content
 // complexity.
@@ -19882,6 +20171,14 @@ const (
 	// Av1SpatialAdaptiveQuantizationEnabled is a Av1SpatialAdaptiveQuantization enum value
 	Av1SpatialAdaptiveQuantizationEnabled = "ENABLED"
 )
+
+// Av1SpatialAdaptiveQuantization_Values returns all elements of the Av1SpatialAdaptiveQuantization enum
+func Av1SpatialAdaptiveQuantization_Values() []string {
+	return []string{
+		Av1SpatialAdaptiveQuantizationDisabled,
+		Av1SpatialAdaptiveQuantizationEnabled,
+	}
+}
 
 // The tag type that AWS Billing and Cost Management will use to sort your AWS
 // Elemental MediaConvert costs on any billing report that you set up.
@@ -19899,6 +20196,16 @@ const (
 	BillingTagsSourceJob = "JOB"
 )
 
+// BillingTagsSource_Values returns all elements of the BillingTagsSource enum
+func BillingTagsSource_Values() []string {
+	return []string{
+		BillingTagsSourceQueue,
+		BillingTagsSourcePreset,
+		BillingTagsSourceJobTemplate,
+		BillingTagsSourceJob,
+	}
+}
+
 // If no explicit x_position or y_position is provided, setting alignment to
 // centered will place the captions at the bottom center of the output. Similarly,
 // setting a left alignment will align captions to the bottom left of the output.
@@ -19915,6 +20222,14 @@ const (
 	BurninSubtitleAlignmentLeft = "LEFT"
 )
 
+// BurninSubtitleAlignment_Values returns all elements of the BurninSubtitleAlignment enum
+func BurninSubtitleAlignment_Values() []string {
+	return []string{
+		BurninSubtitleAlignmentCentered,
+		BurninSubtitleAlignmentLeft,
+	}
+}
+
 // Specifies the color of the rectangle behind the captions.All burn-in and
 // DVB-Sub font settings must match.
 const (
@@ -19927,6 +20242,15 @@ const (
 	// BurninSubtitleBackgroundColorWhite is a BurninSubtitleBackgroundColor enum value
 	BurninSubtitleBackgroundColorWhite = "WHITE"
 )
+
+// BurninSubtitleBackgroundColor_Values returns all elements of the BurninSubtitleBackgroundColor enum
+func BurninSubtitleBackgroundColor_Values() []string {
+	return []string{
+		BurninSubtitleBackgroundColorNone,
+		BurninSubtitleBackgroundColorBlack,
+		BurninSubtitleBackgroundColorWhite,
+	}
+}
 
 // Specifies the color of the burned-in captions. This option is not valid for
 // source captions that are STL, 608/embedded or teletext. These source settings
@@ -19952,6 +20276,18 @@ const (
 	BurninSubtitleFontColorBlue = "BLUE"
 )
 
+// BurninSubtitleFontColor_Values returns all elements of the BurninSubtitleFontColor enum
+func BurninSubtitleFontColor_Values() []string {
+	return []string{
+		BurninSubtitleFontColorWhite,
+		BurninSubtitleFontColorBlack,
+		BurninSubtitleFontColorYellow,
+		BurninSubtitleFontColorRed,
+		BurninSubtitleFontColorGreen,
+		BurninSubtitleFontColorBlue,
+	}
+}
+
 // Specifies font outline color. This option is not valid for source captions
 // that are either 608/embedded or teletext. These source settings are already
 // pre-defined by the caption stream. All burn-in and DVB-Sub font settings
@@ -19976,6 +20312,18 @@ const (
 	BurninSubtitleOutlineColorBlue = "BLUE"
 )
 
+// BurninSubtitleOutlineColor_Values returns all elements of the BurninSubtitleOutlineColor enum
+func BurninSubtitleOutlineColor_Values() []string {
+	return []string{
+		BurninSubtitleOutlineColorBlack,
+		BurninSubtitleOutlineColorWhite,
+		BurninSubtitleOutlineColorYellow,
+		BurninSubtitleOutlineColorRed,
+		BurninSubtitleOutlineColorGreen,
+		BurninSubtitleOutlineColorBlue,
+	}
+}
+
 // Specifies the color of the shadow cast by the captions.All burn-in and DVB-Sub
 // font settings must match.
 const (
@@ -19989,6 +20337,15 @@ const (
 	BurninSubtitleShadowColorWhite = "WHITE"
 )
 
+// BurninSubtitleShadowColor_Values returns all elements of the BurninSubtitleShadowColor enum
+func BurninSubtitleShadowColor_Values() []string {
+	return []string{
+		BurninSubtitleShadowColorNone,
+		BurninSubtitleShadowColorBlack,
+		BurninSubtitleShadowColorWhite,
+	}
+}
+
 // Only applies to jobs with input captions in Teletext or STL formats. Specify
 // whether the spacing between letters in your captions is set by the captions
 // grid or varies depending on letter width. Choose fixed grid to conform to
@@ -20001,6 +20358,14 @@ const (
 	// BurninSubtitleTeletextSpacingProportional is a BurninSubtitleTeletextSpacing enum value
 	BurninSubtitleTeletextSpacingProportional = "PROPORTIONAL"
 )
+
+// BurninSubtitleTeletextSpacing_Values returns all elements of the BurninSubtitleTeletextSpacing enum
+func BurninSubtitleTeletextSpacing_Values() []string {
+	return []string{
+		BurninSubtitleTeletextSpacingFixedGrid,
+		BurninSubtitleTeletextSpacingProportional,
+	}
+}
 
 // Specify the format for this set of captions on this output. The default format
 // is embedded without SCTE-20. Other options are embedded with SCTE-20, burn-in,
@@ -20046,6 +20411,24 @@ const (
 	CaptionDestinationTypeWebvtt = "WEBVTT"
 )
 
+// CaptionDestinationType_Values returns all elements of the CaptionDestinationType enum
+func CaptionDestinationType_Values() []string {
+	return []string{
+		CaptionDestinationTypeBurnIn,
+		CaptionDestinationTypeDvbSub,
+		CaptionDestinationTypeEmbedded,
+		CaptionDestinationTypeEmbeddedPlusScte20,
+		CaptionDestinationTypeImsc,
+		CaptionDestinationTypeScte20PlusEmbedded,
+		CaptionDestinationTypeScc,
+		CaptionDestinationTypeSrt,
+		CaptionDestinationTypeSmi,
+		CaptionDestinationTypeTeletext,
+		CaptionDestinationTypeTtml,
+		CaptionDestinationTypeWebvtt,
+	}
+}
+
 // Use Source (SourceType) to identify the format of your input captions. The
 // service cannot auto-detect caption format.
 const (
@@ -20086,6 +20469,24 @@ const (
 	CaptionSourceTypeImsc = "IMSC"
 )
 
+// CaptionSourceType_Values returns all elements of the CaptionSourceType enum
+func CaptionSourceType_Values() []string {
+	return []string{
+		CaptionSourceTypeAncillary,
+		CaptionSourceTypeDvbSub,
+		CaptionSourceTypeEmbedded,
+		CaptionSourceTypeScte20,
+		CaptionSourceTypeScc,
+		CaptionSourceTypeTtml,
+		CaptionSourceTypeStl,
+		CaptionSourceTypeSrt,
+		CaptionSourceTypeSmi,
+		CaptionSourceTypeTeletext,
+		CaptionSourceTypeNullSource,
+		CaptionSourceTypeImsc,
+	}
+}
+
 // When set to ENABLED, sets #EXT-X-ALLOW-CACHE:no tag, which prevents client
 // from saving media segments for later replay.
 const (
@@ -20095,6 +20496,14 @@ const (
 	// CmafClientCacheEnabled is a CmafClientCache enum value
 	CmafClientCacheEnabled = "ENABLED"
 )
+
+// CmafClientCache_Values returns all elements of the CmafClientCache enum
+func CmafClientCache_Values() []string {
+	return []string{
+		CmafClientCacheDisabled,
+		CmafClientCacheEnabled,
+	}
+}
 
 // Specification to use (RFC-6381 or the default RFC-4281) during m3u8 playlist
 // generation.
@@ -20106,6 +20515,14 @@ const (
 	CmafCodecSpecificationRfc4281 = "RFC_4281"
 )
 
+// CmafCodecSpecification_Values returns all elements of the CmafCodecSpecification enum
+func CmafCodecSpecification_Values() []string {
+	return []string{
+		CmafCodecSpecificationRfc6381,
+		CmafCodecSpecificationRfc4281,
+	}
+}
+
 // Specify the encryption scheme that you want the service to use when encrypting
 // your CMAF segments. Choose AES-CBC subsample (SAMPLE-AES) or AES_CTR (AES-CTR).
 const (
@@ -20115,6 +20532,14 @@ const (
 	// CmafEncryptionTypeAesCtr is a CmafEncryptionType enum value
 	CmafEncryptionTypeAesCtr = "AES_CTR"
 )
+
+// CmafEncryptionType_Values returns all elements of the CmafEncryptionType enum
+func CmafEncryptionType_Values() []string {
+	return []string{
+		CmafEncryptionTypeSampleAes,
+		CmafEncryptionTypeAesCtr,
+	}
+}
 
 // When you use DRM with CMAF outputs, choose whether the service writes the
 // 128-bit encryption initialization vector in the HLS and DASH manifests.
@@ -20126,6 +20551,14 @@ const (
 	CmafInitializationVectorInManifestExclude = "EXCLUDE"
 )
 
+// CmafInitializationVectorInManifest_Values returns all elements of the CmafInitializationVectorInManifest enum
+func CmafInitializationVectorInManifest_Values() []string {
+	return []string{
+		CmafInitializationVectorInManifestInclude,
+		CmafInitializationVectorInManifestExclude,
+	}
+}
+
 // Specify whether your DRM encryption key is static or from a key provider
 // that follows the SPEKE standard. For more information about SPEKE, see https://docs.aws.amazon.com/speke/latest/documentation/what-is-speke.html.
 const (
@@ -20136,6 +20569,14 @@ const (
 	CmafKeyProviderTypeStaticKey = "STATIC_KEY"
 )
 
+// CmafKeyProviderType_Values returns all elements of the CmafKeyProviderType enum
+func CmafKeyProviderType_Values() []string {
+	return []string{
+		CmafKeyProviderTypeSpeke,
+		CmafKeyProviderTypeStaticKey,
+	}
+}
+
 // When set to GZIP, compresses HLS playlist.
 const (
 	// CmafManifestCompressionGzip is a CmafManifestCompression enum value
@@ -20144,6 +20585,14 @@ const (
 	// CmafManifestCompressionNone is a CmafManifestCompression enum value
 	CmafManifestCompressionNone = "NONE"
 )
+
+// CmafManifestCompression_Values returns all elements of the CmafManifestCompression enum
+func CmafManifestCompression_Values() []string {
+	return []string{
+		CmafManifestCompressionGzip,
+		CmafManifestCompressionNone,
+	}
+}
 
 // Indicates whether the output manifest should use floating point values for
 // segment duration.
@@ -20154,6 +20603,14 @@ const (
 	// CmafManifestDurationFormatInteger is a CmafManifestDurationFormat enum value
 	CmafManifestDurationFormatInteger = "INTEGER"
 )
+
+// CmafManifestDurationFormat_Values returns all elements of the CmafManifestDurationFormat enum
+func CmafManifestDurationFormat_Values() []string {
+	return []string{
+		CmafManifestDurationFormatFloatingPoint,
+		CmafManifestDurationFormatInteger,
+	}
+}
 
 // Specify whether your DASH profile is on-demand or main. When you choose Main
 // profile (MAIN_PROFILE), the service signals urn:mpeg:dash:profile:isoff-main:2011
@@ -20169,6 +20626,14 @@ const (
 	CmafMpdProfileOnDemandProfile = "ON_DEMAND_PROFILE"
 )
 
+// CmafMpdProfile_Values returns all elements of the CmafMpdProfile enum
+func CmafMpdProfile_Values() []string {
+	return []string{
+		CmafMpdProfileMainProfile,
+		CmafMpdProfileOnDemandProfile,
+	}
+}
+
 // When set to SINGLE_FILE, a single output file is generated, which is internally
 // segmented using the Fragment Length and Segment Length. When set to SEGMENTED_FILES,
 // separate segment files will be created.
@@ -20180,6 +20645,14 @@ const (
 	CmafSegmentControlSegmentedFiles = "SEGMENTED_FILES"
 )
 
+// CmafSegmentControl_Values returns all elements of the CmafSegmentControl enum
+func CmafSegmentControl_Values() []string {
+	return []string{
+		CmafSegmentControlSingleFile,
+		CmafSegmentControlSegmentedFiles,
+	}
+}
+
 // Include or exclude RESOLUTION attribute for video in EXT-X-STREAM-INF tag
 // of variant manifest.
 const (
@@ -20190,6 +20663,14 @@ const (
 	CmafStreamInfResolutionExclude = "EXCLUDE"
 )
 
+// CmafStreamInfResolution_Values returns all elements of the CmafStreamInfResolution enum
+func CmafStreamInfResolution_Values() []string {
+	return []string{
+		CmafStreamInfResolutionInclude,
+		CmafStreamInfResolutionExclude,
+	}
+}
+
 // When set to ENABLED, a DASH MPD manifest will be generated for this output.
 const (
 	// CmafWriteDASHManifestDisabled is a CmafWriteDASHManifest enum value
@@ -20199,6 +20680,14 @@ const (
 	CmafWriteDASHManifestEnabled = "ENABLED"
 )
 
+// CmafWriteDASHManifest_Values returns all elements of the CmafWriteDASHManifest enum
+func CmafWriteDASHManifest_Values() []string {
+	return []string{
+		CmafWriteDASHManifestDisabled,
+		CmafWriteDASHManifestEnabled,
+	}
+}
+
 // When set to ENABLED, an Apple HLS manifest will be generated for this output.
 const (
 	// CmafWriteHLSManifestDisabled is a CmafWriteHLSManifest enum value
@@ -20207,6 +20696,14 @@ const (
 	// CmafWriteHLSManifestEnabled is a CmafWriteHLSManifest enum value
 	CmafWriteHLSManifestEnabled = "ENABLED"
 )
+
+// CmafWriteHLSManifest_Values returns all elements of the CmafWriteHLSManifest enum
+func CmafWriteHLSManifest_Values() []string {
+	return []string{
+		CmafWriteHLSManifestDisabled,
+		CmafWriteHLSManifestEnabled,
+	}
+}
 
 // When you enable Precise segment duration in DASH manifests (writeSegmentTimelineInRepresentation),
 // your DASH manifest shows precise segment durations. The segment duration
@@ -20222,6 +20719,14 @@ const (
 	CmafWriteSegmentTimelineInRepresentationDisabled = "DISABLED"
 )
 
+// CmafWriteSegmentTimelineInRepresentation_Values returns all elements of the CmafWriteSegmentTimelineInRepresentation enum
+func CmafWriteSegmentTimelineInRepresentation_Values() []string {
+	return []string{
+		CmafWriteSegmentTimelineInRepresentationEnabled,
+		CmafWriteSegmentTimelineInRepresentationDisabled,
+	}
+}
+
 // Use this setting only when you specify SCTE-35 markers from ESAM. Choose
 // INSERT to put SCTE-35 markers in this output at the insertion points that
 // you specify in an ESAM XML document. Provide the document in the setting
@@ -20233,6 +20738,14 @@ const (
 	// CmfcScte35EsamNone is a CmfcScte35Esam enum value
 	CmfcScte35EsamNone = "NONE"
 )
+
+// CmfcScte35Esam_Values returns all elements of the CmfcScte35Esam enum
+func CmfcScte35Esam_Values() []string {
+	return []string{
+		CmfcScte35EsamInsert,
+		CmfcScte35EsamNone,
+	}
+}
 
 // Ignore this setting unless you have SCTE-35 markers in your input video file.
 // Choose Passthrough (PASSTHROUGH) if you want SCTE-35 markers that appear
@@ -20246,6 +20759,14 @@ const (
 	CmfcScte35SourceNone = "NONE"
 )
 
+// CmfcScte35Source_Values returns all elements of the CmfcScte35Source enum
+func CmfcScte35Source_Values() []string {
+	return []string{
+		CmfcScte35SourcePassthrough,
+		CmfcScte35SourceNone,
+	}
+}
+
 // Choose Insert (INSERT) for this setting to include color metadata in this
 // output. Choose Ignore (IGNORE) to exclude color metadata from this output.
 // If you don't specify a value, the service sets this to Insert by default.
@@ -20256,6 +20777,14 @@ const (
 	// ColorMetadataInsert is a ColorMetadata enum value
 	ColorMetadataInsert = "INSERT"
 )
+
+// ColorMetadata_Values returns all elements of the ColorMetadata enum
+func ColorMetadata_Values() []string {
+	return []string{
+		ColorMetadataIgnore,
+		ColorMetadataInsert,
+	}
+}
 
 // If your input video has accurate color space metadata, or if you don't know
 // about color space, leave this set to the default value Follow (FOLLOW). The
@@ -20283,6 +20812,17 @@ const (
 	ColorSpaceHlg2020 = "HLG_2020"
 )
 
+// ColorSpace_Values returns all elements of the ColorSpace enum
+func ColorSpace_Values() []string {
+	return []string{
+		ColorSpaceFollow,
+		ColorSpaceRec601,
+		ColorSpaceRec709,
+		ColorSpaceHdr10,
+		ColorSpaceHlg2020,
+	}
+}
+
 // Specify the color space you want for this output. The service supports conversion
 // between HDR formats, between SDR formats, from SDR to HDR, and from HDR to
 // SDR. SDR to HDR conversion doesn't upgrade the dynamic range. The converted
@@ -20306,6 +20846,17 @@ const (
 	ColorSpaceConversionForceHlg2020 = "FORCE_HLG_2020"
 )
 
+// ColorSpaceConversion_Values returns all elements of the ColorSpaceConversion enum
+func ColorSpaceConversion_Values() []string {
+	return []string{
+		ColorSpaceConversionNone,
+		ColorSpaceConversionForce601,
+		ColorSpaceConversionForce709,
+		ColorSpaceConversionForceHdr10,
+		ColorSpaceConversionForceHlg2020,
+	}
+}
+
 // There are two sources for color metadata, the input file and the job input
 // settings Color space (ColorSpace) and HDR master display information settings(Hdr10Metadata).
 // The Color space usage setting determines which takes precedence. Choose Force
@@ -20322,11 +20873,26 @@ const (
 	ColorSpaceUsageFallback = "FALLBACK"
 )
 
+// ColorSpaceUsage_Values returns all elements of the ColorSpaceUsage enum
+func ColorSpaceUsage_Values() []string {
+	return []string{
+		ColorSpaceUsageForce,
+		ColorSpaceUsageFallback,
+	}
+}
+
 // The length of the term of your reserved queue pricing plan commitment.
 const (
 	// CommitmentOneYear is a Commitment enum value
 	CommitmentOneYear = "ONE_YEAR"
 )
+
+// Commitment_Values returns all elements of the Commitment enum
+func Commitment_Values() []string {
+	return []string{
+		CommitmentOneYear,
+	}
+}
 
 // Container for this output. Some containers require a container settings object.
 // If not specified, the default object will be created.
@@ -20365,6 +20931,23 @@ const (
 	ContainerTypeRaw = "RAW"
 )
 
+// ContainerType_Values returns all elements of the ContainerType enum
+func ContainerType_Values() []string {
+	return []string{
+		ContainerTypeF4v,
+		ContainerTypeIsmv,
+		ContainerTypeM2ts,
+		ContainerTypeM3u8,
+		ContainerTypeCmfc,
+		ContainerTypeMov,
+		ContainerTypeMp4,
+		ContainerTypeMpd,
+		ContainerTypeMxf,
+		ContainerTypeWebm,
+		ContainerTypeRaw,
+	}
+}
+
 // Supports HbbTV specification as indicated
 const (
 	// DashIsoHbbtvComplianceHbbtv15 is a DashIsoHbbtvCompliance enum value
@@ -20373,6 +20956,14 @@ const (
 	// DashIsoHbbtvComplianceNone is a DashIsoHbbtvCompliance enum value
 	DashIsoHbbtvComplianceNone = "NONE"
 )
+
+// DashIsoHbbtvCompliance_Values returns all elements of the DashIsoHbbtvCompliance enum
+func DashIsoHbbtvCompliance_Values() []string {
+	return []string{
+		DashIsoHbbtvComplianceHbbtv15,
+		DashIsoHbbtvComplianceNone,
+	}
+}
 
 // Specify whether your DASH profile is on-demand or main. When you choose Main
 // profile (MAIN_PROFILE), the service signals urn:mpeg:dash:profile:isoff-main:2011
@@ -20388,6 +20979,14 @@ const (
 	DashIsoMpdProfileOnDemandProfile = "ON_DEMAND_PROFILE"
 )
 
+// DashIsoMpdProfile_Values returns all elements of the DashIsoMpdProfile enum
+func DashIsoMpdProfile_Values() []string {
+	return []string{
+		DashIsoMpdProfileMainProfile,
+		DashIsoMpdProfileOnDemandProfile,
+	}
+}
+
 // This setting can improve the compatibility of your output with video players
 // on obsolete devices. It applies only to DASH H.264 outputs with DRM encryption.
 // Choose Unencrypted SEI (UNENCRYPTED_SEI) only to correct problems with playback
@@ -20402,6 +21001,14 @@ const (
 	DashIsoPlaybackDeviceCompatibilityUnencryptedSei = "UNENCRYPTED_SEI"
 )
 
+// DashIsoPlaybackDeviceCompatibility_Values returns all elements of the DashIsoPlaybackDeviceCompatibility enum
+func DashIsoPlaybackDeviceCompatibility_Values() []string {
+	return []string{
+		DashIsoPlaybackDeviceCompatibilityCencV1,
+		DashIsoPlaybackDeviceCompatibilityUnencryptedSei,
+	}
+}
+
 // When set to SINGLE_FILE, a single output file is generated, which is internally
 // segmented using the Fragment Length and Segment Length. When set to SEGMENTED_FILES,
 // separate segment files will be created.
@@ -20412,6 +21019,14 @@ const (
 	// DashIsoSegmentControlSegmentedFiles is a DashIsoSegmentControl enum value
 	DashIsoSegmentControlSegmentedFiles = "SEGMENTED_FILES"
 )
+
+// DashIsoSegmentControl_Values returns all elements of the DashIsoSegmentControl enum
+func DashIsoSegmentControl_Values() []string {
+	return []string{
+		DashIsoSegmentControlSingleFile,
+		DashIsoSegmentControlSegmentedFiles,
+	}
+}
 
 // When you enable Precise segment duration in manifests (writeSegmentTimelineInRepresentation),
 // your DASH manifest shows precise segment durations. The segment duration
@@ -20427,6 +21042,14 @@ const (
 	DashIsoWriteSegmentTimelineInRepresentationDisabled = "DISABLED"
 )
 
+// DashIsoWriteSegmentTimelineInRepresentation_Values returns all elements of the DashIsoWriteSegmentTimelineInRepresentation enum
+func DashIsoWriteSegmentTimelineInRepresentation_Values() []string {
+	return []string{
+		DashIsoWriteSegmentTimelineInRepresentationEnabled,
+		DashIsoWriteSegmentTimelineInRepresentationDisabled,
+	}
+}
+
 // Specify the encryption mode that you used to encrypt your input files.
 const (
 	// DecryptionModeAesCtr is a DecryptionMode enum value
@@ -20438,6 +21061,15 @@ const (
 	// DecryptionModeAesGcm is a DecryptionMode enum value
 	DecryptionModeAesGcm = "AES_GCM"
 )
+
+// DecryptionMode_Values returns all elements of the DecryptionMode enum
+func DecryptionMode_Values() []string {
+	return []string{
+		DecryptionModeAesCtr,
+		DecryptionModeAesCbc,
+		DecryptionModeAesGcm,
+	}
+}
 
 // Only applies when you set Deinterlacer (DeinterlaceMode) to Deinterlace (DEINTERLACE)
 // or Adaptive (ADAPTIVE). Motion adaptive interpolate (INTERPOLATE) produces
@@ -20458,6 +21090,16 @@ const (
 	DeinterlaceAlgorithmBlendTicker = "BLEND_TICKER"
 )
 
+// DeinterlaceAlgorithm_Values returns all elements of the DeinterlaceAlgorithm enum
+func DeinterlaceAlgorithm_Values() []string {
+	return []string{
+		DeinterlaceAlgorithmInterpolate,
+		DeinterlaceAlgorithmInterpolateTicker,
+		DeinterlaceAlgorithmBlend,
+		DeinterlaceAlgorithmBlendTicker,
+	}
+}
+
 // - When set to NORMAL (default), the deinterlacer does not convert frames
 // that are tagged in metadata as progressive. It will only convert those that
 // are tagged as some other type. - When set to FORCE_ALL_FRAMES, the deinterlacer
@@ -20474,6 +21116,14 @@ const (
 	DeinterlacerControlNormal = "NORMAL"
 )
 
+// DeinterlacerControl_Values returns all elements of the DeinterlacerControl enum
+func DeinterlacerControl_Values() []string {
+	return []string{
+		DeinterlacerControlForceAllFrames,
+		DeinterlacerControlNormal,
+	}
+}
+
 // Use Deinterlacer (DeinterlaceMode) to choose how the service will do deinterlacing.
 // Default is Deinterlace. - Deinterlace converts interlaced to progressive.
 // - Inverse telecine converts Hard Telecine 29.97i to progressive 23.976p.
@@ -20489,6 +21139,15 @@ const (
 	DeinterlacerModeAdaptive = "ADAPTIVE"
 )
 
+// DeinterlacerMode_Values returns all elements of the DeinterlacerMode enum
+func DeinterlacerMode_Values() []string {
+	return []string{
+		DeinterlacerModeDeinterlace,
+		DeinterlacerModeInverseTelecine,
+		DeinterlacerModeAdaptive,
+	}
+}
+
 // Optional field, defaults to DEFAULT. Specify DEFAULT for this operation to
 // return your endpoints if any exist, or to create an endpoint for you and
 // return it if one doesn't already exist. Specify GET_ONLY to return your endpoints
@@ -20500,6 +21159,14 @@ const (
 	// DescribeEndpointsModeGetOnly is a DescribeEndpointsMode enum value
 	DescribeEndpointsModeGetOnly = "GET_ONLY"
 )
+
+// DescribeEndpointsMode_Values returns all elements of the DescribeEndpointsMode enum
+func DescribeEndpointsMode_Values() []string {
+	return []string{
+		DescribeEndpointsModeDefault,
+		DescribeEndpointsModeGetOnly,
+	}
+}
 
 // Use Dolby Vision Mode to choose how the service will handle Dolby Vision
 // MaxCLL and MaxFALL properies.
@@ -20514,6 +21181,15 @@ const (
 	DolbyVisionLevel6ModeSpecify = "SPECIFY"
 )
 
+// DolbyVisionLevel6Mode_Values returns all elements of the DolbyVisionLevel6Mode enum
+func DolbyVisionLevel6Mode_Values() []string {
+	return []string{
+		DolbyVisionLevel6ModePassthrough,
+		DolbyVisionLevel6ModeRecalculate,
+		DolbyVisionLevel6ModeSpecify,
+	}
+}
+
 // In the current MediaConvert implementation, the Dolby Vision profile is always
 // 5 (PROFILE_5). Therefore, all of your inputs must contain Dolby Vision frame
 // interleaved data.
@@ -20521,6 +21197,13 @@ const (
 	// DolbyVisionProfileProfile5 is a DolbyVisionProfile enum value
 	DolbyVisionProfileProfile5 = "PROFILE_5"
 )
+
+// DolbyVisionProfile_Values returns all elements of the DolbyVisionProfile enum
+func DolbyVisionProfile_Values() []string {
+	return []string{
+		DolbyVisionProfileProfile5,
+	}
+}
 
 // Applies only to 29.97 fps outputs. When this feature is enabled, the service
 // will use drop-frame timecode on outputs. If it is not possible to use drop-frame
@@ -20533,6 +21216,14 @@ const (
 	// DropFrameTimecodeEnabled is a DropFrameTimecode enum value
 	DropFrameTimecodeEnabled = "ENABLED"
 )
+
+// DropFrameTimecode_Values returns all elements of the DropFrameTimecode enum
+func DropFrameTimecode_Values() []string {
+	return []string{
+		DropFrameTimecodeDisabled,
+		DropFrameTimecodeEnabled,
+	}
+}
 
 // If no explicit x_position or y_position is provided, setting alignment to
 // centered will place the captions at the bottom center of the output. Similarly,
@@ -20550,6 +21241,14 @@ const (
 	DvbSubtitleAlignmentLeft = "LEFT"
 )
 
+// DvbSubtitleAlignment_Values returns all elements of the DvbSubtitleAlignment enum
+func DvbSubtitleAlignment_Values() []string {
+	return []string{
+		DvbSubtitleAlignmentCentered,
+		DvbSubtitleAlignmentLeft,
+	}
+}
+
 // Specifies the color of the rectangle behind the captions.All burn-in and
 // DVB-Sub font settings must match.
 const (
@@ -20562,6 +21261,15 @@ const (
 	// DvbSubtitleBackgroundColorWhite is a DvbSubtitleBackgroundColor enum value
 	DvbSubtitleBackgroundColorWhite = "WHITE"
 )
+
+// DvbSubtitleBackgroundColor_Values returns all elements of the DvbSubtitleBackgroundColor enum
+func DvbSubtitleBackgroundColor_Values() []string {
+	return []string{
+		DvbSubtitleBackgroundColorNone,
+		DvbSubtitleBackgroundColorBlack,
+		DvbSubtitleBackgroundColorWhite,
+	}
+}
 
 // Specifies the color of the burned-in captions. This option is not valid for
 // source captions that are STL, 608/embedded or teletext. These source settings
@@ -20587,6 +21295,18 @@ const (
 	DvbSubtitleFontColorBlue = "BLUE"
 )
 
+// DvbSubtitleFontColor_Values returns all elements of the DvbSubtitleFontColor enum
+func DvbSubtitleFontColor_Values() []string {
+	return []string{
+		DvbSubtitleFontColorWhite,
+		DvbSubtitleFontColorBlack,
+		DvbSubtitleFontColorYellow,
+		DvbSubtitleFontColorRed,
+		DvbSubtitleFontColorGreen,
+		DvbSubtitleFontColorBlue,
+	}
+}
+
 // Specifies font outline color. This option is not valid for source captions
 // that are either 608/embedded or teletext. These source settings are already
 // pre-defined by the caption stream. All burn-in and DVB-Sub font settings
@@ -20611,6 +21331,18 @@ const (
 	DvbSubtitleOutlineColorBlue = "BLUE"
 )
 
+// DvbSubtitleOutlineColor_Values returns all elements of the DvbSubtitleOutlineColor enum
+func DvbSubtitleOutlineColor_Values() []string {
+	return []string{
+		DvbSubtitleOutlineColorBlack,
+		DvbSubtitleOutlineColorWhite,
+		DvbSubtitleOutlineColorYellow,
+		DvbSubtitleOutlineColorRed,
+		DvbSubtitleOutlineColorGreen,
+		DvbSubtitleOutlineColorBlue,
+	}
+}
+
 // Specifies the color of the shadow cast by the captions.All burn-in and DVB-Sub
 // font settings must match.
 const (
@@ -20623,6 +21355,15 @@ const (
 	// DvbSubtitleShadowColorWhite is a DvbSubtitleShadowColor enum value
 	DvbSubtitleShadowColorWhite = "WHITE"
 )
+
+// DvbSubtitleShadowColor_Values returns all elements of the DvbSubtitleShadowColor enum
+func DvbSubtitleShadowColor_Values() []string {
+	return []string{
+		DvbSubtitleShadowColorNone,
+		DvbSubtitleShadowColorBlack,
+		DvbSubtitleShadowColorWhite,
+	}
+}
 
 // Only applies to jobs with input captions in Teletext or STL formats. Specify
 // whether the spacing between letters in your captions is set by the captions
@@ -20637,6 +21378,14 @@ const (
 	DvbSubtitleTeletextSpacingProportional = "PROPORTIONAL"
 )
 
+// DvbSubtitleTeletextSpacing_Values returns all elements of the DvbSubtitleTeletextSpacing enum
+func DvbSubtitleTeletextSpacing_Values() []string {
+	return []string{
+		DvbSubtitleTeletextSpacingFixedGrid,
+		DvbSubtitleTeletextSpacingProportional,
+	}
+}
+
 // Specify whether your DVB subtitles are standard or for hearing impaired.
 // Choose hearing impaired if your subtitles include audio descriptions and
 // dialogue. Choose standard if your subtitles include only dialogue.
@@ -20648,6 +21397,14 @@ const (
 	DvbSubtitlingTypeStandard = "STANDARD"
 )
 
+// DvbSubtitlingType_Values returns all elements of the DvbSubtitlingType enum
+func DvbSubtitlingType_Values() []string {
+	return []string{
+		DvbSubtitlingTypeHearingImpaired,
+		DvbSubtitlingTypeStandard,
+	}
+}
+
 // Specify the bitstream mode for the E-AC-3 stream that the encoder emits.
 // For more information about the EAC3 bitstream mode, see ATSC A/52-2012 (Annex
 // E).
@@ -20656,11 +21413,25 @@ const (
 	Eac3AtmosBitstreamModeCompleteMain = "COMPLETE_MAIN"
 )
 
+// Eac3AtmosBitstreamMode_Values returns all elements of the Eac3AtmosBitstreamMode enum
+func Eac3AtmosBitstreamMode_Values() []string {
+	return []string{
+		Eac3AtmosBitstreamModeCompleteMain,
+	}
+}
+
 // The coding mode for Dolby Digital Plus JOC (Atmos) is always 9.1.6 (CODING_MODE_9_1_6).
 const (
 	// Eac3AtmosCodingModeCodingMode916 is a Eac3AtmosCodingMode enum value
 	Eac3AtmosCodingModeCodingMode916 = "CODING_MODE_9_1_6"
 )
+
+// Eac3AtmosCodingMode_Values returns all elements of the Eac3AtmosCodingMode enum
+func Eac3AtmosCodingMode_Values() []string {
+	return []string{
+		Eac3AtmosCodingModeCodingMode916,
+	}
+}
 
 // Enable Dolby Dialogue Intelligence to adjust loudness based on dialogue analysis.
 const (
@@ -20670,6 +21441,14 @@ const (
 	// Eac3AtmosDialogueIntelligenceDisabled is a Eac3AtmosDialogueIntelligence enum value
 	Eac3AtmosDialogueIntelligenceDisabled = "DISABLED"
 )
+
+// Eac3AtmosDialogueIntelligence_Values returns all elements of the Eac3AtmosDialogueIntelligence enum
+func Eac3AtmosDialogueIntelligence_Values() []string {
+	return []string{
+		Eac3AtmosDialogueIntelligenceEnabled,
+		Eac3AtmosDialogueIntelligenceDisabled,
+	}
+}
 
 // Specify the absolute peak level for a signal with dynamic range compression.
 const (
@@ -20691,6 +21470,18 @@ const (
 	// Eac3AtmosDynamicRangeCompressionLineSpeech is a Eac3AtmosDynamicRangeCompressionLine enum value
 	Eac3AtmosDynamicRangeCompressionLineSpeech = "SPEECH"
 )
+
+// Eac3AtmosDynamicRangeCompressionLine_Values returns all elements of the Eac3AtmosDynamicRangeCompressionLine enum
+func Eac3AtmosDynamicRangeCompressionLine_Values() []string {
+	return []string{
+		Eac3AtmosDynamicRangeCompressionLineNone,
+		Eac3AtmosDynamicRangeCompressionLineFilmStandard,
+		Eac3AtmosDynamicRangeCompressionLineFilmLight,
+		Eac3AtmosDynamicRangeCompressionLineMusicStandard,
+		Eac3AtmosDynamicRangeCompressionLineMusicLight,
+		Eac3AtmosDynamicRangeCompressionLineSpeech,
+	}
+}
 
 // Specify how the service limits the audio dynamic range when compressing the
 // audio.
@@ -20714,6 +21505,18 @@ const (
 	Eac3AtmosDynamicRangeCompressionRfSpeech = "SPEECH"
 )
 
+// Eac3AtmosDynamicRangeCompressionRf_Values returns all elements of the Eac3AtmosDynamicRangeCompressionRf enum
+func Eac3AtmosDynamicRangeCompressionRf_Values() []string {
+	return []string{
+		Eac3AtmosDynamicRangeCompressionRfNone,
+		Eac3AtmosDynamicRangeCompressionRfFilmStandard,
+		Eac3AtmosDynamicRangeCompressionRfFilmLight,
+		Eac3AtmosDynamicRangeCompressionRfMusicStandard,
+		Eac3AtmosDynamicRangeCompressionRfMusicLight,
+		Eac3AtmosDynamicRangeCompressionRfSpeech,
+	}
+}
+
 // Choose how the service meters the loudness of your audio.
 const (
 	// Eac3AtmosMeteringModeLeqA is a Eac3AtmosMeteringMode enum value
@@ -20732,6 +21535,17 @@ const (
 	Eac3AtmosMeteringModeItuBs17704 = "ITU_BS_1770_4"
 )
 
+// Eac3AtmosMeteringMode_Values returns all elements of the Eac3AtmosMeteringMode enum
+func Eac3AtmosMeteringMode_Values() []string {
+	return []string{
+		Eac3AtmosMeteringModeLeqA,
+		Eac3AtmosMeteringModeItuBs17701,
+		Eac3AtmosMeteringModeItuBs17702,
+		Eac3AtmosMeteringModeItuBs17703,
+		Eac3AtmosMeteringModeItuBs17704,
+	}
+}
+
 // Choose how the service does stereo downmixing.
 const (
 	// Eac3AtmosStereoDownmixNotIndicated is a Eac3AtmosStereoDownmix enum value
@@ -20747,6 +21561,16 @@ const (
 	Eac3AtmosStereoDownmixDpl2 = "DPL2"
 )
 
+// Eac3AtmosStereoDownmix_Values returns all elements of the Eac3AtmosStereoDownmix enum
+func Eac3AtmosStereoDownmix_Values() []string {
+	return []string{
+		Eac3AtmosStereoDownmixNotIndicated,
+		Eac3AtmosStereoDownmixStereo,
+		Eac3AtmosStereoDownmixSurround,
+		Eac3AtmosStereoDownmixDpl2,
+	}
+}
+
 // Specify whether your input audio has an additional center rear surround channel
 // matrix encoded into your left and right surround channels.
 const (
@@ -20760,6 +21584,15 @@ const (
 	Eac3AtmosSurroundExModeDisabled = "DISABLED"
 )
 
+// Eac3AtmosSurroundExMode_Values returns all elements of the Eac3AtmosSurroundExMode enum
+func Eac3AtmosSurroundExMode_Values() []string {
+	return []string{
+		Eac3AtmosSurroundExModeNotIndicated,
+		Eac3AtmosSurroundExModeEnabled,
+		Eac3AtmosSurroundExModeDisabled,
+	}
+}
+
 // If set to ATTENUATE_3_DB, applies a 3 dB attenuation to the surround channels.
 // Only used for 3/2 coding mode.
 const (
@@ -20769,6 +21602,14 @@ const (
 	// Eac3AttenuationControlNone is a Eac3AttenuationControl enum value
 	Eac3AttenuationControlNone = "NONE"
 )
+
+// Eac3AttenuationControl_Values returns all elements of the Eac3AttenuationControl enum
+func Eac3AttenuationControl_Values() []string {
+	return []string{
+		Eac3AttenuationControlAttenuate3Db,
+		Eac3AttenuationControlNone,
+	}
+}
 
 // Specify the bitstream mode for the E-AC-3 stream that the encoder emits.
 // For more information about the EAC3 bitstream mode, see ATSC A/52-2012 (Annex
@@ -20790,6 +21631,17 @@ const (
 	Eac3BitstreamModeVisuallyImpaired = "VISUALLY_IMPAIRED"
 )
 
+// Eac3BitstreamMode_Values returns all elements of the Eac3BitstreamMode enum
+func Eac3BitstreamMode_Values() []string {
+	return []string{
+		Eac3BitstreamModeCompleteMain,
+		Eac3BitstreamModeCommentary,
+		Eac3BitstreamModeEmergency,
+		Eac3BitstreamModeHearingImpaired,
+		Eac3BitstreamModeVisuallyImpaired,
+	}
+}
+
 // Dolby Digital Plus coding mode. Determines number of channels.
 const (
 	// Eac3CodingModeCodingMode10 is a Eac3CodingMode enum value
@@ -20802,6 +21654,15 @@ const (
 	Eac3CodingModeCodingMode32 = "CODING_MODE_3_2"
 )
 
+// Eac3CodingMode_Values returns all elements of the Eac3CodingMode enum
+func Eac3CodingMode_Values() []string {
+	return []string{
+		Eac3CodingModeCodingMode10,
+		Eac3CodingModeCodingMode20,
+		Eac3CodingModeCodingMode32,
+	}
+}
+
 // Activates a DC highpass filter for all input channels.
 const (
 	// Eac3DcFilterEnabled is a Eac3DcFilter enum value
@@ -20810,6 +21671,14 @@ const (
 	// Eac3DcFilterDisabled is a Eac3DcFilter enum value
 	Eac3DcFilterDisabled = "DISABLED"
 )
+
+// Eac3DcFilter_Values returns all elements of the Eac3DcFilter enum
+func Eac3DcFilter_Values() []string {
+	return []string{
+		Eac3DcFilterEnabled,
+		Eac3DcFilterDisabled,
+	}
+}
 
 // Specify the absolute peak level for a signal with dynamic range compression.
 const (
@@ -20831,6 +21700,18 @@ const (
 	// Eac3DynamicRangeCompressionLineSpeech is a Eac3DynamicRangeCompressionLine enum value
 	Eac3DynamicRangeCompressionLineSpeech = "SPEECH"
 )
+
+// Eac3DynamicRangeCompressionLine_Values returns all elements of the Eac3DynamicRangeCompressionLine enum
+func Eac3DynamicRangeCompressionLine_Values() []string {
+	return []string{
+		Eac3DynamicRangeCompressionLineNone,
+		Eac3DynamicRangeCompressionLineFilmStandard,
+		Eac3DynamicRangeCompressionLineFilmLight,
+		Eac3DynamicRangeCompressionLineMusicStandard,
+		Eac3DynamicRangeCompressionLineMusicLight,
+		Eac3DynamicRangeCompressionLineSpeech,
+	}
+}
 
 // Specify how the service limits the audio dynamic range when compressing the
 // audio.
@@ -20854,6 +21735,18 @@ const (
 	Eac3DynamicRangeCompressionRfSpeech = "SPEECH"
 )
 
+// Eac3DynamicRangeCompressionRf_Values returns all elements of the Eac3DynamicRangeCompressionRf enum
+func Eac3DynamicRangeCompressionRf_Values() []string {
+	return []string{
+		Eac3DynamicRangeCompressionRfNone,
+		Eac3DynamicRangeCompressionRfFilmStandard,
+		Eac3DynamicRangeCompressionRfFilmLight,
+		Eac3DynamicRangeCompressionRfMusicStandard,
+		Eac3DynamicRangeCompressionRfMusicLight,
+		Eac3DynamicRangeCompressionRfSpeech,
+	}
+}
+
 // When encoding 3/2 audio, controls whether the LFE channel is enabled
 const (
 	// Eac3LfeControlLfe is a Eac3LfeControl enum value
@@ -20862,6 +21755,14 @@ const (
 	// Eac3LfeControlNoLfe is a Eac3LfeControl enum value
 	Eac3LfeControlNoLfe = "NO_LFE"
 )
+
+// Eac3LfeControl_Values returns all elements of the Eac3LfeControl enum
+func Eac3LfeControl_Values() []string {
+	return []string{
+		Eac3LfeControlLfe,
+		Eac3LfeControlNoLfe,
+	}
+}
 
 // Applies a 120Hz lowpass filter to the LFE channel prior to encoding. Only
 // valid with 3_2_LFE coding mode.
@@ -20873,6 +21774,14 @@ const (
 	Eac3LfeFilterDisabled = "DISABLED"
 )
 
+// Eac3LfeFilter_Values returns all elements of the Eac3LfeFilter enum
+func Eac3LfeFilter_Values() []string {
+	return []string{
+		Eac3LfeFilterEnabled,
+		Eac3LfeFilterDisabled,
+	}
+}
+
 // When set to FOLLOW_INPUT, encoder metadata will be sourced from the DD, DD+,
 // or DolbyE decoder that supplied this audio data. If audio was not supplied
 // from one of these streams, then the static metadata settings will be used.
@@ -20883,6 +21792,14 @@ const (
 	// Eac3MetadataControlUseConfigured is a Eac3MetadataControl enum value
 	Eac3MetadataControlUseConfigured = "USE_CONFIGURED"
 )
+
+// Eac3MetadataControl_Values returns all elements of the Eac3MetadataControl enum
+func Eac3MetadataControl_Values() []string {
+	return []string{
+		Eac3MetadataControlFollowInput,
+		Eac3MetadataControlUseConfigured,
+	}
+}
 
 // When set to WHEN_POSSIBLE, input DD+ audio will be passed through if it is
 // present on the input. this detection is dynamic over the life of the transcode.
@@ -20896,6 +21813,14 @@ const (
 	Eac3PassthroughControlNoPassthrough = "NO_PASSTHROUGH"
 )
 
+// Eac3PassthroughControl_Values returns all elements of the Eac3PassthroughControl enum
+func Eac3PassthroughControl_Values() []string {
+	return []string{
+		Eac3PassthroughControlWhenPossible,
+		Eac3PassthroughControlNoPassthrough,
+	}
+}
+
 // Controls the amount of phase-shift applied to the surround channels. Only
 // used for 3/2 coding mode.
 const (
@@ -20905,6 +21830,14 @@ const (
 	// Eac3PhaseControlNoShift is a Eac3PhaseControl enum value
 	Eac3PhaseControlNoShift = "NO_SHIFT"
 )
+
+// Eac3PhaseControl_Values returns all elements of the Eac3PhaseControl enum
+func Eac3PhaseControl_Values() []string {
+	return []string{
+		Eac3PhaseControlShift90Degrees,
+		Eac3PhaseControlNoShift,
+	}
+}
 
 // Choose how the service does stereo downmixing. This setting only applies
 // if you keep the default value of 3/2 - L, R, C, Ls, Rs (CODING_MODE_3_2)
@@ -20924,6 +21857,16 @@ const (
 	Eac3StereoDownmixDpl2 = "DPL2"
 )
 
+// Eac3StereoDownmix_Values returns all elements of the Eac3StereoDownmix enum
+func Eac3StereoDownmix_Values() []string {
+	return []string{
+		Eac3StereoDownmixNotIndicated,
+		Eac3StereoDownmixLoRo,
+		Eac3StereoDownmixLtRt,
+		Eac3StereoDownmixDpl2,
+	}
+}
+
 // When encoding 3/2 audio, sets whether an extra center back surround channel
 // is matrix encoded into the left and right surround channels.
 const (
@@ -20936,6 +21879,15 @@ const (
 	// Eac3SurroundExModeDisabled is a Eac3SurroundExMode enum value
 	Eac3SurroundExModeDisabled = "DISABLED"
 )
+
+// Eac3SurroundExMode_Values returns all elements of the Eac3SurroundExMode enum
+func Eac3SurroundExMode_Values() []string {
+	return []string{
+		Eac3SurroundExModeNotIndicated,
+		Eac3SurroundExModeEnabled,
+		Eac3SurroundExModeDisabled,
+	}
+}
 
 // When encoding 2/0 audio, sets whether Dolby Surround is matrix encoded into
 // the two channels.
@@ -20950,6 +21902,15 @@ const (
 	Eac3SurroundModeDisabled = "DISABLED"
 )
 
+// Eac3SurroundMode_Values returns all elements of the Eac3SurroundMode enum
+func Eac3SurroundMode_Values() []string {
+	return []string{
+		Eac3SurroundModeNotIndicated,
+		Eac3SurroundModeEnabled,
+		Eac3SurroundModeDisabled,
+	}
+}
+
 // Specify whether this set of input captions appears in your outputs in both
 // 608 and 708 format. If you choose Upconvert (UPCONVERT), MediaConvert includes
 // the captions data in two ways: it passes the 608 data through using the 608
@@ -20963,6 +21924,14 @@ const (
 	EmbeddedConvert608To708Disabled = "DISABLED"
 )
 
+// EmbeddedConvert608To708_Values returns all elements of the EmbeddedConvert608To708 enum
+func EmbeddedConvert608To708_Values() []string {
+	return []string{
+		EmbeddedConvert608To708Upconvert,
+		EmbeddedConvert608To708Disabled,
+	}
+}
+
 // By default, the service terminates any unterminated captions at the end of
 // each input. If you want the caption to continue onto your next input, disable
 // this setting.
@@ -20974,6 +21943,14 @@ const (
 	EmbeddedTerminateCaptionsDisabled = "DISABLED"
 )
 
+// EmbeddedTerminateCaptions_Values returns all elements of the EmbeddedTerminateCaptions enum
+func EmbeddedTerminateCaptions_Values() []string {
+	return []string{
+		EmbeddedTerminateCaptionsEndOfInput,
+		EmbeddedTerminateCaptionsDisabled,
+	}
+}
+
 // If set to PROGRESSIVE_DOWNLOAD, the MOOV atom is relocated to the beginning
 // of the archive as required for progressive downloading. Otherwise it is placed
 // normally at the end.
@@ -20984,6 +21961,14 @@ const (
 	// F4vMoovPlacementNormal is a F4vMoovPlacement enum value
 	F4vMoovPlacementNormal = "NORMAL"
 )
+
+// F4vMoovPlacement_Values returns all elements of the F4vMoovPlacement enum
+func F4vMoovPlacement_Values() []string {
+	return []string{
+		F4vMoovPlacementProgressiveDownload,
+		F4vMoovPlacementNormal,
+	}
+}
 
 // Specify whether this set of input captions appears in your outputs in both
 // 608 and 708 format. If you choose Upconvert (UPCONVERT), MediaConvert includes
@@ -20998,6 +21983,14 @@ const (
 	FileSourceConvert608To708Disabled = "DISABLED"
 )
 
+// FileSourceConvert608To708_Values returns all elements of the FileSourceConvert608To708 enum
+func FileSourceConvert608To708_Values() []string {
+	return []string{
+		FileSourceConvert608To708Upconvert,
+		FileSourceConvert608To708Disabled,
+	}
+}
+
 // Provide the font script, using an ISO 15924 script code, if the LanguageCode
 // is not sufficient for determining the script type. Where LanguageCode or
 // CustomLanguageCode is sufficient, use "AUTOMATIC" or leave unset.
@@ -21011,6 +22004,15 @@ const (
 	// FontScriptHant is a FontScript enum value
 	FontScriptHant = "HANT"
 )
+
+// FontScript_Values returns all elements of the FontScript enum
+func FontScript_Values() []string {
+	return []string{
+		FontScriptAutomatic,
+		FontScriptHans,
+		FontScriptHant,
+	}
+}
 
 // Adaptive quantization. Allows intra-frame quantizers to vary to improve visual
 // quality.
@@ -21033,6 +22035,18 @@ const (
 	// H264AdaptiveQuantizationMax is a H264AdaptiveQuantization enum value
 	H264AdaptiveQuantizationMax = "MAX"
 )
+
+// H264AdaptiveQuantization_Values returns all elements of the H264AdaptiveQuantization enum
+func H264AdaptiveQuantization_Values() []string {
+	return []string{
+		H264AdaptiveQuantizationOff,
+		H264AdaptiveQuantizationLow,
+		H264AdaptiveQuantizationMedium,
+		H264AdaptiveQuantizationHigh,
+		H264AdaptiveQuantizationHigher,
+		H264AdaptiveQuantizationMax,
+	}
+}
 
 // Specify an H.264 level that is consistent with your output video settings.
 // If you aren't sure what level to specify, choose Auto (AUTO).
@@ -21089,6 +22103,29 @@ const (
 	H264CodecLevelLevel52 = "LEVEL_5_2"
 )
 
+// H264CodecLevel_Values returns all elements of the H264CodecLevel enum
+func H264CodecLevel_Values() []string {
+	return []string{
+		H264CodecLevelAuto,
+		H264CodecLevelLevel1,
+		H264CodecLevelLevel11,
+		H264CodecLevelLevel12,
+		H264CodecLevelLevel13,
+		H264CodecLevelLevel2,
+		H264CodecLevelLevel21,
+		H264CodecLevelLevel22,
+		H264CodecLevelLevel3,
+		H264CodecLevelLevel31,
+		H264CodecLevelLevel32,
+		H264CodecLevelLevel4,
+		H264CodecLevelLevel41,
+		H264CodecLevelLevel42,
+		H264CodecLevelLevel5,
+		H264CodecLevelLevel51,
+		H264CodecLevelLevel52,
+	}
+}
+
 // H.264 Profile. High 4:2:2 and 10-bit profiles are only available with the
 // AVC-I License.
 const (
@@ -21111,6 +22148,18 @@ const (
 	H264CodecProfileMain = "MAIN"
 )
 
+// H264CodecProfile_Values returns all elements of the H264CodecProfile enum
+func H264CodecProfile_Values() []string {
+	return []string{
+		H264CodecProfileBaseline,
+		H264CodecProfileHigh,
+		H264CodecProfileHigh10bit,
+		H264CodecProfileHigh422,
+		H264CodecProfileHigh42210bit,
+		H264CodecProfileMain,
+	}
+}
+
 // Choose Adaptive to improve subjective video quality for high-motion content.
 // This will cause the service to use fewer B-frames (which infer information
 // based on other frames) for high-motion portions of the video and more B-frames
@@ -21124,6 +22173,14 @@ const (
 	H264DynamicSubGopStatic = "STATIC"
 )
 
+// H264DynamicSubGop_Values returns all elements of the H264DynamicSubGop enum
+func H264DynamicSubGop_Values() []string {
+	return []string{
+		H264DynamicSubGopAdaptive,
+		H264DynamicSubGopStatic,
+	}
+}
+
 // Entropy encoding mode. Use CABAC (must be in Main or High profile) or CAVLC.
 const (
 	// H264EntropyEncodingCabac is a H264EntropyEncoding enum value
@@ -21132,6 +22189,14 @@ const (
 	// H264EntropyEncodingCavlc is a H264EntropyEncoding enum value
 	H264EntropyEncodingCavlc = "CAVLC"
 )
+
+// H264EntropyEncoding_Values returns all elements of the H264EntropyEncoding enum
+func H264EntropyEncoding_Values() []string {
+	return []string{
+		H264EntropyEncodingCabac,
+		H264EntropyEncodingCavlc,
+	}
+}
 
 // Choosing FORCE_FIELD disables PAFF encoding for interlaced outputs.
 const (
@@ -21142,6 +22207,14 @@ const (
 	H264FieldEncodingForceField = "FORCE_FIELD"
 )
 
+// H264FieldEncoding_Values returns all elements of the H264FieldEncoding enum
+func H264FieldEncoding_Values() []string {
+	return []string{
+		H264FieldEncodingPaff,
+		H264FieldEncodingForceField,
+	}
+}
+
 // Adjust quantization within each frame to reduce flicker or 'pop' on I-frames.
 const (
 	// H264FlickerAdaptiveQuantizationDisabled is a H264FlickerAdaptiveQuantization enum value
@@ -21150,6 +22223,14 @@ const (
 	// H264FlickerAdaptiveQuantizationEnabled is a H264FlickerAdaptiveQuantization enum value
 	H264FlickerAdaptiveQuantizationEnabled = "ENABLED"
 )
+
+// H264FlickerAdaptiveQuantization_Values returns all elements of the H264FlickerAdaptiveQuantization enum
+func H264FlickerAdaptiveQuantization_Values() []string {
+	return []string{
+		H264FlickerAdaptiveQuantizationDisabled,
+		H264FlickerAdaptiveQuantizationEnabled,
+	}
+}
 
 // If you are using the console, use the Framerate setting to specify the frame
 // rate for this output. If you want to keep the same frame rate as the input
@@ -21170,6 +22251,14 @@ const (
 	H264FramerateControlSpecified = "SPECIFIED"
 )
 
+// H264FramerateControl_Values returns all elements of the H264FramerateControl enum
+func H264FramerateControl_Values() []string {
+	return []string{
+		H264FramerateControlInitializeFromSource,
+		H264FramerateControlSpecified,
+	}
+}
+
 // Optional. Specify how the transcoder performs framerate conversion. The default
 // behavior is to use duplicate drop conversion.
 const (
@@ -21179,6 +22268,14 @@ const (
 	// H264FramerateConversionAlgorithmInterpolate is a H264FramerateConversionAlgorithm enum value
 	H264FramerateConversionAlgorithmInterpolate = "INTERPOLATE"
 )
+
+// H264FramerateConversionAlgorithm_Values returns all elements of the H264FramerateConversionAlgorithm enum
+func H264FramerateConversionAlgorithm_Values() []string {
+	return []string{
+		H264FramerateConversionAlgorithmDuplicateDrop,
+		H264FramerateConversionAlgorithmInterpolate,
+	}
+}
 
 // If enable, use reference B frames for GOP structures that have B frames >
 // 1.
@@ -21190,6 +22287,14 @@ const (
 	H264GopBReferenceEnabled = "ENABLED"
 )
 
+// H264GopBReference_Values returns all elements of the H264GopBReference enum
+func H264GopBReference_Values() []string {
+	return []string{
+		H264GopBReferenceDisabled,
+		H264GopBReferenceEnabled,
+	}
+}
+
 // Indicates if the GOP Size in H264 is specified in frames or seconds. If seconds
 // the system will convert the GOP Size into a frame count at run time.
 const (
@@ -21199,6 +22304,14 @@ const (
 	// H264GopSizeUnitsSeconds is a H264GopSizeUnits enum value
 	H264GopSizeUnitsSeconds = "SECONDS"
 )
+
+// H264GopSizeUnits_Values returns all elements of the H264GopSizeUnits enum
+func H264GopSizeUnits_Values() []string {
+	return []string{
+		H264GopSizeUnitsFrames,
+		H264GopSizeUnitsSeconds,
+	}
+}
 
 // Use Interlace mode (InterlaceMode) to choose the scan line type for the output.
 // * Top Field First (TOP_FIELD) and Bottom Field First (BOTTOM_FIELD) produce
@@ -21228,6 +22341,17 @@ const (
 	H264InterlaceModeFollowBottomField = "FOLLOW_BOTTOM_FIELD"
 )
 
+// H264InterlaceMode_Values returns all elements of the H264InterlaceMode enum
+func H264InterlaceMode_Values() []string {
+	return []string{
+		H264InterlaceModeProgressive,
+		H264InterlaceModeTopField,
+		H264InterlaceModeBottomField,
+		H264InterlaceModeFollowTopField,
+		H264InterlaceModeFollowBottomField,
+	}
+}
+
 // Optional. Specify how the service determines the pixel aspect ratio (PAR)
 // for this output. The default behavior, Follow source (INITIALIZE_FROM_SOURCE),
 // uses the PAR from your input video for your output. To specify a different
@@ -21243,6 +22367,14 @@ const (
 	H264ParControlSpecified = "SPECIFIED"
 )
 
+// H264ParControl_Values returns all elements of the H264ParControl enum
+func H264ParControl_Values() []string {
+	return []string{
+		H264ParControlInitializeFromSource,
+		H264ParControlSpecified,
+	}
+}
+
 // Optional. Use Quality tuning level (qualityTuningLevel) to choose how you
 // want to trade off encoding speed for output video quality. The default behavior
 // is faster, lower quality, single-pass encoding.
@@ -21257,6 +22389,15 @@ const (
 	H264QualityTuningLevelMultiPassHq = "MULTI_PASS_HQ"
 )
 
+// H264QualityTuningLevel_Values returns all elements of the H264QualityTuningLevel enum
+func H264QualityTuningLevel_Values() []string {
+	return []string{
+		H264QualityTuningLevelSinglePass,
+		H264QualityTuningLevelSinglePassHq,
+		H264QualityTuningLevelMultiPassHq,
+	}
+}
+
 // Use this setting to specify whether this output has a variable bitrate (VBR),
 // constant bitrate (CBR) or quality-defined variable bitrate (QVBR).
 const (
@@ -21270,6 +22411,15 @@ const (
 	H264RateControlModeQvbr = "QVBR"
 )
 
+// H264RateControlMode_Values returns all elements of the H264RateControlMode enum
+func H264RateControlMode_Values() []string {
+	return []string{
+		H264RateControlModeVbr,
+		H264RateControlModeCbr,
+		H264RateControlModeQvbr,
+	}
+}
+
 // Places a PPS header on each encoded picture, even if repeated.
 const (
 	// H264RepeatPpsDisabled is a H264RepeatPps enum value
@@ -21278,6 +22428,14 @@ const (
 	// H264RepeatPpsEnabled is a H264RepeatPps enum value
 	H264RepeatPpsEnabled = "ENABLED"
 )
+
+// H264RepeatPps_Values returns all elements of the H264RepeatPps enum
+func H264RepeatPps_Values() []string {
+	return []string{
+		H264RepeatPpsDisabled,
+		H264RepeatPpsEnabled,
+	}
+}
 
 // Enable this setting to insert I-frames at scene changes that the service
 // automatically detects. This improves video quality and is enabled by default.
@@ -21295,6 +22453,15 @@ const (
 	H264SceneChangeDetectTransitionDetection = "TRANSITION_DETECTION"
 )
 
+// H264SceneChangeDetect_Values returns all elements of the H264SceneChangeDetect enum
+func H264SceneChangeDetect_Values() []string {
+	return []string{
+		H264SceneChangeDetectDisabled,
+		H264SceneChangeDetectEnabled,
+		H264SceneChangeDetectTransitionDetection,
+	}
+}
+
 // Enables Slow PAL rate conversion. 23.976fps and 24fps input is relabeled
 // as 25fps, and audio is sped up correspondingly.
 const (
@@ -21304,6 +22471,14 @@ const (
 	// H264SlowPalEnabled is a H264SlowPal enum value
 	H264SlowPalEnabled = "ENABLED"
 )
+
+// H264SlowPal_Values returns all elements of the H264SlowPal enum
+func H264SlowPal_Values() []string {
+	return []string{
+		H264SlowPalDisabled,
+		H264SlowPalEnabled,
+	}
+}
 
 // Adjust quantization within each frame based on spatial variation of content
 // complexity.
@@ -21315,6 +22490,14 @@ const (
 	H264SpatialAdaptiveQuantizationEnabled = "ENABLED"
 )
 
+// H264SpatialAdaptiveQuantization_Values returns all elements of the H264SpatialAdaptiveQuantization enum
+func H264SpatialAdaptiveQuantization_Values() []string {
+	return []string{
+		H264SpatialAdaptiveQuantizationDisabled,
+		H264SpatialAdaptiveQuantizationEnabled,
+	}
+}
+
 // Produces a bitstream compliant with SMPTE RP-2027.
 const (
 	// H264SyntaxDefault is a H264Syntax enum value
@@ -21323,6 +22506,14 @@ const (
 	// H264SyntaxRp2027 is a H264Syntax enum value
 	H264SyntaxRp2027 = "RP2027"
 )
+
+// H264Syntax_Values returns all elements of the H264Syntax enum
+func H264Syntax_Values() []string {
+	return []string{
+		H264SyntaxDefault,
+		H264SyntaxRp2027,
+	}
+}
 
 // This field applies only if the Streams > Advanced > Framerate (framerate)
 // field is set to 29.970. This field works with the Streams > Advanced > Preprocessors
@@ -21342,6 +22533,15 @@ const (
 	H264TelecineHard = "HARD"
 )
 
+// H264Telecine_Values returns all elements of the H264Telecine enum
+func H264Telecine_Values() []string {
+	return []string{
+		H264TelecineNone,
+		H264TelecineSoft,
+		H264TelecineHard,
+	}
+}
+
 // Adjust quantization within each frame based on temporal variation of content
 // complexity.
 const (
@@ -21352,6 +22552,14 @@ const (
 	H264TemporalAdaptiveQuantizationEnabled = "ENABLED"
 )
 
+// H264TemporalAdaptiveQuantization_Values returns all elements of the H264TemporalAdaptiveQuantization enum
+func H264TemporalAdaptiveQuantization_Values() []string {
+	return []string{
+		H264TemporalAdaptiveQuantizationDisabled,
+		H264TemporalAdaptiveQuantizationEnabled,
+	}
+}
+
 // Inserts timecode for each frame as 4 bytes of an unregistered SEI message.
 const (
 	// H264UnregisteredSeiTimecodeDisabled is a H264UnregisteredSeiTimecode enum value
@@ -21360,6 +22568,14 @@ const (
 	// H264UnregisteredSeiTimecodeEnabled is a H264UnregisteredSeiTimecode enum value
 	H264UnregisteredSeiTimecodeEnabled = "ENABLED"
 )
+
+// H264UnregisteredSeiTimecode_Values returns all elements of the H264UnregisteredSeiTimecode enum
+func H264UnregisteredSeiTimecode_Values() []string {
+	return []string{
+		H264UnregisteredSeiTimecodeDisabled,
+		H264UnregisteredSeiTimecodeEnabled,
+	}
+}
 
 // Adaptive quantization. Allows intra-frame quantizers to vary to improve visual
 // quality.
@@ -21383,6 +22599,18 @@ const (
 	H265AdaptiveQuantizationMax = "MAX"
 )
 
+// H265AdaptiveQuantization_Values returns all elements of the H265AdaptiveQuantization enum
+func H265AdaptiveQuantization_Values() []string {
+	return []string{
+		H265AdaptiveQuantizationOff,
+		H265AdaptiveQuantizationLow,
+		H265AdaptiveQuantizationMedium,
+		H265AdaptiveQuantizationHigh,
+		H265AdaptiveQuantizationHigher,
+		H265AdaptiveQuantizationMax,
+	}
+}
+
 // Enables Alternate Transfer Function SEI message for outputs using Hybrid
 // Log Gamma (HLG) Electro-Optical Transfer Function (EOTF).
 const (
@@ -21392,6 +22620,14 @@ const (
 	// H265AlternateTransferFunctionSeiEnabled is a H265AlternateTransferFunctionSei enum value
 	H265AlternateTransferFunctionSeiEnabled = "ENABLED"
 )
+
+// H265AlternateTransferFunctionSei_Values returns all elements of the H265AlternateTransferFunctionSei enum
+func H265AlternateTransferFunctionSei_Values() []string {
+	return []string{
+		H265AlternateTransferFunctionSeiDisabled,
+		H265AlternateTransferFunctionSeiEnabled,
+	}
+}
 
 // H.265 Level.
 const (
@@ -21438,6 +22674,26 @@ const (
 	H265CodecLevelLevel62 = "LEVEL_6_2"
 )
 
+// H265CodecLevel_Values returns all elements of the H265CodecLevel enum
+func H265CodecLevel_Values() []string {
+	return []string{
+		H265CodecLevelAuto,
+		H265CodecLevelLevel1,
+		H265CodecLevelLevel2,
+		H265CodecLevelLevel21,
+		H265CodecLevelLevel3,
+		H265CodecLevelLevel31,
+		H265CodecLevelLevel4,
+		H265CodecLevelLevel41,
+		H265CodecLevelLevel5,
+		H265CodecLevelLevel51,
+		H265CodecLevelLevel52,
+		H265CodecLevelLevel6,
+		H265CodecLevelLevel61,
+		H265CodecLevelLevel62,
+	}
+}
+
 // Represents the Profile and Tier, per the HEVC (H.265) specification. Selections
 // are grouped as [Profile] / [Tier], so "Main/High" represents Main Profile
 // with High Tier. 4:2:2 profiles are only available with the HEVC 4:2:2 License.
@@ -21467,6 +22723,20 @@ const (
 	H265CodecProfileMain42210bitHigh = "MAIN_422_10BIT_HIGH"
 )
 
+// H265CodecProfile_Values returns all elements of the H265CodecProfile enum
+func H265CodecProfile_Values() []string {
+	return []string{
+		H265CodecProfileMainMain,
+		H265CodecProfileMainHigh,
+		H265CodecProfileMain10Main,
+		H265CodecProfileMain10High,
+		H265CodecProfileMain4228bitMain,
+		H265CodecProfileMain4228bitHigh,
+		H265CodecProfileMain42210bitMain,
+		H265CodecProfileMain42210bitHigh,
+	}
+}
+
 // Choose Adaptive to improve subjective video quality for high-motion content.
 // This will cause the service to use fewer B-frames (which infer information
 // based on other frames) for high-motion portions of the video and more B-frames
@@ -21480,6 +22750,14 @@ const (
 	H265DynamicSubGopStatic = "STATIC"
 )
 
+// H265DynamicSubGop_Values returns all elements of the H265DynamicSubGop enum
+func H265DynamicSubGop_Values() []string {
+	return []string{
+		H265DynamicSubGopAdaptive,
+		H265DynamicSubGopStatic,
+	}
+}
+
 // Adjust quantization within each frame to reduce flicker or 'pop' on I-frames.
 const (
 	// H265FlickerAdaptiveQuantizationDisabled is a H265FlickerAdaptiveQuantization enum value
@@ -21488,6 +22766,14 @@ const (
 	// H265FlickerAdaptiveQuantizationEnabled is a H265FlickerAdaptiveQuantization enum value
 	H265FlickerAdaptiveQuantizationEnabled = "ENABLED"
 )
+
+// H265FlickerAdaptiveQuantization_Values returns all elements of the H265FlickerAdaptiveQuantization enum
+func H265FlickerAdaptiveQuantization_Values() []string {
+	return []string{
+		H265FlickerAdaptiveQuantizationDisabled,
+		H265FlickerAdaptiveQuantizationEnabled,
+	}
+}
 
 // If you are using the console, use the Framerate setting to specify the frame
 // rate for this output. If you want to keep the same frame rate as the input
@@ -21508,6 +22794,14 @@ const (
 	H265FramerateControlSpecified = "SPECIFIED"
 )
 
+// H265FramerateControl_Values returns all elements of the H265FramerateControl enum
+func H265FramerateControl_Values() []string {
+	return []string{
+		H265FramerateControlInitializeFromSource,
+		H265FramerateControlSpecified,
+	}
+}
+
 // Optional. Specify how the transcoder performs framerate conversion. The default
 // behavior is to use duplicate drop conversion.
 const (
@@ -21517,6 +22811,14 @@ const (
 	// H265FramerateConversionAlgorithmInterpolate is a H265FramerateConversionAlgorithm enum value
 	H265FramerateConversionAlgorithmInterpolate = "INTERPOLATE"
 )
+
+// H265FramerateConversionAlgorithm_Values returns all elements of the H265FramerateConversionAlgorithm enum
+func H265FramerateConversionAlgorithm_Values() []string {
+	return []string{
+		H265FramerateConversionAlgorithmDuplicateDrop,
+		H265FramerateConversionAlgorithmInterpolate,
+	}
+}
 
 // If enable, use reference B frames for GOP structures that have B frames >
 // 1.
@@ -21528,6 +22830,14 @@ const (
 	H265GopBReferenceEnabled = "ENABLED"
 )
 
+// H265GopBReference_Values returns all elements of the H265GopBReference enum
+func H265GopBReference_Values() []string {
+	return []string{
+		H265GopBReferenceDisabled,
+		H265GopBReferenceEnabled,
+	}
+}
+
 // Indicates if the GOP Size in H265 is specified in frames or seconds. If seconds
 // the system will convert the GOP Size into a frame count at run time.
 const (
@@ -21537,6 +22847,14 @@ const (
 	// H265GopSizeUnitsSeconds is a H265GopSizeUnits enum value
 	H265GopSizeUnitsSeconds = "SECONDS"
 )
+
+// H265GopSizeUnits_Values returns all elements of the H265GopSizeUnits enum
+func H265GopSizeUnits_Values() []string {
+	return []string{
+		H265GopSizeUnitsFrames,
+		H265GopSizeUnitsSeconds,
+	}
+}
 
 // Choose the scan line type for the output. Choose Progressive (PROGRESSIVE)
 // to create a progressive output, regardless of the scan type of your input.
@@ -21567,6 +22885,17 @@ const (
 	H265InterlaceModeFollowBottomField = "FOLLOW_BOTTOM_FIELD"
 )
 
+// H265InterlaceMode_Values returns all elements of the H265InterlaceMode enum
+func H265InterlaceMode_Values() []string {
+	return []string{
+		H265InterlaceModeProgressive,
+		H265InterlaceModeTopField,
+		H265InterlaceModeBottomField,
+		H265InterlaceModeFollowTopField,
+		H265InterlaceModeFollowBottomField,
+	}
+}
+
 // Optional. Specify how the service determines the pixel aspect ratio (PAR)
 // for this output. The default behavior, Follow source (INITIALIZE_FROM_SOURCE),
 // uses the PAR from your input video for your output. To specify a different
@@ -21582,6 +22911,14 @@ const (
 	H265ParControlSpecified = "SPECIFIED"
 )
 
+// H265ParControl_Values returns all elements of the H265ParControl enum
+func H265ParControl_Values() []string {
+	return []string{
+		H265ParControlInitializeFromSource,
+		H265ParControlSpecified,
+	}
+}
+
 // Optional. Use Quality tuning level (qualityTuningLevel) to choose how you
 // want to trade off encoding speed for output video quality. The default behavior
 // is faster, lower quality, single-pass encoding.
@@ -21596,6 +22933,15 @@ const (
 	H265QualityTuningLevelMultiPassHq = "MULTI_PASS_HQ"
 )
 
+// H265QualityTuningLevel_Values returns all elements of the H265QualityTuningLevel enum
+func H265QualityTuningLevel_Values() []string {
+	return []string{
+		H265QualityTuningLevelSinglePass,
+		H265QualityTuningLevelSinglePassHq,
+		H265QualityTuningLevelMultiPassHq,
+	}
+}
+
 // Use this setting to specify whether this output has a variable bitrate (VBR),
 // constant bitrate (CBR) or quality-defined variable bitrate (QVBR).
 const (
@@ -21609,6 +22955,15 @@ const (
 	H265RateControlModeQvbr = "QVBR"
 )
 
+// H265RateControlMode_Values returns all elements of the H265RateControlMode enum
+func H265RateControlMode_Values() []string {
+	return []string{
+		H265RateControlModeVbr,
+		H265RateControlModeCbr,
+		H265RateControlModeQvbr,
+	}
+}
+
 // Specify Sample Adaptive Offset (SAO) filter strength. Adaptive mode dynamically
 // selects best strength based on content
 const (
@@ -21621,6 +22976,15 @@ const (
 	// H265SampleAdaptiveOffsetFilterModeOff is a H265SampleAdaptiveOffsetFilterMode enum value
 	H265SampleAdaptiveOffsetFilterModeOff = "OFF"
 )
+
+// H265SampleAdaptiveOffsetFilterMode_Values returns all elements of the H265SampleAdaptiveOffsetFilterMode enum
+func H265SampleAdaptiveOffsetFilterMode_Values() []string {
+	return []string{
+		H265SampleAdaptiveOffsetFilterModeDefault,
+		H265SampleAdaptiveOffsetFilterModeAdaptive,
+		H265SampleAdaptiveOffsetFilterModeOff,
+	}
+}
 
 // Enable this setting to insert I-frames at scene changes that the service
 // automatically detects. This improves video quality and is enabled by default.
@@ -21638,6 +23002,15 @@ const (
 	H265SceneChangeDetectTransitionDetection = "TRANSITION_DETECTION"
 )
 
+// H265SceneChangeDetect_Values returns all elements of the H265SceneChangeDetect enum
+func H265SceneChangeDetect_Values() []string {
+	return []string{
+		H265SceneChangeDetectDisabled,
+		H265SceneChangeDetectEnabled,
+		H265SceneChangeDetectTransitionDetection,
+	}
+}
+
 // Enables Slow PAL rate conversion. 23.976fps and 24fps input is relabeled
 // as 25fps, and audio is sped up correspondingly.
 const (
@@ -21648,6 +23021,14 @@ const (
 	H265SlowPalEnabled = "ENABLED"
 )
 
+// H265SlowPal_Values returns all elements of the H265SlowPal enum
+func H265SlowPal_Values() []string {
+	return []string{
+		H265SlowPalDisabled,
+		H265SlowPalEnabled,
+	}
+}
+
 // Adjust quantization within each frame based on spatial variation of content
 // complexity.
 const (
@@ -21657,6 +23038,14 @@ const (
 	// H265SpatialAdaptiveQuantizationEnabled is a H265SpatialAdaptiveQuantization enum value
 	H265SpatialAdaptiveQuantizationEnabled = "ENABLED"
 )
+
+// H265SpatialAdaptiveQuantization_Values returns all elements of the H265SpatialAdaptiveQuantization enum
+func H265SpatialAdaptiveQuantization_Values() []string {
+	return []string{
+		H265SpatialAdaptiveQuantizationDisabled,
+		H265SpatialAdaptiveQuantizationEnabled,
+	}
+}
 
 // This field applies only if the Streams > Advanced > Framerate (framerate)
 // field is set to 29.970. This field works with the Streams > Advanced > Preprocessors
@@ -21676,6 +23065,15 @@ const (
 	H265TelecineHard = "HARD"
 )
 
+// H265Telecine_Values returns all elements of the H265Telecine enum
+func H265Telecine_Values() []string {
+	return []string{
+		H265TelecineNone,
+		H265TelecineSoft,
+		H265TelecineHard,
+	}
+}
+
 // Adjust quantization within each frame based on temporal variation of content
 // complexity.
 const (
@@ -21685,6 +23083,14 @@ const (
 	// H265TemporalAdaptiveQuantizationEnabled is a H265TemporalAdaptiveQuantization enum value
 	H265TemporalAdaptiveQuantizationEnabled = "ENABLED"
 )
+
+// H265TemporalAdaptiveQuantization_Values returns all elements of the H265TemporalAdaptiveQuantization enum
+func H265TemporalAdaptiveQuantization_Values() []string {
+	return []string{
+		H265TemporalAdaptiveQuantizationDisabled,
+		H265TemporalAdaptiveQuantizationEnabled,
+	}
+}
 
 // Enables temporal layer identifiers in the encoded bitstream. Up to 3 layers
 // are supported depending on GOP structure: I- and P-frames form one layer,
@@ -21702,6 +23108,14 @@ const (
 	H265TemporalIdsEnabled = "ENABLED"
 )
 
+// H265TemporalIds_Values returns all elements of the H265TemporalIds enum
+func H265TemporalIds_Values() []string {
+	return []string{
+		H265TemporalIdsDisabled,
+		H265TemporalIdsEnabled,
+	}
+}
+
 // Enable use of tiles, allowing horizontal as well as vertical subdivision
 // of the encoded pictures.
 const (
@@ -21712,6 +23126,14 @@ const (
 	H265TilesEnabled = "ENABLED"
 )
 
+// H265Tiles_Values returns all elements of the H265Tiles enum
+func H265Tiles_Values() []string {
+	return []string{
+		H265TilesDisabled,
+		H265TilesEnabled,
+	}
+}
+
 // Inserts timecode for each frame as 4 bytes of an unregistered SEI message.
 const (
 	// H265UnregisteredSeiTimecodeDisabled is a H265UnregisteredSeiTimecode enum value
@@ -21720,6 +23142,14 @@ const (
 	// H265UnregisteredSeiTimecodeEnabled is a H265UnregisteredSeiTimecode enum value
 	H265UnregisteredSeiTimecodeEnabled = "ENABLED"
 )
+
+// H265UnregisteredSeiTimecode_Values returns all elements of the H265UnregisteredSeiTimecode enum
+func H265UnregisteredSeiTimecode_Values() []string {
+	return []string{
+		H265UnregisteredSeiTimecodeDisabled,
+		H265UnregisteredSeiTimecodeEnabled,
+	}
+}
 
 // If the location of parameter set NAL units doesn't matter in your workflow,
 // ignore this setting. Use this setting only with CMAF or DASH outputs, or
@@ -21740,6 +23170,14 @@ const (
 	H265WriteMp4PackagingTypeHev1 = "HEV1"
 )
 
+// H265WriteMp4PackagingType_Values returns all elements of the H265WriteMp4PackagingType enum
+func H265WriteMp4PackagingType_Values() []string {
+	return []string{
+		H265WriteMp4PackagingTypeHvc1,
+		H265WriteMp4PackagingTypeHev1,
+	}
+}
+
 const (
 	// HlsAdMarkersElemental is a HlsAdMarkers enum value
 	HlsAdMarkersElemental = "ELEMENTAL"
@@ -21747,6 +23185,14 @@ const (
 	// HlsAdMarkersElementalScte35 is a HlsAdMarkers enum value
 	HlsAdMarkersElementalScte35 = "ELEMENTAL_SCTE35"
 )
+
+// HlsAdMarkers_Values returns all elements of the HlsAdMarkers enum
+func HlsAdMarkers_Values() []string {
+	return []string{
+		HlsAdMarkersElemental,
+		HlsAdMarkersElementalScte35,
+	}
+}
 
 // Use this setting only in audio-only outputs. Choose MPEG-2 Transport Stream
 // (M2TS) to create a file in an MPEG2-TS container. Keep the default value
@@ -21760,6 +23206,14 @@ const (
 	// HlsAudioOnlyContainerM2ts is a HlsAudioOnlyContainer enum value
 	HlsAudioOnlyContainerM2ts = "M2TS"
 )
+
+// HlsAudioOnlyContainer_Values returns all elements of the HlsAudioOnlyContainer enum
+func HlsAudioOnlyContainer_Values() []string {
+	return []string{
+		HlsAudioOnlyContainerAutomatic,
+		HlsAudioOnlyContainerM2ts,
+	}
+}
 
 // Four types of audio-only tracks are supported: Audio-Only Variant Stream
 // The client can play back this audio-only stream instead of video in low-bandwidth
@@ -21786,6 +23240,16 @@ const (
 	HlsAudioTrackTypeAudioOnlyVariantStream = "AUDIO_ONLY_VARIANT_STREAM"
 )
 
+// HlsAudioTrackType_Values returns all elements of the HlsAudioTrackType enum
+func HlsAudioTrackType_Values() []string {
+	return []string{
+		HlsAudioTrackTypeAlternateAudioAutoSelectDefault,
+		HlsAudioTrackTypeAlternateAudioAutoSelect,
+		HlsAudioTrackTypeAlternateAudioNotAutoSelect,
+		HlsAudioTrackTypeAudioOnlyVariantStream,
+	}
+}
+
 // Applies only to 608 Embedded output captions. Insert: Include CLOSED-CAPTIONS
 // lines in the manifest. Specify at least one language in the CC1 Language
 // Code field. One CLOSED-CAPTION line is added for each Language Code you specify.
@@ -21806,6 +23270,15 @@ const (
 	HlsCaptionLanguageSettingNone = "NONE"
 )
 
+// HlsCaptionLanguageSetting_Values returns all elements of the HlsCaptionLanguageSetting enum
+func HlsCaptionLanguageSetting_Values() []string {
+	return []string{
+		HlsCaptionLanguageSettingInsert,
+		HlsCaptionLanguageSettingOmit,
+		HlsCaptionLanguageSettingNone,
+	}
+}
+
 // When set to ENABLED, sets #EXT-X-ALLOW-CACHE:no tag, which prevents client
 // from saving media segments for later replay.
 const (
@@ -21815,6 +23288,14 @@ const (
 	// HlsClientCacheEnabled is a HlsClientCache enum value
 	HlsClientCacheEnabled = "ENABLED"
 )
+
+// HlsClientCache_Values returns all elements of the HlsClientCache enum
+func HlsClientCache_Values() []string {
+	return []string{
+		HlsClientCacheDisabled,
+		HlsClientCacheEnabled,
+	}
+}
 
 // Specification to use (RFC-6381 or the default RFC-4281) during m3u8 playlist
 // generation.
@@ -21826,6 +23307,14 @@ const (
 	HlsCodecSpecificationRfc4281 = "RFC_4281"
 )
 
+// HlsCodecSpecification_Values returns all elements of the HlsCodecSpecification enum
+func HlsCodecSpecification_Values() []string {
+	return []string{
+		HlsCodecSpecificationRfc6381,
+		HlsCodecSpecificationRfc4281,
+	}
+}
+
 // Indicates whether segments should be placed in subdirectories.
 const (
 	// HlsDirectoryStructureSingleDirectory is a HlsDirectoryStructure enum value
@@ -21834,6 +23323,14 @@ const (
 	// HlsDirectoryStructureSubdirectoryPerStream is a HlsDirectoryStructure enum value
 	HlsDirectoryStructureSubdirectoryPerStream = "SUBDIRECTORY_PER_STREAM"
 )
+
+// HlsDirectoryStructure_Values returns all elements of the HlsDirectoryStructure enum
+func HlsDirectoryStructure_Values() []string {
+	return []string{
+		HlsDirectoryStructureSingleDirectory,
+		HlsDirectoryStructureSubdirectoryPerStream,
+	}
+}
 
 // Encrypts the segments with the given encryption scheme. Leave blank to disable.
 // Selecting 'Disabled' in the web interface also disables encryption.
@@ -21845,6 +23342,14 @@ const (
 	HlsEncryptionTypeSampleAes = "SAMPLE_AES"
 )
 
+// HlsEncryptionType_Values returns all elements of the HlsEncryptionType enum
+func HlsEncryptionType_Values() []string {
+	return []string{
+		HlsEncryptionTypeAes128,
+		HlsEncryptionTypeSampleAes,
+	}
+}
+
 // When set to INCLUDE, writes I-Frame Only Manifest in addition to the HLS
 // manifest
 const (
@@ -21854,6 +23359,14 @@ const (
 	// HlsIFrameOnlyManifestExclude is a HlsIFrameOnlyManifest enum value
 	HlsIFrameOnlyManifestExclude = "EXCLUDE"
 )
+
+// HlsIFrameOnlyManifest_Values returns all elements of the HlsIFrameOnlyManifest enum
+func HlsIFrameOnlyManifest_Values() []string {
+	return []string{
+		HlsIFrameOnlyManifestInclude,
+		HlsIFrameOnlyManifestExclude,
+	}
+}
 
 // The Initialization Vector is a 128-bit number used in conjunction with the
 // key for encrypting blocks. If set to INCLUDE, Initialization Vector is listed
@@ -21866,6 +23379,14 @@ const (
 	HlsInitializationVectorInManifestExclude = "EXCLUDE"
 )
 
+// HlsInitializationVectorInManifest_Values returns all elements of the HlsInitializationVectorInManifest enum
+func HlsInitializationVectorInManifest_Values() []string {
+	return []string{
+		HlsInitializationVectorInManifestInclude,
+		HlsInitializationVectorInManifestExclude,
+	}
+}
+
 // Specify whether your DRM encryption key is static or from a key provider
 // that follows the SPEKE standard. For more information about SPEKE, see https://docs.aws.amazon.com/speke/latest/documentation/what-is-speke.html.
 const (
@@ -21876,6 +23397,14 @@ const (
 	HlsKeyProviderTypeStaticKey = "STATIC_KEY"
 )
 
+// HlsKeyProviderType_Values returns all elements of the HlsKeyProviderType enum
+func HlsKeyProviderType_Values() []string {
+	return []string{
+		HlsKeyProviderTypeSpeke,
+		HlsKeyProviderTypeStaticKey,
+	}
+}
+
 // When set to GZIP, compresses HLS playlist.
 const (
 	// HlsManifestCompressionGzip is a HlsManifestCompression enum value
@@ -21884,6 +23413,14 @@ const (
 	// HlsManifestCompressionNone is a HlsManifestCompression enum value
 	HlsManifestCompressionNone = "NONE"
 )
+
+// HlsManifestCompression_Values returns all elements of the HlsManifestCompression enum
+func HlsManifestCompression_Values() []string {
+	return []string{
+		HlsManifestCompressionGzip,
+		HlsManifestCompressionNone,
+	}
+}
 
 // Indicates whether the output manifest should use floating point values for
 // segment duration.
@@ -21895,6 +23432,14 @@ const (
 	HlsManifestDurationFormatInteger = "INTEGER"
 )
 
+// HlsManifestDurationFormat_Values returns all elements of the HlsManifestDurationFormat enum
+func HlsManifestDurationFormat_Values() []string {
+	return []string{
+		HlsManifestDurationFormatFloatingPoint,
+		HlsManifestDurationFormatInteger,
+	}
+}
+
 // Enable this setting to insert the EXT-X-SESSION-KEY element into the master
 // playlist. This allows for offline Apple HLS FairPlay content protection.
 const (
@@ -21905,6 +23450,14 @@ const (
 	HlsOfflineEncryptedDisabled = "DISABLED"
 )
 
+// HlsOfflineEncrypted_Values returns all elements of the HlsOfflineEncrypted enum
+func HlsOfflineEncrypted_Values() []string {
+	return []string{
+		HlsOfflineEncryptedEnabled,
+		HlsOfflineEncryptedDisabled,
+	}
+}
+
 // Indicates whether the .m3u8 manifest file should be generated for this HLS
 // output group.
 const (
@@ -21914,6 +23467,14 @@ const (
 	// HlsOutputSelectionSegmentsOnly is a HlsOutputSelection enum value
 	HlsOutputSelectionSegmentsOnly = "SEGMENTS_ONLY"
 )
+
+// HlsOutputSelection_Values returns all elements of the HlsOutputSelection enum
+func HlsOutputSelection_Values() []string {
+	return []string{
+		HlsOutputSelectionManifestsAndSegments,
+		HlsOutputSelectionSegmentsOnly,
+	}
+}
 
 // Includes or excludes EXT-X-PROGRAM-DATE-TIME tag in .m3u8 manifest files.
 // The value is calculated as follows: either the program date and time are
@@ -21927,6 +23488,14 @@ const (
 	HlsProgramDateTimeExclude = "EXCLUDE"
 )
 
+// HlsProgramDateTime_Values returns all elements of the HlsProgramDateTime enum
+func HlsProgramDateTime_Values() []string {
+	return []string{
+		HlsProgramDateTimeInclude,
+		HlsProgramDateTimeExclude,
+	}
+}
+
 // When set to SINGLE_FILE, emits program as a single media resource (.ts) file,
 // uses #EXT-X-BYTERANGE tags to index segment for playback.
 const (
@@ -21937,6 +23506,14 @@ const (
 	HlsSegmentControlSegmentedFiles = "SEGMENTED_FILES"
 )
 
+// HlsSegmentControl_Values returns all elements of the HlsSegmentControl enum
+func HlsSegmentControl_Values() []string {
+	return []string{
+		HlsSegmentControlSingleFile,
+		HlsSegmentControlSegmentedFiles,
+	}
+}
+
 // Include or exclude RESOLUTION attribute for video in EXT-X-STREAM-INF tag
 // of variant manifest.
 const (
@@ -21946,6 +23523,14 @@ const (
 	// HlsStreamInfResolutionExclude is a HlsStreamInfResolution enum value
 	HlsStreamInfResolutionExclude = "EXCLUDE"
 )
+
+// HlsStreamInfResolution_Values returns all elements of the HlsStreamInfResolution enum
+func HlsStreamInfResolution_Values() []string {
+	return []string{
+		HlsStreamInfResolutionInclude,
+		HlsStreamInfResolutionExclude,
+	}
+}
 
 // Indicates ID3 frame that has the timecode.
 const (
@@ -21959,6 +23544,15 @@ const (
 	HlsTimedMetadataId3FrameTdrl = "TDRL"
 )
 
+// HlsTimedMetadataId3Frame_Values returns all elements of the HlsTimedMetadataId3Frame enum
+func HlsTimedMetadataId3Frame_Values() []string {
+	return []string{
+		HlsTimedMetadataId3FrameNone,
+		HlsTimedMetadataId3FramePriv,
+		HlsTimedMetadataId3FrameTdrl,
+	}
+}
+
 // Keep this setting enabled to have MediaConvert use the font style and position
 // information from the captions source in the output. This option is available
 // only when your input captions are IMSC, SMPTE-TT, or TTML. Disable this setting
@@ -21971,6 +23565,14 @@ const (
 	ImscStylePassthroughDisabled = "DISABLED"
 )
 
+// ImscStylePassthrough_Values returns all elements of the ImscStylePassthrough enum
+func ImscStylePassthrough_Values() []string {
+	return []string{
+		ImscStylePassthroughEnabled,
+		ImscStylePassthroughDisabled,
+	}
+}
+
 // Enable Deblock (InputDeblockFilter) to produce smoother motion in the output.
 // Default is disabled. Only manually controllable for MPEG2 and uncompressed
 // video inputs.
@@ -21982,6 +23584,14 @@ const (
 	InputDeblockFilterDisabled = "DISABLED"
 )
 
+// InputDeblockFilter_Values returns all elements of the InputDeblockFilter enum
+func InputDeblockFilter_Values() []string {
+	return []string{
+		InputDeblockFilterEnabled,
+		InputDeblockFilterDisabled,
+	}
+}
+
 // Enable Denoise (InputDenoiseFilter) to filter noise from the input. Default
 // is disabled. Only applicable to MPEG2, H.264, H.265, and uncompressed video
 // inputs.
@@ -21992,6 +23602,14 @@ const (
 	// InputDenoiseFilterDisabled is a InputDenoiseFilter enum value
 	InputDenoiseFilterDisabled = "DISABLED"
 )
+
+// InputDenoiseFilter_Values returns all elements of the InputDenoiseFilter enum
+func InputDenoiseFilter_Values() []string {
+	return []string{
+		InputDenoiseFilterEnabled,
+		InputDenoiseFilterDisabled,
+	}
+}
 
 // Use Filter enable (InputFilterEnable) to specify how the transcoding service
 // applies the denoise and deblock filters. You must also enable the filters
@@ -22011,6 +23629,15 @@ const (
 	InputFilterEnableForce = "FORCE"
 )
 
+// InputFilterEnable_Values returns all elements of the InputFilterEnable enum
+func InputFilterEnable_Values() []string {
+	return []string{
+		InputFilterEnableAuto,
+		InputFilterEnableDisable,
+		InputFilterEnableForce,
+	}
+}
+
 // Set PSI control (InputPsiControl) for transport stream inputs to specify
 // which data the demux process to scans. * Ignore PSI - Scan all PIDs for audio
 // and video. * Use PSI - Scan only PSI data.
@@ -22021,6 +23648,14 @@ const (
 	// InputPsiControlUsePsi is a InputPsiControl enum value
 	InputPsiControlUsePsi = "USE_PSI"
 )
+
+// InputPsiControl_Values returns all elements of the InputPsiControl enum
+func InputPsiControl_Values() []string {
+	return []string{
+		InputPsiControlIgnorePsi,
+		InputPsiControlUsePsi,
+	}
+}
 
 // Use Rotate (InputRotate) to specify how the service rotates your video. You
 // can choose automatic rotation or specify a rotation. You can specify a clockwise
@@ -22049,6 +23684,17 @@ const (
 	InputRotateAuto = "AUTO"
 )
 
+// InputRotate_Values returns all elements of the InputRotate enum
+func InputRotate_Values() []string {
+	return []string{
+		InputRotateDegree0,
+		InputRotateDegrees90,
+		InputRotateDegrees180,
+		InputRotateDegrees270,
+		InputRotateAuto,
+	}
+}
+
 // Use this Timecode source setting, located under the input settings (InputTimecodeSource),
 // to specify how the service counts input video frames. This input frame count
 // affects only the behavior of features that apply to a single input at a time,
@@ -22070,6 +23716,15 @@ const (
 	InputTimecodeSourceSpecifiedstart = "SPECIFIEDSTART"
 )
 
+// InputTimecodeSource_Values returns all elements of the InputTimecodeSource enum
+func InputTimecodeSource_Values() []string {
+	return []string{
+		InputTimecodeSourceEmbedded,
+		InputTimecodeSourceZerobased,
+		InputTimecodeSourceSpecifiedstart,
+	}
+}
+
 // A job's phase can be PROBING, TRANSCODING OR UPLOADING
 const (
 	// JobPhaseProbing is a JobPhase enum value
@@ -22081,6 +23736,15 @@ const (
 	// JobPhaseUploading is a JobPhase enum value
 	JobPhaseUploading = "UPLOADING"
 )
+
+// JobPhase_Values returns all elements of the JobPhase enum
+func JobPhase_Values() []string {
+	return []string{
+		JobPhaseProbing,
+		JobPhaseTranscoding,
+		JobPhaseUploading,
+	}
+}
 
 // A job's status can be SUBMITTED, PROGRESSING, COMPLETE, CANCELED, or ERROR.
 const (
@@ -22100,6 +23764,17 @@ const (
 	JobStatusError = "ERROR"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusSubmitted,
+		JobStatusProgressing,
+		JobStatusComplete,
+		JobStatusCanceled,
+		JobStatusError,
+	}
+}
+
 // Optional. When you request a list of job templates, you can choose to list
 // them alphabetically by NAME or chronologically by CREATION_DATE. If you don't
 // specify, the service will list them by name.
@@ -22113,6 +23788,15 @@ const (
 	// JobTemplateListBySystem is a JobTemplateListBy enum value
 	JobTemplateListBySystem = "SYSTEM"
 )
+
+// JobTemplateListBy_Values returns all elements of the JobTemplateListBy enum
+func JobTemplateListBy_Values() []string {
+	return []string{
+		JobTemplateListByName,
+		JobTemplateListByCreationDate,
+		JobTemplateListBySystem,
+	}
+}
 
 // Specify the language, using the ISO 639-2 three-letter code listed at https://www.loc.gov/standards/iso639-2/php/code_list.php.
 const (
@@ -22690,6 +24374,203 @@ const (
 	LanguageCodeTng = "TNG"
 )
 
+// LanguageCode_Values returns all elements of the LanguageCode enum
+func LanguageCode_Values() []string {
+	return []string{
+		LanguageCodeEng,
+		LanguageCodeSpa,
+		LanguageCodeFra,
+		LanguageCodeDeu,
+		LanguageCodeGer,
+		LanguageCodeZho,
+		LanguageCodeAra,
+		LanguageCodeHin,
+		LanguageCodeJpn,
+		LanguageCodeRus,
+		LanguageCodePor,
+		LanguageCodeIta,
+		LanguageCodeUrd,
+		LanguageCodeVie,
+		LanguageCodeKor,
+		LanguageCodePan,
+		LanguageCodeAbk,
+		LanguageCodeAar,
+		LanguageCodeAfr,
+		LanguageCodeAka,
+		LanguageCodeSqi,
+		LanguageCodeAmh,
+		LanguageCodeArg,
+		LanguageCodeHye,
+		LanguageCodeAsm,
+		LanguageCodeAva,
+		LanguageCodeAve,
+		LanguageCodeAym,
+		LanguageCodeAze,
+		LanguageCodeBam,
+		LanguageCodeBak,
+		LanguageCodeEus,
+		LanguageCodeBel,
+		LanguageCodeBen,
+		LanguageCodeBih,
+		LanguageCodeBis,
+		LanguageCodeBos,
+		LanguageCodeBre,
+		LanguageCodeBul,
+		LanguageCodeMya,
+		LanguageCodeCat,
+		LanguageCodeKhm,
+		LanguageCodeCha,
+		LanguageCodeChe,
+		LanguageCodeNya,
+		LanguageCodeChu,
+		LanguageCodeChv,
+		LanguageCodeCor,
+		LanguageCodeCos,
+		LanguageCodeCre,
+		LanguageCodeHrv,
+		LanguageCodeCes,
+		LanguageCodeDan,
+		LanguageCodeDiv,
+		LanguageCodeNld,
+		LanguageCodeDzo,
+		LanguageCodeEnm,
+		LanguageCodeEpo,
+		LanguageCodeEst,
+		LanguageCodeEwe,
+		LanguageCodeFao,
+		LanguageCodeFij,
+		LanguageCodeFin,
+		LanguageCodeFrm,
+		LanguageCodeFul,
+		LanguageCodeGla,
+		LanguageCodeGlg,
+		LanguageCodeLug,
+		LanguageCodeKat,
+		LanguageCodeEll,
+		LanguageCodeGrn,
+		LanguageCodeGuj,
+		LanguageCodeHat,
+		LanguageCodeHau,
+		LanguageCodeHeb,
+		LanguageCodeHer,
+		LanguageCodeHmo,
+		LanguageCodeHun,
+		LanguageCodeIsl,
+		LanguageCodeIdo,
+		LanguageCodeIbo,
+		LanguageCodeInd,
+		LanguageCodeIna,
+		LanguageCodeIle,
+		LanguageCodeIku,
+		LanguageCodeIpk,
+		LanguageCodeGle,
+		LanguageCodeJav,
+		LanguageCodeKal,
+		LanguageCodeKan,
+		LanguageCodeKau,
+		LanguageCodeKas,
+		LanguageCodeKaz,
+		LanguageCodeKik,
+		LanguageCodeKin,
+		LanguageCodeKir,
+		LanguageCodeKom,
+		LanguageCodeKon,
+		LanguageCodeKua,
+		LanguageCodeKur,
+		LanguageCodeLao,
+		LanguageCodeLat,
+		LanguageCodeLav,
+		LanguageCodeLim,
+		LanguageCodeLin,
+		LanguageCodeLit,
+		LanguageCodeLub,
+		LanguageCodeLtz,
+		LanguageCodeMkd,
+		LanguageCodeMlg,
+		LanguageCodeMsa,
+		LanguageCodeMal,
+		LanguageCodeMlt,
+		LanguageCodeGlv,
+		LanguageCodeMri,
+		LanguageCodeMar,
+		LanguageCodeMah,
+		LanguageCodeMon,
+		LanguageCodeNau,
+		LanguageCodeNav,
+		LanguageCodeNde,
+		LanguageCodeNbl,
+		LanguageCodeNdo,
+		LanguageCodeNep,
+		LanguageCodeSme,
+		LanguageCodeNor,
+		LanguageCodeNob,
+		LanguageCodeNno,
+		LanguageCodeOci,
+		LanguageCodeOji,
+		LanguageCodeOri,
+		LanguageCodeOrm,
+		LanguageCodeOss,
+		LanguageCodePli,
+		LanguageCodeFas,
+		LanguageCodePol,
+		LanguageCodePus,
+		LanguageCodeQue,
+		LanguageCodeQaa,
+		LanguageCodeRon,
+		LanguageCodeRoh,
+		LanguageCodeRun,
+		LanguageCodeSmo,
+		LanguageCodeSag,
+		LanguageCodeSan,
+		LanguageCodeSrd,
+		LanguageCodeSrb,
+		LanguageCodeSna,
+		LanguageCodeIii,
+		LanguageCodeSnd,
+		LanguageCodeSin,
+		LanguageCodeSlk,
+		LanguageCodeSlv,
+		LanguageCodeSom,
+		LanguageCodeSot,
+		LanguageCodeSun,
+		LanguageCodeSwa,
+		LanguageCodeSsw,
+		LanguageCodeSwe,
+		LanguageCodeTgl,
+		LanguageCodeTah,
+		LanguageCodeTgk,
+		LanguageCodeTam,
+		LanguageCodeTat,
+		LanguageCodeTel,
+		LanguageCodeTha,
+		LanguageCodeBod,
+		LanguageCodeTir,
+		LanguageCodeTon,
+		LanguageCodeTso,
+		LanguageCodeTsn,
+		LanguageCodeTur,
+		LanguageCodeTuk,
+		LanguageCodeTwi,
+		LanguageCodeUig,
+		LanguageCodeUkr,
+		LanguageCodeUzb,
+		LanguageCodeVen,
+		LanguageCodeVol,
+		LanguageCodeWln,
+		LanguageCodeCym,
+		LanguageCodeFry,
+		LanguageCodeWol,
+		LanguageCodeXho,
+		LanguageCodeYid,
+		LanguageCodeYor,
+		LanguageCodeZha,
+		LanguageCodeZul,
+		LanguageCodeOrj,
+		LanguageCodeQpc,
+		LanguageCodeTng,
+	}
+}
+
 // Selects between the DVB and ATSC buffer models for Dolby Digital audio.
 const (
 	// M2tsAudioBufferModelDvb is a M2tsAudioBufferModel enum value
@@ -22698,6 +24579,14 @@ const (
 	// M2tsAudioBufferModelAtsc is a M2tsAudioBufferModel enum value
 	M2tsAudioBufferModelAtsc = "ATSC"
 )
+
+// M2tsAudioBufferModel_Values returns all elements of the M2tsAudioBufferModel enum
+func M2tsAudioBufferModel_Values() []string {
+	return []string{
+		M2tsAudioBufferModelDvb,
+		M2tsAudioBufferModelAtsc,
+	}
+}
 
 // Controls what buffer model to use for accurate interleaving. If set to MULTIPLEX,
 // use multiplex buffer model. If set to NONE, this can lead to lower latency,
@@ -22709,6 +24598,14 @@ const (
 	// M2tsBufferModelNone is a M2tsBufferModel enum value
 	M2tsBufferModelNone = "NONE"
 )
+
+// M2tsBufferModel_Values returns all elements of the M2tsBufferModel enum
+func M2tsBufferModel_Values() []string {
+	return []string{
+		M2tsBufferModelMultiplex,
+		M2tsBufferModelNone,
+	}
+}
 
 // When set to VIDEO_AND_FIXED_INTERVALS, audio EBP markers will be added to
 // partitions 3 and 4. The interval between these additional markers will be
@@ -22724,6 +24621,14 @@ const (
 	M2tsEbpAudioIntervalVideoInterval = "VIDEO_INTERVAL"
 )
 
+// M2tsEbpAudioInterval_Values returns all elements of the M2tsEbpAudioInterval enum
+func M2tsEbpAudioInterval_Values() []string {
+	return []string{
+		M2tsEbpAudioIntervalVideoAndFixedIntervals,
+		M2tsEbpAudioIntervalVideoInterval,
+	}
+}
+
 // Selects which PIDs to place EBP markers on. They can either be placed only
 // on the video PID, or on both the video PID and all audio PIDs. Only applicable
 // when EBP segmentation markers are is selected (segmentationMarkers is EBP
@@ -22736,6 +24641,14 @@ const (
 	M2tsEbpPlacementVideoPid = "VIDEO_PID"
 )
 
+// M2tsEbpPlacement_Values returns all elements of the M2tsEbpPlacement enum
+func M2tsEbpPlacement_Values() []string {
+	return []string{
+		M2tsEbpPlacementVideoAndAudioPids,
+		M2tsEbpPlacementVideoPid,
+	}
+}
+
 // Controls whether to include the ES Rate field in the PES header.
 const (
 	// M2tsEsRateInPesInclude is a M2tsEsRateInPes enum value
@@ -22744,6 +24657,14 @@ const (
 	// M2tsEsRateInPesExclude is a M2tsEsRateInPes enum value
 	M2tsEsRateInPesExclude = "EXCLUDE"
 )
+
+// M2tsEsRateInPes_Values returns all elements of the M2tsEsRateInPes enum
+func M2tsEsRateInPes_Values() []string {
+	return []string{
+		M2tsEsRateInPesInclude,
+		M2tsEsRateInPesExclude,
+	}
+}
 
 // Keep the default value (DEFAULT) unless you know that your audio EBP markers
 // are incorrectly appearing before your video EBP markers. To correct this
@@ -22756,6 +24677,14 @@ const (
 	M2tsForceTsVideoEbpOrderDefault = "DEFAULT"
 )
 
+// M2tsForceTsVideoEbpOrder_Values returns all elements of the M2tsForceTsVideoEbpOrder enum
+func M2tsForceTsVideoEbpOrder_Values() []string {
+	return []string{
+		M2tsForceTsVideoEbpOrderForce,
+		M2tsForceTsVideoEbpOrderDefault,
+	}
+}
+
 // If INSERT, Nielsen inaudible tones for media tracking will be detected in
 // the input audio and an equivalent ID3 tag will be inserted in the output.
 const (
@@ -22765,6 +24694,14 @@ const (
 	// M2tsNielsenId3None is a M2tsNielsenId3 enum value
 	M2tsNielsenId3None = "NONE"
 )
+
+// M2tsNielsenId3_Values returns all elements of the M2tsNielsenId3 enum
+func M2tsNielsenId3_Values() []string {
+	return []string{
+		M2tsNielsenId3Insert,
+		M2tsNielsenId3None,
+	}
+}
 
 // When set to PCR_EVERY_PES_PACKET, a Program Clock Reference value is inserted
 // for every Packetized Elementary Stream (PES) header. This is effective only
@@ -22777,6 +24714,14 @@ const (
 	M2tsPcrControlConfiguredPcrPeriod = "CONFIGURED_PCR_PERIOD"
 )
 
+// M2tsPcrControl_Values returns all elements of the M2tsPcrControl enum
+func M2tsPcrControl_Values() []string {
+	return []string{
+		M2tsPcrControlPcrEveryPesPacket,
+		M2tsPcrControlConfiguredPcrPeriod,
+	}
+}
+
 // When set to CBR, inserts null packets into transport stream to fill specified
 // bitrate. When set to VBR, the bitrate setting acts as the maximum bitrate,
 // but the output will not be padded up to that bitrate.
@@ -22787,6 +24732,14 @@ const (
 	// M2tsRateModeCbr is a M2tsRateMode enum value
 	M2tsRateModeCbr = "CBR"
 )
+
+// M2tsRateMode_Values returns all elements of the M2tsRateMode enum
+func M2tsRateMode_Values() []string {
+	return []string{
+		M2tsRateModeVbr,
+		M2tsRateModeCbr,
+	}
+}
 
 // For SCTE-35 markers from your input-- Choose Passthrough (PASSTHROUGH) if
 // you want SCTE-35 markers that appear in your input to also appear in this
@@ -22801,6 +24754,14 @@ const (
 	// M2tsScte35SourceNone is a M2tsScte35Source enum value
 	M2tsScte35SourceNone = "NONE"
 )
+
+// M2tsScte35Source_Values returns all elements of the M2tsScte35Source enum
+func M2tsScte35Source_Values() []string {
+	return []string{
+		M2tsScte35SourcePassthrough,
+		M2tsScte35SourceNone,
+	}
+}
 
 // Inserts segmentation markers at each segmentation_time period. rai_segstart
 // sets the Random Access Indicator bit in the adaptation field. rai_adapt sets
@@ -22829,6 +24790,18 @@ const (
 	M2tsSegmentationMarkersEbpLegacy = "EBP_LEGACY"
 )
 
+// M2tsSegmentationMarkers_Values returns all elements of the M2tsSegmentationMarkers enum
+func M2tsSegmentationMarkers_Values() []string {
+	return []string{
+		M2tsSegmentationMarkersNone,
+		M2tsSegmentationMarkersRaiSegstart,
+		M2tsSegmentationMarkersRaiAdapt,
+		M2tsSegmentationMarkersPsiSegstart,
+		M2tsSegmentationMarkersEbp,
+		M2tsSegmentationMarkersEbpLegacy,
+	}
+}
+
 // The segmentation style parameter controls how segmentation markers are inserted
 // into the transport stream. With avails, it is possible that segments may
 // be truncated, which can influence where future segmentation markers are inserted.
@@ -22848,6 +24821,14 @@ const (
 	M2tsSegmentationStyleResetCadence = "RESET_CADENCE"
 )
 
+// M2tsSegmentationStyle_Values returns all elements of the M2tsSegmentationStyle enum
+func M2tsSegmentationStyle_Values() []string {
+	return []string{
+		M2tsSegmentationStyleMaintainCadence,
+		M2tsSegmentationStyleResetCadence,
+	}
+}
+
 // If INSERT, Nielsen inaudible tones for media tracking will be detected in
 // the input audio and an equivalent ID3 tag will be inserted in the output.
 const (
@@ -22857,6 +24838,14 @@ const (
 	// M3u8NielsenId3None is a M3u8NielsenId3 enum value
 	M3u8NielsenId3None = "NONE"
 )
+
+// M3u8NielsenId3_Values returns all elements of the M3u8NielsenId3 enum
+func M3u8NielsenId3_Values() []string {
+	return []string{
+		M3u8NielsenId3Insert,
+		M3u8NielsenId3None,
+	}
+}
 
 // When set to PCR_EVERY_PES_PACKET a Program Clock Reference value is inserted
 // for every Packetized Elementary Stream (PES) header. This parameter is effective
@@ -22868,6 +24857,14 @@ const (
 	// M3u8PcrControlConfiguredPcrPeriod is a M3u8PcrControl enum value
 	M3u8PcrControlConfiguredPcrPeriod = "CONFIGURED_PCR_PERIOD"
 )
+
+// M3u8PcrControl_Values returns all elements of the M3u8PcrControl enum
+func M3u8PcrControl_Values() []string {
+	return []string{
+		M3u8PcrControlPcrEveryPesPacket,
+		M3u8PcrControlConfiguredPcrPeriod,
+	}
+}
 
 // For SCTE-35 markers from your input-- Choose Passthrough (PASSTHROUGH) if
 // you want SCTE-35 markers that appear in your input to also appear in this
@@ -22885,6 +24882,14 @@ const (
 	M3u8Scte35SourceNone = "NONE"
 )
 
+// M3u8Scte35Source_Values returns all elements of the M3u8Scte35Source enum
+func M3u8Scte35Source_Values() []string {
+	return []string{
+		M3u8Scte35SourcePassthrough,
+		M3u8Scte35SourceNone,
+	}
+}
+
 // Choose the type of motion graphic asset that you are providing for your overlay.
 // You can choose either a .mov file or a series of .png files.
 const (
@@ -22894,6 +24899,14 @@ const (
 	// MotionImageInsertionModePng is a MotionImageInsertionMode enum value
 	MotionImageInsertionModePng = "PNG"
 )
+
+// MotionImageInsertionMode_Values returns all elements of the MotionImageInsertionMode enum
+func MotionImageInsertionMode_Values() []string {
+	return []string{
+		MotionImageInsertionModeMov,
+		MotionImageInsertionModePng,
+	}
+}
 
 // Specify whether your motion graphic overlay repeats on a loop or plays only
 // once.
@@ -22905,6 +24918,14 @@ const (
 	MotionImagePlaybackRepeat = "REPEAT"
 )
 
+// MotionImagePlayback_Values returns all elements of the MotionImagePlayback enum
+func MotionImagePlayback_Values() []string {
+	return []string{
+		MotionImagePlaybackOnce,
+		MotionImagePlaybackRepeat,
+	}
+}
+
 // When enabled, include 'clap' atom if appropriate for the video output settings.
 const (
 	// MovClapAtomInclude is a MovClapAtom enum value
@@ -22913,6 +24934,14 @@ const (
 	// MovClapAtomExclude is a MovClapAtom enum value
 	MovClapAtomExclude = "EXCLUDE"
 )
+
+// MovClapAtom_Values returns all elements of the MovClapAtom enum
+func MovClapAtom_Values() []string {
+	return []string{
+		MovClapAtomInclude,
+		MovClapAtomExclude,
+	}
+}
 
 // When enabled, file composition times will start at zero, composition times
 // in the 'ctts' (composition time to sample) box for B-frames will be negative,
@@ -22926,6 +24955,14 @@ const (
 	MovCslgAtomExclude = "EXCLUDE"
 )
 
+// MovCslgAtom_Values returns all elements of the MovCslgAtom enum
+func MovCslgAtom_Values() []string {
+	return []string{
+		MovCslgAtomInclude,
+		MovCslgAtomExclude,
+	}
+}
+
 // When set to XDCAM, writes MPEG2 video streams into the QuickTime file using
 // XDCAM fourcc codes. This increases compatibility with Apple editors and players,
 // but may decrease compatibility with other players. Only applicable when the
@@ -22938,6 +24975,14 @@ const (
 	MovMpeg2FourCCControlMpeg = "MPEG"
 )
 
+// MovMpeg2FourCCControl_Values returns all elements of the MovMpeg2FourCCControl enum
+func MovMpeg2FourCCControl_Values() []string {
+	return []string{
+		MovMpeg2FourCCControlXdcam,
+		MovMpeg2FourCCControlMpeg,
+	}
+}
+
 // If set to OMNEON, inserts Omneon-compatible padding
 const (
 	// MovPaddingControlOmneon is a MovPaddingControl enum value
@@ -22946,6 +24991,14 @@ const (
 	// MovPaddingControlNone is a MovPaddingControl enum value
 	MovPaddingControlNone = "NONE"
 )
+
+// MovPaddingControl_Values returns all elements of the MovPaddingControl enum
+func MovPaddingControl_Values() []string {
+	return []string{
+		MovPaddingControlOmneon,
+		MovPaddingControlNone,
+	}
+}
 
 // Always keep the default value (SELF_CONTAINED) for this setting.
 const (
@@ -22956,6 +25009,14 @@ const (
 	MovReferenceExternal = "EXTERNAL"
 )
 
+// MovReference_Values returns all elements of the MovReference enum
+func MovReference_Values() []string {
+	return []string{
+		MovReferenceSelfContained,
+		MovReferenceExternal,
+	}
+}
+
 // Specify whether the service encodes this MP3 audio output with a constant
 // bitrate (CBR) or a variable bitrate (VBR).
 const (
@@ -22965,6 +25026,14 @@ const (
 	// Mp3RateControlModeVbr is a Mp3RateControlMode enum value
 	Mp3RateControlModeVbr = "VBR"
 )
+
+// Mp3RateControlMode_Values returns all elements of the Mp3RateControlMode enum
+func Mp3RateControlMode_Values() []string {
+	return []string{
+		Mp3RateControlModeCbr,
+		Mp3RateControlModeVbr,
+	}
+}
 
 // When enabled, file composition times will start at zero, composition times
 // in the 'ctts' (composition time to sample) box for B-frames will be negative,
@@ -22978,6 +25047,14 @@ const (
 	Mp4CslgAtomExclude = "EXCLUDE"
 )
 
+// Mp4CslgAtom_Values returns all elements of the Mp4CslgAtom enum
+func Mp4CslgAtom_Values() []string {
+	return []string{
+		Mp4CslgAtomInclude,
+		Mp4CslgAtomExclude,
+	}
+}
+
 // Inserts a free-space box immediately after the moov box.
 const (
 	// Mp4FreeSpaceBoxInclude is a Mp4FreeSpaceBox enum value
@@ -22986,6 +25063,14 @@ const (
 	// Mp4FreeSpaceBoxExclude is a Mp4FreeSpaceBox enum value
 	Mp4FreeSpaceBoxExclude = "EXCLUDE"
 )
+
+// Mp4FreeSpaceBox_Values returns all elements of the Mp4FreeSpaceBox enum
+func Mp4FreeSpaceBox_Values() []string {
+	return []string{
+		Mp4FreeSpaceBoxInclude,
+		Mp4FreeSpaceBoxExclude,
+	}
+}
 
 // If set to PROGRESSIVE_DOWNLOAD, the MOOV atom is relocated to the beginning
 // of the archive as required for progressive downloading. Otherwise it is placed
@@ -22997,6 +25082,14 @@ const (
 	// Mp4MoovPlacementNormal is a Mp4MoovPlacement enum value
 	Mp4MoovPlacementNormal = "NORMAL"
 )
+
+// Mp4MoovPlacement_Values returns all elements of the Mp4MoovPlacement enum
+func Mp4MoovPlacement_Values() []string {
+	return []string{
+		Mp4MoovPlacementProgressiveDownload,
+		Mp4MoovPlacementNormal,
+	}
+}
 
 // Use this setting only in DASH output groups that include sidecar TTML or
 // IMSC captions. You specify sidecar captions in a separate output from your
@@ -23012,6 +25105,14 @@ const (
 	MpdCaptionContainerTypeFragmentedMp4 = "FRAGMENTED_MP4"
 )
 
+// MpdCaptionContainerType_Values returns all elements of the MpdCaptionContainerType enum
+func MpdCaptionContainerType_Values() []string {
+	return []string{
+		MpdCaptionContainerTypeRaw,
+		MpdCaptionContainerTypeFragmentedMp4,
+	}
+}
+
 // Use this setting only when you specify SCTE-35 markers from ESAM. Choose
 // INSERT to put SCTE-35 markers in this output at the insertion points that
 // you specify in an ESAM XML document. Provide the document in the setting
@@ -23024,6 +25125,14 @@ const (
 	MpdScte35EsamNone = "NONE"
 )
 
+// MpdScte35Esam_Values returns all elements of the MpdScte35Esam enum
+func MpdScte35Esam_Values() []string {
+	return []string{
+		MpdScte35EsamInsert,
+		MpdScte35EsamNone,
+	}
+}
+
 // Ignore this setting unless you have SCTE-35 markers in your input video file.
 // Choose Passthrough (PASSTHROUGH) if you want SCTE-35 markers that appear
 // in your input to also appear in this output. Choose None (NONE) if you don't
@@ -23035,6 +25144,14 @@ const (
 	// MpdScte35SourceNone is a MpdScte35Source enum value
 	MpdScte35SourceNone = "NONE"
 )
+
+// MpdScte35Source_Values returns all elements of the MpdScte35Source enum
+func MpdScte35Source_Values() []string {
+	return []string{
+		MpdScte35SourcePassthrough,
+		MpdScte35SourceNone,
+	}
+}
 
 // Adaptive quantization. Allows intra-frame quantizers to vary to improve visual
 // quality.
@@ -23051,6 +25168,16 @@ const (
 	// Mpeg2AdaptiveQuantizationHigh is a Mpeg2AdaptiveQuantization enum value
 	Mpeg2AdaptiveQuantizationHigh = "HIGH"
 )
+
+// Mpeg2AdaptiveQuantization_Values returns all elements of the Mpeg2AdaptiveQuantization enum
+func Mpeg2AdaptiveQuantization_Values() []string {
+	return []string{
+		Mpeg2AdaptiveQuantizationOff,
+		Mpeg2AdaptiveQuantizationLow,
+		Mpeg2AdaptiveQuantizationMedium,
+		Mpeg2AdaptiveQuantizationHigh,
+	}
+}
 
 // Use Level (Mpeg2CodecLevel) to set the MPEG-2 level for the video output.
 const (
@@ -23070,6 +25197,17 @@ const (
 	Mpeg2CodecLevelHigh = "HIGH"
 )
 
+// Mpeg2CodecLevel_Values returns all elements of the Mpeg2CodecLevel enum
+func Mpeg2CodecLevel_Values() []string {
+	return []string{
+		Mpeg2CodecLevelAuto,
+		Mpeg2CodecLevelLow,
+		Mpeg2CodecLevelMain,
+		Mpeg2CodecLevelHigh1440,
+		Mpeg2CodecLevelHigh,
+	}
+}
+
 // Use Profile (Mpeg2CodecProfile) to set the MPEG-2 profile for the video output.
 const (
 	// Mpeg2CodecProfileMain is a Mpeg2CodecProfile enum value
@@ -23078,6 +25216,14 @@ const (
 	// Mpeg2CodecProfileProfile422 is a Mpeg2CodecProfile enum value
 	Mpeg2CodecProfileProfile422 = "PROFILE_422"
 )
+
+// Mpeg2CodecProfile_Values returns all elements of the Mpeg2CodecProfile enum
+func Mpeg2CodecProfile_Values() []string {
+	return []string{
+		Mpeg2CodecProfileMain,
+		Mpeg2CodecProfileProfile422,
+	}
+}
 
 // Choose Adaptive to improve subjective video quality for high-motion content.
 // This will cause the service to use fewer B-frames (which infer information
@@ -23091,6 +25237,14 @@ const (
 	// Mpeg2DynamicSubGopStatic is a Mpeg2DynamicSubGop enum value
 	Mpeg2DynamicSubGopStatic = "STATIC"
 )
+
+// Mpeg2DynamicSubGop_Values returns all elements of the Mpeg2DynamicSubGop enum
+func Mpeg2DynamicSubGop_Values() []string {
+	return []string{
+		Mpeg2DynamicSubGopAdaptive,
+		Mpeg2DynamicSubGopStatic,
+	}
+}
 
 // If you are using the console, use the Framerate setting to specify the frame
 // rate for this output. If you want to keep the same frame rate as the input
@@ -23111,6 +25265,14 @@ const (
 	Mpeg2FramerateControlSpecified = "SPECIFIED"
 )
 
+// Mpeg2FramerateControl_Values returns all elements of the Mpeg2FramerateControl enum
+func Mpeg2FramerateControl_Values() []string {
+	return []string{
+		Mpeg2FramerateControlInitializeFromSource,
+		Mpeg2FramerateControlSpecified,
+	}
+}
+
 // Optional. Specify how the transcoder performs framerate conversion. The default
 // behavior is to use duplicate drop conversion.
 const (
@@ -23121,6 +25283,14 @@ const (
 	Mpeg2FramerateConversionAlgorithmInterpolate = "INTERPOLATE"
 )
 
+// Mpeg2FramerateConversionAlgorithm_Values returns all elements of the Mpeg2FramerateConversionAlgorithm enum
+func Mpeg2FramerateConversionAlgorithm_Values() []string {
+	return []string{
+		Mpeg2FramerateConversionAlgorithmDuplicateDrop,
+		Mpeg2FramerateConversionAlgorithmInterpolate,
+	}
+}
+
 // Indicates if the GOP Size in MPEG2 is specified in frames or seconds. If
 // seconds the system will convert the GOP Size into a frame count at run time.
 const (
@@ -23130,6 +25300,14 @@ const (
 	// Mpeg2GopSizeUnitsSeconds is a Mpeg2GopSizeUnits enum value
 	Mpeg2GopSizeUnitsSeconds = "SECONDS"
 )
+
+// Mpeg2GopSizeUnits_Values returns all elements of the Mpeg2GopSizeUnits enum
+func Mpeg2GopSizeUnits_Values() []string {
+	return []string{
+		Mpeg2GopSizeUnitsFrames,
+		Mpeg2GopSizeUnitsSeconds,
+	}
+}
 
 // Use Interlace mode (InterlaceMode) to choose the scan line type for the output.
 // * Top Field First (TOP_FIELD) and Bottom Field First (BOTTOM_FIELD) produce
@@ -23159,6 +25337,17 @@ const (
 	Mpeg2InterlaceModeFollowBottomField = "FOLLOW_BOTTOM_FIELD"
 )
 
+// Mpeg2InterlaceMode_Values returns all elements of the Mpeg2InterlaceMode enum
+func Mpeg2InterlaceMode_Values() []string {
+	return []string{
+		Mpeg2InterlaceModeProgressive,
+		Mpeg2InterlaceModeTopField,
+		Mpeg2InterlaceModeBottomField,
+		Mpeg2InterlaceModeFollowTopField,
+		Mpeg2InterlaceModeFollowBottomField,
+	}
+}
+
 // Use Intra DC precision (Mpeg2IntraDcPrecision) to set quantization precision
 // for intra-block DC coefficients. If you choose the value auto, the service
 // will automatically select the precision based on the per-frame compression
@@ -23180,6 +25369,17 @@ const (
 	Mpeg2IntraDcPrecisionIntraDcPrecision11 = "INTRA_DC_PRECISION_11"
 )
 
+// Mpeg2IntraDcPrecision_Values returns all elements of the Mpeg2IntraDcPrecision enum
+func Mpeg2IntraDcPrecision_Values() []string {
+	return []string{
+		Mpeg2IntraDcPrecisionAuto,
+		Mpeg2IntraDcPrecisionIntraDcPrecision8,
+		Mpeg2IntraDcPrecisionIntraDcPrecision9,
+		Mpeg2IntraDcPrecisionIntraDcPrecision10,
+		Mpeg2IntraDcPrecisionIntraDcPrecision11,
+	}
+}
+
 // Optional. Specify how the service determines the pixel aspect ratio (PAR)
 // for this output. The default behavior, Follow source (INITIALIZE_FROM_SOURCE),
 // uses the PAR from your input video for your output. To specify a different
@@ -23195,6 +25395,14 @@ const (
 	Mpeg2ParControlSpecified = "SPECIFIED"
 )
 
+// Mpeg2ParControl_Values returns all elements of the Mpeg2ParControl enum
+func Mpeg2ParControl_Values() []string {
+	return []string{
+		Mpeg2ParControlInitializeFromSource,
+		Mpeg2ParControlSpecified,
+	}
+}
+
 // Optional. Use Quality tuning level (qualityTuningLevel) to choose how you
 // want to trade off encoding speed for output video quality. The default behavior
 // is faster, lower quality, single-pass encoding.
@@ -23206,6 +25414,14 @@ const (
 	Mpeg2QualityTuningLevelMultiPass = "MULTI_PASS"
 )
 
+// Mpeg2QualityTuningLevel_Values returns all elements of the Mpeg2QualityTuningLevel enum
+func Mpeg2QualityTuningLevel_Values() []string {
+	return []string{
+		Mpeg2QualityTuningLevelSinglePass,
+		Mpeg2QualityTuningLevelMultiPass,
+	}
+}
+
 // Use Rate control mode (Mpeg2RateControlMode) to specifiy whether the bitrate
 // is variable (vbr) or constant (cbr).
 const (
@@ -23215,6 +25431,14 @@ const (
 	// Mpeg2RateControlModeCbr is a Mpeg2RateControlMode enum value
 	Mpeg2RateControlModeCbr = "CBR"
 )
+
+// Mpeg2RateControlMode_Values returns all elements of the Mpeg2RateControlMode enum
+func Mpeg2RateControlMode_Values() []string {
+	return []string{
+		Mpeg2RateControlModeVbr,
+		Mpeg2RateControlModeCbr,
+	}
+}
 
 // Enable this setting to insert I-frames at scene changes that the service
 // automatically detects. This improves video quality and is enabled by default.
@@ -23226,6 +25450,14 @@ const (
 	Mpeg2SceneChangeDetectEnabled = "ENABLED"
 )
 
+// Mpeg2SceneChangeDetect_Values returns all elements of the Mpeg2SceneChangeDetect enum
+func Mpeg2SceneChangeDetect_Values() []string {
+	return []string{
+		Mpeg2SceneChangeDetectDisabled,
+		Mpeg2SceneChangeDetectEnabled,
+	}
+}
+
 // Enables Slow PAL rate conversion. 23.976fps and 24fps input is relabeled
 // as 25fps, and audio is sped up correspondingly.
 const (
@@ -23235,6 +25467,14 @@ const (
 	// Mpeg2SlowPalEnabled is a Mpeg2SlowPal enum value
 	Mpeg2SlowPalEnabled = "ENABLED"
 )
+
+// Mpeg2SlowPal_Values returns all elements of the Mpeg2SlowPal enum
+func Mpeg2SlowPal_Values() []string {
+	return []string{
+		Mpeg2SlowPalDisabled,
+		Mpeg2SlowPalEnabled,
+	}
+}
 
 // Adjust quantization within each frame based on spatial variation of content
 // complexity.
@@ -23246,6 +25486,14 @@ const (
 	Mpeg2SpatialAdaptiveQuantizationEnabled = "ENABLED"
 )
 
+// Mpeg2SpatialAdaptiveQuantization_Values returns all elements of the Mpeg2SpatialAdaptiveQuantization enum
+func Mpeg2SpatialAdaptiveQuantization_Values() []string {
+	return []string{
+		Mpeg2SpatialAdaptiveQuantizationDisabled,
+		Mpeg2SpatialAdaptiveQuantizationEnabled,
+	}
+}
+
 // Produces a Type D-10 compatible bitstream (SMPTE 356M-2001).
 const (
 	// Mpeg2SyntaxDefault is a Mpeg2Syntax enum value
@@ -23254,6 +25502,14 @@ const (
 	// Mpeg2SyntaxD10 is a Mpeg2Syntax enum value
 	Mpeg2SyntaxD10 = "D_10"
 )
+
+// Mpeg2Syntax_Values returns all elements of the Mpeg2Syntax enum
+func Mpeg2Syntax_Values() []string {
+	return []string{
+		Mpeg2SyntaxDefault,
+		Mpeg2SyntaxD10,
+	}
+}
 
 // Only use Telecine (Mpeg2Telecine) when you set Framerate (Framerate) to 29.970.
 // Set Telecine (Mpeg2Telecine) to Hard (hard) to produce a 29.97i output from
@@ -23270,6 +25526,15 @@ const (
 	Mpeg2TelecineHard = "HARD"
 )
 
+// Mpeg2Telecine_Values returns all elements of the Mpeg2Telecine enum
+func Mpeg2Telecine_Values() []string {
+	return []string{
+		Mpeg2TelecineNone,
+		Mpeg2TelecineSoft,
+		Mpeg2TelecineHard,
+	}
+}
+
 // Adjust quantization within each frame based on temporal variation of content
 // complexity.
 const (
@@ -23279,6 +25544,14 @@ const (
 	// Mpeg2TemporalAdaptiveQuantizationEnabled is a Mpeg2TemporalAdaptiveQuantization enum value
 	Mpeg2TemporalAdaptiveQuantizationEnabled = "ENABLED"
 )
+
+// Mpeg2TemporalAdaptiveQuantization_Values returns all elements of the Mpeg2TemporalAdaptiveQuantization enum
+func Mpeg2TemporalAdaptiveQuantization_Values() []string {
+	return []string{
+		Mpeg2TemporalAdaptiveQuantizationDisabled,
+		Mpeg2TemporalAdaptiveQuantizationEnabled,
+	}
+}
 
 // COMBINE_DUPLICATE_STREAMS combines identical audio encoding settings across
 // a Microsoft Smooth output group into a single audio stream.
@@ -23290,6 +25563,14 @@ const (
 	MsSmoothAudioDeduplicationNone = "NONE"
 )
 
+// MsSmoothAudioDeduplication_Values returns all elements of the MsSmoothAudioDeduplication enum
+func MsSmoothAudioDeduplication_Values() []string {
+	return []string{
+		MsSmoothAudioDeduplicationCombineDuplicateStreams,
+		MsSmoothAudioDeduplicationNone,
+	}
+}
+
 // Use Manifest encoding (MsSmoothManifestEncoding) to specify the encoding
 // format for the server and client manifest. Valid options are utf8 and utf16.
 const (
@@ -23299,6 +25580,14 @@ const (
 	// MsSmoothManifestEncodingUtf16 is a MsSmoothManifestEncoding enum value
 	MsSmoothManifestEncodingUtf16 = "UTF16"
 )
+
+// MsSmoothManifestEncoding_Values returns all elements of the MsSmoothManifestEncoding enum
+func MsSmoothManifestEncoding_Values() []string {
+	return []string{
+		MsSmoothManifestEncodingUtf8,
+		MsSmoothManifestEncodingUtf16,
+	}
+}
 
 // Optional. When you have AFD signaling set up in your output video stream,
 // use this setting to choose whether to also include it in the MXF wrapper.
@@ -23317,6 +25606,14 @@ const (
 	MxfAfdSignalingCopyFromVideo = "COPY_FROM_VIDEO"
 )
 
+// MxfAfdSignaling_Values returns all elements of the MxfAfdSignaling enum
+func MxfAfdSignaling_Values() []string {
+	return []string{
+		MxfAfdSignalingNoCopy,
+		MxfAfdSignalingCopyFromVideo,
+	}
+}
+
 // Optional. When you set Noise reducer (noiseReducer) to Temporal (TEMPORAL),
 // you can optionally use this setting to apply additional sharpening. The default
 // behavior, Auto (AUTO) allows the transcoder to determine whether to apply
@@ -23331,6 +25628,15 @@ const (
 	// NoiseFilterPostTemporalSharpeningAuto is a NoiseFilterPostTemporalSharpening enum value
 	NoiseFilterPostTemporalSharpeningAuto = "AUTO"
 )
+
+// NoiseFilterPostTemporalSharpening_Values returns all elements of the NoiseFilterPostTemporalSharpening enum
+func NoiseFilterPostTemporalSharpening_Values() []string {
+	return []string{
+		NoiseFilterPostTemporalSharpeningDisabled,
+		NoiseFilterPostTemporalSharpeningEnabled,
+		NoiseFilterPostTemporalSharpeningAuto,
+	}
+}
 
 // Use Noise reducer filter (NoiseReducerFilter) to select one of the following
 // spatial image filtering functions. To use this setting, you must also enable
@@ -23365,6 +25671,20 @@ const (
 	NoiseReducerFilterTemporal = "TEMPORAL"
 )
 
+// NoiseReducerFilter_Values returns all elements of the NoiseReducerFilter enum
+func NoiseReducerFilter_Values() []string {
+	return []string{
+		NoiseReducerFilterBilateral,
+		NoiseReducerFilterMean,
+		NoiseReducerFilterGaussian,
+		NoiseReducerFilterLanczos,
+		NoiseReducerFilterSharpen,
+		NoiseReducerFilterConserve,
+		NoiseReducerFilterSpatial,
+		NoiseReducerFilterTemporal,
+	}
+}
+
 // Optional. When you request lists of resources, you can specify whether they
 // are sorted in ASCENDING or DESCENDING order. Default varies by resource.
 const (
@@ -23374,6 +25694,14 @@ const (
 	// OrderDescending is a Order enum value
 	OrderDescending = "DESCENDING"
 )
+
+// Order_Values returns all elements of the Order enum
+func Order_Values() []string {
+	return []string{
+		OrderAscending,
+		OrderDescending,
+	}
+}
 
 // Type of output group (File group, Apple HLS, DASH ISO, Microsoft Smooth Streaming,
 // CMAF)
@@ -23393,6 +25721,17 @@ const (
 	// OutputGroupTypeCmafGroupSettings is a OutputGroupType enum value
 	OutputGroupTypeCmafGroupSettings = "CMAF_GROUP_SETTINGS"
 )
+
+// OutputGroupType_Values returns all elements of the OutputGroupType enum
+func OutputGroupType_Values() []string {
+	return []string{
+		OutputGroupTypeHlsGroupSettings,
+		OutputGroupTypeDashIsoGroupSettings,
+		OutputGroupTypeFileGroupSettings,
+		OutputGroupTypeMsSmoothGroupSettings,
+		OutputGroupTypeCmafGroupSettings,
+	}
+}
 
 // Selects method of inserting SDT information into output stream. "Follow input
 // SDT" copies SDT information from input stream to output stream. "Follow input
@@ -23414,6 +25753,16 @@ const (
 	OutputSdtSdtNone = "SDT_NONE"
 )
 
+// OutputSdt_Values returns all elements of the OutputSdt enum
+func OutputSdt_Values() []string {
+	return []string{
+		OutputSdtSdtFollow,
+		OutputSdtSdtFollowIfPresent,
+		OutputSdtSdtManual,
+		OutputSdtSdtNone,
+	}
+}
+
 // Optional. When you request a list of presets, you can choose to list them
 // alphabetically by NAME or chronologically by CREATION_DATE. If you don't
 // specify, the service will list them by name.
@@ -23428,6 +25777,15 @@ const (
 	PresetListBySystem = "SYSTEM"
 )
 
+// PresetListBy_Values returns all elements of the PresetListBy enum
+func PresetListBy_Values() []string {
+	return []string{
+		PresetListByName,
+		PresetListByCreationDate,
+		PresetListBySystem,
+	}
+}
+
 // Specifies whether the pricing plan for the queue is on-demand or reserved.
 // For on-demand, you pay per minute, billed in increments of .01 minute. For
 // reserved, you pay for the transcoding capacity of the entire queue, regardless
@@ -23440,6 +25798,14 @@ const (
 	// PricingPlanReserved is a PricingPlan enum value
 	PricingPlanReserved = "RESERVED"
 )
+
+// PricingPlan_Values returns all elements of the PricingPlan enum
+func PricingPlan_Values() []string {
+	return []string{
+		PricingPlanOnDemand,
+		PricingPlanReserved,
+	}
+}
 
 // Use Profile (ProResCodecProfile) to specifiy the type of Apple ProRes codec
 // to use for this output.
@@ -23456,6 +25822,16 @@ const (
 	// ProresCodecProfileAppleProres422Proxy is a ProresCodecProfile enum value
 	ProresCodecProfileAppleProres422Proxy = "APPLE_PRORES_422_PROXY"
 )
+
+// ProresCodecProfile_Values returns all elements of the ProresCodecProfile enum
+func ProresCodecProfile_Values() []string {
+	return []string{
+		ProresCodecProfileAppleProres422,
+		ProresCodecProfileAppleProres422Hq,
+		ProresCodecProfileAppleProres422Lt,
+		ProresCodecProfileAppleProres422Proxy,
+	}
+}
 
 // If you are using the console, use the Framerate setting to specify the frame
 // rate for this output. If you want to keep the same frame rate as the input
@@ -23476,6 +25852,14 @@ const (
 	ProresFramerateControlSpecified = "SPECIFIED"
 )
 
+// ProresFramerateControl_Values returns all elements of the ProresFramerateControl enum
+func ProresFramerateControl_Values() []string {
+	return []string{
+		ProresFramerateControlInitializeFromSource,
+		ProresFramerateControlSpecified,
+	}
+}
+
 // Optional. Specify how the transcoder performs framerate conversion. The default
 // behavior is to use duplicate drop conversion.
 const (
@@ -23485,6 +25869,14 @@ const (
 	// ProresFramerateConversionAlgorithmInterpolate is a ProresFramerateConversionAlgorithm enum value
 	ProresFramerateConversionAlgorithmInterpolate = "INTERPOLATE"
 )
+
+// ProresFramerateConversionAlgorithm_Values returns all elements of the ProresFramerateConversionAlgorithm enum
+func ProresFramerateConversionAlgorithm_Values() []string {
+	return []string{
+		ProresFramerateConversionAlgorithmDuplicateDrop,
+		ProresFramerateConversionAlgorithmInterpolate,
+	}
+}
 
 // Use Interlace mode (InterlaceMode) to choose the scan line type for the output.
 // * Top Field First (TOP_FIELD) and Bottom Field First (BOTTOM_FIELD) produce
@@ -23514,6 +25906,17 @@ const (
 	ProresInterlaceModeFollowBottomField = "FOLLOW_BOTTOM_FIELD"
 )
 
+// ProresInterlaceMode_Values returns all elements of the ProresInterlaceMode enum
+func ProresInterlaceMode_Values() []string {
+	return []string{
+		ProresInterlaceModeProgressive,
+		ProresInterlaceModeTopField,
+		ProresInterlaceModeBottomField,
+		ProresInterlaceModeFollowTopField,
+		ProresInterlaceModeFollowBottomField,
+	}
+}
+
 // Optional. Specify how the service determines the pixel aspect ratio (PAR)
 // for this output. The default behavior, Follow source (INITIALIZE_FROM_SOURCE),
 // uses the PAR from your input video for your output. To specify a different
@@ -23529,6 +25932,14 @@ const (
 	ProresParControlSpecified = "SPECIFIED"
 )
 
+// ProresParControl_Values returns all elements of the ProresParControl enum
+func ProresParControl_Values() []string {
+	return []string{
+		ProresParControlInitializeFromSource,
+		ProresParControlSpecified,
+	}
+}
+
 // Enables Slow PAL rate conversion. 23.976fps and 24fps input is relabeled
 // as 25fps, and audio is sped up correspondingly.
 const (
@@ -23538,6 +25949,14 @@ const (
 	// ProresSlowPalEnabled is a ProresSlowPal enum value
 	ProresSlowPalEnabled = "ENABLED"
 )
+
+// ProresSlowPal_Values returns all elements of the ProresSlowPal enum
+func ProresSlowPal_Values() []string {
+	return []string{
+		ProresSlowPalDisabled,
+		ProresSlowPalEnabled,
+	}
+}
 
 // Only use Telecine (ProresTelecine) when you set Framerate (Framerate) to
 // 29.970. Set Telecine (ProresTelecine) to Hard (hard) to produce a 29.97i
@@ -23551,6 +25970,14 @@ const (
 	ProresTelecineHard = "HARD"
 )
 
+// ProresTelecine_Values returns all elements of the ProresTelecine enum
+func ProresTelecine_Values() []string {
+	return []string{
+		ProresTelecineNone,
+		ProresTelecineHard,
+	}
+}
+
 // Optional. When you request a list of queues, you can choose to list them
 // alphabetically by NAME or chronologically by CREATION_DATE. If you don't
 // specify, the service will list them by creation date.
@@ -23561,6 +25988,14 @@ const (
 	// QueueListByCreationDate is a QueueListBy enum value
 	QueueListByCreationDate = "CREATION_DATE"
 )
+
+// QueueListBy_Values returns all elements of the QueueListBy enum
+func QueueListBy_Values() []string {
+	return []string{
+		QueueListByName,
+		QueueListByCreationDate,
+	}
+}
 
 // Queues can be ACTIVE or PAUSED. If you pause a queue, jobs in that queue
 // won't begin. Jobs that are running when you pause a queue continue to run
@@ -23573,6 +26008,14 @@ const (
 	QueueStatusPaused = "PAUSED"
 )
 
+// QueueStatus_Values returns all elements of the QueueStatus enum
+func QueueStatus_Values() []string {
+	return []string{
+		QueueStatusActive,
+		QueueStatusPaused,
+	}
+}
+
 // Specifies whether the term of your reserved queue pricing plan is automatically
 // extended (AUTO_RENEW) or expires (EXPIRE) at the end of the term.
 const (
@@ -23583,6 +26026,14 @@ const (
 	RenewalTypeExpire = "EXPIRE"
 )
 
+// RenewalType_Values returns all elements of the RenewalType enum
+func RenewalType_Values() []string {
+	return []string{
+		RenewalTypeAutoRenew,
+		RenewalTypeExpire,
+	}
+}
+
 // Specifies whether the pricing plan for your reserved queue is ACTIVE or EXPIRED.
 const (
 	// ReservationPlanStatusActive is a ReservationPlanStatus enum value
@@ -23591,6 +26042,14 @@ const (
 	// ReservationPlanStatusExpired is a ReservationPlanStatus enum value
 	ReservationPlanStatusExpired = "EXPIRED"
 )
+
+// ReservationPlanStatus_Values returns all elements of the ReservationPlanStatus enum
+func ReservationPlanStatus_Values() []string {
+	return []string{
+		ReservationPlanStatusActive,
+		ReservationPlanStatusExpired,
+	}
+}
 
 // Use Respond to AFD (RespondToAfd) to specify how the service changes the
 // video itself in response to AFD values in the input. * Choose Respond to
@@ -23611,6 +26070,15 @@ const (
 	RespondToAfdPassthrough = "PASSTHROUGH"
 )
 
+// RespondToAfd_Values returns all elements of the RespondToAfd enum
+func RespondToAfd_Values() []string {
+	return []string{
+		RespondToAfdNone,
+		RespondToAfdRespond,
+		RespondToAfdPassthrough,
+	}
+}
+
 // Choose an Amazon S3 canned ACL for MediaConvert to apply to this output.
 const (
 	// S3ObjectCannedAclPublicRead is a S3ObjectCannedAcl enum value
@@ -23625,6 +26093,16 @@ const (
 	// S3ObjectCannedAclBucketOwnerFullControl is a S3ObjectCannedAcl enum value
 	S3ObjectCannedAclBucketOwnerFullControl = "BUCKET_OWNER_FULL_CONTROL"
 )
+
+// S3ObjectCannedAcl_Values returns all elements of the S3ObjectCannedAcl enum
+func S3ObjectCannedAcl_Values() []string {
+	return []string{
+		S3ObjectCannedAclPublicRead,
+		S3ObjectCannedAclAuthenticatedRead,
+		S3ObjectCannedAclBucketOwnerRead,
+		S3ObjectCannedAclBucketOwnerFullControl,
+	}
+}
 
 // Specify how you want your data keys managed. AWS uses data keys to encrypt
 // your content. AWS also encrypts the data keys themselves, using a customer
@@ -23645,6 +26123,14 @@ const (
 	S3ServerSideEncryptionTypeServerSideEncryptionKms = "SERVER_SIDE_ENCRYPTION_KMS"
 )
 
+// S3ServerSideEncryptionType_Values returns all elements of the S3ServerSideEncryptionType enum
+func S3ServerSideEncryptionType_Values() []string {
+	return []string{
+		S3ServerSideEncryptionTypeServerSideEncryptionS3,
+		S3ServerSideEncryptionTypeServerSideEncryptionKms,
+	}
+}
+
 // Specify how the service handles outputs that have a different aspect ratio
 // from the input aspect ratio. Choose Stretch to output (STRETCH_TO_OUTPUT)
 // to have the service stretch your video image to fit. Keep the setting Default
@@ -23658,6 +26144,14 @@ const (
 	// ScalingBehaviorStretchToOutput is a ScalingBehavior enum value
 	ScalingBehaviorStretchToOutput = "STRETCH_TO_OUTPUT"
 )
+
+// ScalingBehavior_Values returns all elements of the ScalingBehavior enum
+func ScalingBehavior_Values() []string {
+	return []string{
+		ScalingBehaviorDefault,
+		ScalingBehaviorStretchToOutput,
+	}
+}
 
 // Set Framerate (SccDestinationFramerate) to make sure that the captions and
 // the video are synchronized in the output. Specify a frame rate that matches
@@ -23682,6 +26176,17 @@ const (
 	SccDestinationFramerateFramerate2997NonDropframe = "FRAMERATE_29_97_NON_DROPFRAME"
 )
 
+// SccDestinationFramerate_Values returns all elements of the SccDestinationFramerate enum
+func SccDestinationFramerate_Values() []string {
+	return []string{
+		SccDestinationFramerateFramerate2397,
+		SccDestinationFramerateFramerate24,
+		SccDestinationFramerateFramerate25,
+		SccDestinationFramerateFramerate2997Dropframe,
+		SccDestinationFramerateFramerate2997NonDropframe,
+	}
+}
+
 // Enable this setting when you run a test job to estimate how many reserved
 // transcoding slots (RTS) you need. When this is enabled, MediaConvert runs
 // your job from an on-demand queue with similar performance to what you will
@@ -23693,6 +26198,14 @@ const (
 	// SimulateReservedQueueEnabled is a SimulateReservedQueue enum value
 	SimulateReservedQueueEnabled = "ENABLED"
 )
+
+// SimulateReservedQueue_Values returns all elements of the SimulateReservedQueue enum
+func SimulateReservedQueue_Values() []string {
+	return []string{
+		SimulateReservedQueueDisabled,
+		SimulateReservedQueueEnabled,
+	}
+}
 
 // Specify how often MediaConvert sends STATUS_UPDATE events to Amazon CloudWatch
 // Events. Set the interval, in seconds, between status updates. MediaConvert
@@ -23745,6 +26258,27 @@ const (
 	StatusUpdateIntervalSeconds600 = "SECONDS_600"
 )
 
+// StatusUpdateInterval_Values returns all elements of the StatusUpdateInterval enum
+func StatusUpdateInterval_Values() []string {
+	return []string{
+		StatusUpdateIntervalSeconds10,
+		StatusUpdateIntervalSeconds12,
+		StatusUpdateIntervalSeconds15,
+		StatusUpdateIntervalSeconds20,
+		StatusUpdateIntervalSeconds30,
+		StatusUpdateIntervalSeconds60,
+		StatusUpdateIntervalSeconds120,
+		StatusUpdateIntervalSeconds180,
+		StatusUpdateIntervalSeconds240,
+		StatusUpdateIntervalSeconds300,
+		StatusUpdateIntervalSeconds360,
+		StatusUpdateIntervalSeconds420,
+		StatusUpdateIntervalSeconds480,
+		StatusUpdateIntervalSeconds540,
+		StatusUpdateIntervalSeconds600,
+	}
+}
+
 // A page type as defined in the standard ETSI EN 300 468, Table 94
 const (
 	// TeletextPageTypePageTypeInitial is a TeletextPageType enum value
@@ -23762,6 +26296,17 @@ const (
 	// TeletextPageTypePageTypeHearingImpairedSubtitle is a TeletextPageType enum value
 	TeletextPageTypePageTypeHearingImpairedSubtitle = "PAGE_TYPE_HEARING_IMPAIRED_SUBTITLE"
 )
+
+// TeletextPageType_Values returns all elements of the TeletextPageType enum
+func TeletextPageType_Values() []string {
+	return []string{
+		TeletextPageTypePageTypeInitial,
+		TeletextPageTypePageTypeSubtitle,
+		TeletextPageTypePageTypeAddlInfo,
+		TeletextPageTypePageTypeProgramSchedule,
+		TeletextPageTypePageTypeHearingImpairedSubtitle,
+	}
+}
 
 // Use Position (Position) under under Timecode burn-in (TimecodeBurnIn) to
 // specify the location the burned-in timecode on output video.
@@ -23794,6 +26339,21 @@ const (
 	TimecodeBurninPositionBottomRight = "BOTTOM_RIGHT"
 )
 
+// TimecodeBurninPosition_Values returns all elements of the TimecodeBurninPosition enum
+func TimecodeBurninPosition_Values() []string {
+	return []string{
+		TimecodeBurninPositionTopCenter,
+		TimecodeBurninPositionTopLeft,
+		TimecodeBurninPositionTopRight,
+		TimecodeBurninPositionMiddleLeft,
+		TimecodeBurninPositionMiddleCenter,
+		TimecodeBurninPositionMiddleRight,
+		TimecodeBurninPositionBottomLeft,
+		TimecodeBurninPositionBottomCenter,
+		TimecodeBurninPositionBottomRight,
+	}
+}
+
 // Use Source (TimecodeSource) to set how timecodes are handled within this
 // job. To make sure that your video, audio, captions, and markers are synchronized
 // and that time-based features, such as image inserter, work correctly, choose
@@ -23816,6 +26376,15 @@ const (
 	TimecodeSourceSpecifiedstart = "SPECIFIEDSTART"
 )
 
+// TimecodeSource_Values returns all elements of the TimecodeSource enum
+func TimecodeSource_Values() []string {
+	return []string{
+		TimecodeSourceEmbedded,
+		TimecodeSourceZerobased,
+		TimecodeSourceSpecifiedstart,
+	}
+}
+
 // Applies only to HLS outputs. Use this setting to specify whether the service
 // inserts the ID3 timed metadata from the input in this output.
 const (
@@ -23825,6 +26394,14 @@ const (
 	// TimedMetadataNone is a TimedMetadata enum value
 	TimedMetadataNone = "NONE"
 )
+
+// TimedMetadata_Values returns all elements of the TimedMetadata enum
+func TimedMetadata_Values() []string {
+	return []string{
+		TimedMetadataPassthrough,
+		TimedMetadataNone,
+	}
+}
 
 // Pass through style and position information from a TTML-like input source
 // (TTML, SMPTE-TT) to the TTML output.
@@ -23836,6 +26413,14 @@ const (
 	TtmlStylePassthroughDisabled = "DISABLED"
 )
 
+// TtmlStylePassthrough_Values returns all elements of the TtmlStylePassthrough enum
+func TtmlStylePassthrough_Values() []string {
+	return []string{
+		TtmlStylePassthroughEnabled,
+		TtmlStylePassthroughDisabled,
+	}
+}
+
 const (
 	// TypeSystem is a Type enum value
 	TypeSystem = "SYSTEM"
@@ -23843,6 +26428,14 @@ const (
 	// TypeCustom is a Type enum value
 	TypeCustom = "CUSTOM"
 )
+
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypeSystem,
+		TypeCustom,
+	}
+}
 
 // Type of video codec
 const (
@@ -23871,6 +26464,20 @@ const (
 	VideoCodecVp9 = "VP9"
 )
 
+// VideoCodec_Values returns all elements of the VideoCodec enum
+func VideoCodec_Values() []string {
+	return []string{
+		VideoCodecFrameCapture,
+		VideoCodecAv1,
+		VideoCodecH264,
+		VideoCodecH265,
+		VideoCodecMpeg2,
+		VideoCodecProres,
+		VideoCodecVp8,
+		VideoCodecVp9,
+	}
+}
+
 // Applies only to H.264, H.265, MPEG2, and ProRes outputs. Only enable Timecode
 // insertion when the input frame rate is identical to the output frame rate.
 // To include timecodes in this output, set Timecode insertion (VideoTimecodeInsertion)
@@ -23891,6 +26498,14 @@ const (
 	VideoTimecodeInsertionPicTimingSei = "PIC_TIMING_SEI"
 )
 
+// VideoTimecodeInsertion_Values returns all elements of the VideoTimecodeInsertion enum
+func VideoTimecodeInsertion_Values() []string {
+	return []string{
+		VideoTimecodeInsertionDisabled,
+		VideoTimecodeInsertionPicTimingSei,
+	}
+}
+
 // If you are using the console, use the Framerate setting to specify the frame
 // rate for this output. If you want to keep the same frame rate as the input
 // video, choose Follow source. If you want to do frame rate conversion, choose
@@ -23910,6 +26525,14 @@ const (
 	Vp8FramerateControlSpecified = "SPECIFIED"
 )
 
+// Vp8FramerateControl_Values returns all elements of the Vp8FramerateControl enum
+func Vp8FramerateControl_Values() []string {
+	return []string{
+		Vp8FramerateControlInitializeFromSource,
+		Vp8FramerateControlSpecified,
+	}
+}
+
 // Optional. Specify how the transcoder performs framerate conversion. The default
 // behavior is to use Drop duplicate (DUPLICATE_DROP) conversion. When you choose
 // Interpolate (INTERPOLATE) instead, the conversion produces smoother motion.
@@ -23920,6 +26543,14 @@ const (
 	// Vp8FramerateConversionAlgorithmInterpolate is a Vp8FramerateConversionAlgorithm enum value
 	Vp8FramerateConversionAlgorithmInterpolate = "INTERPOLATE"
 )
+
+// Vp8FramerateConversionAlgorithm_Values returns all elements of the Vp8FramerateConversionAlgorithm enum
+func Vp8FramerateConversionAlgorithm_Values() []string {
+	return []string{
+		Vp8FramerateConversionAlgorithmDuplicateDrop,
+		Vp8FramerateConversionAlgorithmInterpolate,
+	}
+}
 
 // Optional. Specify how the service determines the pixel aspect ratio (PAR)
 // for this output. The default behavior, Follow source (INITIALIZE_FROM_SOURCE),
@@ -23936,6 +26567,14 @@ const (
 	Vp8ParControlSpecified = "SPECIFIED"
 )
 
+// Vp8ParControl_Values returns all elements of the Vp8ParControl enum
+func Vp8ParControl_Values() []string {
+	return []string{
+		Vp8ParControlInitializeFromSource,
+		Vp8ParControlSpecified,
+	}
+}
+
 // Optional. Use Quality tuning level (qualityTuningLevel) to choose how you
 // want to trade off encoding speed for output video quality. The default behavior
 // is faster, lower quality, multi-pass encoding.
@@ -23947,12 +26586,27 @@ const (
 	Vp8QualityTuningLevelMultiPassHq = "MULTI_PASS_HQ"
 )
 
+// Vp8QualityTuningLevel_Values returns all elements of the Vp8QualityTuningLevel enum
+func Vp8QualityTuningLevel_Values() []string {
+	return []string{
+		Vp8QualityTuningLevelMultiPass,
+		Vp8QualityTuningLevelMultiPassHq,
+	}
+}
+
 // With the VP8 codec, you can use only the variable bitrate (VBR) rate control
 // mode.
 const (
 	// Vp8RateControlModeVbr is a Vp8RateControlMode enum value
 	Vp8RateControlModeVbr = "VBR"
 )
+
+// Vp8RateControlMode_Values returns all elements of the Vp8RateControlMode enum
+func Vp8RateControlMode_Values() []string {
+	return []string{
+		Vp8RateControlModeVbr,
+	}
+}
 
 // If you are using the console, use the Framerate setting to specify the frame
 // rate for this output. If you want to keep the same frame rate as the input
@@ -23973,6 +26627,14 @@ const (
 	Vp9FramerateControlSpecified = "SPECIFIED"
 )
 
+// Vp9FramerateControl_Values returns all elements of the Vp9FramerateControl enum
+func Vp9FramerateControl_Values() []string {
+	return []string{
+		Vp9FramerateControlInitializeFromSource,
+		Vp9FramerateControlSpecified,
+	}
+}
+
 // Optional. Specify how the transcoder performs framerate conversion. The default
 // behavior is to use Drop duplicate (DUPLICATE_DROP) conversion. When you choose
 // Interpolate (INTERPOLATE) instead, the conversion produces smoother motion.
@@ -23983,6 +26645,14 @@ const (
 	// Vp9FramerateConversionAlgorithmInterpolate is a Vp9FramerateConversionAlgorithm enum value
 	Vp9FramerateConversionAlgorithmInterpolate = "INTERPOLATE"
 )
+
+// Vp9FramerateConversionAlgorithm_Values returns all elements of the Vp9FramerateConversionAlgorithm enum
+func Vp9FramerateConversionAlgorithm_Values() []string {
+	return []string{
+		Vp9FramerateConversionAlgorithmDuplicateDrop,
+		Vp9FramerateConversionAlgorithmInterpolate,
+	}
+}
 
 // Optional. Specify how the service determines the pixel aspect ratio (PAR)
 // for this output. The default behavior, Follow source (INITIALIZE_FROM_SOURCE),
@@ -23999,6 +26669,14 @@ const (
 	Vp9ParControlSpecified = "SPECIFIED"
 )
 
+// Vp9ParControl_Values returns all elements of the Vp9ParControl enum
+func Vp9ParControl_Values() []string {
+	return []string{
+		Vp9ParControlInitializeFromSource,
+		Vp9ParControlSpecified,
+	}
+}
+
 // Optional. Use Quality tuning level (qualityTuningLevel) to choose how you
 // want to trade off encoding speed for output video quality. The default behavior
 // is faster, lower quality, multi-pass encoding.
@@ -24010,12 +26688,27 @@ const (
 	Vp9QualityTuningLevelMultiPassHq = "MULTI_PASS_HQ"
 )
 
+// Vp9QualityTuningLevel_Values returns all elements of the Vp9QualityTuningLevel enum
+func Vp9QualityTuningLevel_Values() []string {
+	return []string{
+		Vp9QualityTuningLevelMultiPass,
+		Vp9QualityTuningLevelMultiPassHq,
+	}
+}
+
 // With the VP9 codec, you can use only the variable bitrate (VBR) rate control
 // mode.
 const (
 	// Vp9RateControlModeVbr is a Vp9RateControlMode enum value
 	Vp9RateControlModeVbr = "VBR"
 )
+
+// Vp9RateControlMode_Values returns all elements of the Vp9RateControlMode enum
+func Vp9RateControlMode_Values() []string {
+	return []string{
+		Vp9RateControlModeVbr,
+	}
+}
 
 // Optional. Ignore this setting unless Nagra support directs you to specify
 // a value. When you don't specify a value here, the Nagra NexGuard library
@@ -24037,6 +26730,17 @@ const (
 	WatermarkingStrengthStrongest = "STRONGEST"
 )
 
+// WatermarkingStrength_Values returns all elements of the WatermarkingStrength enum
+func WatermarkingStrength_Values() []string {
+	return []string{
+		WatermarkingStrengthLightest,
+		WatermarkingStrengthLighter,
+		WatermarkingStrengthDefault,
+		WatermarkingStrengthStronger,
+		WatermarkingStrengthStrongest,
+	}
+}
+
 // The service defaults to using RIFF for WAV outputs. If your output audio
 // is likely to exceed 4 GB in file size, or if you otherwise need the extended
 // support of the RF64 format, set your output WAV file format to RF64.
@@ -24047,3 +26751,11 @@ const (
 	// WavFormatRf64 is a WavFormat enum value
 	WavFormatRf64 = "RF64"
 )
+
+// WavFormat_Values returns all elements of the WavFormat enum
+func WavFormat_Values() []string {
+	return []string{
+		WavFormatRiff,
+		WavFormatRf64,
+	}
+}

--- a/service/medialive/api.go
+++ b/service/medialive/api.go
@@ -23988,6 +23988,17 @@ const (
 	AacCodingModeCodingMode51 = "CODING_MODE_5_1"
 )
 
+// AacCodingMode_Values returns all elements of the AacCodingMode enum
+func AacCodingMode_Values() []string {
+	return []string{
+		AacCodingModeAdReceiverMix,
+		AacCodingModeCodingMode10,
+		AacCodingModeCodingMode11,
+		AacCodingModeCodingMode20,
+		AacCodingModeCodingMode51,
+	}
+}
+
 // Aac Input Type
 const (
 	// AacInputTypeBroadcasterMixedAd is a AacInputType enum value
@@ -23996,6 +24007,14 @@ const (
 	// AacInputTypeNormal is a AacInputType enum value
 	AacInputTypeNormal = "NORMAL"
 )
+
+// AacInputType_Values returns all elements of the AacInputType enum
+func AacInputType_Values() []string {
+	return []string{
+		AacInputTypeBroadcasterMixedAd,
+		AacInputTypeNormal,
+	}
+}
 
 // Aac Profile
 const (
@@ -24009,6 +24028,15 @@ const (
 	AacProfileLc = "LC"
 )
 
+// AacProfile_Values returns all elements of the AacProfile enum
+func AacProfile_Values() []string {
+	return []string{
+		AacProfileHev1,
+		AacProfileHev2,
+		AacProfileLc,
+	}
+}
+
 // Aac Rate Control Mode
 const (
 	// AacRateControlModeCbr is a AacRateControlMode enum value
@@ -24017,6 +24045,14 @@ const (
 	// AacRateControlModeVbr is a AacRateControlMode enum value
 	AacRateControlModeVbr = "VBR"
 )
+
+// AacRateControlMode_Values returns all elements of the AacRateControlMode enum
+func AacRateControlMode_Values() []string {
+	return []string{
+		AacRateControlModeCbr,
+		AacRateControlModeVbr,
+	}
+}
 
 // Aac Raw Format
 const (
@@ -24027,6 +24063,14 @@ const (
 	AacRawFormatNone = "NONE"
 )
 
+// AacRawFormat_Values returns all elements of the AacRawFormat enum
+func AacRawFormat_Values() []string {
+	return []string{
+		AacRawFormatLatmLoas,
+		AacRawFormatNone,
+	}
+}
+
 // Aac Spec
 const (
 	// AacSpecMpeg2 is a AacSpec enum value
@@ -24035,6 +24079,14 @@ const (
 	// AacSpecMpeg4 is a AacSpec enum value
 	AacSpecMpeg4 = "MPEG4"
 )
+
+// AacSpec_Values returns all elements of the AacSpec enum
+func AacSpec_Values() []string {
+	return []string{
+		AacSpecMpeg2,
+		AacSpecMpeg4,
+	}
+}
 
 // Aac Vbr Quality
 const (
@@ -24050,6 +24102,16 @@ const (
 	// AacVbrQualityMediumLow is a AacVbrQuality enum value
 	AacVbrQualityMediumLow = "MEDIUM_LOW"
 )
+
+// AacVbrQuality_Values returns all elements of the AacVbrQuality enum
+func AacVbrQuality_Values() []string {
+	return []string{
+		AacVbrQualityHigh,
+		AacVbrQualityLow,
+		AacVbrQualityMediumHigh,
+		AacVbrQualityMediumLow,
+	}
+}
 
 // Ac3 Bitstream Mode
 const (
@@ -24078,6 +24140,20 @@ const (
 	Ac3BitstreamModeVoiceOver = "VOICE_OVER"
 )
 
+// Ac3BitstreamMode_Values returns all elements of the Ac3BitstreamMode enum
+func Ac3BitstreamMode_Values() []string {
+	return []string{
+		Ac3BitstreamModeCommentary,
+		Ac3BitstreamModeCompleteMain,
+		Ac3BitstreamModeDialogue,
+		Ac3BitstreamModeEmergency,
+		Ac3BitstreamModeHearingImpaired,
+		Ac3BitstreamModeMusicAndEffects,
+		Ac3BitstreamModeVisuallyImpaired,
+		Ac3BitstreamModeVoiceOver,
+	}
+}
+
 // Ac3 Coding Mode
 const (
 	// Ac3CodingModeCodingMode10 is a Ac3CodingMode enum value
@@ -24093,6 +24169,16 @@ const (
 	Ac3CodingModeCodingMode32Lfe = "CODING_MODE_3_2_LFE"
 )
 
+// Ac3CodingMode_Values returns all elements of the Ac3CodingMode enum
+func Ac3CodingMode_Values() []string {
+	return []string{
+		Ac3CodingModeCodingMode10,
+		Ac3CodingModeCodingMode11,
+		Ac3CodingModeCodingMode20,
+		Ac3CodingModeCodingMode32Lfe,
+	}
+}
+
 // Ac3 Drc Profile
 const (
 	// Ac3DrcProfileFilmStandard is a Ac3DrcProfile enum value
@@ -24101,6 +24187,14 @@ const (
 	// Ac3DrcProfileNone is a Ac3DrcProfile enum value
 	Ac3DrcProfileNone = "NONE"
 )
+
+// Ac3DrcProfile_Values returns all elements of the Ac3DrcProfile enum
+func Ac3DrcProfile_Values() []string {
+	return []string{
+		Ac3DrcProfileFilmStandard,
+		Ac3DrcProfileNone,
+	}
+}
 
 // Ac3 Lfe Filter
 const (
@@ -24111,6 +24205,14 @@ const (
 	Ac3LfeFilterEnabled = "ENABLED"
 )
 
+// Ac3LfeFilter_Values returns all elements of the Ac3LfeFilter enum
+func Ac3LfeFilter_Values() []string {
+	return []string{
+		Ac3LfeFilterDisabled,
+		Ac3LfeFilterEnabled,
+	}
+}
+
 // Ac3 Metadata Control
 const (
 	// Ac3MetadataControlFollowInput is a Ac3MetadataControl enum value
@@ -24120,11 +24222,26 @@ const (
 	Ac3MetadataControlUseConfigured = "USE_CONFIGURED"
 )
 
+// Ac3MetadataControl_Values returns all elements of the Ac3MetadataControl enum
+func Ac3MetadataControl_Values() []string {
+	return []string{
+		Ac3MetadataControlFollowInput,
+		Ac3MetadataControlUseConfigured,
+	}
+}
+
 // Accept Header
 const (
 	// AcceptHeaderImageJpeg is a AcceptHeader enum value
 	AcceptHeaderImageJpeg = "image/jpeg"
 )
+
+// AcceptHeader_Values returns all elements of the AcceptHeader enum
+func AcceptHeader_Values() []string {
+	return []string{
+		AcceptHeaderImageJpeg,
+	}
+}
 
 // Afd Signaling
 const (
@@ -24138,6 +24255,15 @@ const (
 	AfdSignalingNone = "NONE"
 )
 
+// AfdSignaling_Values returns all elements of the AfdSignaling enum
+func AfdSignaling_Values() []string {
+	return []string{
+		AfdSignalingAuto,
+		AfdSignalingFixed,
+		AfdSignalingNone,
+	}
+}
+
 // Audio Description Audio Type Control
 const (
 	// AudioDescriptionAudioTypeControlFollowInput is a AudioDescriptionAudioTypeControl enum value
@@ -24146,6 +24272,14 @@ const (
 	// AudioDescriptionAudioTypeControlUseConfigured is a AudioDescriptionAudioTypeControl enum value
 	AudioDescriptionAudioTypeControlUseConfigured = "USE_CONFIGURED"
 )
+
+// AudioDescriptionAudioTypeControl_Values returns all elements of the AudioDescriptionAudioTypeControl enum
+func AudioDescriptionAudioTypeControl_Values() []string {
+	return []string{
+		AudioDescriptionAudioTypeControlFollowInput,
+		AudioDescriptionAudioTypeControlUseConfigured,
+	}
+}
 
 // Audio Description Language Code Control
 const (
@@ -24156,6 +24290,14 @@ const (
 	AudioDescriptionLanguageCodeControlUseConfigured = "USE_CONFIGURED"
 )
 
+// AudioDescriptionLanguageCodeControl_Values returns all elements of the AudioDescriptionLanguageCodeControl enum
+func AudioDescriptionLanguageCodeControl_Values() []string {
+	return []string{
+		AudioDescriptionLanguageCodeControlFollowInput,
+		AudioDescriptionLanguageCodeControlUseConfigured,
+	}
+}
+
 // Audio Language Selection Policy
 const (
 	// AudioLanguageSelectionPolicyLoose is a AudioLanguageSelectionPolicy enum value
@@ -24164,6 +24306,14 @@ const (
 	// AudioLanguageSelectionPolicyStrict is a AudioLanguageSelectionPolicy enum value
 	AudioLanguageSelectionPolicyStrict = "STRICT"
 )
+
+// AudioLanguageSelectionPolicy_Values returns all elements of the AudioLanguageSelectionPolicy enum
+func AudioLanguageSelectionPolicy_Values() []string {
+	return []string{
+		AudioLanguageSelectionPolicyLoose,
+		AudioLanguageSelectionPolicyStrict,
+	}
+}
 
 // Audio Normalization Algorithm
 const (
@@ -24174,11 +24324,26 @@ const (
 	AudioNormalizationAlgorithmItu17702 = "ITU_1770_2"
 )
 
+// AudioNormalizationAlgorithm_Values returns all elements of the AudioNormalizationAlgorithm enum
+func AudioNormalizationAlgorithm_Values() []string {
+	return []string{
+		AudioNormalizationAlgorithmItu17701,
+		AudioNormalizationAlgorithmItu17702,
+	}
+}
+
 // Audio Normalization Algorithm Control
 const (
 	// AudioNormalizationAlgorithmControlCorrectAudio is a AudioNormalizationAlgorithmControl enum value
 	AudioNormalizationAlgorithmControlCorrectAudio = "CORRECT_AUDIO"
 )
+
+// AudioNormalizationAlgorithmControl_Values returns all elements of the AudioNormalizationAlgorithmControl enum
+func AudioNormalizationAlgorithmControl_Values() []string {
+	return []string{
+		AudioNormalizationAlgorithmControlCorrectAudio,
+	}
+}
 
 // Audio Only Hls Segment Type
 const (
@@ -24188,6 +24353,14 @@ const (
 	// AudioOnlyHlsSegmentTypeFmp4 is a AudioOnlyHlsSegmentType enum value
 	AudioOnlyHlsSegmentTypeFmp4 = "FMP4"
 )
+
+// AudioOnlyHlsSegmentType_Values returns all elements of the AudioOnlyHlsSegmentType enum
+func AudioOnlyHlsSegmentType_Values() []string {
+	return []string{
+		AudioOnlyHlsSegmentTypeAac,
+		AudioOnlyHlsSegmentTypeFmp4,
+	}
+}
 
 // Audio Only Hls Track Type
 const (
@@ -24204,6 +24377,16 @@ const (
 	AudioOnlyHlsTrackTypeAudioOnlyVariantStream = "AUDIO_ONLY_VARIANT_STREAM"
 )
 
+// AudioOnlyHlsTrackType_Values returns all elements of the AudioOnlyHlsTrackType enum
+func AudioOnlyHlsTrackType_Values() []string {
+	return []string{
+		AudioOnlyHlsTrackTypeAlternateAudioAutoSelect,
+		AudioOnlyHlsTrackTypeAlternateAudioAutoSelectDefault,
+		AudioOnlyHlsTrackTypeAlternateAudioNotAutoSelect,
+		AudioOnlyHlsTrackTypeAudioOnlyVariantStream,
+	}
+}
+
 // Audio Type
 const (
 	// AudioTypeCleanEffects is a AudioType enum value
@@ -24219,6 +24402,16 @@ const (
 	AudioTypeVisualImpairedCommentary = "VISUAL_IMPAIRED_COMMENTARY"
 )
 
+// AudioType_Values returns all elements of the AudioType enum
+func AudioType_Values() []string {
+	return []string{
+		AudioTypeCleanEffects,
+		AudioTypeHearingImpaired,
+		AudioTypeUndefined,
+		AudioTypeVisualImpairedCommentary,
+	}
+}
+
 // Authentication Scheme
 const (
 	// AuthenticationSchemeAkamai is a AuthenticationScheme enum value
@@ -24227,6 +24420,14 @@ const (
 	// AuthenticationSchemeCommon is a AuthenticationScheme enum value
 	AuthenticationSchemeCommon = "COMMON"
 )
+
+// AuthenticationScheme_Values returns all elements of the AuthenticationScheme enum
+func AuthenticationScheme_Values() []string {
+	return []string{
+		AuthenticationSchemeAkamai,
+		AuthenticationSchemeCommon,
+	}
+}
 
 // Avail Blanking State
 const (
@@ -24237,6 +24438,14 @@ const (
 	AvailBlankingStateEnabled = "ENABLED"
 )
 
+// AvailBlankingState_Values returns all elements of the AvailBlankingState enum
+func AvailBlankingState_Values() []string {
+	return []string{
+		AvailBlankingStateDisabled,
+		AvailBlankingStateEnabled,
+	}
+}
+
 // Blackout Slate Network End Blackout
 const (
 	// BlackoutSlateNetworkEndBlackoutDisabled is a BlackoutSlateNetworkEndBlackout enum value
@@ -24246,6 +24455,14 @@ const (
 	BlackoutSlateNetworkEndBlackoutEnabled = "ENABLED"
 )
 
+// BlackoutSlateNetworkEndBlackout_Values returns all elements of the BlackoutSlateNetworkEndBlackout enum
+func BlackoutSlateNetworkEndBlackout_Values() []string {
+	return []string{
+		BlackoutSlateNetworkEndBlackoutDisabled,
+		BlackoutSlateNetworkEndBlackoutEnabled,
+	}
+}
+
 // Blackout Slate State
 const (
 	// BlackoutSlateStateDisabled is a BlackoutSlateState enum value
@@ -24254,6 +24471,14 @@ const (
 	// BlackoutSlateStateEnabled is a BlackoutSlateState enum value
 	BlackoutSlateStateEnabled = "ENABLED"
 )
+
+// BlackoutSlateState_Values returns all elements of the BlackoutSlateState enum
+func BlackoutSlateState_Values() []string {
+	return []string{
+		BlackoutSlateStateDisabled,
+		BlackoutSlateStateEnabled,
+	}
+}
 
 // Burn In Alignment
 const (
@@ -24267,6 +24492,15 @@ const (
 	BurnInAlignmentSmart = "SMART"
 )
 
+// BurnInAlignment_Values returns all elements of the BurnInAlignment enum
+func BurnInAlignment_Values() []string {
+	return []string{
+		BurnInAlignmentCentered,
+		BurnInAlignmentLeft,
+		BurnInAlignmentSmart,
+	}
+}
+
 // Burn In Background Color
 const (
 	// BurnInBackgroundColorBlack is a BurnInBackgroundColor enum value
@@ -24278,6 +24512,15 @@ const (
 	// BurnInBackgroundColorWhite is a BurnInBackgroundColor enum value
 	BurnInBackgroundColorWhite = "WHITE"
 )
+
+// BurnInBackgroundColor_Values returns all elements of the BurnInBackgroundColor enum
+func BurnInBackgroundColor_Values() []string {
+	return []string{
+		BurnInBackgroundColorBlack,
+		BurnInBackgroundColorNone,
+		BurnInBackgroundColorWhite,
+	}
+}
 
 // Burn In Font Color
 const (
@@ -24300,6 +24543,18 @@ const (
 	BurnInFontColorYellow = "YELLOW"
 )
 
+// BurnInFontColor_Values returns all elements of the BurnInFontColor enum
+func BurnInFontColor_Values() []string {
+	return []string{
+		BurnInFontColorBlack,
+		BurnInFontColorBlue,
+		BurnInFontColorGreen,
+		BurnInFontColorRed,
+		BurnInFontColorWhite,
+		BurnInFontColorYellow,
+	}
+}
+
 // Burn In Outline Color
 const (
 	// BurnInOutlineColorBlack is a BurnInOutlineColor enum value
@@ -24321,6 +24576,18 @@ const (
 	BurnInOutlineColorYellow = "YELLOW"
 )
 
+// BurnInOutlineColor_Values returns all elements of the BurnInOutlineColor enum
+func BurnInOutlineColor_Values() []string {
+	return []string{
+		BurnInOutlineColorBlack,
+		BurnInOutlineColorBlue,
+		BurnInOutlineColorGreen,
+		BurnInOutlineColorRed,
+		BurnInOutlineColorWhite,
+		BurnInOutlineColorYellow,
+	}
+}
+
 // Burn In Shadow Color
 const (
 	// BurnInShadowColorBlack is a BurnInShadowColor enum value
@@ -24333,6 +24600,15 @@ const (
 	BurnInShadowColorWhite = "WHITE"
 )
 
+// BurnInShadowColor_Values returns all elements of the BurnInShadowColor enum
+func BurnInShadowColor_Values() []string {
+	return []string{
+		BurnInShadowColorBlack,
+		BurnInShadowColorNone,
+		BurnInShadowColorWhite,
+	}
+}
+
 // Burn In Teletext Grid Control
 const (
 	// BurnInTeletextGridControlFixed is a BurnInTeletextGridControl enum value
@@ -24341,6 +24617,14 @@ const (
 	// BurnInTeletextGridControlScaled is a BurnInTeletextGridControl enum value
 	BurnInTeletextGridControlScaled = "SCALED"
 )
+
+// BurnInTeletextGridControl_Values returns all elements of the BurnInTeletextGridControl enum
+func BurnInTeletextGridControl_Values() []string {
+	return []string{
+		BurnInTeletextGridControlFixed,
+		BurnInTeletextGridControlScaled,
+	}
+}
 
 // A standard channel has two encoding pipelines and a single pipeline channel
 // only has one.
@@ -24351,6 +24635,14 @@ const (
 	// ChannelClassSinglePipeline is a ChannelClass enum value
 	ChannelClassSinglePipeline = "SINGLE_PIPELINE"
 )
+
+// ChannelClass_Values returns all elements of the ChannelClass enum
+func ChannelClass_Values() []string {
+	return []string{
+		ChannelClassStandard,
+		ChannelClassSinglePipeline,
+	}
+}
 
 const (
 	// ChannelStateCreating is a ChannelState enum value
@@ -24387,10 +24679,34 @@ const (
 	ChannelStateUpdateFailed = "UPDATE_FAILED"
 )
 
+// ChannelState_Values returns all elements of the ChannelState enum
+func ChannelState_Values() []string {
+	return []string{
+		ChannelStateCreating,
+		ChannelStateCreateFailed,
+		ChannelStateIdle,
+		ChannelStateStarting,
+		ChannelStateRunning,
+		ChannelStateRecovering,
+		ChannelStateStopping,
+		ChannelStateDeleting,
+		ChannelStateDeleted,
+		ChannelStateUpdating,
+		ChannelStateUpdateFailed,
+	}
+}
+
 const (
 	// ContentTypeImageJpeg is a ContentType enum value
 	ContentTypeImageJpeg = "image/jpeg"
 )
+
+// ContentType_Values returns all elements of the ContentType enum
+func ContentType_Values() []string {
+	return []string{
+		ContentTypeImageJpeg,
+	}
+}
 
 // The status of the action to synchronize the device configuration. If you
 // change the configuration of the input device (for example, the maximum bitrate),
@@ -24404,6 +24720,14 @@ const (
 	// DeviceSettingsSyncStateSyncing is a DeviceSettingsSyncState enum value
 	DeviceSettingsSyncStateSyncing = "SYNCING"
 )
+
+// DeviceSettingsSyncState_Values returns all elements of the DeviceSettingsSyncState enum
+func DeviceSettingsSyncState_Values() []string {
+	return []string{
+		DeviceSettingsSyncStateSynced,
+		DeviceSettingsSyncStateSyncing,
+	}
+}
 
 // Dvb Sdt Output Sdt
 const (
@@ -24420,6 +24744,16 @@ const (
 	DvbSdtOutputSdtSdtNone = "SDT_NONE"
 )
 
+// DvbSdtOutputSdt_Values returns all elements of the DvbSdtOutputSdt enum
+func DvbSdtOutputSdt_Values() []string {
+	return []string{
+		DvbSdtOutputSdtSdtFollow,
+		DvbSdtOutputSdtSdtFollowIfPresent,
+		DvbSdtOutputSdtSdtManual,
+		DvbSdtOutputSdtSdtNone,
+	}
+}
+
 // Dvb Sub Destination Alignment
 const (
 	// DvbSubDestinationAlignmentCentered is a DvbSubDestinationAlignment enum value
@@ -24432,6 +24766,15 @@ const (
 	DvbSubDestinationAlignmentSmart = "SMART"
 )
 
+// DvbSubDestinationAlignment_Values returns all elements of the DvbSubDestinationAlignment enum
+func DvbSubDestinationAlignment_Values() []string {
+	return []string{
+		DvbSubDestinationAlignmentCentered,
+		DvbSubDestinationAlignmentLeft,
+		DvbSubDestinationAlignmentSmart,
+	}
+}
+
 // Dvb Sub Destination Background Color
 const (
 	// DvbSubDestinationBackgroundColorBlack is a DvbSubDestinationBackgroundColor enum value
@@ -24443,6 +24786,15 @@ const (
 	// DvbSubDestinationBackgroundColorWhite is a DvbSubDestinationBackgroundColor enum value
 	DvbSubDestinationBackgroundColorWhite = "WHITE"
 )
+
+// DvbSubDestinationBackgroundColor_Values returns all elements of the DvbSubDestinationBackgroundColor enum
+func DvbSubDestinationBackgroundColor_Values() []string {
+	return []string{
+		DvbSubDestinationBackgroundColorBlack,
+		DvbSubDestinationBackgroundColorNone,
+		DvbSubDestinationBackgroundColorWhite,
+	}
+}
 
 // Dvb Sub Destination Font Color
 const (
@@ -24465,6 +24817,18 @@ const (
 	DvbSubDestinationFontColorYellow = "YELLOW"
 )
 
+// DvbSubDestinationFontColor_Values returns all elements of the DvbSubDestinationFontColor enum
+func DvbSubDestinationFontColor_Values() []string {
+	return []string{
+		DvbSubDestinationFontColorBlack,
+		DvbSubDestinationFontColorBlue,
+		DvbSubDestinationFontColorGreen,
+		DvbSubDestinationFontColorRed,
+		DvbSubDestinationFontColorWhite,
+		DvbSubDestinationFontColorYellow,
+	}
+}
+
 // Dvb Sub Destination Outline Color
 const (
 	// DvbSubDestinationOutlineColorBlack is a DvbSubDestinationOutlineColor enum value
@@ -24486,6 +24850,18 @@ const (
 	DvbSubDestinationOutlineColorYellow = "YELLOW"
 )
 
+// DvbSubDestinationOutlineColor_Values returns all elements of the DvbSubDestinationOutlineColor enum
+func DvbSubDestinationOutlineColor_Values() []string {
+	return []string{
+		DvbSubDestinationOutlineColorBlack,
+		DvbSubDestinationOutlineColorBlue,
+		DvbSubDestinationOutlineColorGreen,
+		DvbSubDestinationOutlineColorRed,
+		DvbSubDestinationOutlineColorWhite,
+		DvbSubDestinationOutlineColorYellow,
+	}
+}
+
 // Dvb Sub Destination Shadow Color
 const (
 	// DvbSubDestinationShadowColorBlack is a DvbSubDestinationShadowColor enum value
@@ -24498,6 +24874,15 @@ const (
 	DvbSubDestinationShadowColorWhite = "WHITE"
 )
 
+// DvbSubDestinationShadowColor_Values returns all elements of the DvbSubDestinationShadowColor enum
+func DvbSubDestinationShadowColor_Values() []string {
+	return []string{
+		DvbSubDestinationShadowColorBlack,
+		DvbSubDestinationShadowColorNone,
+		DvbSubDestinationShadowColorWhite,
+	}
+}
+
 // Dvb Sub Destination Teletext Grid Control
 const (
 	// DvbSubDestinationTeletextGridControlFixed is a DvbSubDestinationTeletextGridControl enum value
@@ -24507,6 +24892,14 @@ const (
 	DvbSubDestinationTeletextGridControlScaled = "SCALED"
 )
 
+// DvbSubDestinationTeletextGridControl_Values returns all elements of the DvbSubDestinationTeletextGridControl enum
+func DvbSubDestinationTeletextGridControl_Values() []string {
+	return []string{
+		DvbSubDestinationTeletextGridControlFixed,
+		DvbSubDestinationTeletextGridControlScaled,
+	}
+}
+
 // Eac3 Attenuation Control
 const (
 	// Eac3AttenuationControlAttenuate3Db is a Eac3AttenuationControl enum value
@@ -24515,6 +24908,14 @@ const (
 	// Eac3AttenuationControlNone is a Eac3AttenuationControl enum value
 	Eac3AttenuationControlNone = "NONE"
 )
+
+// Eac3AttenuationControl_Values returns all elements of the Eac3AttenuationControl enum
+func Eac3AttenuationControl_Values() []string {
+	return []string{
+		Eac3AttenuationControlAttenuate3Db,
+		Eac3AttenuationControlNone,
+	}
+}
 
 // Eac3 Bitstream Mode
 const (
@@ -24534,6 +24935,17 @@ const (
 	Eac3BitstreamModeVisuallyImpaired = "VISUALLY_IMPAIRED"
 )
 
+// Eac3BitstreamMode_Values returns all elements of the Eac3BitstreamMode enum
+func Eac3BitstreamMode_Values() []string {
+	return []string{
+		Eac3BitstreamModeCommentary,
+		Eac3BitstreamModeCompleteMain,
+		Eac3BitstreamModeEmergency,
+		Eac3BitstreamModeHearingImpaired,
+		Eac3BitstreamModeVisuallyImpaired,
+	}
+}
+
 // Eac3 Coding Mode
 const (
 	// Eac3CodingModeCodingMode10 is a Eac3CodingMode enum value
@@ -24546,6 +24958,15 @@ const (
 	Eac3CodingModeCodingMode32 = "CODING_MODE_3_2"
 )
 
+// Eac3CodingMode_Values returns all elements of the Eac3CodingMode enum
+func Eac3CodingMode_Values() []string {
+	return []string{
+		Eac3CodingModeCodingMode10,
+		Eac3CodingModeCodingMode20,
+		Eac3CodingModeCodingMode32,
+	}
+}
+
 // Eac3 Dc Filter
 const (
 	// Eac3DcFilterDisabled is a Eac3DcFilter enum value
@@ -24554,6 +24975,14 @@ const (
 	// Eac3DcFilterEnabled is a Eac3DcFilter enum value
 	Eac3DcFilterEnabled = "ENABLED"
 )
+
+// Eac3DcFilter_Values returns all elements of the Eac3DcFilter enum
+func Eac3DcFilter_Values() []string {
+	return []string{
+		Eac3DcFilterDisabled,
+		Eac3DcFilterEnabled,
+	}
+}
 
 // Eac3 Drc Line
 const (
@@ -24576,6 +25005,18 @@ const (
 	Eac3DrcLineSpeech = "SPEECH"
 )
 
+// Eac3DrcLine_Values returns all elements of the Eac3DrcLine enum
+func Eac3DrcLine_Values() []string {
+	return []string{
+		Eac3DrcLineFilmLight,
+		Eac3DrcLineFilmStandard,
+		Eac3DrcLineMusicLight,
+		Eac3DrcLineMusicStandard,
+		Eac3DrcLineNone,
+		Eac3DrcLineSpeech,
+	}
+}
+
 // Eac3 Drc Rf
 const (
 	// Eac3DrcRfFilmLight is a Eac3DrcRf enum value
@@ -24597,6 +25038,18 @@ const (
 	Eac3DrcRfSpeech = "SPEECH"
 )
 
+// Eac3DrcRf_Values returns all elements of the Eac3DrcRf enum
+func Eac3DrcRf_Values() []string {
+	return []string{
+		Eac3DrcRfFilmLight,
+		Eac3DrcRfFilmStandard,
+		Eac3DrcRfMusicLight,
+		Eac3DrcRfMusicStandard,
+		Eac3DrcRfNone,
+		Eac3DrcRfSpeech,
+	}
+}
+
 // Eac3 Lfe Control
 const (
 	// Eac3LfeControlLfe is a Eac3LfeControl enum value
@@ -24605,6 +25058,14 @@ const (
 	// Eac3LfeControlNoLfe is a Eac3LfeControl enum value
 	Eac3LfeControlNoLfe = "NO_LFE"
 )
+
+// Eac3LfeControl_Values returns all elements of the Eac3LfeControl enum
+func Eac3LfeControl_Values() []string {
+	return []string{
+		Eac3LfeControlLfe,
+		Eac3LfeControlNoLfe,
+	}
+}
 
 // Eac3 Lfe Filter
 const (
@@ -24615,6 +25076,14 @@ const (
 	Eac3LfeFilterEnabled = "ENABLED"
 )
 
+// Eac3LfeFilter_Values returns all elements of the Eac3LfeFilter enum
+func Eac3LfeFilter_Values() []string {
+	return []string{
+		Eac3LfeFilterDisabled,
+		Eac3LfeFilterEnabled,
+	}
+}
+
 // Eac3 Metadata Control
 const (
 	// Eac3MetadataControlFollowInput is a Eac3MetadataControl enum value
@@ -24623,6 +25092,14 @@ const (
 	// Eac3MetadataControlUseConfigured is a Eac3MetadataControl enum value
 	Eac3MetadataControlUseConfigured = "USE_CONFIGURED"
 )
+
+// Eac3MetadataControl_Values returns all elements of the Eac3MetadataControl enum
+func Eac3MetadataControl_Values() []string {
+	return []string{
+		Eac3MetadataControlFollowInput,
+		Eac3MetadataControlUseConfigured,
+	}
+}
 
 // Eac3 Passthrough Control
 const (
@@ -24633,6 +25110,14 @@ const (
 	Eac3PassthroughControlWhenPossible = "WHEN_POSSIBLE"
 )
 
+// Eac3PassthroughControl_Values returns all elements of the Eac3PassthroughControl enum
+func Eac3PassthroughControl_Values() []string {
+	return []string{
+		Eac3PassthroughControlNoPassthrough,
+		Eac3PassthroughControlWhenPossible,
+	}
+}
+
 // Eac3 Phase Control
 const (
 	// Eac3PhaseControlNoShift is a Eac3PhaseControl enum value
@@ -24641,6 +25126,14 @@ const (
 	// Eac3PhaseControlShift90Degrees is a Eac3PhaseControl enum value
 	Eac3PhaseControlShift90Degrees = "SHIFT_90_DEGREES"
 )
+
+// Eac3PhaseControl_Values returns all elements of the Eac3PhaseControl enum
+func Eac3PhaseControl_Values() []string {
+	return []string{
+		Eac3PhaseControlNoShift,
+		Eac3PhaseControlShift90Degrees,
+	}
+}
 
 // Eac3 Stereo Downmix
 const (
@@ -24657,6 +25150,16 @@ const (
 	Eac3StereoDownmixNotIndicated = "NOT_INDICATED"
 )
 
+// Eac3StereoDownmix_Values returns all elements of the Eac3StereoDownmix enum
+func Eac3StereoDownmix_Values() []string {
+	return []string{
+		Eac3StereoDownmixDpl2,
+		Eac3StereoDownmixLoRo,
+		Eac3StereoDownmixLtRt,
+		Eac3StereoDownmixNotIndicated,
+	}
+}
+
 // Eac3 Surround Ex Mode
 const (
 	// Eac3SurroundExModeDisabled is a Eac3SurroundExMode enum value
@@ -24668,6 +25171,15 @@ const (
 	// Eac3SurroundExModeNotIndicated is a Eac3SurroundExMode enum value
 	Eac3SurroundExModeNotIndicated = "NOT_INDICATED"
 )
+
+// Eac3SurroundExMode_Values returns all elements of the Eac3SurroundExMode enum
+func Eac3SurroundExMode_Values() []string {
+	return []string{
+		Eac3SurroundExModeDisabled,
+		Eac3SurroundExModeEnabled,
+		Eac3SurroundExModeNotIndicated,
+	}
+}
 
 // Eac3 Surround Mode
 const (
@@ -24681,6 +25193,15 @@ const (
 	Eac3SurroundModeNotIndicated = "NOT_INDICATED"
 )
 
+// Eac3SurroundMode_Values returns all elements of the Eac3SurroundMode enum
+func Eac3SurroundMode_Values() []string {
+	return []string{
+		Eac3SurroundModeDisabled,
+		Eac3SurroundModeEnabled,
+		Eac3SurroundModeNotIndicated,
+	}
+}
+
 // Ebu Tt DDestination Style Control
 const (
 	// EbuTtDDestinationStyleControlExclude is a EbuTtDDestinationStyleControl enum value
@@ -24689,6 +25210,14 @@ const (
 	// EbuTtDDestinationStyleControlInclude is a EbuTtDDestinationStyleControl enum value
 	EbuTtDDestinationStyleControlInclude = "INCLUDE"
 )
+
+// EbuTtDDestinationStyleControl_Values returns all elements of the EbuTtDDestinationStyleControl enum
+func EbuTtDDestinationStyleControl_Values() []string {
+	return []string{
+		EbuTtDDestinationStyleControlExclude,
+		EbuTtDDestinationStyleControlInclude,
+	}
+}
 
 // Ebu Tt DFill Line Gap Control
 const (
@@ -24699,6 +25228,14 @@ const (
 	EbuTtDFillLineGapControlEnabled = "ENABLED"
 )
 
+// EbuTtDFillLineGapControl_Values returns all elements of the EbuTtDFillLineGapControl enum
+func EbuTtDFillLineGapControl_Values() []string {
+	return []string{
+		EbuTtDFillLineGapControlDisabled,
+		EbuTtDFillLineGapControlEnabled,
+	}
+}
+
 // Embedded Convert608 To708
 const (
 	// EmbeddedConvert608To708Disabled is a EmbeddedConvert608To708 enum value
@@ -24707,6 +25244,14 @@ const (
 	// EmbeddedConvert608To708Upconvert is a EmbeddedConvert608To708 enum value
 	EmbeddedConvert608To708Upconvert = "UPCONVERT"
 )
+
+// EmbeddedConvert608To708_Values returns all elements of the EmbeddedConvert608To708 enum
+func EmbeddedConvert608To708_Values() []string {
+	return []string{
+		EmbeddedConvert608To708Disabled,
+		EmbeddedConvert608To708Upconvert,
+	}
+}
 
 // Embedded Scte20 Detection
 const (
@@ -24717,6 +25262,14 @@ const (
 	EmbeddedScte20DetectionOff = "OFF"
 )
 
+// EmbeddedScte20Detection_Values returns all elements of the EmbeddedScte20Detection enum
+func EmbeddedScte20Detection_Values() []string {
+	return []string{
+		EmbeddedScte20DetectionAuto,
+		EmbeddedScte20DetectionOff,
+	}
+}
+
 // Feature Activations Input Prepare Schedule Actions
 const (
 	// FeatureActivationsInputPrepareScheduleActionsDisabled is a FeatureActivationsInputPrepareScheduleActions enum value
@@ -24726,6 +25279,14 @@ const (
 	FeatureActivationsInputPrepareScheduleActionsEnabled = "ENABLED"
 )
 
+// FeatureActivationsInputPrepareScheduleActions_Values returns all elements of the FeatureActivationsInputPrepareScheduleActions enum
+func FeatureActivationsInputPrepareScheduleActions_Values() []string {
+	return []string{
+		FeatureActivationsInputPrepareScheduleActionsDisabled,
+		FeatureActivationsInputPrepareScheduleActionsEnabled,
+	}
+}
+
 // Fec Output Include Fec
 const (
 	// FecOutputIncludeFecColumn is a FecOutputIncludeFec enum value
@@ -24734,6 +25295,14 @@ const (
 	// FecOutputIncludeFecColumnAndRow is a FecOutputIncludeFec enum value
 	FecOutputIncludeFecColumnAndRow = "COLUMN_AND_ROW"
 )
+
+// FecOutputIncludeFec_Values returns all elements of the FecOutputIncludeFec enum
+func FecOutputIncludeFec_Values() []string {
+	return []string{
+		FecOutputIncludeFecColumn,
+		FecOutputIncludeFecColumnAndRow,
+	}
+}
 
 // Fixed Afd
 const (
@@ -24771,6 +25340,23 @@ const (
 	FixedAfdAfd1111 = "AFD_1111"
 )
 
+// FixedAfd_Values returns all elements of the FixedAfd enum
+func FixedAfd_Values() []string {
+	return []string{
+		FixedAfdAfd0000,
+		FixedAfdAfd0010,
+		FixedAfdAfd0011,
+		FixedAfdAfd0100,
+		FixedAfdAfd1000,
+		FixedAfdAfd1001,
+		FixedAfdAfd1010,
+		FixedAfdAfd1011,
+		FixedAfdAfd1101,
+		FixedAfdAfd1110,
+		FixedAfdAfd1111,
+	}
+}
+
 // Fmp4 Nielsen Id3 Behavior
 const (
 	// Fmp4NielsenId3BehaviorNoPassthrough is a Fmp4NielsenId3Behavior enum value
@@ -24779,6 +25365,14 @@ const (
 	// Fmp4NielsenId3BehaviorPassthrough is a Fmp4NielsenId3Behavior enum value
 	Fmp4NielsenId3BehaviorPassthrough = "PASSTHROUGH"
 )
+
+// Fmp4NielsenId3Behavior_Values returns all elements of the Fmp4NielsenId3Behavior enum
+func Fmp4NielsenId3Behavior_Values() []string {
+	return []string{
+		Fmp4NielsenId3BehaviorNoPassthrough,
+		Fmp4NielsenId3BehaviorPassthrough,
+	}
+}
 
 // Fmp4 Timed Metadata Behavior
 const (
@@ -24789,6 +25383,14 @@ const (
 	Fmp4TimedMetadataBehaviorPassthrough = "PASSTHROUGH"
 )
 
+// Fmp4TimedMetadataBehavior_Values returns all elements of the Fmp4TimedMetadataBehavior enum
+func Fmp4TimedMetadataBehavior_Values() []string {
+	return []string{
+		Fmp4TimedMetadataBehaviorNoPassthrough,
+		Fmp4TimedMetadataBehaviorPassthrough,
+	}
+}
+
 // Follow reference point.
 const (
 	// FollowPointEnd is a FollowPoint enum value
@@ -24797,6 +25399,14 @@ const (
 	// FollowPointStart is a FollowPoint enum value
 	FollowPointStart = "START"
 )
+
+// FollowPoint_Values returns all elements of the FollowPoint enum
+func FollowPoint_Values() []string {
+	return []string{
+		FollowPointEnd,
+		FollowPointStart,
+	}
+}
 
 // Frame Capture Interval Unit
 const (
@@ -24807,6 +25417,14 @@ const (
 	FrameCaptureIntervalUnitSeconds = "SECONDS"
 )
 
+// FrameCaptureIntervalUnit_Values returns all elements of the FrameCaptureIntervalUnit enum
+func FrameCaptureIntervalUnit_Values() []string {
+	return []string{
+		FrameCaptureIntervalUnitMilliseconds,
+		FrameCaptureIntervalUnitSeconds,
+	}
+}
+
 // Global Configuration Input End Action
 const (
 	// GlobalConfigurationInputEndActionNone is a GlobalConfigurationInputEndAction enum value
@@ -24815,6 +25433,14 @@ const (
 	// GlobalConfigurationInputEndActionSwitchAndLoopInputs is a GlobalConfigurationInputEndAction enum value
 	GlobalConfigurationInputEndActionSwitchAndLoopInputs = "SWITCH_AND_LOOP_INPUTS"
 )
+
+// GlobalConfigurationInputEndAction_Values returns all elements of the GlobalConfigurationInputEndAction enum
+func GlobalConfigurationInputEndAction_Values() []string {
+	return []string{
+		GlobalConfigurationInputEndActionNone,
+		GlobalConfigurationInputEndActionSwitchAndLoopInputs,
+	}
+}
 
 // Global Configuration Low Framerate Inputs
 const (
@@ -24825,6 +25451,14 @@ const (
 	GlobalConfigurationLowFramerateInputsEnabled = "ENABLED"
 )
 
+// GlobalConfigurationLowFramerateInputs_Values returns all elements of the GlobalConfigurationLowFramerateInputs enum
+func GlobalConfigurationLowFramerateInputs_Values() []string {
+	return []string{
+		GlobalConfigurationLowFramerateInputsDisabled,
+		GlobalConfigurationLowFramerateInputsEnabled,
+	}
+}
+
 // Global Configuration Output Locking Mode
 const (
 	// GlobalConfigurationOutputLockingModeEpochLocking is a GlobalConfigurationOutputLockingMode enum value
@@ -24834,6 +25468,14 @@ const (
 	GlobalConfigurationOutputLockingModePipelineLocking = "PIPELINE_LOCKING"
 )
 
+// GlobalConfigurationOutputLockingMode_Values returns all elements of the GlobalConfigurationOutputLockingMode enum
+func GlobalConfigurationOutputLockingMode_Values() []string {
+	return []string{
+		GlobalConfigurationOutputLockingModeEpochLocking,
+		GlobalConfigurationOutputLockingModePipelineLocking,
+	}
+}
+
 // Global Configuration Output Timing Source
 const (
 	// GlobalConfigurationOutputTimingSourceInputClock is a GlobalConfigurationOutputTimingSource enum value
@@ -24842,6 +25484,14 @@ const (
 	// GlobalConfigurationOutputTimingSourceSystemClock is a GlobalConfigurationOutputTimingSource enum value
 	GlobalConfigurationOutputTimingSourceSystemClock = "SYSTEM_CLOCK"
 )
+
+// GlobalConfigurationOutputTimingSource_Values returns all elements of the GlobalConfigurationOutputTimingSource enum
+func GlobalConfigurationOutputTimingSource_Values() []string {
+	return []string{
+		GlobalConfigurationOutputTimingSourceInputClock,
+		GlobalConfigurationOutputTimingSourceSystemClock,
+	}
+}
 
 // H264 Adaptive Quantization
 const (
@@ -24864,6 +25514,18 @@ const (
 	H264AdaptiveQuantizationOff = "OFF"
 )
 
+// H264AdaptiveQuantization_Values returns all elements of the H264AdaptiveQuantization enum
+func H264AdaptiveQuantization_Values() []string {
+	return []string{
+		H264AdaptiveQuantizationHigh,
+		H264AdaptiveQuantizationHigher,
+		H264AdaptiveQuantizationLow,
+		H264AdaptiveQuantizationMax,
+		H264AdaptiveQuantizationMedium,
+		H264AdaptiveQuantizationOff,
+	}
+}
+
 // H264 Color Metadata
 const (
 	// H264ColorMetadataIgnore is a H264ColorMetadata enum value
@@ -24872,6 +25534,14 @@ const (
 	// H264ColorMetadataInsert is a H264ColorMetadata enum value
 	H264ColorMetadataInsert = "INSERT"
 )
+
+// H264ColorMetadata_Values returns all elements of the H264ColorMetadata enum
+func H264ColorMetadata_Values() []string {
+	return []string{
+		H264ColorMetadataIgnore,
+		H264ColorMetadataInsert,
+	}
+}
 
 // H264 Entropy Encoding
 const (
@@ -24882,6 +25552,14 @@ const (
 	H264EntropyEncodingCavlc = "CAVLC"
 )
 
+// H264EntropyEncoding_Values returns all elements of the H264EntropyEncoding enum
+func H264EntropyEncoding_Values() []string {
+	return []string{
+		H264EntropyEncodingCabac,
+		H264EntropyEncodingCavlc,
+	}
+}
+
 // H264 Flicker Aq
 const (
 	// H264FlickerAqDisabled is a H264FlickerAq enum value
@@ -24890,6 +25568,14 @@ const (
 	// H264FlickerAqEnabled is a H264FlickerAq enum value
 	H264FlickerAqEnabled = "ENABLED"
 )
+
+// H264FlickerAq_Values returns all elements of the H264FlickerAq enum
+func H264FlickerAq_Values() []string {
+	return []string{
+		H264FlickerAqDisabled,
+		H264FlickerAqEnabled,
+	}
+}
 
 // H264 Force Field Pictures
 const (
@@ -24900,6 +25586,14 @@ const (
 	H264ForceFieldPicturesEnabled = "ENABLED"
 )
 
+// H264ForceFieldPictures_Values returns all elements of the H264ForceFieldPictures enum
+func H264ForceFieldPictures_Values() []string {
+	return []string{
+		H264ForceFieldPicturesDisabled,
+		H264ForceFieldPicturesEnabled,
+	}
+}
+
 // H264 Framerate Control
 const (
 	// H264FramerateControlInitializeFromSource is a H264FramerateControl enum value
@@ -24908,6 +25602,14 @@ const (
 	// H264FramerateControlSpecified is a H264FramerateControl enum value
 	H264FramerateControlSpecified = "SPECIFIED"
 )
+
+// H264FramerateControl_Values returns all elements of the H264FramerateControl enum
+func H264FramerateControl_Values() []string {
+	return []string{
+		H264FramerateControlInitializeFromSource,
+		H264FramerateControlSpecified,
+	}
+}
 
 // H264 Gop BReference
 const (
@@ -24918,6 +25620,14 @@ const (
 	H264GopBReferenceEnabled = "ENABLED"
 )
 
+// H264GopBReference_Values returns all elements of the H264GopBReference enum
+func H264GopBReference_Values() []string {
+	return []string{
+		H264GopBReferenceDisabled,
+		H264GopBReferenceEnabled,
+	}
+}
+
 // H264 Gop Size Units
 const (
 	// H264GopSizeUnitsFrames is a H264GopSizeUnits enum value
@@ -24926,6 +25636,14 @@ const (
 	// H264GopSizeUnitsSeconds is a H264GopSizeUnits enum value
 	H264GopSizeUnitsSeconds = "SECONDS"
 )
+
+// H264GopSizeUnits_Values returns all elements of the H264GopSizeUnits enum
+func H264GopSizeUnits_Values() []string {
+	return []string{
+		H264GopSizeUnitsFrames,
+		H264GopSizeUnitsSeconds,
+	}
+}
 
 // H264 Level
 const (
@@ -24981,6 +25699,29 @@ const (
 	H264LevelH264LevelAuto = "H264_LEVEL_AUTO"
 )
 
+// H264Level_Values returns all elements of the H264Level enum
+func H264Level_Values() []string {
+	return []string{
+		H264LevelH264Level1,
+		H264LevelH264Level11,
+		H264LevelH264Level12,
+		H264LevelH264Level13,
+		H264LevelH264Level2,
+		H264LevelH264Level21,
+		H264LevelH264Level22,
+		H264LevelH264Level3,
+		H264LevelH264Level31,
+		H264LevelH264Level32,
+		H264LevelH264Level4,
+		H264LevelH264Level41,
+		H264LevelH264Level42,
+		H264LevelH264Level5,
+		H264LevelH264Level51,
+		H264LevelH264Level52,
+		H264LevelH264LevelAuto,
+	}
+}
+
 // H264 Look Ahead Rate Control
 const (
 	// H264LookAheadRateControlHigh is a H264LookAheadRateControl enum value
@@ -24993,6 +25734,15 @@ const (
 	H264LookAheadRateControlMedium = "MEDIUM"
 )
 
+// H264LookAheadRateControl_Values returns all elements of the H264LookAheadRateControl enum
+func H264LookAheadRateControl_Values() []string {
+	return []string{
+		H264LookAheadRateControlHigh,
+		H264LookAheadRateControlLow,
+		H264LookAheadRateControlMedium,
+	}
+}
+
 // H264 Par Control
 const (
 	// H264ParControlInitializeFromSource is a H264ParControl enum value
@@ -25001,6 +25751,14 @@ const (
 	// H264ParControlSpecified is a H264ParControl enum value
 	H264ParControlSpecified = "SPECIFIED"
 )
+
+// H264ParControl_Values returns all elements of the H264ParControl enum
+func H264ParControl_Values() []string {
+	return []string{
+		H264ParControlInitializeFromSource,
+		H264ParControlSpecified,
+	}
+}
 
 // H264 Profile
 const (
@@ -25023,6 +25781,18 @@ const (
 	H264ProfileMain = "MAIN"
 )
 
+// H264Profile_Values returns all elements of the H264Profile enum
+func H264Profile_Values() []string {
+	return []string{
+		H264ProfileBaseline,
+		H264ProfileHigh,
+		H264ProfileHigh10bit,
+		H264ProfileHigh422,
+		H264ProfileHigh42210bit,
+		H264ProfileMain,
+	}
+}
+
 // H264 Quality Level
 const (
 	// H264QualityLevelEnhancedQuality is a H264QualityLevel enum value
@@ -25031,6 +25801,14 @@ const (
 	// H264QualityLevelStandardQuality is a H264QualityLevel enum value
 	H264QualityLevelStandardQuality = "STANDARD_QUALITY"
 )
+
+// H264QualityLevel_Values returns all elements of the H264QualityLevel enum
+func H264QualityLevel_Values() []string {
+	return []string{
+		H264QualityLevelEnhancedQuality,
+		H264QualityLevelStandardQuality,
+	}
+}
 
 // H264 Rate Control Mode
 const (
@@ -25047,6 +25825,16 @@ const (
 	H264RateControlModeVbr = "VBR"
 )
 
+// H264RateControlMode_Values returns all elements of the H264RateControlMode enum
+func H264RateControlMode_Values() []string {
+	return []string{
+		H264RateControlModeCbr,
+		H264RateControlModeMultiplex,
+		H264RateControlModeQvbr,
+		H264RateControlModeVbr,
+	}
+}
+
 // H264 Scan Type
 const (
 	// H264ScanTypeInterlaced is a H264ScanType enum value
@@ -25055,6 +25843,14 @@ const (
 	// H264ScanTypeProgressive is a H264ScanType enum value
 	H264ScanTypeProgressive = "PROGRESSIVE"
 )
+
+// H264ScanType_Values returns all elements of the H264ScanType enum
+func H264ScanType_Values() []string {
+	return []string{
+		H264ScanTypeInterlaced,
+		H264ScanTypeProgressive,
+	}
+}
 
 // H264 Scene Change Detect
 const (
@@ -25065,6 +25861,14 @@ const (
 	H264SceneChangeDetectEnabled = "ENABLED"
 )
 
+// H264SceneChangeDetect_Values returns all elements of the H264SceneChangeDetect enum
+func H264SceneChangeDetect_Values() []string {
+	return []string{
+		H264SceneChangeDetectDisabled,
+		H264SceneChangeDetectEnabled,
+	}
+}
+
 // H264 Spatial Aq
 const (
 	// H264SpatialAqDisabled is a H264SpatialAq enum value
@@ -25073,6 +25877,14 @@ const (
 	// H264SpatialAqEnabled is a H264SpatialAq enum value
 	H264SpatialAqEnabled = "ENABLED"
 )
+
+// H264SpatialAq_Values returns all elements of the H264SpatialAq enum
+func H264SpatialAq_Values() []string {
+	return []string{
+		H264SpatialAqDisabled,
+		H264SpatialAqEnabled,
+	}
+}
 
 // H264 Sub Gop Length
 const (
@@ -25083,6 +25895,14 @@ const (
 	H264SubGopLengthFixed = "FIXED"
 )
 
+// H264SubGopLength_Values returns all elements of the H264SubGopLength enum
+func H264SubGopLength_Values() []string {
+	return []string{
+		H264SubGopLengthDynamic,
+		H264SubGopLengthFixed,
+	}
+}
+
 // H264 Syntax
 const (
 	// H264SyntaxDefault is a H264Syntax enum value
@@ -25091,6 +25911,14 @@ const (
 	// H264SyntaxRp2027 is a H264Syntax enum value
 	H264SyntaxRp2027 = "RP2027"
 )
+
+// H264Syntax_Values returns all elements of the H264Syntax enum
+func H264Syntax_Values() []string {
+	return []string{
+		H264SyntaxDefault,
+		H264SyntaxRp2027,
+	}
+}
 
 // H264 Temporal Aq
 const (
@@ -25101,6 +25929,14 @@ const (
 	H264TemporalAqEnabled = "ENABLED"
 )
 
+// H264TemporalAq_Values returns all elements of the H264TemporalAq enum
+func H264TemporalAq_Values() []string {
+	return []string{
+		H264TemporalAqDisabled,
+		H264TemporalAqEnabled,
+	}
+}
+
 // H264 Timecode Insertion Behavior
 const (
 	// H264TimecodeInsertionBehaviorDisabled is a H264TimecodeInsertionBehavior enum value
@@ -25109,6 +25945,14 @@ const (
 	// H264TimecodeInsertionBehaviorPicTimingSei is a H264TimecodeInsertionBehavior enum value
 	H264TimecodeInsertionBehaviorPicTimingSei = "PIC_TIMING_SEI"
 )
+
+// H264TimecodeInsertionBehavior_Values returns all elements of the H264TimecodeInsertionBehavior enum
+func H264TimecodeInsertionBehavior_Values() []string {
+	return []string{
+		H264TimecodeInsertionBehaviorDisabled,
+		H264TimecodeInsertionBehaviorPicTimingSei,
+	}
+}
 
 // H265 Adaptive Quantization
 const (
@@ -25131,6 +25975,18 @@ const (
 	H265AdaptiveQuantizationOff = "OFF"
 )
 
+// H265AdaptiveQuantization_Values returns all elements of the H265AdaptiveQuantization enum
+func H265AdaptiveQuantization_Values() []string {
+	return []string{
+		H265AdaptiveQuantizationHigh,
+		H265AdaptiveQuantizationHigher,
+		H265AdaptiveQuantizationLow,
+		H265AdaptiveQuantizationMax,
+		H265AdaptiveQuantizationMedium,
+		H265AdaptiveQuantizationOff,
+	}
+}
+
 // H265 Alternative Transfer Function
 const (
 	// H265AlternativeTransferFunctionInsert is a H265AlternativeTransferFunction enum value
@@ -25139,6 +25995,14 @@ const (
 	// H265AlternativeTransferFunctionOmit is a H265AlternativeTransferFunction enum value
 	H265AlternativeTransferFunctionOmit = "OMIT"
 )
+
+// H265AlternativeTransferFunction_Values returns all elements of the H265AlternativeTransferFunction enum
+func H265AlternativeTransferFunction_Values() []string {
+	return []string{
+		H265AlternativeTransferFunctionInsert,
+		H265AlternativeTransferFunctionOmit,
+	}
+}
 
 // H265 Color Metadata
 const (
@@ -25149,6 +26013,14 @@ const (
 	H265ColorMetadataInsert = "INSERT"
 )
 
+// H265ColorMetadata_Values returns all elements of the H265ColorMetadata enum
+func H265ColorMetadata_Values() []string {
+	return []string{
+		H265ColorMetadataIgnore,
+		H265ColorMetadataInsert,
+	}
+}
+
 // H265 Flicker Aq
 const (
 	// H265FlickerAqDisabled is a H265FlickerAq enum value
@@ -25158,6 +26030,14 @@ const (
 	H265FlickerAqEnabled = "ENABLED"
 )
 
+// H265FlickerAq_Values returns all elements of the H265FlickerAq enum
+func H265FlickerAq_Values() []string {
+	return []string{
+		H265FlickerAqDisabled,
+		H265FlickerAqEnabled,
+	}
+}
+
 // H265 Gop Size Units
 const (
 	// H265GopSizeUnitsFrames is a H265GopSizeUnits enum value
@@ -25166,6 +26046,14 @@ const (
 	// H265GopSizeUnitsSeconds is a H265GopSizeUnits enum value
 	H265GopSizeUnitsSeconds = "SECONDS"
 )
+
+// H265GopSizeUnits_Values returns all elements of the H265GopSizeUnits enum
+func H265GopSizeUnits_Values() []string {
+	return []string{
+		H265GopSizeUnitsFrames,
+		H265GopSizeUnitsSeconds,
+	}
+}
 
 // H265 Level
 const (
@@ -25212,6 +26100,26 @@ const (
 	H265LevelH265LevelAuto = "H265_LEVEL_AUTO"
 )
 
+// H265Level_Values returns all elements of the H265Level enum
+func H265Level_Values() []string {
+	return []string{
+		H265LevelH265Level1,
+		H265LevelH265Level2,
+		H265LevelH265Level21,
+		H265LevelH265Level3,
+		H265LevelH265Level31,
+		H265LevelH265Level4,
+		H265LevelH265Level41,
+		H265LevelH265Level5,
+		H265LevelH265Level51,
+		H265LevelH265Level52,
+		H265LevelH265Level6,
+		H265LevelH265Level61,
+		H265LevelH265Level62,
+		H265LevelH265LevelAuto,
+	}
+}
+
 // H265 Look Ahead Rate Control
 const (
 	// H265LookAheadRateControlHigh is a H265LookAheadRateControl enum value
@@ -25224,6 +26132,15 @@ const (
 	H265LookAheadRateControlMedium = "MEDIUM"
 )
 
+// H265LookAheadRateControl_Values returns all elements of the H265LookAheadRateControl enum
+func H265LookAheadRateControl_Values() []string {
+	return []string{
+		H265LookAheadRateControlHigh,
+		H265LookAheadRateControlLow,
+		H265LookAheadRateControlMedium,
+	}
+}
+
 // H265 Profile
 const (
 	// H265ProfileMain is a H265Profile enum value
@@ -25232,6 +26149,14 @@ const (
 	// H265ProfileMain10bit is a H265Profile enum value
 	H265ProfileMain10bit = "MAIN_10BIT"
 )
+
+// H265Profile_Values returns all elements of the H265Profile enum
+func H265Profile_Values() []string {
+	return []string{
+		H265ProfileMain,
+		H265ProfileMain10bit,
+	}
+}
 
 // H265 Rate Control Mode
 const (
@@ -25245,6 +26170,15 @@ const (
 	H265RateControlModeQvbr = "QVBR"
 )
 
+// H265RateControlMode_Values returns all elements of the H265RateControlMode enum
+func H265RateControlMode_Values() []string {
+	return []string{
+		H265RateControlModeCbr,
+		H265RateControlModeMultiplex,
+		H265RateControlModeQvbr,
+	}
+}
+
 // H265 Scan Type
 const (
 	// H265ScanTypeInterlaced is a H265ScanType enum value
@@ -25253,6 +26187,14 @@ const (
 	// H265ScanTypeProgressive is a H265ScanType enum value
 	H265ScanTypeProgressive = "PROGRESSIVE"
 )
+
+// H265ScanType_Values returns all elements of the H265ScanType enum
+func H265ScanType_Values() []string {
+	return []string{
+		H265ScanTypeInterlaced,
+		H265ScanTypeProgressive,
+	}
+}
 
 // H265 Scene Change Detect
 const (
@@ -25263,6 +26205,14 @@ const (
 	H265SceneChangeDetectEnabled = "ENABLED"
 )
 
+// H265SceneChangeDetect_Values returns all elements of the H265SceneChangeDetect enum
+func H265SceneChangeDetect_Values() []string {
+	return []string{
+		H265SceneChangeDetectDisabled,
+		H265SceneChangeDetectEnabled,
+	}
+}
+
 // H265 Tier
 const (
 	// H265TierHigh is a H265Tier enum value
@@ -25272,6 +26222,14 @@ const (
 	H265TierMain = "MAIN"
 )
 
+// H265Tier_Values returns all elements of the H265Tier enum
+func H265Tier_Values() []string {
+	return []string{
+		H265TierHigh,
+		H265TierMain,
+	}
+}
+
 // H265 Timecode Insertion Behavior
 const (
 	// H265TimecodeInsertionBehaviorDisabled is a H265TimecodeInsertionBehavior enum value
@@ -25280,6 +26238,14 @@ const (
 	// H265TimecodeInsertionBehaviorPicTimingSei is a H265TimecodeInsertionBehavior enum value
 	H265TimecodeInsertionBehaviorPicTimingSei = "PIC_TIMING_SEI"
 )
+
+// H265TimecodeInsertionBehavior_Values returns all elements of the H265TimecodeInsertionBehavior enum
+func H265TimecodeInsertionBehavior_Values() []string {
+	return []string{
+		H265TimecodeInsertionBehaviorDisabled,
+		H265TimecodeInsertionBehaviorPicTimingSei,
+	}
+}
 
 // Hls Ad Markers
 const (
@@ -25293,6 +26259,15 @@ const (
 	HlsAdMarkersElementalScte35 = "ELEMENTAL_SCTE35"
 )
 
+// HlsAdMarkers_Values returns all elements of the HlsAdMarkers enum
+func HlsAdMarkers_Values() []string {
+	return []string{
+		HlsAdMarkersAdobe,
+		HlsAdMarkersElemental,
+		HlsAdMarkersElementalScte35,
+	}
+}
+
 // Hls Akamai Http Transfer Mode
 const (
 	// HlsAkamaiHttpTransferModeChunked is a HlsAkamaiHttpTransferMode enum value
@@ -25301,6 +26276,14 @@ const (
 	// HlsAkamaiHttpTransferModeNonChunked is a HlsAkamaiHttpTransferMode enum value
 	HlsAkamaiHttpTransferModeNonChunked = "NON_CHUNKED"
 )
+
+// HlsAkamaiHttpTransferMode_Values returns all elements of the HlsAkamaiHttpTransferMode enum
+func HlsAkamaiHttpTransferMode_Values() []string {
+	return []string{
+		HlsAkamaiHttpTransferModeChunked,
+		HlsAkamaiHttpTransferModeNonChunked,
+	}
+}
 
 // Hls Caption Language Setting
 const (
@@ -25314,6 +26297,15 @@ const (
 	HlsCaptionLanguageSettingOmit = "OMIT"
 )
 
+// HlsCaptionLanguageSetting_Values returns all elements of the HlsCaptionLanguageSetting enum
+func HlsCaptionLanguageSetting_Values() []string {
+	return []string{
+		HlsCaptionLanguageSettingInsert,
+		HlsCaptionLanguageSettingNone,
+		HlsCaptionLanguageSettingOmit,
+	}
+}
+
 // Hls Client Cache
 const (
 	// HlsClientCacheDisabled is a HlsClientCache enum value
@@ -25322,6 +26314,14 @@ const (
 	// HlsClientCacheEnabled is a HlsClientCache enum value
 	HlsClientCacheEnabled = "ENABLED"
 )
+
+// HlsClientCache_Values returns all elements of the HlsClientCache enum
+func HlsClientCache_Values() []string {
+	return []string{
+		HlsClientCacheDisabled,
+		HlsClientCacheEnabled,
+	}
+}
 
 // Hls Codec Specification
 const (
@@ -25332,6 +26332,14 @@ const (
 	HlsCodecSpecificationRfc6381 = "RFC_6381"
 )
 
+// HlsCodecSpecification_Values returns all elements of the HlsCodecSpecification enum
+func HlsCodecSpecification_Values() []string {
+	return []string{
+		HlsCodecSpecificationRfc4281,
+		HlsCodecSpecificationRfc6381,
+	}
+}
+
 // Hls Directory Structure
 const (
 	// HlsDirectoryStructureSingleDirectory is a HlsDirectoryStructure enum value
@@ -25340,6 +26348,14 @@ const (
 	// HlsDirectoryStructureSubdirectoryPerStream is a HlsDirectoryStructure enum value
 	HlsDirectoryStructureSubdirectoryPerStream = "SUBDIRECTORY_PER_STREAM"
 )
+
+// HlsDirectoryStructure_Values returns all elements of the HlsDirectoryStructure enum
+func HlsDirectoryStructure_Values() []string {
+	return []string{
+		HlsDirectoryStructureSingleDirectory,
+		HlsDirectoryStructureSubdirectoryPerStream,
+	}
+}
 
 // Hls Encryption Type
 const (
@@ -25350,6 +26366,14 @@ const (
 	HlsEncryptionTypeSampleAes = "SAMPLE_AES"
 )
 
+// HlsEncryptionType_Values returns all elements of the HlsEncryptionType enum
+func HlsEncryptionType_Values() []string {
+	return []string{
+		HlsEncryptionTypeAes128,
+		HlsEncryptionTypeSampleAes,
+	}
+}
+
 // Hls H265 Packaging Type
 const (
 	// HlsH265PackagingTypeHev1 is a HlsH265PackagingType enum value
@@ -25358,6 +26382,14 @@ const (
 	// HlsH265PackagingTypeHvc1 is a HlsH265PackagingType enum value
 	HlsH265PackagingTypeHvc1 = "HVC1"
 )
+
+// HlsH265PackagingType_Values returns all elements of the HlsH265PackagingType enum
+func HlsH265PackagingType_Values() []string {
+	return []string{
+		HlsH265PackagingTypeHev1,
+		HlsH265PackagingTypeHvc1,
+	}
+}
 
 // State of HLS ID3 Segment Tagging
 const (
@@ -25368,6 +26400,14 @@ const (
 	HlsId3SegmentTaggingStateEnabled = "ENABLED"
 )
 
+// HlsId3SegmentTaggingState_Values returns all elements of the HlsId3SegmentTaggingState enum
+func HlsId3SegmentTaggingState_Values() []string {
+	return []string{
+		HlsId3SegmentTaggingStateDisabled,
+		HlsId3SegmentTaggingStateEnabled,
+	}
+}
+
 // Hls Iv In Manifest
 const (
 	// HlsIvInManifestExclude is a HlsIvInManifest enum value
@@ -25376,6 +26416,14 @@ const (
 	// HlsIvInManifestInclude is a HlsIvInManifest enum value
 	HlsIvInManifestInclude = "INCLUDE"
 )
+
+// HlsIvInManifest_Values returns all elements of the HlsIvInManifest enum
+func HlsIvInManifest_Values() []string {
+	return []string{
+		HlsIvInManifestExclude,
+		HlsIvInManifestInclude,
+	}
+}
 
 // Hls Iv Source
 const (
@@ -25386,6 +26434,14 @@ const (
 	HlsIvSourceFollowsSegmentNumber = "FOLLOWS_SEGMENT_NUMBER"
 )
 
+// HlsIvSource_Values returns all elements of the HlsIvSource enum
+func HlsIvSource_Values() []string {
+	return []string{
+		HlsIvSourceExplicit,
+		HlsIvSourceFollowsSegmentNumber,
+	}
+}
+
 // Hls Manifest Compression
 const (
 	// HlsManifestCompressionGzip is a HlsManifestCompression enum value
@@ -25394,6 +26450,14 @@ const (
 	// HlsManifestCompressionNone is a HlsManifestCompression enum value
 	HlsManifestCompressionNone = "NONE"
 )
+
+// HlsManifestCompression_Values returns all elements of the HlsManifestCompression enum
+func HlsManifestCompression_Values() []string {
+	return []string{
+		HlsManifestCompressionGzip,
+		HlsManifestCompressionNone,
+	}
+}
 
 // Hls Manifest Duration Format
 const (
@@ -25404,11 +26468,26 @@ const (
 	HlsManifestDurationFormatInteger = "INTEGER"
 )
 
+// HlsManifestDurationFormat_Values returns all elements of the HlsManifestDurationFormat enum
+func HlsManifestDurationFormat_Values() []string {
+	return []string{
+		HlsManifestDurationFormatFloatingPoint,
+		HlsManifestDurationFormatInteger,
+	}
+}
+
 // Hls Media Store Storage Class
 const (
 	// HlsMediaStoreStorageClassTemporal is a HlsMediaStoreStorageClass enum value
 	HlsMediaStoreStorageClassTemporal = "TEMPORAL"
 )
+
+// HlsMediaStoreStorageClass_Values returns all elements of the HlsMediaStoreStorageClass enum
+func HlsMediaStoreStorageClass_Values() []string {
+	return []string{
+		HlsMediaStoreStorageClassTemporal,
+	}
+}
 
 // Hls Mode
 const (
@@ -25418,6 +26497,14 @@ const (
 	// HlsModeVod is a HlsMode enum value
 	HlsModeVod = "VOD"
 )
+
+// HlsMode_Values returns all elements of the HlsMode enum
+func HlsMode_Values() []string {
+	return []string{
+		HlsModeLive,
+		HlsModeVod,
+	}
+}
 
 // Hls Output Selection
 const (
@@ -25431,6 +26518,15 @@ const (
 	HlsOutputSelectionVariantManifestsAndSegments = "VARIANT_MANIFESTS_AND_SEGMENTS"
 )
 
+// HlsOutputSelection_Values returns all elements of the HlsOutputSelection enum
+func HlsOutputSelection_Values() []string {
+	return []string{
+		HlsOutputSelectionManifestsAndSegments,
+		HlsOutputSelectionSegmentsOnly,
+		HlsOutputSelectionVariantManifestsAndSegments,
+	}
+}
+
 // Hls Program Date Time
 const (
 	// HlsProgramDateTimeExclude is a HlsProgramDateTime enum value
@@ -25439,6 +26535,14 @@ const (
 	// HlsProgramDateTimeInclude is a HlsProgramDateTime enum value
 	HlsProgramDateTimeInclude = "INCLUDE"
 )
+
+// HlsProgramDateTime_Values returns all elements of the HlsProgramDateTime enum
+func HlsProgramDateTime_Values() []string {
+	return []string{
+		HlsProgramDateTimeExclude,
+		HlsProgramDateTimeInclude,
+	}
+}
 
 // Hls Redundant Manifest
 const (
@@ -25449,6 +26553,14 @@ const (
 	HlsRedundantManifestEnabled = "ENABLED"
 )
 
+// HlsRedundantManifest_Values returns all elements of the HlsRedundantManifest enum
+func HlsRedundantManifest_Values() []string {
+	return []string{
+		HlsRedundantManifestDisabled,
+		HlsRedundantManifestEnabled,
+	}
+}
+
 // Hls Segmentation Mode
 const (
 	// HlsSegmentationModeUseInputSegmentation is a HlsSegmentationMode enum value
@@ -25458,6 +26570,14 @@ const (
 	HlsSegmentationModeUseSegmentDuration = "USE_SEGMENT_DURATION"
 )
 
+// HlsSegmentationMode_Values returns all elements of the HlsSegmentationMode enum
+func HlsSegmentationMode_Values() []string {
+	return []string{
+		HlsSegmentationModeUseInputSegmentation,
+		HlsSegmentationModeUseSegmentDuration,
+	}
+}
+
 // Hls Stream Inf Resolution
 const (
 	// HlsStreamInfResolutionExclude is a HlsStreamInfResolution enum value
@@ -25466,6 +26586,14 @@ const (
 	// HlsStreamInfResolutionInclude is a HlsStreamInfResolution enum value
 	HlsStreamInfResolutionInclude = "INCLUDE"
 )
+
+// HlsStreamInfResolution_Values returns all elements of the HlsStreamInfResolution enum
+func HlsStreamInfResolution_Values() []string {
+	return []string{
+		HlsStreamInfResolutionExclude,
+		HlsStreamInfResolutionInclude,
+	}
+}
 
 // Hls Timed Metadata Id3 Frame
 const (
@@ -25479,6 +26607,15 @@ const (
 	HlsTimedMetadataId3FrameTdrl = "TDRL"
 )
 
+// HlsTimedMetadataId3Frame_Values returns all elements of the HlsTimedMetadataId3Frame enum
+func HlsTimedMetadataId3Frame_Values() []string {
+	return []string{
+		HlsTimedMetadataId3FrameNone,
+		HlsTimedMetadataId3FramePriv,
+		HlsTimedMetadataId3FrameTdrl,
+	}
+}
+
 // Hls Ts File Mode
 const (
 	// HlsTsFileModeSegmentedFiles is a HlsTsFileMode enum value
@@ -25488,6 +26625,14 @@ const (
 	HlsTsFileModeSingleFile = "SINGLE_FILE"
 )
 
+// HlsTsFileMode_Values returns all elements of the HlsTsFileMode enum
+func HlsTsFileMode_Values() []string {
+	return []string{
+		HlsTsFileModeSegmentedFiles,
+		HlsTsFileModeSingleFile,
+	}
+}
+
 // Hls Webdav Http Transfer Mode
 const (
 	// HlsWebdavHttpTransferModeChunked is a HlsWebdavHttpTransferMode enum value
@@ -25496,6 +26641,14 @@ const (
 	// HlsWebdavHttpTransferModeNonChunked is a HlsWebdavHttpTransferMode enum value
 	HlsWebdavHttpTransferModeNonChunked = "NON_CHUNKED"
 )
+
+// HlsWebdavHttpTransferMode_Values returns all elements of the HlsWebdavHttpTransferMode enum
+func HlsWebdavHttpTransferMode_Values() []string {
+	return []string{
+		HlsWebdavHttpTransferModeChunked,
+		HlsWebdavHttpTransferModeNonChunked,
+	}
+}
 
 // When set to "standard", an I-Frame only playlist will be written out for
 // each video output in the output group. This I-Frame only playlist will contain
@@ -25508,6 +26661,14 @@ const (
 	IFrameOnlyPlaylistTypeStandard = "STANDARD"
 )
 
+// IFrameOnlyPlaylistType_Values returns all elements of the IFrameOnlyPlaylistType enum
+func IFrameOnlyPlaylistType_Values() []string {
+	return []string{
+		IFrameOnlyPlaylistTypeDisabled,
+		IFrameOnlyPlaylistTypeStandard,
+	}
+}
+
 // A standard input has two sources and a single pipeline input only has one.
 const (
 	// InputClassStandard is a InputClass enum value
@@ -25516,6 +26677,14 @@ const (
 	// InputClassSinglePipeline is a InputClass enum value
 	InputClassSinglePipeline = "SINGLE_PIPELINE"
 )
+
+// InputClass_Values returns all elements of the InputClass enum
+func InputClass_Values() []string {
+	return []string{
+		InputClassStandard,
+		InputClassSinglePipeline,
+	}
+}
 
 // codec in increasing order of complexity
 const (
@@ -25529,6 +26698,15 @@ const (
 	InputCodecHevc = "HEVC"
 )
 
+// InputCodec_Values returns all elements of the InputCodec enum
+func InputCodec_Values() []string {
+	return []string{
+		InputCodecMpeg2,
+		InputCodecAvc,
+		InputCodecHevc,
+	}
+}
+
 // Input Deblock Filter
 const (
 	// InputDeblockFilterDisabled is a InputDeblockFilter enum value
@@ -25537,6 +26715,14 @@ const (
 	// InputDeblockFilterEnabled is a InputDeblockFilter enum value
 	InputDeblockFilterEnabled = "ENABLED"
 )
+
+// InputDeblockFilter_Values returns all elements of the InputDeblockFilter enum
+func InputDeblockFilter_Values() []string {
+	return []string{
+		InputDeblockFilterDisabled,
+		InputDeblockFilterEnabled,
+	}
+}
 
 // Input Denoise Filter
 const (
@@ -25547,6 +26733,14 @@ const (
 	InputDenoiseFilterEnabled = "ENABLED"
 )
 
+// InputDenoiseFilter_Values returns all elements of the InputDenoiseFilter enum
+func InputDenoiseFilter_Values() []string {
+	return []string{
+		InputDenoiseFilterDisabled,
+		InputDenoiseFilterEnabled,
+	}
+}
+
 // The source at the input device that is currently active.
 const (
 	// InputDeviceActiveInputHdmi is a InputDeviceActiveInput enum value
@@ -25555,6 +26749,14 @@ const (
 	// InputDeviceActiveInputSdi is a InputDeviceActiveInput enum value
 	InputDeviceActiveInputSdi = "SDI"
 )
+
+// InputDeviceActiveInput_Values returns all elements of the InputDeviceActiveInput enum
+func InputDeviceActiveInput_Values() []string {
+	return []string{
+		InputDeviceActiveInputHdmi,
+		InputDeviceActiveInputSdi,
+	}
+}
 
 // The source to activate (use) from the input device.
 const (
@@ -25568,6 +26770,15 @@ const (
 	InputDeviceConfiguredInputSdi = "SDI"
 )
 
+// InputDeviceConfiguredInput_Values returns all elements of the InputDeviceConfiguredInput enum
+func InputDeviceConfiguredInput_Values() []string {
+	return []string{
+		InputDeviceConfiguredInputAuto,
+		InputDeviceConfiguredInputHdmi,
+		InputDeviceConfiguredInputSdi,
+	}
+}
+
 // The state of the connection between the input device and AWS.
 const (
 	// InputDeviceConnectionStateDisconnected is a InputDeviceConnectionState enum value
@@ -25576,6 +26787,14 @@ const (
 	// InputDeviceConnectionStateConnected is a InputDeviceConnectionState enum value
 	InputDeviceConnectionStateConnected = "CONNECTED"
 )
+
+// InputDeviceConnectionState_Values returns all elements of the InputDeviceConnectionState enum
+func InputDeviceConnectionState_Values() []string {
+	return []string{
+		InputDeviceConnectionStateDisconnected,
+		InputDeviceConnectionStateConnected,
+	}
+}
 
 // Specifies whether the input device has been configured (outside of MediaLive)
 // to use a dynamic IP address assignment (DHCP) or a static IP address.
@@ -25587,6 +26806,14 @@ const (
 	InputDeviceIpSchemeDhcp = "DHCP"
 )
 
+// InputDeviceIpScheme_Values returns all elements of the InputDeviceIpScheme enum
+func InputDeviceIpScheme_Values() []string {
+	return []string{
+		InputDeviceIpSchemeStatic,
+		InputDeviceIpSchemeDhcp,
+	}
+}
+
 // The scan type of the video source.
 const (
 	// InputDeviceScanTypeInterlaced is a InputDeviceScanType enum value
@@ -25595,6 +26822,14 @@ const (
 	// InputDeviceScanTypeProgressive is a InputDeviceScanType enum value
 	InputDeviceScanTypeProgressive = "PROGRESSIVE"
 )
+
+// InputDeviceScanType_Values returns all elements of the InputDeviceScanType enum
+func InputDeviceScanType_Values() []string {
+	return []string{
+		InputDeviceScanTypeInterlaced,
+		InputDeviceScanTypeProgressive,
+	}
+}
 
 // The state of the input device.
 const (
@@ -25605,12 +26840,27 @@ const (
 	InputDeviceStateStreaming = "STREAMING"
 )
 
+// InputDeviceState_Values returns all elements of the InputDeviceState enum
+func InputDeviceState_Values() []string {
+	return []string{
+		InputDeviceStateIdle,
+		InputDeviceStateStreaming,
+	}
+}
+
 // The type of the input device. For an AWS Elemental Link device that outputs
 // resolutions up to 1080, choose "HD".
 const (
 	// InputDeviceTypeHd is a InputDeviceType enum value
 	InputDeviceTypeHd = "HD"
 )
+
+// InputDeviceType_Values returns all elements of the InputDeviceType enum
+func InputDeviceType_Values() []string {
+	return []string{
+		InputDeviceTypeHd,
+	}
+}
 
 // Input Filter
 const (
@@ -25624,6 +26874,15 @@ const (
 	InputFilterForced = "FORCED"
 )
 
+// InputFilter_Values returns all elements of the InputFilter enum
+func InputFilter_Values() []string {
+	return []string{
+		InputFilterAuto,
+		InputFilterDisabled,
+		InputFilterForced,
+	}
+}
+
 // Input Loss Action For Hls Out
 const (
 	// InputLossActionForHlsOutEmitOutput is a InputLossActionForHlsOut enum value
@@ -25632,6 +26891,14 @@ const (
 	// InputLossActionForHlsOutPauseOutput is a InputLossActionForHlsOut enum value
 	InputLossActionForHlsOutPauseOutput = "PAUSE_OUTPUT"
 )
+
+// InputLossActionForHlsOut_Values returns all elements of the InputLossActionForHlsOut enum
+func InputLossActionForHlsOut_Values() []string {
+	return []string{
+		InputLossActionForHlsOutEmitOutput,
+		InputLossActionForHlsOutPauseOutput,
+	}
+}
 
 // Input Loss Action For Ms Smooth Out
 const (
@@ -25642,6 +26909,14 @@ const (
 	InputLossActionForMsSmoothOutPauseOutput = "PAUSE_OUTPUT"
 )
 
+// InputLossActionForMsSmoothOut_Values returns all elements of the InputLossActionForMsSmoothOut enum
+func InputLossActionForMsSmoothOut_Values() []string {
+	return []string{
+		InputLossActionForMsSmoothOutEmitOutput,
+		InputLossActionForMsSmoothOutPauseOutput,
+	}
+}
+
 // Input Loss Action For Rtmp Out
 const (
 	// InputLossActionForRtmpOutEmitOutput is a InputLossActionForRtmpOut enum value
@@ -25650,6 +26925,14 @@ const (
 	// InputLossActionForRtmpOutPauseOutput is a InputLossActionForRtmpOut enum value
 	InputLossActionForRtmpOutPauseOutput = "PAUSE_OUTPUT"
 )
+
+// InputLossActionForRtmpOut_Values returns all elements of the InputLossActionForRtmpOut enum
+func InputLossActionForRtmpOut_Values() []string {
+	return []string{
+		InputLossActionForRtmpOutEmitOutput,
+		InputLossActionForRtmpOutPauseOutput,
+	}
+}
 
 // Input Loss Action For Udp Out
 const (
@@ -25663,6 +26946,15 @@ const (
 	InputLossActionForUdpOutEmitProgram = "EMIT_PROGRAM"
 )
 
+// InputLossActionForUdpOut_Values returns all elements of the InputLossActionForUdpOut enum
+func InputLossActionForUdpOut_Values() []string {
+	return []string{
+		InputLossActionForUdpOutDropProgram,
+		InputLossActionForUdpOutDropTs,
+		InputLossActionForUdpOutEmitProgram,
+	}
+}
+
 // Input Loss Image Type
 const (
 	// InputLossImageTypeColor is a InputLossImageType enum value
@@ -25671,6 +26963,14 @@ const (
 	// InputLossImageTypeSlate is a InputLossImageType enum value
 	InputLossImageTypeSlate = "SLATE"
 )
+
+// InputLossImageType_Values returns all elements of the InputLossImageType enum
+func InputLossImageType_Values() []string {
+	return []string{
+		InputLossImageTypeColor,
+		InputLossImageTypeSlate,
+	}
+}
 
 // Maximum input bitrate in megabits per second. Bitrates up to 50 Mbps are
 // supported currently.
@@ -25685,6 +26985,15 @@ const (
 	InputMaximumBitrateMax50Mbps = "MAX_50_MBPS"
 )
 
+// InputMaximumBitrate_Values returns all elements of the InputMaximumBitrate enum
+func InputMaximumBitrate_Values() []string {
+	return []string{
+		InputMaximumBitrateMax10Mbps,
+		InputMaximumBitrateMax20Mbps,
+		InputMaximumBitrateMax50Mbps,
+	}
+}
+
 // Input preference when deciding which input to make active when a previously
 // failed input has recovered.If \"EQUAL_INPUT_PREFERENCE\", then the active
 // input will stay active as long as it is healthy.If \"PRIMARY_INPUT_PREFERRED\",
@@ -25696,6 +27005,14 @@ const (
 	// InputPreferencePrimaryInputPreferred is a InputPreference enum value
 	InputPreferencePrimaryInputPreferred = "PRIMARY_INPUT_PREFERRED"
 )
+
+// InputPreference_Values returns all elements of the InputPreference enum
+func InputPreference_Values() []string {
+	return []string{
+		InputPreferenceEqualInputPreference,
+		InputPreferencePrimaryInputPreferred,
+	}
+}
 
 // Input resolution based on lines of vertical resolution in the input; SD is
 // less than 720 lines, HD is 720 to 1080 lines, UHD is greater than 1080 lines
@@ -25709,6 +27026,15 @@ const (
 	// InputResolutionUhd is a InputResolution enum value
 	InputResolutionUhd = "UHD"
 )
+
+// InputResolution_Values returns all elements of the InputResolution enum
+func InputResolution_Values() []string {
+	return []string{
+		InputResolutionSd,
+		InputResolutionHd,
+		InputResolutionUhd,
+	}
+}
 
 const (
 	// InputSecurityGroupStateIdle is a InputSecurityGroupState enum value
@@ -25724,6 +27050,16 @@ const (
 	InputSecurityGroupStateDeleted = "DELETED"
 )
 
+// InputSecurityGroupState_Values returns all elements of the InputSecurityGroupState enum
+func InputSecurityGroupState_Values() []string {
+	return []string{
+		InputSecurityGroupStateIdle,
+		InputSecurityGroupStateInUse,
+		InputSecurityGroupStateUpdating,
+		InputSecurityGroupStateDeleted,
+	}
+}
+
 // Input Source End Behavior
 const (
 	// InputSourceEndBehaviorContinue is a InputSourceEndBehavior enum value
@@ -25732,6 +27068,14 @@ const (
 	// InputSourceEndBehaviorLoop is a InputSourceEndBehavior enum value
 	InputSourceEndBehaviorLoop = "LOOP"
 )
+
+// InputSourceEndBehavior_Values returns all elements of the InputSourceEndBehavior enum
+func InputSourceEndBehavior_Values() []string {
+	return []string{
+		InputSourceEndBehaviorContinue,
+		InputSourceEndBehaviorLoop,
+	}
+}
 
 // There are two types of input sources, static and dynamic. If an input source
 // is dynamic you canchange the source url of the input dynamically using an
@@ -25744,6 +27088,14 @@ const (
 	// InputSourceTypeDynamic is a InputSourceType enum value
 	InputSourceTypeDynamic = "DYNAMIC"
 )
+
+// InputSourceType_Values returns all elements of the InputSourceType enum
+func InputSourceType_Values() []string {
+	return []string{
+		InputSourceTypeStatic,
+		InputSourceTypeDynamic,
+	}
+}
 
 const (
 	// InputStateCreating is a InputState enum value
@@ -25762,6 +27114,17 @@ const (
 	InputStateDeleted = "DELETED"
 )
 
+// InputState_Values returns all elements of the InputState enum
+func InputState_Values() []string {
+	return []string{
+		InputStateCreating,
+		InputStateDetached,
+		InputStateAttached,
+		InputStateDeleting,
+		InputStateDeleted,
+	}
+}
+
 // To clip the file, you must specify the timecode for the start and end of
 // the clip. Specify EMBEDDED to use the timecode embedded in the source content.
 // The embedded timecode must exist in the source content, otherwise MediaLive
@@ -25776,6 +27139,14 @@ const (
 	// InputTimecodeSourceEmbedded is a InputTimecodeSource enum value
 	InputTimecodeSourceEmbedded = "EMBEDDED"
 )
+
+// InputTimecodeSource_Values returns all elements of the InputTimecodeSource enum
+func InputTimecodeSource_Values() []string {
+	return []string{
+		InputTimecodeSourceZerobased,
+		InputTimecodeSourceEmbedded,
+	}
+}
 
 const (
 	// InputTypeUdpPush is a InputType enum value
@@ -25803,6 +27174,20 @@ const (
 	InputTypeInputDevice = "INPUT_DEVICE"
 )
 
+// InputType_Values returns all elements of the InputType enum
+func InputType_Values() []string {
+	return []string{
+		InputTypeUdpPush,
+		InputTypeRtpPush,
+		InputTypeRtmpPush,
+		InputTypeRtmpPull,
+		InputTypeUrlPull,
+		InputTypeMp4File,
+		InputTypeMediaconnect,
+		InputTypeInputDevice,
+	}
+}
+
 // If you specify a StopTimecode in an input (in order to clip the file), you
 // can specify if you want the clip to exclude (the default) or include the
 // frame specified by the timecode.
@@ -25813,6 +27198,14 @@ const (
 	// LastFrameClippingBehaviorIncludeLastFrame is a LastFrameClippingBehavior enum value
 	LastFrameClippingBehaviorIncludeLastFrame = "INCLUDE_LAST_FRAME"
 )
+
+// LastFrameClippingBehavior_Values returns all elements of the LastFrameClippingBehavior enum
+func LastFrameClippingBehavior_Values() []string {
+	return []string{
+		LastFrameClippingBehaviorExcludeLastFrame,
+		LastFrameClippingBehaviorIncludeLastFrame,
+	}
+}
 
 // The log level the user wants for their channel.
 const (
@@ -25832,6 +27225,17 @@ const (
 	LogLevelDisabled = "DISABLED"
 )
 
+// LogLevel_Values returns all elements of the LogLevel enum
+func LogLevel_Values() []string {
+	return []string{
+		LogLevelError,
+		LogLevelWarning,
+		LogLevelInfo,
+		LogLevelDebug,
+		LogLevelDisabled,
+	}
+}
+
 // M2ts Absent Input Audio Behavior
 const (
 	// M2tsAbsentInputAudioBehaviorDrop is a M2tsAbsentInputAudioBehavior enum value
@@ -25840,6 +27244,14 @@ const (
 	// M2tsAbsentInputAudioBehaviorEncodeSilence is a M2tsAbsentInputAudioBehavior enum value
 	M2tsAbsentInputAudioBehaviorEncodeSilence = "ENCODE_SILENCE"
 )
+
+// M2tsAbsentInputAudioBehavior_Values returns all elements of the M2tsAbsentInputAudioBehavior enum
+func M2tsAbsentInputAudioBehavior_Values() []string {
+	return []string{
+		M2tsAbsentInputAudioBehaviorDrop,
+		M2tsAbsentInputAudioBehaviorEncodeSilence,
+	}
+}
 
 // M2ts Arib
 const (
@@ -25850,6 +27262,14 @@ const (
 	M2tsAribEnabled = "ENABLED"
 )
 
+// M2tsArib_Values returns all elements of the M2tsArib enum
+func M2tsArib_Values() []string {
+	return []string{
+		M2tsAribDisabled,
+		M2tsAribEnabled,
+	}
+}
+
 // M2ts Arib Captions Pid Control
 const (
 	// M2tsAribCaptionsPidControlAuto is a M2tsAribCaptionsPidControl enum value
@@ -25858,6 +27278,14 @@ const (
 	// M2tsAribCaptionsPidControlUseConfigured is a M2tsAribCaptionsPidControl enum value
 	M2tsAribCaptionsPidControlUseConfigured = "USE_CONFIGURED"
 )
+
+// M2tsAribCaptionsPidControl_Values returns all elements of the M2tsAribCaptionsPidControl enum
+func M2tsAribCaptionsPidControl_Values() []string {
+	return []string{
+		M2tsAribCaptionsPidControlAuto,
+		M2tsAribCaptionsPidControlUseConfigured,
+	}
+}
 
 // M2ts Audio Buffer Model
 const (
@@ -25868,6 +27296,14 @@ const (
 	M2tsAudioBufferModelDvb = "DVB"
 )
 
+// M2tsAudioBufferModel_Values returns all elements of the M2tsAudioBufferModel enum
+func M2tsAudioBufferModel_Values() []string {
+	return []string{
+		M2tsAudioBufferModelAtsc,
+		M2tsAudioBufferModelDvb,
+	}
+}
+
 // M2ts Audio Interval
 const (
 	// M2tsAudioIntervalVideoAndFixedIntervals is a M2tsAudioInterval enum value
@@ -25876,6 +27312,14 @@ const (
 	// M2tsAudioIntervalVideoInterval is a M2tsAudioInterval enum value
 	M2tsAudioIntervalVideoInterval = "VIDEO_INTERVAL"
 )
+
+// M2tsAudioInterval_Values returns all elements of the M2tsAudioInterval enum
+func M2tsAudioInterval_Values() []string {
+	return []string{
+		M2tsAudioIntervalVideoAndFixedIntervals,
+		M2tsAudioIntervalVideoInterval,
+	}
+}
 
 // M2ts Audio Stream Type
 const (
@@ -25886,6 +27330,14 @@ const (
 	M2tsAudioStreamTypeDvb = "DVB"
 )
 
+// M2tsAudioStreamType_Values returns all elements of the M2tsAudioStreamType enum
+func M2tsAudioStreamType_Values() []string {
+	return []string{
+		M2tsAudioStreamTypeAtsc,
+		M2tsAudioStreamTypeDvb,
+	}
+}
+
 // M2ts Buffer Model
 const (
 	// M2tsBufferModelMultiplex is a M2tsBufferModel enum value
@@ -25894,6 +27346,14 @@ const (
 	// M2tsBufferModelNone is a M2tsBufferModel enum value
 	M2tsBufferModelNone = "NONE"
 )
+
+// M2tsBufferModel_Values returns all elements of the M2tsBufferModel enum
+func M2tsBufferModel_Values() []string {
+	return []string{
+		M2tsBufferModelMultiplex,
+		M2tsBufferModelNone,
+	}
+}
 
 // M2ts Cc Descriptor
 const (
@@ -25904,6 +27364,14 @@ const (
 	M2tsCcDescriptorEnabled = "ENABLED"
 )
 
+// M2tsCcDescriptor_Values returns all elements of the M2tsCcDescriptor enum
+func M2tsCcDescriptor_Values() []string {
+	return []string{
+		M2tsCcDescriptorDisabled,
+		M2tsCcDescriptorEnabled,
+	}
+}
+
 // M2ts Ebif Control
 const (
 	// M2tsEbifControlNone is a M2tsEbifControl enum value
@@ -25912,6 +27380,14 @@ const (
 	// M2tsEbifControlPassthrough is a M2tsEbifControl enum value
 	M2tsEbifControlPassthrough = "PASSTHROUGH"
 )
+
+// M2tsEbifControl_Values returns all elements of the M2tsEbifControl enum
+func M2tsEbifControl_Values() []string {
+	return []string{
+		M2tsEbifControlNone,
+		M2tsEbifControlPassthrough,
+	}
+}
 
 // M2ts Ebp Placement
 const (
@@ -25922,6 +27398,14 @@ const (
 	M2tsEbpPlacementVideoPid = "VIDEO_PID"
 )
 
+// M2tsEbpPlacement_Values returns all elements of the M2tsEbpPlacement enum
+func M2tsEbpPlacement_Values() []string {
+	return []string{
+		M2tsEbpPlacementVideoAndAudioPids,
+		M2tsEbpPlacementVideoPid,
+	}
+}
+
 // M2ts Es Rate In Pes
 const (
 	// M2tsEsRateInPesExclude is a M2tsEsRateInPes enum value
@@ -25930,6 +27414,14 @@ const (
 	// M2tsEsRateInPesInclude is a M2tsEsRateInPes enum value
 	M2tsEsRateInPesInclude = "INCLUDE"
 )
+
+// M2tsEsRateInPes_Values returns all elements of the M2tsEsRateInPes enum
+func M2tsEsRateInPes_Values() []string {
+	return []string{
+		M2tsEsRateInPesExclude,
+		M2tsEsRateInPesInclude,
+	}
+}
 
 // M2ts Klv
 const (
@@ -25940,6 +27432,14 @@ const (
 	M2tsKlvPassthrough = "PASSTHROUGH"
 )
 
+// M2tsKlv_Values returns all elements of the M2tsKlv enum
+func M2tsKlv_Values() []string {
+	return []string{
+		M2tsKlvNone,
+		M2tsKlvPassthrough,
+	}
+}
+
 // M2ts Nielsen Id3 Behavior
 const (
 	// M2tsNielsenId3BehaviorNoPassthrough is a M2tsNielsenId3Behavior enum value
@@ -25948,6 +27448,14 @@ const (
 	// M2tsNielsenId3BehaviorPassthrough is a M2tsNielsenId3Behavior enum value
 	M2tsNielsenId3BehaviorPassthrough = "PASSTHROUGH"
 )
+
+// M2tsNielsenId3Behavior_Values returns all elements of the M2tsNielsenId3Behavior enum
+func M2tsNielsenId3Behavior_Values() []string {
+	return []string{
+		M2tsNielsenId3BehaviorNoPassthrough,
+		M2tsNielsenId3BehaviorPassthrough,
+	}
+}
 
 // M2ts Pcr Control
 const (
@@ -25958,6 +27466,14 @@ const (
 	M2tsPcrControlPcrEveryPesPacket = "PCR_EVERY_PES_PACKET"
 )
 
+// M2tsPcrControl_Values returns all elements of the M2tsPcrControl enum
+func M2tsPcrControl_Values() []string {
+	return []string{
+		M2tsPcrControlConfiguredPcrPeriod,
+		M2tsPcrControlPcrEveryPesPacket,
+	}
+}
+
 // M2ts Rate Mode
 const (
 	// M2tsRateModeCbr is a M2tsRateMode enum value
@@ -25967,6 +27483,14 @@ const (
 	M2tsRateModeVbr = "VBR"
 )
 
+// M2tsRateMode_Values returns all elements of the M2tsRateMode enum
+func M2tsRateMode_Values() []string {
+	return []string{
+		M2tsRateModeCbr,
+		M2tsRateModeVbr,
+	}
+}
+
 // M2ts Scte35 Control
 const (
 	// M2tsScte35ControlNone is a M2tsScte35Control enum value
@@ -25975,6 +27499,14 @@ const (
 	// M2tsScte35ControlPassthrough is a M2tsScte35Control enum value
 	M2tsScte35ControlPassthrough = "PASSTHROUGH"
 )
+
+// M2tsScte35Control_Values returns all elements of the M2tsScte35Control enum
+func M2tsScte35Control_Values() []string {
+	return []string{
+		M2tsScte35ControlNone,
+		M2tsScte35ControlPassthrough,
+	}
+}
 
 // M2ts Segmentation Markers
 const (
@@ -25997,6 +27529,18 @@ const (
 	M2tsSegmentationMarkersRaiSegstart = "RAI_SEGSTART"
 )
 
+// M2tsSegmentationMarkers_Values returns all elements of the M2tsSegmentationMarkers enum
+func M2tsSegmentationMarkers_Values() []string {
+	return []string{
+		M2tsSegmentationMarkersEbp,
+		M2tsSegmentationMarkersEbpLegacy,
+		M2tsSegmentationMarkersNone,
+		M2tsSegmentationMarkersPsiSegstart,
+		M2tsSegmentationMarkersRaiAdapt,
+		M2tsSegmentationMarkersRaiSegstart,
+	}
+}
+
 // M2ts Segmentation Style
 const (
 	// M2tsSegmentationStyleMaintainCadence is a M2tsSegmentationStyle enum value
@@ -26005,6 +27549,14 @@ const (
 	// M2tsSegmentationStyleResetCadence is a M2tsSegmentationStyle enum value
 	M2tsSegmentationStyleResetCadence = "RESET_CADENCE"
 )
+
+// M2tsSegmentationStyle_Values returns all elements of the M2tsSegmentationStyle enum
+func M2tsSegmentationStyle_Values() []string {
+	return []string{
+		M2tsSegmentationStyleMaintainCadence,
+		M2tsSegmentationStyleResetCadence,
+	}
+}
 
 // M2ts Timed Metadata Behavior
 const (
@@ -26015,6 +27567,14 @@ const (
 	M2tsTimedMetadataBehaviorPassthrough = "PASSTHROUGH"
 )
 
+// M2tsTimedMetadataBehavior_Values returns all elements of the M2tsTimedMetadataBehavior enum
+func M2tsTimedMetadataBehavior_Values() []string {
+	return []string{
+		M2tsTimedMetadataBehaviorNoPassthrough,
+		M2tsTimedMetadataBehaviorPassthrough,
+	}
+}
+
 // M3u8 Nielsen Id3 Behavior
 const (
 	// M3u8NielsenId3BehaviorNoPassthrough is a M3u8NielsenId3Behavior enum value
@@ -26023,6 +27583,14 @@ const (
 	// M3u8NielsenId3BehaviorPassthrough is a M3u8NielsenId3Behavior enum value
 	M3u8NielsenId3BehaviorPassthrough = "PASSTHROUGH"
 )
+
+// M3u8NielsenId3Behavior_Values returns all elements of the M3u8NielsenId3Behavior enum
+func M3u8NielsenId3Behavior_Values() []string {
+	return []string{
+		M3u8NielsenId3BehaviorNoPassthrough,
+		M3u8NielsenId3BehaviorPassthrough,
+	}
+}
 
 // M3u8 Pcr Control
 const (
@@ -26033,6 +27601,14 @@ const (
 	M3u8PcrControlPcrEveryPesPacket = "PCR_EVERY_PES_PACKET"
 )
 
+// M3u8PcrControl_Values returns all elements of the M3u8PcrControl enum
+func M3u8PcrControl_Values() []string {
+	return []string{
+		M3u8PcrControlConfiguredPcrPeriod,
+		M3u8PcrControlPcrEveryPesPacket,
+	}
+}
+
 // M3u8 Scte35 Behavior
 const (
 	// M3u8Scte35BehaviorNoPassthrough is a M3u8Scte35Behavior enum value
@@ -26041,6 +27617,14 @@ const (
 	// M3u8Scte35BehaviorPassthrough is a M3u8Scte35Behavior enum value
 	M3u8Scte35BehaviorPassthrough = "PASSTHROUGH"
 )
+
+// M3u8Scte35Behavior_Values returns all elements of the M3u8Scte35Behavior enum
+func M3u8Scte35Behavior_Values() []string {
+	return []string{
+		M3u8Scte35BehaviorNoPassthrough,
+		M3u8Scte35BehaviorPassthrough,
+	}
+}
 
 // M3u8 Timed Metadata Behavior
 const (
@@ -26051,6 +27635,14 @@ const (
 	M3u8TimedMetadataBehaviorPassthrough = "PASSTHROUGH"
 )
 
+// M3u8TimedMetadataBehavior_Values returns all elements of the M3u8TimedMetadataBehavior enum
+func M3u8TimedMetadataBehavior_Values() []string {
+	return []string{
+		M3u8TimedMetadataBehaviorNoPassthrough,
+		M3u8TimedMetadataBehaviorPassthrough,
+	}
+}
+
 // Mp2 Coding Mode
 const (
 	// Mp2CodingModeCodingMode10 is a Mp2CodingMode enum value
@@ -26060,6 +27652,14 @@ const (
 	Mp2CodingModeCodingMode20 = "CODING_MODE_2_0"
 )
 
+// Mp2CodingMode_Values returns all elements of the Mp2CodingMode enum
+func Mp2CodingMode_Values() []string {
+	return []string{
+		Mp2CodingModeCodingMode10,
+		Mp2CodingModeCodingMode20,
+	}
+}
+
 // Ms Smooth H265 Packaging Type
 const (
 	// MsSmoothH265PackagingTypeHev1 is a MsSmoothH265PackagingType enum value
@@ -26068,6 +27668,14 @@ const (
 	// MsSmoothH265PackagingTypeHvc1 is a MsSmoothH265PackagingType enum value
 	MsSmoothH265PackagingTypeHvc1 = "HVC1"
 )
+
+// MsSmoothH265PackagingType_Values returns all elements of the MsSmoothH265PackagingType enum
+func MsSmoothH265PackagingType_Values() []string {
+	return []string{
+		MsSmoothH265PackagingTypeHev1,
+		MsSmoothH265PackagingTypeHvc1,
+	}
+}
 
 // The current state of the multiplex.
 const (
@@ -26099,6 +27707,21 @@ const (
 	MultiplexStateDeleted = "DELETED"
 )
 
+// MultiplexState_Values returns all elements of the MultiplexState enum
+func MultiplexState_Values() []string {
+	return []string{
+		MultiplexStateCreating,
+		MultiplexStateCreateFailed,
+		MultiplexStateIdle,
+		MultiplexStateStarting,
+		MultiplexStateRunning,
+		MultiplexStateRecovering,
+		MultiplexStateStopping,
+		MultiplexStateDeleting,
+		MultiplexStateDeleted,
+	}
+}
+
 // Network Input Server Validation
 const (
 	// NetworkInputServerValidationCheckCryptographyAndValidateName is a NetworkInputServerValidation enum value
@@ -26107,6 +27730,14 @@ const (
 	// NetworkInputServerValidationCheckCryptographyOnly is a NetworkInputServerValidation enum value
 	NetworkInputServerValidationCheckCryptographyOnly = "CHECK_CRYPTOGRAPHY_ONLY"
 )
+
+// NetworkInputServerValidation_Values returns all elements of the NetworkInputServerValidation enum
+func NetworkInputServerValidation_Values() []string {
+	return []string{
+		NetworkInputServerValidationCheckCryptographyAndValidateName,
+		NetworkInputServerValidationCheckCryptographyOnly,
+	}
+}
 
 // State of Nielsen PCM to ID3 tagging
 const (
@@ -26117,17 +27748,39 @@ const (
 	NielsenPcmToId3TaggingStateEnabled = "ENABLED"
 )
 
+// NielsenPcmToId3TaggingState_Values returns all elements of the NielsenPcmToId3TaggingState enum
+func NielsenPcmToId3TaggingState_Values() []string {
+	return []string{
+		NielsenPcmToId3TaggingStateDisabled,
+		NielsenPcmToId3TaggingStateEnabled,
+	}
+}
+
 // Units for duration, e.g. 'MONTHS'
 const (
 	// OfferingDurationUnitsMonths is a OfferingDurationUnits enum value
 	OfferingDurationUnitsMonths = "MONTHS"
 )
 
+// OfferingDurationUnits_Values returns all elements of the OfferingDurationUnits enum
+func OfferingDurationUnits_Values() []string {
+	return []string{
+		OfferingDurationUnitsMonths,
+	}
+}
+
 // Offering type, e.g. 'NO_UPFRONT'
 const (
 	// OfferingTypeNoUpfront is a OfferingType enum value
 	OfferingTypeNoUpfront = "NO_UPFRONT"
 )
+
+// OfferingType_Values returns all elements of the OfferingType enum
+func OfferingType_Values() []string {
+	return []string{
+		OfferingTypeNoUpfront,
+	}
+}
 
 // Pipeline ID
 const (
@@ -26137,6 +27790,14 @@ const (
 	// PipelineIdPipeline1 is a PipelineId enum value
 	PipelineIdPipeline1 = "PIPELINE_1"
 )
+
+// PipelineId_Values returns all elements of the PipelineId enum
+func PipelineId_Values() []string {
+	return []string{
+		PipelineIdPipeline0,
+		PipelineIdPipeline1,
+	}
+}
 
 // Indicates which pipeline is preferred by the multiplex for program ingest.If
 // set to \"PIPELINE_0\" or \"PIPELINE_1\" and an unhealthy ingest causes the
@@ -26155,6 +27816,15 @@ const (
 	PreferredChannelPipelinePipeline1 = "PIPELINE_1"
 )
 
+// PreferredChannelPipeline_Values returns all elements of the PreferredChannelPipeline enum
+func PreferredChannelPipeline_Values() []string {
+	return []string{
+		PreferredChannelPipelineCurrentlyActive,
+		PreferredChannelPipelinePipeline0,
+		PreferredChannelPipelinePipeline1,
+	}
+}
+
 // Codec, 'MPEG2', 'AVC', 'HEVC', or 'AUDIO'
 const (
 	// ReservationCodecMpeg2 is a ReservationCodec enum value
@@ -26170,6 +27840,16 @@ const (
 	ReservationCodecAudio = "AUDIO"
 )
 
+// ReservationCodec_Values returns all elements of the ReservationCodec enum
+func ReservationCodec_Values() []string {
+	return []string{
+		ReservationCodecMpeg2,
+		ReservationCodecAvc,
+		ReservationCodecHevc,
+		ReservationCodecAudio,
+	}
+}
+
 // Maximum bitrate in megabits per second
 const (
 	// ReservationMaximumBitrateMax10Mbps is a ReservationMaximumBitrate enum value
@@ -26182,6 +27862,15 @@ const (
 	ReservationMaximumBitrateMax50Mbps = "MAX_50_MBPS"
 )
 
+// ReservationMaximumBitrate_Values returns all elements of the ReservationMaximumBitrate enum
+func ReservationMaximumBitrate_Values() []string {
+	return []string{
+		ReservationMaximumBitrateMax10Mbps,
+		ReservationMaximumBitrateMax20Mbps,
+		ReservationMaximumBitrateMax50Mbps,
+	}
+}
+
 // Maximum framerate in frames per second (Outputs only)
 const (
 	// ReservationMaximumFramerateMax30Fps is a ReservationMaximumFramerate enum value
@@ -26190,6 +27879,14 @@ const (
 	// ReservationMaximumFramerateMax60Fps is a ReservationMaximumFramerate enum value
 	ReservationMaximumFramerateMax60Fps = "MAX_60_FPS"
 )
+
+// ReservationMaximumFramerate_Values returns all elements of the ReservationMaximumFramerate enum
+func ReservationMaximumFramerate_Values() []string {
+	return []string{
+		ReservationMaximumFramerateMax30Fps,
+		ReservationMaximumFramerateMax60Fps,
+	}
+}
 
 // Resolution based on lines of vertical resolution; SD is less than 720 lines,
 // HD is 720 to 1080 lines, FHD is 1080 lines, UHD is greater than 1080 lines
@@ -26207,6 +27904,16 @@ const (
 	ReservationResolutionUhd = "UHD"
 )
 
+// ReservationResolution_Values returns all elements of the ReservationResolution enum
+func ReservationResolution_Values() []string {
+	return []string{
+		ReservationResolutionSd,
+		ReservationResolutionHd,
+		ReservationResolutionFhd,
+		ReservationResolutionUhd,
+	}
+}
+
 // Resource type, 'INPUT', 'OUTPUT', 'MULTIPLEX', or 'CHANNEL'
 const (
 	// ReservationResourceTypeInput is a ReservationResourceType enum value
@@ -26222,6 +27929,16 @@ const (
 	ReservationResourceTypeChannel = "CHANNEL"
 )
 
+// ReservationResourceType_Values returns all elements of the ReservationResourceType enum
+func ReservationResourceType_Values() []string {
+	return []string{
+		ReservationResourceTypeInput,
+		ReservationResourceTypeOutput,
+		ReservationResourceTypeMultiplex,
+		ReservationResourceTypeChannel,
+	}
+}
+
 // Special features, 'ADVANCED_AUDIO' or 'AUDIO_NORMALIZATION'
 const (
 	// ReservationSpecialFeatureAdvancedAudio is a ReservationSpecialFeature enum value
@@ -26230,6 +27947,14 @@ const (
 	// ReservationSpecialFeatureAudioNormalization is a ReservationSpecialFeature enum value
 	ReservationSpecialFeatureAudioNormalization = "AUDIO_NORMALIZATION"
 )
+
+// ReservationSpecialFeature_Values returns all elements of the ReservationSpecialFeature enum
+func ReservationSpecialFeature_Values() []string {
+	return []string{
+		ReservationSpecialFeatureAdvancedAudio,
+		ReservationSpecialFeatureAudioNormalization,
+	}
+}
 
 // Current reservation state
 const (
@@ -26246,6 +27971,16 @@ const (
 	ReservationStateDeleted = "DELETED"
 )
 
+// ReservationState_Values returns all elements of the ReservationState enum
+func ReservationState_Values() []string {
+	return []string{
+		ReservationStateActive,
+		ReservationStateExpired,
+		ReservationStateCanceled,
+		ReservationStateDeleted,
+	}
+}
+
 // Video quality, e.g. 'STANDARD' (Outputs only)
 const (
 	// ReservationVideoQualityStandard is a ReservationVideoQuality enum value
@@ -26258,6 +27993,15 @@ const (
 	ReservationVideoQualityPremium = "PREMIUM"
 )
 
+// ReservationVideoQuality_Values returns all elements of the ReservationVideoQuality enum
+func ReservationVideoQuality_Values() []string {
+	return []string{
+		ReservationVideoQualityStandard,
+		ReservationVideoQualityEnhanced,
+		ReservationVideoQualityPremium,
+	}
+}
+
 // Rtmp Cache Full Behavior
 const (
 	// RtmpCacheFullBehaviorDisconnectImmediately is a RtmpCacheFullBehavior enum value
@@ -26266,6 +28010,14 @@ const (
 	// RtmpCacheFullBehaviorWaitForServer is a RtmpCacheFullBehavior enum value
 	RtmpCacheFullBehaviorWaitForServer = "WAIT_FOR_SERVER"
 )
+
+// RtmpCacheFullBehavior_Values returns all elements of the RtmpCacheFullBehavior enum
+func RtmpCacheFullBehavior_Values() []string {
+	return []string{
+		RtmpCacheFullBehaviorDisconnectImmediately,
+		RtmpCacheFullBehaviorWaitForServer,
+	}
+}
 
 // Rtmp Caption Data
 const (
@@ -26279,6 +28031,15 @@ const (
 	RtmpCaptionDataField1AndField2608 = "FIELD1_AND_FIELD2_608"
 )
 
+// RtmpCaptionData_Values returns all elements of the RtmpCaptionData enum
+func RtmpCaptionData_Values() []string {
+	return []string{
+		RtmpCaptionDataAll,
+		RtmpCaptionDataField1608,
+		RtmpCaptionDataField1AndField2608,
+	}
+}
+
 // Rtmp Output Certificate Mode
 const (
 	// RtmpOutputCertificateModeSelfSigned is a RtmpOutputCertificateMode enum value
@@ -26287,6 +28048,14 @@ const (
 	// RtmpOutputCertificateModeVerifyAuthenticity is a RtmpOutputCertificateMode enum value
 	RtmpOutputCertificateModeVerifyAuthenticity = "VERIFY_AUTHENTICITY"
 )
+
+// RtmpOutputCertificateMode_Values returns all elements of the RtmpOutputCertificateMode enum
+func RtmpOutputCertificateMode_Values() []string {
+	return []string{
+		RtmpOutputCertificateModeSelfSigned,
+		RtmpOutputCertificateModeVerifyAuthenticity,
+	}
+}
 
 // Scte20 Convert608 To708
 const (
@@ -26297,6 +28066,14 @@ const (
 	Scte20Convert608To708Upconvert = "UPCONVERT"
 )
 
+// Scte20Convert608To708_Values returns all elements of the Scte20Convert608To708 enum
+func Scte20Convert608To708_Values() []string {
+	return []string{
+		Scte20Convert608To708Disabled,
+		Scte20Convert608To708Upconvert,
+	}
+}
+
 // Scte35 Apos No Regional Blackout Behavior
 const (
 	// Scte35AposNoRegionalBlackoutBehaviorFollow is a Scte35AposNoRegionalBlackoutBehavior enum value
@@ -26306,6 +28083,14 @@ const (
 	Scte35AposNoRegionalBlackoutBehaviorIgnore = "IGNORE"
 )
 
+// Scte35AposNoRegionalBlackoutBehavior_Values returns all elements of the Scte35AposNoRegionalBlackoutBehavior enum
+func Scte35AposNoRegionalBlackoutBehavior_Values() []string {
+	return []string{
+		Scte35AposNoRegionalBlackoutBehaviorFollow,
+		Scte35AposNoRegionalBlackoutBehaviorIgnore,
+	}
+}
+
 // Scte35 Apos Web Delivery Allowed Behavior
 const (
 	// Scte35AposWebDeliveryAllowedBehaviorFollow is a Scte35AposWebDeliveryAllowedBehavior enum value
@@ -26314,6 +28099,14 @@ const (
 	// Scte35AposWebDeliveryAllowedBehaviorIgnore is a Scte35AposWebDeliveryAllowedBehavior enum value
 	Scte35AposWebDeliveryAllowedBehaviorIgnore = "IGNORE"
 )
+
+// Scte35AposWebDeliveryAllowedBehavior_Values returns all elements of the Scte35AposWebDeliveryAllowedBehavior enum
+func Scte35AposWebDeliveryAllowedBehavior_Values() []string {
+	return []string{
+		Scte35AposWebDeliveryAllowedBehaviorFollow,
+		Scte35AposWebDeliveryAllowedBehaviorIgnore,
+	}
+}
 
 // Corresponds to the archive_allowed parameter. A value of ARCHIVE_NOT_ALLOWED
 // corresponds to 0 (false) in the SCTE-35 specification. If you include one
@@ -26325,6 +28118,14 @@ const (
 	// Scte35ArchiveAllowedFlagArchiveAllowed is a Scte35ArchiveAllowedFlag enum value
 	Scte35ArchiveAllowedFlagArchiveAllowed = "ARCHIVE_ALLOWED"
 )
+
+// Scte35ArchiveAllowedFlag_Values returns all elements of the Scte35ArchiveAllowedFlag enum
+func Scte35ArchiveAllowedFlag_Values() []string {
+	return []string{
+		Scte35ArchiveAllowedFlagArchiveNotAllowed,
+		Scte35ArchiveAllowedFlagArchiveAllowed,
+	}
+}
 
 // Corresponds to the device_restrictions parameter in a segmentation_descriptor.
 // If you include one of the "restriction" flags then you must include all four
@@ -26343,6 +28144,16 @@ const (
 	Scte35DeviceRestrictionsRestrictGroup2 = "RESTRICT_GROUP2"
 )
 
+// Scte35DeviceRestrictions_Values returns all elements of the Scte35DeviceRestrictions enum
+func Scte35DeviceRestrictions_Values() []string {
+	return []string{
+		Scte35DeviceRestrictionsNone,
+		Scte35DeviceRestrictionsRestrictGroup0,
+		Scte35DeviceRestrictionsRestrictGroup1,
+		Scte35DeviceRestrictionsRestrictGroup2,
+	}
+}
+
 // Corresponds to the no_regional_blackout_flag parameter. A value of REGIONAL_BLACKOUT
 // corresponds to 0 (false) in the SCTE-35 specification. If you include one
 // of the "restriction" flags then you must include all four of them.
@@ -26353,6 +28164,14 @@ const (
 	// Scte35NoRegionalBlackoutFlagNoRegionalBlackout is a Scte35NoRegionalBlackoutFlag enum value
 	Scte35NoRegionalBlackoutFlagNoRegionalBlackout = "NO_REGIONAL_BLACKOUT"
 )
+
+// Scte35NoRegionalBlackoutFlag_Values returns all elements of the Scte35NoRegionalBlackoutFlag enum
+func Scte35NoRegionalBlackoutFlag_Values() []string {
+	return []string{
+		Scte35NoRegionalBlackoutFlagRegionalBlackout,
+		Scte35NoRegionalBlackoutFlagNoRegionalBlackout,
+	}
+}
 
 // Corresponds to SCTE-35 segmentation_event_cancel_indicator. SEGMENTATION_EVENT_NOT_CANCELED
 // corresponds to 0 in the SCTE-35 specification and indicates that this is
@@ -26367,6 +28186,14 @@ const (
 	Scte35SegmentationCancelIndicatorSegmentationEventCanceled = "SEGMENTATION_EVENT_CANCELED"
 )
 
+// Scte35SegmentationCancelIndicator_Values returns all elements of the Scte35SegmentationCancelIndicator enum
+func Scte35SegmentationCancelIndicator_Values() []string {
+	return []string{
+		Scte35SegmentationCancelIndicatorSegmentationEventNotCanceled,
+		Scte35SegmentationCancelIndicatorSegmentationEventCanceled,
+	}
+}
+
 // Scte35 Splice Insert No Regional Blackout Behavior
 const (
 	// Scte35SpliceInsertNoRegionalBlackoutBehaviorFollow is a Scte35SpliceInsertNoRegionalBlackoutBehavior enum value
@@ -26376,6 +28203,14 @@ const (
 	Scte35SpliceInsertNoRegionalBlackoutBehaviorIgnore = "IGNORE"
 )
 
+// Scte35SpliceInsertNoRegionalBlackoutBehavior_Values returns all elements of the Scte35SpliceInsertNoRegionalBlackoutBehavior enum
+func Scte35SpliceInsertNoRegionalBlackoutBehavior_Values() []string {
+	return []string{
+		Scte35SpliceInsertNoRegionalBlackoutBehaviorFollow,
+		Scte35SpliceInsertNoRegionalBlackoutBehaviorIgnore,
+	}
+}
+
 // Scte35 Splice Insert Web Delivery Allowed Behavior
 const (
 	// Scte35SpliceInsertWebDeliveryAllowedBehaviorFollow is a Scte35SpliceInsertWebDeliveryAllowedBehavior enum value
@@ -26384,6 +28219,14 @@ const (
 	// Scte35SpliceInsertWebDeliveryAllowedBehaviorIgnore is a Scte35SpliceInsertWebDeliveryAllowedBehavior enum value
 	Scte35SpliceInsertWebDeliveryAllowedBehaviorIgnore = "IGNORE"
 )
+
+// Scte35SpliceInsertWebDeliveryAllowedBehavior_Values returns all elements of the Scte35SpliceInsertWebDeliveryAllowedBehavior enum
+func Scte35SpliceInsertWebDeliveryAllowedBehavior_Values() []string {
+	return []string{
+		Scte35SpliceInsertWebDeliveryAllowedBehaviorFollow,
+		Scte35SpliceInsertWebDeliveryAllowedBehaviorIgnore,
+	}
+}
 
 // Corresponds to the web_delivery_allowed_flag parameter. A value of WEB_DELIVERY_NOT_ALLOWED
 // corresponds to 0 (false) in the SCTE-35 specification. If you include one
@@ -26396,6 +28239,14 @@ const (
 	Scte35WebDeliveryAllowedFlagWebDeliveryAllowed = "WEB_DELIVERY_ALLOWED"
 )
 
+// Scte35WebDeliveryAllowedFlag_Values returns all elements of the Scte35WebDeliveryAllowedFlag enum
+func Scte35WebDeliveryAllowedFlag_Values() []string {
+	return []string{
+		Scte35WebDeliveryAllowedFlagWebDeliveryNotAllowed,
+		Scte35WebDeliveryAllowedFlagWebDeliveryAllowed,
+	}
+}
+
 // Smooth Group Audio Only Timecode Control
 const (
 	// SmoothGroupAudioOnlyTimecodeControlPassthrough is a SmoothGroupAudioOnlyTimecodeControl enum value
@@ -26405,6 +28256,14 @@ const (
 	SmoothGroupAudioOnlyTimecodeControlUseConfiguredClock = "USE_CONFIGURED_CLOCK"
 )
 
+// SmoothGroupAudioOnlyTimecodeControl_Values returns all elements of the SmoothGroupAudioOnlyTimecodeControl enum
+func SmoothGroupAudioOnlyTimecodeControl_Values() []string {
+	return []string{
+		SmoothGroupAudioOnlyTimecodeControlPassthrough,
+		SmoothGroupAudioOnlyTimecodeControlUseConfiguredClock,
+	}
+}
+
 // Smooth Group Certificate Mode
 const (
 	// SmoothGroupCertificateModeSelfSigned is a SmoothGroupCertificateMode enum value
@@ -26413,6 +28272,14 @@ const (
 	// SmoothGroupCertificateModeVerifyAuthenticity is a SmoothGroupCertificateMode enum value
 	SmoothGroupCertificateModeVerifyAuthenticity = "VERIFY_AUTHENTICITY"
 )
+
+// SmoothGroupCertificateMode_Values returns all elements of the SmoothGroupCertificateMode enum
+func SmoothGroupCertificateMode_Values() []string {
+	return []string{
+		SmoothGroupCertificateModeSelfSigned,
+		SmoothGroupCertificateModeVerifyAuthenticity,
+	}
+}
 
 // Smooth Group Event Id Mode
 const (
@@ -26426,6 +28293,15 @@ const (
 	SmoothGroupEventIdModeUseTimestamp = "USE_TIMESTAMP"
 )
 
+// SmoothGroupEventIdMode_Values returns all elements of the SmoothGroupEventIdMode enum
+func SmoothGroupEventIdMode_Values() []string {
+	return []string{
+		SmoothGroupEventIdModeNoEventId,
+		SmoothGroupEventIdModeUseConfigured,
+		SmoothGroupEventIdModeUseTimestamp,
+	}
+}
+
 // Smooth Group Event Stop Behavior
 const (
 	// SmoothGroupEventStopBehaviorNone is a SmoothGroupEventStopBehavior enum value
@@ -26435,6 +28311,14 @@ const (
 	SmoothGroupEventStopBehaviorSendEos = "SEND_EOS"
 )
 
+// SmoothGroupEventStopBehavior_Values returns all elements of the SmoothGroupEventStopBehavior enum
+func SmoothGroupEventStopBehavior_Values() []string {
+	return []string{
+		SmoothGroupEventStopBehaviorNone,
+		SmoothGroupEventStopBehaviorSendEos,
+	}
+}
+
 // Smooth Group Segmentation Mode
 const (
 	// SmoothGroupSegmentationModeUseInputSegmentation is a SmoothGroupSegmentationMode enum value
@@ -26443,6 +28327,14 @@ const (
 	// SmoothGroupSegmentationModeUseSegmentDuration is a SmoothGroupSegmentationMode enum value
 	SmoothGroupSegmentationModeUseSegmentDuration = "USE_SEGMENT_DURATION"
 )
+
+// SmoothGroupSegmentationMode_Values returns all elements of the SmoothGroupSegmentationMode enum
+func SmoothGroupSegmentationMode_Values() []string {
+	return []string{
+		SmoothGroupSegmentationModeUseInputSegmentation,
+		SmoothGroupSegmentationModeUseSegmentDuration,
+	}
+}
 
 // Smooth Group Sparse Track Type
 const (
@@ -26456,6 +28348,15 @@ const (
 	SmoothGroupSparseTrackTypeScte35WithoutSegmentation = "SCTE_35_WITHOUT_SEGMENTATION"
 )
 
+// SmoothGroupSparseTrackType_Values returns all elements of the SmoothGroupSparseTrackType enum
+func SmoothGroupSparseTrackType_Values() []string {
+	return []string{
+		SmoothGroupSparseTrackTypeNone,
+		SmoothGroupSparseTrackTypeScte35,
+		SmoothGroupSparseTrackTypeScte35WithoutSegmentation,
+	}
+}
+
 // Smooth Group Stream Manifest Behavior
 const (
 	// SmoothGroupStreamManifestBehaviorDoNotSend is a SmoothGroupStreamManifestBehavior enum value
@@ -26464,6 +28365,14 @@ const (
 	// SmoothGroupStreamManifestBehaviorSend is a SmoothGroupStreamManifestBehavior enum value
 	SmoothGroupStreamManifestBehaviorSend = "SEND"
 )
+
+// SmoothGroupStreamManifestBehavior_Values returns all elements of the SmoothGroupStreamManifestBehavior enum
+func SmoothGroupStreamManifestBehavior_Values() []string {
+	return []string{
+		SmoothGroupStreamManifestBehaviorDoNotSend,
+		SmoothGroupStreamManifestBehaviorSend,
+	}
+}
 
 // Smooth Group Timestamp Offset Mode
 const (
@@ -26474,6 +28383,14 @@ const (
 	SmoothGroupTimestampOffsetModeUseEventStartDate = "USE_EVENT_START_DATE"
 )
 
+// SmoothGroupTimestampOffsetMode_Values returns all elements of the SmoothGroupTimestampOffsetMode enum
+func SmoothGroupTimestampOffsetMode_Values() []string {
+	return []string{
+		SmoothGroupTimestampOffsetModeUseConfiguredOffset,
+		SmoothGroupTimestampOffsetModeUseEventStartDate,
+	}
+}
+
 // Smpte2038 Data Preference
 const (
 	// Smpte2038DataPreferenceIgnore is a Smpte2038DataPreference enum value
@@ -26482,6 +28399,14 @@ const (
 	// Smpte2038DataPreferencePrefer is a Smpte2038DataPreference enum value
 	Smpte2038DataPreferencePrefer = "PREFER"
 )
+
+// Smpte2038DataPreference_Values returns all elements of the Smpte2038DataPreference enum
+func Smpte2038DataPreference_Values() []string {
+	return []string{
+		Smpte2038DataPreferenceIgnore,
+		Smpte2038DataPreferencePrefer,
+	}
+}
 
 // Temporal Filter Post Filter Sharpening
 const (
@@ -26494,6 +28419,15 @@ const (
 	// TemporalFilterPostFilterSharpeningEnabled is a TemporalFilterPostFilterSharpening enum value
 	TemporalFilterPostFilterSharpeningEnabled = "ENABLED"
 )
+
+// TemporalFilterPostFilterSharpening_Values returns all elements of the TemporalFilterPostFilterSharpening enum
+func TemporalFilterPostFilterSharpening_Values() []string {
+	return []string{
+		TemporalFilterPostFilterSharpeningAuto,
+		TemporalFilterPostFilterSharpeningDisabled,
+		TemporalFilterPostFilterSharpeningEnabled,
+	}
+}
 
 // Temporal Filter Strength
 const (
@@ -26549,6 +28483,29 @@ const (
 	TemporalFilterStrengthStrength16 = "STRENGTH_16"
 )
 
+// TemporalFilterStrength_Values returns all elements of the TemporalFilterStrength enum
+func TemporalFilterStrength_Values() []string {
+	return []string{
+		TemporalFilterStrengthAuto,
+		TemporalFilterStrengthStrength1,
+		TemporalFilterStrengthStrength2,
+		TemporalFilterStrengthStrength3,
+		TemporalFilterStrengthStrength4,
+		TemporalFilterStrengthStrength5,
+		TemporalFilterStrengthStrength6,
+		TemporalFilterStrengthStrength7,
+		TemporalFilterStrengthStrength8,
+		TemporalFilterStrengthStrength9,
+		TemporalFilterStrengthStrength10,
+		TemporalFilterStrengthStrength11,
+		TemporalFilterStrengthStrength12,
+		TemporalFilterStrengthStrength13,
+		TemporalFilterStrengthStrength14,
+		TemporalFilterStrengthStrength15,
+		TemporalFilterStrengthStrength16,
+	}
+}
+
 // Timecode Config Source
 const (
 	// TimecodeConfigSourceEmbedded is a TimecodeConfigSource enum value
@@ -26561,6 +28518,15 @@ const (
 	TimecodeConfigSourceZerobased = "ZEROBASED"
 )
 
+// TimecodeConfigSource_Values returns all elements of the TimecodeConfigSource enum
+func TimecodeConfigSource_Values() []string {
+	return []string{
+		TimecodeConfigSourceEmbedded,
+		TimecodeConfigSourceSystemclock,
+		TimecodeConfigSourceZerobased,
+	}
+}
+
 // Ttml Destination Style Control
 const (
 	// TtmlDestinationStyleControlPassthrough is a TtmlDestinationStyleControl enum value
@@ -26569,6 +28535,14 @@ const (
 	// TtmlDestinationStyleControlUseConfigured is a TtmlDestinationStyleControl enum value
 	TtmlDestinationStyleControlUseConfigured = "USE_CONFIGURED"
 )
+
+// TtmlDestinationStyleControl_Values returns all elements of the TtmlDestinationStyleControl enum
+func TtmlDestinationStyleControl_Values() []string {
+	return []string{
+		TtmlDestinationStyleControlPassthrough,
+		TtmlDestinationStyleControlUseConfigured,
+	}
+}
 
 // Udp Timed Metadata Id3 Frame
 const (
@@ -26582,6 +28556,15 @@ const (
 	UdpTimedMetadataId3FrameTdrl = "TDRL"
 )
 
+// UdpTimedMetadataId3Frame_Values returns all elements of the UdpTimedMetadataId3Frame enum
+func UdpTimedMetadataId3Frame_Values() []string {
+	return []string{
+		UdpTimedMetadataId3FrameNone,
+		UdpTimedMetadataId3FramePriv,
+		UdpTimedMetadataId3FrameTdrl,
+	}
+}
+
 // Video Description Respond To Afd
 const (
 	// VideoDescriptionRespondToAfdNone is a VideoDescriptionRespondToAfd enum value
@@ -26594,6 +28577,15 @@ const (
 	VideoDescriptionRespondToAfdRespond = "RESPOND"
 )
 
+// VideoDescriptionRespondToAfd_Values returns all elements of the VideoDescriptionRespondToAfd enum
+func VideoDescriptionRespondToAfd_Values() []string {
+	return []string{
+		VideoDescriptionRespondToAfdNone,
+		VideoDescriptionRespondToAfdPassthrough,
+		VideoDescriptionRespondToAfdRespond,
+	}
+}
+
 // Video Description Scaling Behavior
 const (
 	// VideoDescriptionScalingBehaviorDefault is a VideoDescriptionScalingBehavior enum value
@@ -26602,6 +28594,14 @@ const (
 	// VideoDescriptionScalingBehaviorStretchToOutput is a VideoDescriptionScalingBehavior enum value
 	VideoDescriptionScalingBehaviorStretchToOutput = "STRETCH_TO_OUTPUT"
 )
+
+// VideoDescriptionScalingBehavior_Values returns all elements of the VideoDescriptionScalingBehavior enum
+func VideoDescriptionScalingBehavior_Values() []string {
+	return []string{
+		VideoDescriptionScalingBehaviorDefault,
+		VideoDescriptionScalingBehaviorStretchToOutput,
+	}
+}
 
 // Video Selector Color Space
 const (
@@ -26615,6 +28615,15 @@ const (
 	VideoSelectorColorSpaceRec709 = "REC_709"
 )
 
+// VideoSelectorColorSpace_Values returns all elements of the VideoSelectorColorSpace enum
+func VideoSelectorColorSpace_Values() []string {
+	return []string{
+		VideoSelectorColorSpaceFollow,
+		VideoSelectorColorSpaceRec601,
+		VideoSelectorColorSpaceRec709,
+	}
+}
+
 // Video Selector Color Space Usage
 const (
 	// VideoSelectorColorSpaceUsageFallback is a VideoSelectorColorSpaceUsage enum value
@@ -26623,3 +28632,11 @@ const (
 	// VideoSelectorColorSpaceUsageForce is a VideoSelectorColorSpaceUsage enum value
 	VideoSelectorColorSpaceUsageForce = "FORCE"
 )
+
+// VideoSelectorColorSpaceUsage_Values returns all elements of the VideoSelectorColorSpaceUsage enum
+func VideoSelectorColorSpaceUsage_Values() []string {
+	return []string{
+		VideoSelectorColorSpaceUsageFallback,
+		VideoSelectorColorSpaceUsageForce,
+	}
+}

--- a/service/mediapackage/api.go
+++ b/service/mediapackage/api.go
@@ -5947,6 +5947,16 @@ const (
 	AdMarkersDaterange = "DATERANGE"
 )
 
+// AdMarkers_Values returns all elements of the AdMarkers enum
+func AdMarkers_Values() []string {
+	return []string{
+		AdMarkersNone,
+		AdMarkersScte35Enhanced,
+		AdMarkersPassthrough,
+		AdMarkersDaterange,
+	}
+}
+
 // This setting allows the delivery restriction flags on SCTE-35 segmentation
 // descriptors todetermine whether a message signals an ad. Choosing "NONE"
 // means no SCTE-35 messages becomeads. Choosing "RESTRICTED" means SCTE-35
@@ -5971,6 +5981,16 @@ const (
 	AdsOnDeliveryRestrictionsBoth = "BOTH"
 )
 
+// AdsOnDeliveryRestrictions_Values returns all elements of the AdsOnDeliveryRestrictions enum
+func AdsOnDeliveryRestrictions_Values() []string {
+	return []string{
+		AdsOnDeliveryRestrictionsNone,
+		AdsOnDeliveryRestrictionsRestricted,
+		AdsOnDeliveryRestrictionsUnrestricted,
+		AdsOnDeliveryRestrictionsBoth,
+	}
+}
+
 const (
 	// EncryptionMethodAes128 is a EncryptionMethod enum value
 	EncryptionMethodAes128 = "AES_128"
@@ -5978,6 +5998,14 @@ const (
 	// EncryptionMethodSampleAes is a EncryptionMethod enum value
 	EncryptionMethodSampleAes = "SAMPLE_AES"
 )
+
+// EncryptionMethod_Values returns all elements of the EncryptionMethod enum
+func EncryptionMethod_Values() []string {
+	return []string{
+		EncryptionMethodAes128,
+		EncryptionMethodSampleAes,
+	}
+}
 
 const (
 	// ManifestLayoutFull is a ManifestLayout enum value
@@ -5987,6 +6015,14 @@ const (
 	ManifestLayoutCompact = "COMPACT"
 )
 
+// ManifestLayout_Values returns all elements of the ManifestLayout enum
+func ManifestLayout_Values() []string {
+	return []string{
+		ManifestLayoutFull,
+		ManifestLayoutCompact,
+	}
+}
+
 const (
 	// OriginationAllow is a Origination enum value
 	OriginationAllow = "ALLOW"
@@ -5994,6 +6030,14 @@ const (
 	// OriginationDeny is a Origination enum value
 	OriginationDeny = "DENY"
 )
+
+// Origination_Values returns all elements of the Origination enum
+func Origination_Values() []string {
+	return []string{
+		OriginationAllow,
+		OriginationDeny,
+	}
+}
 
 const (
 	// PlaylistTypeNone is a PlaylistType enum value
@@ -6006,6 +6050,15 @@ const (
 	PlaylistTypeVod = "VOD"
 )
 
+// PlaylistType_Values returns all elements of the PlaylistType enum
+func PlaylistType_Values() []string {
+	return []string{
+		PlaylistTypeNone,
+		PlaylistTypeEvent,
+		PlaylistTypeVod,
+	}
+}
+
 const (
 	// ProfileNone is a Profile enum value
 	ProfileNone = "NONE"
@@ -6013,6 +6066,14 @@ const (
 	// ProfileHbbtv15 is a Profile enum value
 	ProfileHbbtv15 = "HBBTV_1_5"
 )
+
+// Profile_Values returns all elements of the Profile enum
+func Profile_Values() []string {
+	return []string{
+		ProfileNone,
+		ProfileHbbtv15,
+	}
+}
 
 const (
 	// SegmentTemplateFormatNumberWithTimeline is a SegmentTemplateFormat enum value
@@ -6025,6 +6086,15 @@ const (
 	SegmentTemplateFormatNumberWithDuration = "NUMBER_WITH_DURATION"
 )
 
+// SegmentTemplateFormat_Values returns all elements of the SegmentTemplateFormat enum
+func SegmentTemplateFormat_Values() []string {
+	return []string{
+		SegmentTemplateFormatNumberWithTimeline,
+		SegmentTemplateFormatTimeWithTimeline,
+		SegmentTemplateFormatNumberWithDuration,
+	}
+}
+
 const (
 	// StatusInProgress is a Status enum value
 	StatusInProgress = "IN_PROGRESS"
@@ -6036,6 +6106,15 @@ const (
 	StatusFailed = "FAILED"
 )
 
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusInProgress,
+		StatusSucceeded,
+		StatusFailed,
+	}
+}
+
 const (
 	// StreamOrderOriginal is a StreamOrder enum value
 	StreamOrderOriginal = "ORIGINAL"
@@ -6046,6 +6125,15 @@ const (
 	// StreamOrderVideoBitrateDescending is a StreamOrder enum value
 	StreamOrderVideoBitrateDescending = "VIDEO_BITRATE_DESCENDING"
 )
+
+// StreamOrder_Values returns all elements of the StreamOrder enum
+func StreamOrder_Values() []string {
+	return []string{
+		StreamOrderOriginal,
+		StreamOrderVideoBitrateAscending,
+		StreamOrderVideoBitrateDescending,
+	}
+}
 
 const (
 	// __AdTriggersElementSpliceInsert is a __AdTriggersElement enum value
@@ -6073,7 +6161,28 @@ const (
 	__AdTriggersElementDistributorOverlayPlacementOpportunity = "DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY"
 )
 
+// __AdTriggersElement_Values returns all elements of the __AdTriggersElement enum
+func __AdTriggersElement_Values() []string {
+	return []string{
+		__AdTriggersElementSpliceInsert,
+		__AdTriggersElementBreak,
+		__AdTriggersElementProviderAdvertisement,
+		__AdTriggersElementDistributorAdvertisement,
+		__AdTriggersElementProviderPlacementOpportunity,
+		__AdTriggersElementDistributorPlacementOpportunity,
+		__AdTriggersElementProviderOverlayPlacementOpportunity,
+		__AdTriggersElementDistributorOverlayPlacementOpportunity,
+	}
+}
+
 const (
 	// __PeriodTriggersElementAds is a __PeriodTriggersElement enum value
 	__PeriodTriggersElementAds = "ADS"
 )
+
+// __PeriodTriggersElement_Values returns all elements of the __PeriodTriggersElement enum
+func __PeriodTriggersElement_Values() []string {
+	return []string{
+		__PeriodTriggersElementAds,
+	}
+}

--- a/service/mediapackagevod/api.go
+++ b/service/mediapackagevod/api.go
@@ -4522,6 +4522,15 @@ const (
 	AdMarkersPassthrough = "PASSTHROUGH"
 )
 
+// AdMarkers_Values returns all elements of the AdMarkers enum
+func AdMarkers_Values() []string {
+	return []string{
+		AdMarkersNone,
+		AdMarkersScte35Enhanced,
+		AdMarkersPassthrough,
+	}
+}
+
 const (
 	// EncryptionMethodAes128 is a EncryptionMethod enum value
 	EncryptionMethodAes128 = "AES_128"
@@ -4529,6 +4538,14 @@ const (
 	// EncryptionMethodSampleAes is a EncryptionMethod enum value
 	EncryptionMethodSampleAes = "SAMPLE_AES"
 )
+
+// EncryptionMethod_Values returns all elements of the EncryptionMethod enum
+func EncryptionMethod_Values() []string {
+	return []string{
+		EncryptionMethodAes128,
+		EncryptionMethodSampleAes,
+	}
+}
 
 const (
 	// ManifestLayoutFull is a ManifestLayout enum value
@@ -4538,10 +4555,25 @@ const (
 	ManifestLayoutCompact = "COMPACT"
 )
 
+// ManifestLayout_Values returns all elements of the ManifestLayout enum
+func ManifestLayout_Values() []string {
+	return []string{
+		ManifestLayoutFull,
+		ManifestLayoutCompact,
+	}
+}
+
 const (
 	// PeriodTriggersElementAds is a PeriodTriggersElement enum value
 	PeriodTriggersElementAds = "ADS"
 )
+
+// PeriodTriggersElement_Values returns all elements of the PeriodTriggersElement enum
+func PeriodTriggersElement_Values() []string {
+	return []string{
+		PeriodTriggersElementAds,
+	}
+}
 
 const (
 	// ProfileNone is a Profile enum value
@@ -4550,6 +4582,14 @@ const (
 	// ProfileHbbtv15 is a Profile enum value
 	ProfileHbbtv15 = "HBBTV_1_5"
 )
+
+// Profile_Values returns all elements of the Profile enum
+func Profile_Values() []string {
+	return []string{
+		ProfileNone,
+		ProfileHbbtv15,
+	}
+}
 
 const (
 	// SegmentTemplateFormatNumberWithTimeline is a SegmentTemplateFormat enum value
@@ -4562,6 +4602,15 @@ const (
 	SegmentTemplateFormatNumberWithDuration = "NUMBER_WITH_DURATION"
 )
 
+// SegmentTemplateFormat_Values returns all elements of the SegmentTemplateFormat enum
+func SegmentTemplateFormat_Values() []string {
+	return []string{
+		SegmentTemplateFormatNumberWithTimeline,
+		SegmentTemplateFormatTimeWithTimeline,
+		SegmentTemplateFormatNumberWithDuration,
+	}
+}
+
 const (
 	// StreamOrderOriginal is a StreamOrder enum value
 	StreamOrderOriginal = "ORIGINAL"
@@ -4572,3 +4621,12 @@ const (
 	// StreamOrderVideoBitrateDescending is a StreamOrder enum value
 	StreamOrderVideoBitrateDescending = "VIDEO_BITRATE_DESCENDING"
 )
+
+// StreamOrder_Values returns all elements of the StreamOrder enum
+func StreamOrder_Values() []string {
+	return []string{
+		StreamOrderOriginal,
+		StreamOrderVideoBitrateAscending,
+		StreamOrderVideoBitrateDescending,
+	}
+}

--- a/service/mediastore/api.go
+++ b/service/mediastore/api.go
@@ -4153,6 +4153,14 @@ const (
 	ContainerLevelMetricsDisabled = "DISABLED"
 )
 
+// ContainerLevelMetrics_Values returns all elements of the ContainerLevelMetrics enum
+func ContainerLevelMetrics_Values() []string {
+	return []string{
+		ContainerLevelMetricsEnabled,
+		ContainerLevelMetricsDisabled,
+	}
+}
+
 const (
 	// ContainerStatusActive is a ContainerStatus enum value
 	ContainerStatusActive = "ACTIVE"
@@ -4163,6 +4171,15 @@ const (
 	// ContainerStatusDeleting is a ContainerStatus enum value
 	ContainerStatusDeleting = "DELETING"
 )
+
+// ContainerStatus_Values returns all elements of the ContainerStatus enum
+func ContainerStatus_Values() []string {
+	return []string{
+		ContainerStatusActive,
+		ContainerStatusCreating,
+		ContainerStatusDeleting,
+	}
+}
 
 const (
 	// MethodNamePut is a MethodName enum value
@@ -4177,3 +4194,13 @@ const (
 	// MethodNameHead is a MethodName enum value
 	MethodNameHead = "HEAD"
 )
+
+// MethodName_Values returns all elements of the MethodName enum
+func MethodName_Values() []string {
+	return []string{
+		MethodNamePut,
+		MethodNameGet,
+		MethodNameDelete,
+		MethodNameHead,
+	}
+}

--- a/service/mediastoredata/api.go
+++ b/service/mediastoredata/api.go
@@ -1418,10 +1418,25 @@ const (
 	ItemTypeFolder = "FOLDER"
 )
 
+// ItemType_Values returns all elements of the ItemType enum
+func ItemType_Values() []string {
+	return []string{
+		ItemTypeObject,
+		ItemTypeFolder,
+	}
+}
+
 const (
 	// StorageClassTemporal is a StorageClass enum value
 	StorageClassTemporal = "TEMPORAL"
 )
+
+// StorageClass_Values returns all elements of the StorageClass enum
+func StorageClass_Values() []string {
+	return []string{
+		StorageClassTemporal,
+	}
+}
 
 const (
 	// UploadAvailabilityStandard is a UploadAvailability enum value
@@ -1430,3 +1445,11 @@ const (
 	// UploadAvailabilityStreaming is a UploadAvailability enum value
 	UploadAvailabilityStreaming = "STREAMING"
 )
+
+// UploadAvailability_Values returns all elements of the UploadAvailability enum
+func UploadAvailability_Values() []string {
+	return []string{
+		UploadAvailabilityStandard,
+		UploadAvailabilityStreaming,
+	}
+}

--- a/service/mediatailor/api.go
+++ b/service/mediatailor/api.go
@@ -1837,6 +1837,14 @@ const (
 	ModeBehindLiveEdge = "BEHIND_LIVE_EDGE"
 )
 
+// Mode_Values returns all elements of the Mode enum
+func Mode_Values() []string {
+	return []string{
+		ModeOff,
+		ModeBehindLiveEdge,
+	}
+}
+
 const (
 	// OriginManifestTypeSinglePeriod is a OriginManifestType enum value
 	OriginManifestTypeSinglePeriod = "SINGLE_PERIOD"
@@ -1844,3 +1852,11 @@ const (
 	// OriginManifestTypeMultiPeriod is a OriginManifestType enum value
 	OriginManifestTypeMultiPeriod = "MULTI_PERIOD"
 )
+
+// OriginManifestType_Values returns all elements of the OriginManifestType enum
+func OriginManifestType_Values() []string {
+	return []string{
+		OriginManifestTypeSinglePeriod,
+		OriginManifestTypeMultiPeriod,
+	}
+}

--- a/service/migrationhub/api.go
+++ b/service/migrationhub/api.go
@@ -4905,6 +4905,15 @@ const (
 	ApplicationStatusCompleted = "COMPLETED"
 )
 
+// ApplicationStatus_Values returns all elements of the ApplicationStatus enum
+func ApplicationStatus_Values() []string {
+	return []string{
+		ApplicationStatusNotStarted,
+		ApplicationStatusInProgress,
+		ApplicationStatusCompleted,
+	}
+}
+
 const (
 	// ResourceAttributeTypeIpv4Address is a ResourceAttributeType enum value
 	ResourceAttributeTypeIpv4Address = "IPV4_ADDRESS"
@@ -4937,6 +4946,22 @@ const (
 	ResourceAttributeTypeMotherboardSerialNumber = "MOTHERBOARD_SERIAL_NUMBER"
 )
 
+// ResourceAttributeType_Values returns all elements of the ResourceAttributeType enum
+func ResourceAttributeType_Values() []string {
+	return []string{
+		ResourceAttributeTypeIpv4Address,
+		ResourceAttributeTypeIpv6Address,
+		ResourceAttributeTypeMacAddress,
+		ResourceAttributeTypeFqdn,
+		ResourceAttributeTypeVmManagerId,
+		ResourceAttributeTypeVmManagedObjectReference,
+		ResourceAttributeTypeVmName,
+		ResourceAttributeTypeVmPath,
+		ResourceAttributeTypeBiosId,
+		ResourceAttributeTypeMotherboardSerialNumber,
+	}
+}
+
 const (
 	// StatusNotStarted is a Status enum value
 	StatusNotStarted = "NOT_STARTED"
@@ -4950,3 +4975,13 @@ const (
 	// StatusCompleted is a Status enum value
 	StatusCompleted = "COMPLETED"
 )
+
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusNotStarted,
+		StatusInProgress,
+		StatusFailed,
+		StatusCompleted,
+	}
+}

--- a/service/migrationhubconfig/api.go
+++ b/service/migrationhubconfig/api.go
@@ -1072,3 +1072,10 @@ const (
 	// TargetTypeAccount is a TargetType enum value
 	TargetTypeAccount = "ACCOUNT"
 )
+
+// TargetType_Values returns all elements of the TargetType enum
+func TargetType_Values() []string {
+	return []string{
+		TargetTypeAccount,
+	}
+}

--- a/service/mobile/api.go
+++ b/service/mobile/api.go
@@ -2450,6 +2450,19 @@ const (
 	PlatformJavascript = "JAVASCRIPT"
 )
 
+// Platform_Values returns all elements of the Platform enum
+func Platform_Values() []string {
+	return []string{
+		PlatformOsx,
+		PlatformWindows,
+		PlatformLinux,
+		PlatformObjc,
+		PlatformSwift,
+		PlatformAndroid,
+		PlatformJavascript,
+	}
+}
+
 // Synchronization state for a project.
 const (
 	// ProjectStateNormal is a ProjectState enum value
@@ -2461,3 +2474,12 @@ const (
 	// ProjectStateImporting is a ProjectState enum value
 	ProjectStateImporting = "IMPORTING"
 )
+
+// ProjectState_Values returns all elements of the ProjectState enum
+func ProjectState_Values() []string {
+	return []string{
+		ProjectStateNormal,
+		ProjectStateSyncing,
+		ProjectStateImporting,
+	}
+}

--- a/service/mq/api.go
+++ b/service/mq/api.go
@@ -5912,6 +5912,14 @@ const (
 	AuthenticationStrategyLdap = "LDAP"
 )
 
+// AuthenticationStrategy_Values returns all elements of the AuthenticationStrategy enum
+func AuthenticationStrategy_Values() []string {
+	return []string{
+		AuthenticationStrategySimple,
+		AuthenticationStrategyLdap,
+	}
+}
+
 // The status of the broker.
 const (
 	// BrokerStateCreationInProgress is a BrokerState enum value
@@ -5930,6 +5938,17 @@ const (
 	BrokerStateRebootInProgress = "REBOOT_IN_PROGRESS"
 )
 
+// BrokerState_Values returns all elements of the BrokerState enum
+func BrokerState_Values() []string {
+	return []string{
+		BrokerStateCreationInProgress,
+		BrokerStateCreationFailed,
+		BrokerStateDeletionInProgress,
+		BrokerStateRunning,
+		BrokerStateRebootInProgress,
+	}
+}
+
 // The storage type of the broker.
 const (
 	// BrokerStorageTypeEbs is a BrokerStorageType enum value
@@ -5938,6 +5957,14 @@ const (
 	// BrokerStorageTypeEfs is a BrokerStorageType enum value
 	BrokerStorageTypeEfs = "EFS"
 )
+
+// BrokerStorageType_Values returns all elements of the BrokerStorageType enum
+func BrokerStorageType_Values() []string {
+	return []string{
+		BrokerStorageTypeEbs,
+		BrokerStorageTypeEfs,
+	}
+}
 
 // The type of change pending for the ActiveMQ user.
 const (
@@ -5950,6 +5977,15 @@ const (
 	// ChangeTypeDelete is a ChangeType enum value
 	ChangeTypeDelete = "DELETE"
 )
+
+// ChangeType_Values returns all elements of the ChangeType enum
+func ChangeType_Values() []string {
+	return []string{
+		ChangeTypeCreate,
+		ChangeTypeUpdate,
+		ChangeTypeDelete,
+	}
+}
 
 const (
 	// DayOfWeekMonday is a DayOfWeek enum value
@@ -5974,6 +6010,19 @@ const (
 	DayOfWeekSunday = "SUNDAY"
 )
 
+// DayOfWeek_Values returns all elements of the DayOfWeek enum
+func DayOfWeek_Values() []string {
+	return []string{
+		DayOfWeekMonday,
+		DayOfWeekTuesday,
+		DayOfWeekWednesday,
+		DayOfWeekThursday,
+		DayOfWeekFriday,
+		DayOfWeekSaturday,
+		DayOfWeekSunday,
+	}
+}
+
 // The deployment mode of the broker.
 const (
 	// DeploymentModeSingleInstance is a DeploymentMode enum value
@@ -5983,11 +6032,26 @@ const (
 	DeploymentModeActiveStandbyMultiAz = "ACTIVE_STANDBY_MULTI_AZ"
 )
 
+// DeploymentMode_Values returns all elements of the DeploymentMode enum
+func DeploymentMode_Values() []string {
+	return []string{
+		DeploymentModeSingleInstance,
+		DeploymentModeActiveStandbyMultiAz,
+	}
+}
+
 // The type of broker engine. Note: Currently, Amazon MQ supports only ActiveMQ.
 const (
 	// EngineTypeActivemq is a EngineType enum value
 	EngineTypeActivemq = "ACTIVEMQ"
 )
+
+// EngineType_Values returns all elements of the EngineType enum
+func EngineType_Values() []string {
+	return []string{
+		EngineTypeActivemq,
+	}
+}
 
 // The reason for which the XML elements or attributes were sanitized.
 const (
@@ -6000,3 +6064,12 @@ const (
 	// SanitizationWarningReasonInvalidAttributeValueRemoved is a SanitizationWarningReason enum value
 	SanitizationWarningReasonInvalidAttributeValueRemoved = "INVALID_ATTRIBUTE_VALUE_REMOVED"
 )
+
+// SanitizationWarningReason_Values returns all elements of the SanitizationWarningReason enum
+func SanitizationWarningReason_Values() []string {
+	return []string{
+		SanitizationWarningReasonDisallowedElementRemoved,
+		SanitizationWarningReasonDisallowedAttributeRemoved,
+		SanitizationWarningReasonInvalidAttributeValueRemoved,
+	}
+}

--- a/service/mturk/api.go
+++ b/service/mturk/api.go
@@ -9691,6 +9691,15 @@ const (
 	AssignmentStatusRejected = "Rejected"
 )
 
+// AssignmentStatus_Values returns all elements of the AssignmentStatus enum
+func AssignmentStatus_Values() []string {
+	return []string{
+		AssignmentStatusSubmitted,
+		AssignmentStatusApproved,
+		AssignmentStatusRejected,
+	}
+}
+
 const (
 	// ComparatorLessThan is a Comparator enum value
 	ComparatorLessThan = "LessThan"
@@ -9722,6 +9731,22 @@ const (
 	// ComparatorNotIn is a Comparator enum value
 	ComparatorNotIn = "NotIn"
 )
+
+// Comparator_Values returns all elements of the Comparator enum
+func Comparator_Values() []string {
+	return []string{
+		ComparatorLessThan,
+		ComparatorLessThanOrEqualTo,
+		ComparatorGreaterThan,
+		ComparatorGreaterThanOrEqualTo,
+		ComparatorEqualTo,
+		ComparatorNotEqualTo,
+		ComparatorExists,
+		ComparatorDoesNotExist,
+		ComparatorIn,
+		ComparatorNotIn,
+	}
+}
 
 const (
 	// EventTypeAssignmentAccepted is a EventType enum value
@@ -9761,6 +9786,24 @@ const (
 	EventTypePing = "Ping"
 )
 
+// EventType_Values returns all elements of the EventType enum
+func EventType_Values() []string {
+	return []string{
+		EventTypeAssignmentAccepted,
+		EventTypeAssignmentAbandoned,
+		EventTypeAssignmentReturned,
+		EventTypeAssignmentSubmitted,
+		EventTypeAssignmentRejected,
+		EventTypeAssignmentApproved,
+		EventTypeHitcreated,
+		EventTypeHitexpired,
+		EventTypeHitreviewable,
+		EventTypeHitextended,
+		EventTypeHitdisposed,
+		EventTypePing,
+	}
+}
+
 const (
 	// HITAccessActionsAccept is a HITAccessActions enum value
 	HITAccessActionsAccept = "Accept"
@@ -9771,6 +9814,15 @@ const (
 	// HITAccessActionsDiscoverPreviewAndAccept is a HITAccessActions enum value
 	HITAccessActionsDiscoverPreviewAndAccept = "DiscoverPreviewAndAccept"
 )
+
+// HITAccessActions_Values returns all elements of the HITAccessActions enum
+func HITAccessActions_Values() []string {
+	return []string{
+		HITAccessActionsAccept,
+		HITAccessActionsPreviewAndAccept,
+		HITAccessActionsDiscoverPreviewAndAccept,
+	}
+}
 
 const (
 	// HITReviewStatusNotReviewed is a HITReviewStatus enum value
@@ -9785,6 +9837,16 @@ const (
 	// HITReviewStatusReviewedInappropriate is a HITReviewStatus enum value
 	HITReviewStatusReviewedInappropriate = "ReviewedInappropriate"
 )
+
+// HITReviewStatus_Values returns all elements of the HITReviewStatus enum
+func HITReviewStatus_Values() []string {
+	return []string{
+		HITReviewStatusNotReviewed,
+		HITReviewStatusMarkedForReview,
+		HITReviewStatusReviewedAppropriate,
+		HITReviewStatusReviewedInappropriate,
+	}
+}
 
 const (
 	// HITStatusAssignable is a HITStatus enum value
@@ -9803,6 +9865,17 @@ const (
 	HITStatusDisposed = "Disposed"
 )
 
+// HITStatus_Values returns all elements of the HITStatus enum
+func HITStatus_Values() []string {
+	return []string{
+		HITStatusAssignable,
+		HITStatusUnassignable,
+		HITStatusReviewable,
+		HITStatusReviewing,
+		HITStatusDisposed,
+	}
+}
+
 const (
 	// NotificationTransportEmail is a NotificationTransport enum value
 	NotificationTransportEmail = "Email"
@@ -9814,6 +9887,15 @@ const (
 	NotificationTransportSns = "SNS"
 )
 
+// NotificationTransport_Values returns all elements of the NotificationTransport enum
+func NotificationTransport_Values() []string {
+	return []string{
+		NotificationTransportEmail,
+		NotificationTransportSqs,
+		NotificationTransportSns,
+	}
+}
+
 const (
 	// NotifyWorkersFailureCodeSoftFailure is a NotifyWorkersFailureCode enum value
 	NotifyWorkersFailureCodeSoftFailure = "SoftFailure"
@@ -9821,6 +9903,14 @@ const (
 	// NotifyWorkersFailureCodeHardFailure is a NotifyWorkersFailureCode enum value
 	NotifyWorkersFailureCodeHardFailure = "HardFailure"
 )
+
+// NotifyWorkersFailureCode_Values returns all elements of the NotifyWorkersFailureCode enum
+func NotifyWorkersFailureCode_Values() []string {
+	return []string{
+		NotifyWorkersFailureCodeSoftFailure,
+		NotifyWorkersFailureCodeHardFailure,
+	}
+}
 
 const (
 	// QualificationStatusGranted is a QualificationStatus enum value
@@ -9830,6 +9920,14 @@ const (
 	QualificationStatusRevoked = "Revoked"
 )
 
+// QualificationStatus_Values returns all elements of the QualificationStatus enum
+func QualificationStatus_Values() []string {
+	return []string{
+		QualificationStatusGranted,
+		QualificationStatusRevoked,
+	}
+}
+
 const (
 	// QualificationTypeStatusActive is a QualificationTypeStatus enum value
 	QualificationTypeStatusActive = "Active"
@@ -9837,6 +9935,14 @@ const (
 	// QualificationTypeStatusInactive is a QualificationTypeStatus enum value
 	QualificationTypeStatusInactive = "Inactive"
 )
+
+// QualificationTypeStatus_Values returns all elements of the QualificationTypeStatus enum
+func QualificationTypeStatus_Values() []string {
+	return []string{
+		QualificationTypeStatusActive,
+		QualificationTypeStatusInactive,
+	}
+}
 
 const (
 	// ReviewActionStatusIntended is a ReviewActionStatus enum value
@@ -9852,6 +9958,16 @@ const (
 	ReviewActionStatusCancelled = "Cancelled"
 )
 
+// ReviewActionStatus_Values returns all elements of the ReviewActionStatus enum
+func ReviewActionStatus_Values() []string {
+	return []string{
+		ReviewActionStatusIntended,
+		ReviewActionStatusSucceeded,
+		ReviewActionStatusFailed,
+		ReviewActionStatusCancelled,
+	}
+}
+
 const (
 	// ReviewPolicyLevelAssignment is a ReviewPolicyLevel enum value
 	ReviewPolicyLevelAssignment = "Assignment"
@@ -9860,6 +9976,14 @@ const (
 	ReviewPolicyLevelHit = "HIT"
 )
 
+// ReviewPolicyLevel_Values returns all elements of the ReviewPolicyLevel enum
+func ReviewPolicyLevel_Values() []string {
+	return []string{
+		ReviewPolicyLevelAssignment,
+		ReviewPolicyLevelHit,
+	}
+}
+
 const (
 	// ReviewableHITStatusReviewable is a ReviewableHITStatus enum value
 	ReviewableHITStatusReviewable = "Reviewable"
@@ -9867,3 +9991,11 @@ const (
 	// ReviewableHITStatusReviewing is a ReviewableHITStatus enum value
 	ReviewableHITStatusReviewing = "Reviewing"
 )
+
+// ReviewableHITStatus_Values returns all elements of the ReviewableHITStatus enum
+func ReviewableHITStatus_Values() []string {
+	return []string{
+		ReviewableHITStatusReviewable,
+		ReviewableHITStatusReviewing,
+	}
+}

--- a/service/neptune/api.go
+++ b/service/neptune/api.go
@@ -16953,6 +16953,14 @@ const (
 	ApplyMethodPendingReboot = "pending-reboot"
 )
 
+// ApplyMethod_Values returns all elements of the ApplyMethod enum
+func ApplyMethod_Values() []string {
+	return []string{
+		ApplyMethodImmediate,
+		ApplyMethodPendingReboot,
+	}
+}
+
 const (
 	// SourceTypeDbInstance is a SourceType enum value
 	SourceTypeDbInstance = "db-instance"
@@ -16972,3 +16980,15 @@ const (
 	// SourceTypeDbClusterSnapshot is a SourceType enum value
 	SourceTypeDbClusterSnapshot = "db-cluster-snapshot"
 )
+
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeDbInstance,
+		SourceTypeDbParameterGroup,
+		SourceTypeDbSecurityGroup,
+		SourceTypeDbSnapshot,
+		SourceTypeDbCluster,
+		SourceTypeDbClusterSnapshot,
+	}
+}

--- a/service/networkmanager/api.go
+++ b/service/networkmanager/api.go
@@ -6991,6 +6991,16 @@ const (
 	CustomerGatewayAssociationStateDeleted = "DELETED"
 )
 
+// CustomerGatewayAssociationState_Values returns all elements of the CustomerGatewayAssociationState enum
+func CustomerGatewayAssociationState_Values() []string {
+	return []string{
+		CustomerGatewayAssociationStatePending,
+		CustomerGatewayAssociationStateAvailable,
+		CustomerGatewayAssociationStateDeleting,
+		CustomerGatewayAssociationStateDeleted,
+	}
+}
+
 const (
 	// DeviceStatePending is a DeviceState enum value
 	DeviceStatePending = "PENDING"
@@ -7004,6 +7014,16 @@ const (
 	// DeviceStateUpdating is a DeviceState enum value
 	DeviceStateUpdating = "UPDATING"
 )
+
+// DeviceState_Values returns all elements of the DeviceState enum
+func DeviceState_Values() []string {
+	return []string{
+		DeviceStatePending,
+		DeviceStateAvailable,
+		DeviceStateDeleting,
+		DeviceStateUpdating,
+	}
+}
 
 const (
 	// GlobalNetworkStatePending is a GlobalNetworkState enum value
@@ -7019,6 +7039,16 @@ const (
 	GlobalNetworkStateUpdating = "UPDATING"
 )
 
+// GlobalNetworkState_Values returns all elements of the GlobalNetworkState enum
+func GlobalNetworkState_Values() []string {
+	return []string{
+		GlobalNetworkStatePending,
+		GlobalNetworkStateAvailable,
+		GlobalNetworkStateDeleting,
+		GlobalNetworkStateUpdating,
+	}
+}
+
 const (
 	// LinkAssociationStatePending is a LinkAssociationState enum value
 	LinkAssociationStatePending = "PENDING"
@@ -7032,6 +7062,16 @@ const (
 	// LinkAssociationStateDeleted is a LinkAssociationState enum value
 	LinkAssociationStateDeleted = "DELETED"
 )
+
+// LinkAssociationState_Values returns all elements of the LinkAssociationState enum
+func LinkAssociationState_Values() []string {
+	return []string{
+		LinkAssociationStatePending,
+		LinkAssociationStateAvailable,
+		LinkAssociationStateDeleting,
+		LinkAssociationStateDeleted,
+	}
+}
 
 const (
 	// LinkStatePending is a LinkState enum value
@@ -7047,6 +7087,16 @@ const (
 	LinkStateUpdating = "UPDATING"
 )
 
+// LinkState_Values returns all elements of the LinkState enum
+func LinkState_Values() []string {
+	return []string{
+		LinkStatePending,
+		LinkStateAvailable,
+		LinkStateDeleting,
+		LinkStateUpdating,
+	}
+}
+
 const (
 	// SiteStatePending is a SiteState enum value
 	SiteStatePending = "PENDING"
@@ -7060,6 +7110,16 @@ const (
 	// SiteStateUpdating is a SiteState enum value
 	SiteStateUpdating = "UPDATING"
 )
+
+// SiteState_Values returns all elements of the SiteState enum
+func SiteState_Values() []string {
+	return []string{
+		SiteStatePending,
+		SiteStateAvailable,
+		SiteStateDeleting,
+		SiteStateUpdating,
+	}
+}
 
 const (
 	// TransitGatewayRegistrationStatePending is a TransitGatewayRegistrationState enum value
@@ -7078,6 +7138,17 @@ const (
 	TransitGatewayRegistrationStateFailed = "FAILED"
 )
 
+// TransitGatewayRegistrationState_Values returns all elements of the TransitGatewayRegistrationState enum
+func TransitGatewayRegistrationState_Values() []string {
+	return []string{
+		TransitGatewayRegistrationStatePending,
+		TransitGatewayRegistrationStateAvailable,
+		TransitGatewayRegistrationStateDeleting,
+		TransitGatewayRegistrationStateDeleted,
+		TransitGatewayRegistrationStateFailed,
+	}
+}
+
 const (
 	// ValidationExceptionReasonUnknownOperation is a ValidationExceptionReason enum value
 	ValidationExceptionReasonUnknownOperation = "UnknownOperation"
@@ -7091,3 +7162,13 @@ const (
 	// ValidationExceptionReasonOther is a ValidationExceptionReason enum value
 	ValidationExceptionReasonOther = "Other"
 )
+
+// ValidationExceptionReason_Values returns all elements of the ValidationExceptionReason enum
+func ValidationExceptionReason_Values() []string {
+	return []string{
+		ValidationExceptionReasonUnknownOperation,
+		ValidationExceptionReasonCannotParse,
+		ValidationExceptionReasonFieldValidationFailed,
+		ValidationExceptionReasonOther,
+	}
+}

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -17616,6 +17616,16 @@ const (
 	AppAttributesKeysAwsFlowRubySettings = "AwsFlowRubySettings"
 )
 
+// AppAttributesKeys_Values returns all elements of the AppAttributesKeys enum
+func AppAttributesKeys_Values() []string {
+	return []string{
+		AppAttributesKeysDocumentRoot,
+		AppAttributesKeysRailsEnv,
+		AppAttributesKeysAutoBundleOnDeploy,
+		AppAttributesKeysAwsFlowRubySettings,
+	}
+}
+
 const (
 	// AppTypeAwsFlowRuby is a AppType enum value
 	AppTypeAwsFlowRuby = "aws-flow-ruby"
@@ -17639,6 +17649,19 @@ const (
 	AppTypeOther = "other"
 )
 
+// AppType_Values returns all elements of the AppType enum
+func AppType_Values() []string {
+	return []string{
+		AppTypeAwsFlowRuby,
+		AppTypeJava,
+		AppTypeRails,
+		AppTypePhp,
+		AppTypeNodejs,
+		AppTypeStatic,
+		AppTypeOther,
+	}
+}
+
 const (
 	// ArchitectureX8664 is a Architecture enum value
 	ArchitectureX8664 = "x86_64"
@@ -17647,6 +17670,14 @@ const (
 	ArchitectureI386 = "i386"
 )
 
+// Architecture_Values returns all elements of the Architecture enum
+func Architecture_Values() []string {
+	return []string{
+		ArchitectureX8664,
+		ArchitectureI386,
+	}
+}
+
 const (
 	// AutoScalingTypeLoad is a AutoScalingType enum value
 	AutoScalingTypeLoad = "load"
@@ -17654,6 +17685,14 @@ const (
 	// AutoScalingTypeTimer is a AutoScalingType enum value
 	AutoScalingTypeTimer = "timer"
 )
+
+// AutoScalingType_Values returns all elements of the AutoScalingType enum
+func AutoScalingType_Values() []string {
+	return []string{
+		AutoScalingTypeLoad,
+		AutoScalingTypeTimer,
+	}
+}
 
 // Specifies the encoding of the log file so that the file can be read correctly.
 // The default is utf_8. Encodings supported by Python codecs.decode() can be
@@ -17936,6 +17975,104 @@ const (
 	CloudWatchLogsEncodingUtf8Sig = "utf_8_sig"
 )
 
+// CloudWatchLogsEncoding_Values returns all elements of the CloudWatchLogsEncoding enum
+func CloudWatchLogsEncoding_Values() []string {
+	return []string{
+		CloudWatchLogsEncodingAscii,
+		CloudWatchLogsEncodingBig5,
+		CloudWatchLogsEncodingBig5hkscs,
+		CloudWatchLogsEncodingCp037,
+		CloudWatchLogsEncodingCp424,
+		CloudWatchLogsEncodingCp437,
+		CloudWatchLogsEncodingCp500,
+		CloudWatchLogsEncodingCp720,
+		CloudWatchLogsEncodingCp737,
+		CloudWatchLogsEncodingCp775,
+		CloudWatchLogsEncodingCp850,
+		CloudWatchLogsEncodingCp852,
+		CloudWatchLogsEncodingCp855,
+		CloudWatchLogsEncodingCp856,
+		CloudWatchLogsEncodingCp857,
+		CloudWatchLogsEncodingCp858,
+		CloudWatchLogsEncodingCp860,
+		CloudWatchLogsEncodingCp861,
+		CloudWatchLogsEncodingCp862,
+		CloudWatchLogsEncodingCp863,
+		CloudWatchLogsEncodingCp864,
+		CloudWatchLogsEncodingCp865,
+		CloudWatchLogsEncodingCp866,
+		CloudWatchLogsEncodingCp869,
+		CloudWatchLogsEncodingCp874,
+		CloudWatchLogsEncodingCp875,
+		CloudWatchLogsEncodingCp932,
+		CloudWatchLogsEncodingCp949,
+		CloudWatchLogsEncodingCp950,
+		CloudWatchLogsEncodingCp1006,
+		CloudWatchLogsEncodingCp1026,
+		CloudWatchLogsEncodingCp1140,
+		CloudWatchLogsEncodingCp1250,
+		CloudWatchLogsEncodingCp1251,
+		CloudWatchLogsEncodingCp1252,
+		CloudWatchLogsEncodingCp1253,
+		CloudWatchLogsEncodingCp1254,
+		CloudWatchLogsEncodingCp1255,
+		CloudWatchLogsEncodingCp1256,
+		CloudWatchLogsEncodingCp1257,
+		CloudWatchLogsEncodingCp1258,
+		CloudWatchLogsEncodingEucJp,
+		CloudWatchLogsEncodingEucJis2004,
+		CloudWatchLogsEncodingEucJisx0213,
+		CloudWatchLogsEncodingEucKr,
+		CloudWatchLogsEncodingGb2312,
+		CloudWatchLogsEncodingGbk,
+		CloudWatchLogsEncodingGb18030,
+		CloudWatchLogsEncodingHz,
+		CloudWatchLogsEncodingIso2022Jp,
+		CloudWatchLogsEncodingIso2022Jp1,
+		CloudWatchLogsEncodingIso2022Jp2,
+		CloudWatchLogsEncodingIso2022Jp2004,
+		CloudWatchLogsEncodingIso2022Jp3,
+		CloudWatchLogsEncodingIso2022JpExt,
+		CloudWatchLogsEncodingIso2022Kr,
+		CloudWatchLogsEncodingLatin1,
+		CloudWatchLogsEncodingIso88592,
+		CloudWatchLogsEncodingIso88593,
+		CloudWatchLogsEncodingIso88594,
+		CloudWatchLogsEncodingIso88595,
+		CloudWatchLogsEncodingIso88596,
+		CloudWatchLogsEncodingIso88597,
+		CloudWatchLogsEncodingIso88598,
+		CloudWatchLogsEncodingIso88599,
+		CloudWatchLogsEncodingIso885910,
+		CloudWatchLogsEncodingIso885913,
+		CloudWatchLogsEncodingIso885914,
+		CloudWatchLogsEncodingIso885915,
+		CloudWatchLogsEncodingIso885916,
+		CloudWatchLogsEncodingJohab,
+		CloudWatchLogsEncodingKoi8R,
+		CloudWatchLogsEncodingKoi8U,
+		CloudWatchLogsEncodingMacCyrillic,
+		CloudWatchLogsEncodingMacGreek,
+		CloudWatchLogsEncodingMacIceland,
+		CloudWatchLogsEncodingMacLatin2,
+		CloudWatchLogsEncodingMacRoman,
+		CloudWatchLogsEncodingMacTurkish,
+		CloudWatchLogsEncodingPtcp154,
+		CloudWatchLogsEncodingShiftJis,
+		CloudWatchLogsEncodingShiftJis2004,
+		CloudWatchLogsEncodingShiftJisx0213,
+		CloudWatchLogsEncodingUtf32,
+		CloudWatchLogsEncodingUtf32Be,
+		CloudWatchLogsEncodingUtf32Le,
+		CloudWatchLogsEncodingUtf16,
+		CloudWatchLogsEncodingUtf16Be,
+		CloudWatchLogsEncodingUtf16Le,
+		CloudWatchLogsEncodingUtf7,
+		CloudWatchLogsEncodingUtf8,
+		CloudWatchLogsEncodingUtf8Sig,
+	}
+}
+
 // Specifies where to start to read data (start_of_file or end_of_file). The
 // default is start_of_file. It's only used if there is no state persisted for
 // that log stream.
@@ -17947,6 +18084,14 @@ const (
 	CloudWatchLogsInitialPositionEndOfFile = "end_of_file"
 )
 
+// CloudWatchLogsInitialPosition_Values returns all elements of the CloudWatchLogsInitialPosition enum
+func CloudWatchLogsInitialPosition_Values() []string {
+	return []string{
+		CloudWatchLogsInitialPositionStartOfFile,
+		CloudWatchLogsInitialPositionEndOfFile,
+	}
+}
+
 // The preferred time zone for logs streamed to CloudWatch Logs. Valid values
 // are LOCAL and UTC, for Coordinated Universal Time.
 const (
@@ -17956,6 +18101,14 @@ const (
 	// CloudWatchLogsTimeZoneUtc is a CloudWatchLogsTimeZone enum value
 	CloudWatchLogsTimeZoneUtc = "UTC"
 )
+
+// CloudWatchLogsTimeZone_Values returns all elements of the CloudWatchLogsTimeZone enum
+func CloudWatchLogsTimeZone_Values() []string {
+	return []string{
+		CloudWatchLogsTimeZoneLocal,
+		CloudWatchLogsTimeZoneUtc,
+	}
+}
 
 const (
 	// DeploymentCommandNameInstallDependencies is a DeploymentCommandName enum value
@@ -17994,6 +18147,24 @@ const (
 	// DeploymentCommandNameUndeploy is a DeploymentCommandName enum value
 	DeploymentCommandNameUndeploy = "undeploy"
 )
+
+// DeploymentCommandName_Values returns all elements of the DeploymentCommandName enum
+func DeploymentCommandName_Values() []string {
+	return []string{
+		DeploymentCommandNameInstallDependencies,
+		DeploymentCommandNameUpdateDependencies,
+		DeploymentCommandNameUpdateCustomCookbooks,
+		DeploymentCommandNameExecuteRecipes,
+		DeploymentCommandNameConfigure,
+		DeploymentCommandNameSetup,
+		DeploymentCommandNameDeploy,
+		DeploymentCommandNameRollback,
+		DeploymentCommandNameStart,
+		DeploymentCommandNameStop,
+		DeploymentCommandNameRestart,
+		DeploymentCommandNameUndeploy,
+	}
+}
 
 const (
 	// LayerAttributesKeysEcsClusterArn is a LayerAttributesKeys enum value
@@ -18072,6 +18243,37 @@ const (
 	LayerAttributesKeysJavaAppServerVersion = "JavaAppServerVersion"
 )
 
+// LayerAttributesKeys_Values returns all elements of the LayerAttributesKeys enum
+func LayerAttributesKeys_Values() []string {
+	return []string{
+		LayerAttributesKeysEcsClusterArn,
+		LayerAttributesKeysEnableHaproxyStats,
+		LayerAttributesKeysHaproxyStatsUrl,
+		LayerAttributesKeysHaproxyStatsUser,
+		LayerAttributesKeysHaproxyStatsPassword,
+		LayerAttributesKeysHaproxyHealthCheckUrl,
+		LayerAttributesKeysHaproxyHealthCheckMethod,
+		LayerAttributesKeysMysqlRootPassword,
+		LayerAttributesKeysMysqlRootPasswordUbiquitous,
+		LayerAttributesKeysGangliaUrl,
+		LayerAttributesKeysGangliaUser,
+		LayerAttributesKeysGangliaPassword,
+		LayerAttributesKeysMemcachedMemory,
+		LayerAttributesKeysNodejsVersion,
+		LayerAttributesKeysRubyVersion,
+		LayerAttributesKeysRubygemsVersion,
+		LayerAttributesKeysManageBundler,
+		LayerAttributesKeysBundlerVersion,
+		LayerAttributesKeysRailsStack,
+		LayerAttributesKeysPassengerVersion,
+		LayerAttributesKeysJvm,
+		LayerAttributesKeysJvmVersion,
+		LayerAttributesKeysJvmOptions,
+		LayerAttributesKeysJavaAppServer,
+		LayerAttributesKeysJavaAppServerVersion,
+	}
+}
+
 const (
 	// LayerTypeAwsFlowRuby is a LayerType enum value
 	LayerTypeAwsFlowRuby = "aws-flow-ruby"
@@ -18110,6 +18312,24 @@ const (
 	LayerTypeCustom = "custom"
 )
 
+// LayerType_Values returns all elements of the LayerType enum
+func LayerType_Values() []string {
+	return []string{
+		LayerTypeAwsFlowRuby,
+		LayerTypeEcsCluster,
+		LayerTypeJavaApp,
+		LayerTypeLb,
+		LayerTypeWeb,
+		LayerTypePhpApp,
+		LayerTypeRailsApp,
+		LayerTypeNodejsApp,
+		LayerTypeMemcached,
+		LayerTypeDbMaster,
+		LayerTypeMonitoringMaster,
+		LayerTypeCustom,
+	}
+}
+
 const (
 	// RootDeviceTypeEbs is a RootDeviceType enum value
 	RootDeviceTypeEbs = "ebs"
@@ -18117,6 +18337,14 @@ const (
 	// RootDeviceTypeInstanceStore is a RootDeviceType enum value
 	RootDeviceTypeInstanceStore = "instance-store"
 )
+
+// RootDeviceType_Values returns all elements of the RootDeviceType enum
+func RootDeviceType_Values() []string {
+	return []string{
+		RootDeviceTypeEbs,
+		RootDeviceTypeInstanceStore,
+	}
+}
 
 const (
 	// SourceTypeGit is a SourceType enum value
@@ -18132,10 +18360,27 @@ const (
 	SourceTypeS3 = "s3"
 )
 
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeGit,
+		SourceTypeSvn,
+		SourceTypeArchive,
+		SourceTypeS3,
+	}
+}
+
 const (
 	// StackAttributesKeysColor is a StackAttributesKeys enum value
 	StackAttributesKeysColor = "Color"
 )
+
+// StackAttributesKeys_Values returns all elements of the StackAttributesKeys enum
+func StackAttributesKeys_Values() []string {
+	return []string{
+		StackAttributesKeysColor,
+	}
+}
 
 const (
 	// VirtualizationTypeParavirtual is a VirtualizationType enum value
@@ -18144,6 +18389,14 @@ const (
 	// VirtualizationTypeHvm is a VirtualizationType enum value
 	VirtualizationTypeHvm = "hvm"
 )
+
+// VirtualizationType_Values returns all elements of the VirtualizationType enum
+func VirtualizationType_Values() []string {
+	return []string{
+		VirtualizationTypeParavirtual,
+		VirtualizationTypeHvm,
+	}
+}
 
 const (
 	// VolumeTypeGp2 is a VolumeType enum value
@@ -18155,3 +18408,12 @@ const (
 	// VolumeTypeStandard is a VolumeType enum value
 	VolumeTypeStandard = "standard"
 )
+
+// VolumeType_Values returns all elements of the VolumeType enum
+func VolumeType_Values() []string {
+	return []string{
+		VolumeTypeGp2,
+		VolumeTypeIo1,
+		VolumeTypeStandard,
+	}
+}

--- a/service/opsworkscm/api.go
+++ b/service/opsworkscm/api.go
@@ -5119,6 +5119,16 @@ const (
 	BackupStatusDeleting = "DELETING"
 )
 
+// BackupStatus_Values returns all elements of the BackupStatus enum
+func BackupStatus_Values() []string {
+	return []string{
+		BackupStatusInProgress,
+		BackupStatusOk,
+		BackupStatusFailed,
+		BackupStatusDeleting,
+	}
+}
+
 const (
 	// BackupTypeAutomated is a BackupType enum value
 	BackupTypeAutomated = "AUTOMATED"
@@ -5127,6 +5137,14 @@ const (
 	BackupTypeManual = "MANUAL"
 )
 
+// BackupType_Values returns all elements of the BackupType enum
+func BackupType_Values() []string {
+	return []string{
+		BackupTypeAutomated,
+		BackupTypeManual,
+	}
+}
+
 const (
 	// MaintenanceStatusSuccess is a MaintenanceStatus enum value
 	MaintenanceStatusSuccess = "SUCCESS"
@@ -5134,6 +5152,14 @@ const (
 	// MaintenanceStatusFailed is a MaintenanceStatus enum value
 	MaintenanceStatusFailed = "FAILED"
 )
+
+// MaintenanceStatus_Values returns all elements of the MaintenanceStatus enum
+func MaintenanceStatus_Values() []string {
+	return []string{
+		MaintenanceStatusSuccess,
+		MaintenanceStatusFailed,
+	}
+}
 
 // The status of the association or disassociation request.
 //
@@ -5154,6 +5180,15 @@ const (
 	// NodeAssociationStatusInProgress is a NodeAssociationStatus enum value
 	NodeAssociationStatusInProgress = "IN_PROGRESS"
 )
+
+// NodeAssociationStatus_Values returns all elements of the NodeAssociationStatus enum
+func NodeAssociationStatus_Values() []string {
+	return []string{
+		NodeAssociationStatusSuccess,
+		NodeAssociationStatusFailed,
+		NodeAssociationStatusInProgress,
+	}
+}
 
 const (
 	// ServerStatusBackingUp is a ServerStatus enum value
@@ -5195,3 +5230,22 @@ const (
 	// ServerStatusTerminated is a ServerStatus enum value
 	ServerStatusTerminated = "TERMINATED"
 )
+
+// ServerStatus_Values returns all elements of the ServerStatus enum
+func ServerStatus_Values() []string {
+	return []string{
+		ServerStatusBackingUp,
+		ServerStatusConnectionLost,
+		ServerStatusCreating,
+		ServerStatusDeleting,
+		ServerStatusModifying,
+		ServerStatusFailed,
+		ServerStatusHealthy,
+		ServerStatusRunning,
+		ServerStatusRestoring,
+		ServerStatusSetup,
+		ServerStatusUnderMaintenance,
+		ServerStatusUnhealthy,
+		ServerStatusTerminated,
+	}
+}

--- a/service/organizations/api.go
+++ b/service/organizations/api.go
@@ -21990,6 +21990,13 @@ const (
 	AccessDeniedForDependencyExceptionReasonAccessDeniedDuringCreateServiceLinkedRole = "ACCESS_DENIED_DURING_CREATE_SERVICE_LINKED_ROLE"
 )
 
+// AccessDeniedForDependencyExceptionReason_Values returns all elements of the AccessDeniedForDependencyExceptionReason enum
+func AccessDeniedForDependencyExceptionReason_Values() []string {
+	return []string{
+		AccessDeniedForDependencyExceptionReasonAccessDeniedDuringCreateServiceLinkedRole,
+	}
+}
+
 const (
 	// AccountJoinedMethodInvited is a AccountJoinedMethod enum value
 	AccountJoinedMethodInvited = "INVITED"
@@ -21998,6 +22005,14 @@ const (
 	AccountJoinedMethodCreated = "CREATED"
 )
 
+// AccountJoinedMethod_Values returns all elements of the AccountJoinedMethod enum
+func AccountJoinedMethod_Values() []string {
+	return []string{
+		AccountJoinedMethodInvited,
+		AccountJoinedMethodCreated,
+	}
+}
+
 const (
 	// AccountStatusActive is a AccountStatus enum value
 	AccountStatusActive = "ACTIVE"
@@ -22005,6 +22020,14 @@ const (
 	// AccountStatusSuspended is a AccountStatus enum value
 	AccountStatusSuspended = "SUSPENDED"
 )
+
+// AccountStatus_Values returns all elements of the AccountStatus enum
+func AccountStatus_Values() []string {
+	return []string{
+		AccountStatusActive,
+		AccountStatusSuspended,
+	}
+}
 
 const (
 	// ActionTypeInvite is a ActionType enum value
@@ -22020,6 +22043,16 @@ const (
 	ActionTypeAddOrganizationsServiceLinkedRole = "ADD_ORGANIZATIONS_SERVICE_LINKED_ROLE"
 )
 
+// ActionType_Values returns all elements of the ActionType enum
+func ActionType_Values() []string {
+	return []string{
+		ActionTypeInvite,
+		ActionTypeEnableAllFeatures,
+		ActionTypeApproveAllFeatures,
+		ActionTypeAddOrganizationsServiceLinkedRole,
+	}
+}
+
 const (
 	// ChildTypeAccount is a ChildType enum value
 	ChildTypeAccount = "ACCOUNT"
@@ -22027,6 +22060,14 @@ const (
 	// ChildTypeOrganizationalUnit is a ChildType enum value
 	ChildTypeOrganizationalUnit = "ORGANIZATIONAL_UNIT"
 )
+
+// ChildType_Values returns all elements of the ChildType enum
+func ChildType_Values() []string {
+	return []string{
+		ChildTypeAccount,
+		ChildTypeOrganizationalUnit,
+	}
+}
 
 const (
 	// ConstraintViolationExceptionReasonAccountNumberLimitExceeded is a ConstraintViolationExceptionReason enum value
@@ -22114,6 +22155,40 @@ const (
 	ConstraintViolationExceptionReasonMasterAccountMissingBusinessLicense = "MASTER_ACCOUNT_MISSING_BUSINESS_LICENSE"
 )
 
+// ConstraintViolationExceptionReason_Values returns all elements of the ConstraintViolationExceptionReason enum
+func ConstraintViolationExceptionReason_Values() []string {
+	return []string{
+		ConstraintViolationExceptionReasonAccountNumberLimitExceeded,
+		ConstraintViolationExceptionReasonHandshakeRateLimitExceeded,
+		ConstraintViolationExceptionReasonOuNumberLimitExceeded,
+		ConstraintViolationExceptionReasonOuDepthLimitExceeded,
+		ConstraintViolationExceptionReasonPolicyNumberLimitExceeded,
+		ConstraintViolationExceptionReasonPolicyContentLimitExceeded,
+		ConstraintViolationExceptionReasonMaxPolicyTypeAttachmentLimitExceeded,
+		ConstraintViolationExceptionReasonMinPolicyTypeAttachmentLimitExceeded,
+		ConstraintViolationExceptionReasonAccountCannotLeaveOrganization,
+		ConstraintViolationExceptionReasonAccountCannotLeaveWithoutEula,
+		ConstraintViolationExceptionReasonAccountCannotLeaveWithoutPhoneVerification,
+		ConstraintViolationExceptionReasonMasterAccountPaymentInstrumentRequired,
+		ConstraintViolationExceptionReasonMemberAccountPaymentInstrumentRequired,
+		ConstraintViolationExceptionReasonAccountCreationRateLimitExceeded,
+		ConstraintViolationExceptionReasonMasterAccountAddressDoesNotMatchMarketplace,
+		ConstraintViolationExceptionReasonMasterAccountMissingContactInfo,
+		ConstraintViolationExceptionReasonMasterAccountNotGovcloudEnabled,
+		ConstraintViolationExceptionReasonOrganizationNotInAllFeaturesMode,
+		ConstraintViolationExceptionReasonCreateOrganizationInBillingModeUnsupportedRegion,
+		ConstraintViolationExceptionReasonEmailVerificationCodeExpired,
+		ConstraintViolationExceptionReasonWaitPeriodActive,
+		ConstraintViolationExceptionReasonMaxTagLimitExceeded,
+		ConstraintViolationExceptionReasonTagPolicyViolation,
+		ConstraintViolationExceptionReasonMaxDelegatedAdministratorsForServiceLimitExceeded,
+		ConstraintViolationExceptionReasonCannotRegisterMasterAsDelegatedAdministrator,
+		ConstraintViolationExceptionReasonCannotRemoveDelegatedAdministratorFromOrg,
+		ConstraintViolationExceptionReasonDelegatedAdministratorExistsForThisService,
+		ConstraintViolationExceptionReasonMasterAccountMissingBusinessLicense,
+	}
+}
+
 const (
 	// CreateAccountFailureReasonAccountLimitExceeded is a CreateAccountFailureReason enum value
 	CreateAccountFailureReasonAccountLimitExceeded = "ACCOUNT_LIMIT_EXCEEDED"
@@ -22143,6 +22218,21 @@ const (
 	CreateAccountFailureReasonMissingPaymentInstrument = "MISSING_PAYMENT_INSTRUMENT"
 )
 
+// CreateAccountFailureReason_Values returns all elements of the CreateAccountFailureReason enum
+func CreateAccountFailureReason_Values() []string {
+	return []string{
+		CreateAccountFailureReasonAccountLimitExceeded,
+		CreateAccountFailureReasonEmailAlreadyExists,
+		CreateAccountFailureReasonInvalidAddress,
+		CreateAccountFailureReasonInvalidEmail,
+		CreateAccountFailureReasonConcurrentAccountModification,
+		CreateAccountFailureReasonInternalFailure,
+		CreateAccountFailureReasonGovcloudAccountAlreadyExists,
+		CreateAccountFailureReasonMissingBusinessValidation,
+		CreateAccountFailureReasonMissingPaymentInstrument,
+	}
+}
+
 const (
 	// CreateAccountStateInProgress is a CreateAccountState enum value
 	CreateAccountStateInProgress = "IN_PROGRESS"
@@ -22154,6 +22244,15 @@ const (
 	CreateAccountStateFailed = "FAILED"
 )
 
+// CreateAccountState_Values returns all elements of the CreateAccountState enum
+func CreateAccountState_Values() []string {
+	return []string{
+		CreateAccountStateInProgress,
+		CreateAccountStateSucceeded,
+		CreateAccountStateFailed,
+	}
+}
+
 const (
 	// EffectivePolicyTypeTagPolicy is a EffectivePolicyType enum value
 	EffectivePolicyTypeTagPolicy = "TAG_POLICY"
@@ -22164,6 +22263,15 @@ const (
 	// EffectivePolicyTypeAiservicesOptOutPolicy is a EffectivePolicyType enum value
 	EffectivePolicyTypeAiservicesOptOutPolicy = "AISERVICES_OPT_OUT_POLICY"
 )
+
+// EffectivePolicyType_Values returns all elements of the EffectivePolicyType enum
+func EffectivePolicyType_Values() []string {
+	return []string{
+		EffectivePolicyTypeTagPolicy,
+		EffectivePolicyTypeBackupPolicy,
+		EffectivePolicyTypeAiservicesOptOutPolicy,
+	}
+}
 
 const (
 	// HandshakeConstraintViolationExceptionReasonAccountNumberLimitExceeded is a HandshakeConstraintViolationExceptionReason enum value
@@ -22191,6 +22299,20 @@ const (
 	HandshakeConstraintViolationExceptionReasonOrganizationMembershipChangeRateLimitExceeded = "ORGANIZATION_MEMBERSHIP_CHANGE_RATE_LIMIT_EXCEEDED"
 )
 
+// HandshakeConstraintViolationExceptionReason_Values returns all elements of the HandshakeConstraintViolationExceptionReason enum
+func HandshakeConstraintViolationExceptionReason_Values() []string {
+	return []string{
+		HandshakeConstraintViolationExceptionReasonAccountNumberLimitExceeded,
+		HandshakeConstraintViolationExceptionReasonHandshakeRateLimitExceeded,
+		HandshakeConstraintViolationExceptionReasonAlreadyInAnOrganization,
+		HandshakeConstraintViolationExceptionReasonOrganizationAlreadyHasAllFeatures,
+		HandshakeConstraintViolationExceptionReasonInviteDisabledDuringEnableAllFeatures,
+		HandshakeConstraintViolationExceptionReasonPaymentInstrumentRequired,
+		HandshakeConstraintViolationExceptionReasonOrganizationFromDifferentSellerOfRecord,
+		HandshakeConstraintViolationExceptionReasonOrganizationMembershipChangeRateLimitExceeded,
+	}
+}
+
 const (
 	// HandshakePartyTypeAccount is a HandshakePartyType enum value
 	HandshakePartyTypeAccount = "ACCOUNT"
@@ -22201,6 +22323,15 @@ const (
 	// HandshakePartyTypeEmail is a HandshakePartyType enum value
 	HandshakePartyTypeEmail = "EMAIL"
 )
+
+// HandshakePartyType_Values returns all elements of the HandshakePartyType enum
+func HandshakePartyType_Values() []string {
+	return []string{
+		HandshakePartyTypeAccount,
+		HandshakePartyTypeOrganization,
+		HandshakePartyTypeEmail,
+	}
+}
 
 const (
 	// HandshakeResourceTypeAccount is a HandshakeResourceType enum value
@@ -22228,6 +22359,20 @@ const (
 	HandshakeResourceTypeParentHandshake = "PARENT_HANDSHAKE"
 )
 
+// HandshakeResourceType_Values returns all elements of the HandshakeResourceType enum
+func HandshakeResourceType_Values() []string {
+	return []string{
+		HandshakeResourceTypeAccount,
+		HandshakeResourceTypeOrganization,
+		HandshakeResourceTypeOrganizationFeatureSet,
+		HandshakeResourceTypeEmail,
+		HandshakeResourceTypeMasterEmail,
+		HandshakeResourceTypeMasterName,
+		HandshakeResourceTypeNotes,
+		HandshakeResourceTypeParentHandshake,
+	}
+}
+
 const (
 	// HandshakeStateRequested is a HandshakeState enum value
 	HandshakeStateRequested = "REQUESTED"
@@ -22248,6 +22393,18 @@ const (
 	HandshakeStateExpired = "EXPIRED"
 )
 
+// HandshakeState_Values returns all elements of the HandshakeState enum
+func HandshakeState_Values() []string {
+	return []string{
+		HandshakeStateRequested,
+		HandshakeStateOpen,
+		HandshakeStateCanceled,
+		HandshakeStateAccepted,
+		HandshakeStateDeclined,
+		HandshakeStateExpired,
+	}
+}
+
 const (
 	// IAMUserAccessToBillingAllow is a IAMUserAccessToBilling enum value
 	IAMUserAccessToBillingAllow = "ALLOW"
@@ -22255,6 +22412,14 @@ const (
 	// IAMUserAccessToBillingDeny is a IAMUserAccessToBilling enum value
 	IAMUserAccessToBillingDeny = "DENY"
 )
+
+// IAMUserAccessToBilling_Values returns all elements of the IAMUserAccessToBilling enum
+func IAMUserAccessToBilling_Values() []string {
+	return []string{
+		IAMUserAccessToBillingAllow,
+		IAMUserAccessToBillingDeny,
+	}
+}
 
 const (
 	// InvalidInputExceptionReasonInvalidPartyTypeTarget is a InvalidInputExceptionReason enum value
@@ -22324,6 +22489,34 @@ const (
 	InvalidInputExceptionReasonTargetNotSupported = "TARGET_NOT_SUPPORTED"
 )
 
+// InvalidInputExceptionReason_Values returns all elements of the InvalidInputExceptionReason enum
+func InvalidInputExceptionReason_Values() []string {
+	return []string{
+		InvalidInputExceptionReasonInvalidPartyTypeTarget,
+		InvalidInputExceptionReasonInvalidSyntaxOrganizationArn,
+		InvalidInputExceptionReasonInvalidSyntaxPolicyId,
+		InvalidInputExceptionReasonInvalidEnum,
+		InvalidInputExceptionReasonInvalidEnumPolicyType,
+		InvalidInputExceptionReasonInvalidListMember,
+		InvalidInputExceptionReasonMaxLengthExceeded,
+		InvalidInputExceptionReasonMaxValueExceeded,
+		InvalidInputExceptionReasonMinLengthExceeded,
+		InvalidInputExceptionReasonMinValueExceeded,
+		InvalidInputExceptionReasonImmutablePolicy,
+		InvalidInputExceptionReasonInvalidPattern,
+		InvalidInputExceptionReasonInvalidPatternTargetId,
+		InvalidInputExceptionReasonInputRequired,
+		InvalidInputExceptionReasonInvalidNextToken,
+		InvalidInputExceptionReasonMaxLimitExceededFilter,
+		InvalidInputExceptionReasonMovingAccountBetweenDifferentRoots,
+		InvalidInputExceptionReasonInvalidFullNameTarget,
+		InvalidInputExceptionReasonUnrecognizedServicePrincipal,
+		InvalidInputExceptionReasonInvalidRoleName,
+		InvalidInputExceptionReasonInvalidSystemTagsParameter,
+		InvalidInputExceptionReasonTargetNotSupported,
+	}
+}
+
 const (
 	// OrganizationFeatureSetAll is a OrganizationFeatureSet enum value
 	OrganizationFeatureSetAll = "ALL"
@@ -22332,6 +22525,14 @@ const (
 	OrganizationFeatureSetConsolidatedBilling = "CONSOLIDATED_BILLING"
 )
 
+// OrganizationFeatureSet_Values returns all elements of the OrganizationFeatureSet enum
+func OrganizationFeatureSet_Values() []string {
+	return []string{
+		OrganizationFeatureSetAll,
+		OrganizationFeatureSetConsolidatedBilling,
+	}
+}
+
 const (
 	// ParentTypeRoot is a ParentType enum value
 	ParentTypeRoot = "ROOT"
@@ -22339,6 +22540,14 @@ const (
 	// ParentTypeOrganizationalUnit is a ParentType enum value
 	ParentTypeOrganizationalUnit = "ORGANIZATIONAL_UNIT"
 )
+
+// ParentType_Values returns all elements of the ParentType enum
+func ParentType_Values() []string {
+	return []string{
+		ParentTypeRoot,
+		ParentTypeOrganizationalUnit,
+	}
+}
 
 const (
 	// PolicyTypeServiceControlPolicy is a PolicyType enum value
@@ -22354,6 +22563,16 @@ const (
 	PolicyTypeAiservicesOptOutPolicy = "AISERVICES_OPT_OUT_POLICY"
 )
 
+// PolicyType_Values returns all elements of the PolicyType enum
+func PolicyType_Values() []string {
+	return []string{
+		PolicyTypeServiceControlPolicy,
+		PolicyTypeTagPolicy,
+		PolicyTypeBackupPolicy,
+		PolicyTypeAiservicesOptOutPolicy,
+	}
+}
+
 const (
 	// PolicyTypeStatusEnabled is a PolicyTypeStatus enum value
 	PolicyTypeStatusEnabled = "ENABLED"
@@ -22365,6 +22584,15 @@ const (
 	PolicyTypeStatusPendingDisable = "PENDING_DISABLE"
 )
 
+// PolicyTypeStatus_Values returns all elements of the PolicyTypeStatus enum
+func PolicyTypeStatus_Values() []string {
+	return []string{
+		PolicyTypeStatusEnabled,
+		PolicyTypeStatusPendingEnable,
+		PolicyTypeStatusPendingDisable,
+	}
+}
+
 const (
 	// TargetTypeAccount is a TargetType enum value
 	TargetTypeAccount = "ACCOUNT"
@@ -22375,3 +22603,12 @@ const (
 	// TargetTypeRoot is a TargetType enum value
 	TargetTypeRoot = "ROOT"
 )
+
+// TargetType_Values returns all elements of the TargetType enum
+func TargetType_Values() []string {
+	return []string{
+		TargetTypeAccount,
+		TargetTypeOrganizationalUnit,
+		TargetTypeRoot,
+	}
+}

--- a/service/personalize/api.go
+++ b/service/personalize/api.go
@@ -11510,6 +11510,13 @@ const (
 	RecipeProviderService = "SERVICE"
 )
 
+// RecipeProvider_Values returns all elements of the RecipeProvider enum
+func RecipeProvider_Values() []string {
+	return []string{
+		RecipeProviderService,
+	}
+}
+
 const (
 	// TrainingModeFull is a TrainingMode enum value
 	TrainingModeFull = "FULL"
@@ -11517,3 +11524,11 @@ const (
 	// TrainingModeUpdate is a TrainingMode enum value
 	TrainingModeUpdate = "UPDATE"
 )
+
+// TrainingMode_Values returns all elements of the TrainingMode enum
+func TrainingMode_Values() []string {
+	return []string{
+		TrainingModeFull,
+		TrainingModeUpdate,
+	}
+}

--- a/service/pi/api.go
+++ b/service/pi/api.go
@@ -1255,3 +1255,10 @@ const (
 	// ServiceTypeRds is a ServiceType enum value
 	ServiceTypeRds = "RDS"
 )
+
+// ServiceType_Values returns all elements of the ServiceType enum
+func ServiceType_Values() []string {
+	return []string{
+		ServiceTypeRds,
+	}
+}

--- a/service/pinpoint/api.go
+++ b/service/pinpoint/api.go
@@ -34960,6 +34960,15 @@ const (
 	ActionUrl = "URL"
 )
 
+// Action_Values returns all elements of the Action enum
+func Action_Values() []string {
+	return []string{
+		ActionOpenApp,
+		ActionDeepLink,
+		ActionUrl,
+	}
+}
+
 const (
 	// AttributeTypeInclusive is a AttributeType enum value
 	AttributeTypeInclusive = "INCLUSIVE"
@@ -34967,6 +34976,14 @@ const (
 	// AttributeTypeExclusive is a AttributeType enum value
 	AttributeTypeExclusive = "EXCLUSIVE"
 )
+
+// AttributeType_Values returns all elements of the AttributeType enum
+func AttributeType_Values() []string {
+	return []string{
+		AttributeTypeInclusive,
+		AttributeTypeExclusive,
+	}
+}
 
 const (
 	// CampaignStatusScheduled is a CampaignStatus enum value
@@ -34987,6 +35004,18 @@ const (
 	// CampaignStatusDeleted is a CampaignStatus enum value
 	CampaignStatusDeleted = "DELETED"
 )
+
+// CampaignStatus_Values returns all elements of the CampaignStatus enum
+func CampaignStatus_Values() []string {
+	return []string{
+		CampaignStatusScheduled,
+		CampaignStatusExecuting,
+		CampaignStatusPendingNextRun,
+		CampaignStatusCompleted,
+		CampaignStatusPaused,
+		CampaignStatusDeleted,
+	}
+}
 
 const (
 	// ChannelTypePush is a ChannelType enum value
@@ -35026,6 +35055,24 @@ const (
 	ChannelTypeCustom = "CUSTOM"
 )
 
+// ChannelType_Values returns all elements of the ChannelType enum
+func ChannelType_Values() []string {
+	return []string{
+		ChannelTypePush,
+		ChannelTypeGcm,
+		ChannelTypeApns,
+		ChannelTypeApnsSandbox,
+		ChannelTypeApnsVoip,
+		ChannelTypeApnsVoipSandbox,
+		ChannelTypeAdm,
+		ChannelTypeSms,
+		ChannelTypeVoice,
+		ChannelTypeEmail,
+		ChannelTypeBaidu,
+		ChannelTypeCustom,
+	}
+}
+
 const (
 	// DeliveryStatusSuccessful is a DeliveryStatus enum value
 	DeliveryStatusSuccessful = "SUCCESSFUL"
@@ -35049,6 +35096,19 @@ const (
 	DeliveryStatusDuplicate = "DUPLICATE"
 )
 
+// DeliveryStatus_Values returns all elements of the DeliveryStatus enum
+func DeliveryStatus_Values() []string {
+	return []string{
+		DeliveryStatusSuccessful,
+		DeliveryStatusThrottled,
+		DeliveryStatusTemporaryFailure,
+		DeliveryStatusPermanentFailure,
+		DeliveryStatusUnknownFailure,
+		DeliveryStatusOptOut,
+		DeliveryStatusDuplicate,
+	}
+}
+
 const (
 	// DimensionTypeInclusive is a DimensionType enum value
 	DimensionTypeInclusive = "INCLUSIVE"
@@ -35056,6 +35116,14 @@ const (
 	// DimensionTypeExclusive is a DimensionType enum value
 	DimensionTypeExclusive = "EXCLUSIVE"
 )
+
+// DimensionType_Values returns all elements of the DimensionType enum
+func DimensionType_Values() []string {
+	return []string{
+		DimensionTypeInclusive,
+		DimensionTypeExclusive,
+	}
+}
 
 const (
 	// DurationHr24 is a Duration enum value
@@ -35070,6 +35138,16 @@ const (
 	// DurationDay30 is a Duration enum value
 	DurationDay30 = "DAY_30"
 )
+
+// Duration_Values returns all elements of the Duration enum
+func Duration_Values() []string {
+	return []string{
+		DurationHr24,
+		DurationDay7,
+		DurationDay14,
+		DurationDay30,
+	}
+}
 
 const (
 	// EndpointTypesElementPush is a EndpointTypesElement enum value
@@ -35109,6 +35187,24 @@ const (
 	EndpointTypesElementCustom = "CUSTOM"
 )
 
+// EndpointTypesElement_Values returns all elements of the EndpointTypesElement enum
+func EndpointTypesElement_Values() []string {
+	return []string{
+		EndpointTypesElementPush,
+		EndpointTypesElementGcm,
+		EndpointTypesElementApns,
+		EndpointTypesElementApnsSandbox,
+		EndpointTypesElementApnsVoip,
+		EndpointTypesElementApnsVoipSandbox,
+		EndpointTypesElementAdm,
+		EndpointTypesElementSms,
+		EndpointTypesElementVoice,
+		EndpointTypesElementEmail,
+		EndpointTypesElementBaidu,
+		EndpointTypesElementCustom,
+	}
+}
+
 const (
 	// FilterTypeSystem is a FilterType enum value
 	FilterTypeSystem = "SYSTEM"
@@ -35117,6 +35213,14 @@ const (
 	FilterTypeEndpoint = "ENDPOINT"
 )
 
+// FilterType_Values returns all elements of the FilterType enum
+func FilterType_Values() []string {
+	return []string{
+		FilterTypeSystem,
+		FilterTypeEndpoint,
+	}
+}
+
 const (
 	// FormatCsv is a Format enum value
 	FormatCsv = "CSV"
@@ -35124,6 +35228,14 @@ const (
 	// FormatJson is a Format enum value
 	FormatJson = "JSON"
 )
+
+// Format_Values returns all elements of the Format enum
+func Format_Values() []string {
+	return []string{
+		FormatCsv,
+		FormatJson,
+	}
+}
 
 const (
 	// FrequencyOnce is a Frequency enum value
@@ -35145,6 +35257,18 @@ const (
 	FrequencyEvent = "EVENT"
 )
 
+// Frequency_Values returns all elements of the Frequency enum
+func Frequency_Values() []string {
+	return []string{
+		FrequencyOnce,
+		FrequencyHourly,
+		FrequencyDaily,
+		FrequencyWeekly,
+		FrequencyMonthly,
+		FrequencyEvent,
+	}
+}
+
 const (
 	// IncludeAll is a Include enum value
 	IncludeAll = "ALL"
@@ -35155,6 +35279,15 @@ const (
 	// IncludeNone is a Include enum value
 	IncludeNone = "NONE"
 )
+
+// Include_Values returns all elements of the Include enum
+func Include_Values() []string {
+	return []string{
+		IncludeAll,
+		IncludeAny,
+		IncludeNone,
+	}
+}
 
 const (
 	// JobStatusCreated is a JobStatus enum value
@@ -35185,6 +35318,21 @@ const (
 	JobStatusFailed = "FAILED"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusCreated,
+		JobStatusPreparingForInitialization,
+		JobStatusInitializing,
+		JobStatusProcessing,
+		JobStatusPendingJob,
+		JobStatusCompleting,
+		JobStatusCompleted,
+		JobStatusFailing,
+		JobStatusFailed,
+	}
+}
+
 const (
 	// MessageTypeTransactional is a MessageType enum value
 	MessageTypeTransactional = "TRANSACTIONAL"
@@ -35192,6 +35340,14 @@ const (
 	// MessageTypePromotional is a MessageType enum value
 	MessageTypePromotional = "PROMOTIONAL"
 )
+
+// MessageType_Values returns all elements of the MessageType enum
+func MessageType_Values() []string {
+	return []string{
+		MessageTypeTransactional,
+		MessageTypePromotional,
+	}
+}
 
 const (
 	// ModeDelivery is a Mode enum value
@@ -35201,6 +35357,14 @@ const (
 	ModeFilter = "FILTER"
 )
 
+// Mode_Values returns all elements of the Mode enum
+func Mode_Values() []string {
+	return []string{
+		ModeDelivery,
+		ModeFilter,
+	}
+}
+
 const (
 	// OperatorAll is a Operator enum value
 	OperatorAll = "ALL"
@@ -35208,6 +35372,14 @@ const (
 	// OperatorAny is a Operator enum value
 	OperatorAny = "ANY"
 )
+
+// Operator_Values returns all elements of the Operator enum
+func Operator_Values() []string {
+	return []string{
+		OperatorAll,
+		OperatorAny,
+	}
+}
 
 const (
 	// RecencyTypeActive is a RecencyType enum value
@@ -35217,6 +35389,14 @@ const (
 	RecencyTypeInactive = "INACTIVE"
 )
 
+// RecencyType_Values returns all elements of the RecencyType enum
+func RecencyType_Values() []string {
+	return []string{
+		RecencyTypeActive,
+		RecencyTypeInactive,
+	}
+}
+
 const (
 	// SegmentTypeDimensional is a SegmentType enum value
 	SegmentTypeDimensional = "DIMENSIONAL"
@@ -35224,6 +35404,14 @@ const (
 	// SegmentTypeImport is a SegmentType enum value
 	SegmentTypeImport = "IMPORT"
 )
+
+// SegmentType_Values returns all elements of the SegmentType enum
+func SegmentType_Values() []string {
+	return []string{
+		SegmentTypeDimensional,
+		SegmentTypeImport,
+	}
+}
 
 const (
 	// SourceTypeAll is a SourceType enum value
@@ -35235,6 +35423,15 @@ const (
 	// SourceTypeNone is a SourceType enum value
 	SourceTypeNone = "NONE"
 )
+
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeAll,
+		SourceTypeAny,
+		SourceTypeNone,
+	}
+}
 
 const (
 	// StateDraft is a State enum value
@@ -35253,6 +35450,17 @@ const (
 	StateClosed = "CLOSED"
 )
 
+// State_Values returns all elements of the State enum
+func State_Values() []string {
+	return []string{
+		StateDraft,
+		StateActive,
+		StateCompleted,
+		StateCancelled,
+		StateClosed,
+	}
+}
+
 const (
 	// TemplateTypeEmail is a TemplateType enum value
 	TemplateTypeEmail = "EMAIL"
@@ -35267,6 +35475,16 @@ const (
 	TemplateTypePush = "PUSH"
 )
 
+// TemplateType_Values returns all elements of the TemplateType enum
+func TemplateType_Values() []string {
+	return []string{
+		TemplateTypeEmail,
+		TemplateTypeSms,
+		TemplateTypeVoice,
+		TemplateTypePush,
+	}
+}
+
 const (
 	// TypeAll is a Type enum value
 	TypeAll = "ALL"
@@ -35277,3 +35495,12 @@ const (
 	// TypeNone is a Type enum value
 	TypeNone = "NONE"
 )
+
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypeAll,
+		TypeAny,
+		TypeNone,
+	}
+}

--- a/service/pinpointemail/api.go
+++ b/service/pinpointemail/api.go
@@ -10502,6 +10502,14 @@ const (
 	BehaviorOnMxFailureRejectMessage = "REJECT_MESSAGE"
 )
 
+// BehaviorOnMxFailure_Values returns all elements of the BehaviorOnMxFailure enum
+func BehaviorOnMxFailure_Values() []string {
+	return []string{
+		BehaviorOnMxFailureUseDefaultValue,
+		BehaviorOnMxFailureRejectMessage,
+	}
+}
+
 // The current status of your Deliverability dashboard subscription. If this
 // value is PENDING_EXPIRATION, your subscription is scheduled to expire at
 // the end of the current calendar month.
@@ -10516,6 +10524,15 @@ const (
 	DeliverabilityDashboardAccountStatusDisabled = "DISABLED"
 )
 
+// DeliverabilityDashboardAccountStatus_Values returns all elements of the DeliverabilityDashboardAccountStatus enum
+func DeliverabilityDashboardAccountStatus_Values() []string {
+	return []string{
+		DeliverabilityDashboardAccountStatusActive,
+		DeliverabilityDashboardAccountStatusPendingExpiration,
+		DeliverabilityDashboardAccountStatusDisabled,
+	}
+}
+
 // The status of a predictive inbox placement test. If the status is IN_PROGRESS,
 // then the predictive inbox placement test is currently running. Predictive
 // inbox placement tests are usually complete within 24 hours of creating the
@@ -10528,6 +10545,14 @@ const (
 	// DeliverabilityTestStatusCompleted is a DeliverabilityTestStatus enum value
 	DeliverabilityTestStatusCompleted = "COMPLETED"
 )
+
+// DeliverabilityTestStatus_Values returns all elements of the DeliverabilityTestStatus enum
+func DeliverabilityTestStatus_Values() []string {
+	return []string{
+		DeliverabilityTestStatusInProgress,
+		DeliverabilityTestStatusCompleted,
+	}
+}
 
 // The location where Amazon Pinpoint finds the value of a dimension to publish
 // to Amazon CloudWatch. If you want Amazon Pinpoint to use the message tags
@@ -10545,6 +10570,15 @@ const (
 	// DimensionValueSourceLinkTag is a DimensionValueSource enum value
 	DimensionValueSourceLinkTag = "LINK_TAG"
 )
+
+// DimensionValueSource_Values returns all elements of the DimensionValueSource enum
+func DimensionValueSource_Values() []string {
+	return []string{
+		DimensionValueSourceMessageTag,
+		DimensionValueSourceEmailHeader,
+		DimensionValueSourceLinkTag,
+	}
+}
 
 // The DKIM authentication status of the identity. The status can be one of
 // the following:
@@ -10581,6 +10615,17 @@ const (
 	DkimStatusNotStarted = "NOT_STARTED"
 )
 
+// DkimStatus_Values returns all elements of the DkimStatus enum
+func DkimStatus_Values() []string {
+	return []string{
+		DkimStatusPending,
+		DkimStatusSuccess,
+		DkimStatusFailed,
+		DkimStatusTemporaryFailure,
+		DkimStatusNotStarted,
+	}
+}
+
 // An email sending event type. For example, email sends, opens, and bounces
 // are all email events.
 const (
@@ -10609,6 +10654,20 @@ const (
 	EventTypeRenderingFailure = "RENDERING_FAILURE"
 )
 
+// EventType_Values returns all elements of the EventType enum
+func EventType_Values() []string {
+	return []string{
+		EventTypeSend,
+		EventTypeReject,
+		EventTypeBounce,
+		EventTypeComplaint,
+		EventTypeDelivery,
+		EventTypeOpen,
+		EventTypeClick,
+		EventTypeRenderingFailure,
+	}
+}
+
 // The email identity type. The identity type can be one of the following:
 //
 //    * EMAIL_ADDRESS – The identity is an email address.
@@ -10624,6 +10683,15 @@ const (
 	// IdentityTypeManagedDomain is a IdentityType enum value
 	IdentityTypeManagedDomain = "MANAGED_DOMAIN"
 )
+
+// IdentityType_Values returns all elements of the IdentityType enum
+func IdentityType_Values() []string {
+	return []string{
+		IdentityTypeEmailAddress,
+		IdentityTypeDomain,
+		IdentityTypeManagedDomain,
+	}
+}
 
 // The status of the MAIL FROM domain. This status can have the following values:
 //
@@ -10652,6 +10720,16 @@ const (
 	MailFromDomainStatusTemporaryFailure = "TEMPORARY_FAILURE"
 )
 
+// MailFromDomainStatus_Values returns all elements of the MailFromDomainStatus enum
+func MailFromDomainStatus_Values() []string {
+	return []string{
+		MailFromDomainStatusPending,
+		MailFromDomainStatusSuccess,
+		MailFromDomainStatusFailed,
+		MailFromDomainStatusTemporaryFailure,
+	}
+}
+
 // Specifies whether messages that use the configuration set are required to
 // use Transport Layer Security (TLS). If the value is Require, messages are
 // only delivered if a TLS connection can be established. If the value is Optional,
@@ -10664,6 +10742,14 @@ const (
 	TlsPolicyOptional = "OPTIONAL"
 )
 
+// TlsPolicy_Values returns all elements of the TlsPolicy enum
+func TlsPolicy_Values() []string {
+	return []string{
+		TlsPolicyRequire,
+		TlsPolicyOptional,
+	}
+}
+
 // The warmup status of a dedicated IP.
 const (
 	// WarmupStatusInProgress is a WarmupStatus enum value
@@ -10672,3 +10758,11 @@ const (
 	// WarmupStatusDone is a WarmupStatus enum value
 	WarmupStatusDone = "DONE"
 )
+
+// WarmupStatus_Values returns all elements of the WarmupStatus enum
+func WarmupStatus_Values() []string {
+	return []string{
+		WarmupStatusInProgress,
+		WarmupStatusDone,
+	}
+}

--- a/service/pinpointsmsvoice/api.go
+++ b/service/pinpointsmsvoice/api.go
@@ -2040,3 +2040,16 @@ const (
 	// EventTypeNoAnswer is a EventType enum value
 	EventTypeNoAnswer = "NO_ANSWER"
 )
+
+// EventType_Values returns all elements of the EventType enum
+func EventType_Values() []string {
+	return []string{
+		EventTypeInitiatedCall,
+		EventTypeRinging,
+		EventTypeAnswered,
+		EventTypeCompletedCall,
+		EventTypeBusy,
+		EventTypeFailed,
+		EventTypeNoAnswer,
+	}
+}

--- a/service/polly/api.go
+++ b/service/polly/api.go
@@ -3478,6 +3478,14 @@ const (
 	EngineNeural = "neural"
 )
 
+// Engine_Values returns all elements of the Engine enum
+func Engine_Values() []string {
+	return []string{
+		EngineStandard,
+		EngineNeural,
+	}
+}
+
 const (
 	// GenderFemale is a Gender enum value
 	GenderFemale = "Female"
@@ -3485,6 +3493,14 @@ const (
 	// GenderMale is a Gender enum value
 	GenderMale = "Male"
 )
+
+// Gender_Values returns all elements of the Gender enum
+func Gender_Values() []string {
+	return []string{
+		GenderFemale,
+		GenderMale,
+	}
+}
 
 const (
 	// LanguageCodeArb is a LanguageCode enum value
@@ -3575,6 +3591,41 @@ const (
 	LanguageCodeTrTr = "tr-TR"
 )
 
+// LanguageCode_Values returns all elements of the LanguageCode enum
+func LanguageCode_Values() []string {
+	return []string{
+		LanguageCodeArb,
+		LanguageCodeCmnCn,
+		LanguageCodeCyGb,
+		LanguageCodeDaDk,
+		LanguageCodeDeDe,
+		LanguageCodeEnAu,
+		LanguageCodeEnGb,
+		LanguageCodeEnGbWls,
+		LanguageCodeEnIn,
+		LanguageCodeEnUs,
+		LanguageCodeEsEs,
+		LanguageCodeEsMx,
+		LanguageCodeEsUs,
+		LanguageCodeFrCa,
+		LanguageCodeFrFr,
+		LanguageCodeIsIs,
+		LanguageCodeItIt,
+		LanguageCodeJaJp,
+		LanguageCodeHiIn,
+		LanguageCodeKoKr,
+		LanguageCodeNbNo,
+		LanguageCodeNlNl,
+		LanguageCodePlPl,
+		LanguageCodePtBr,
+		LanguageCodePtPt,
+		LanguageCodeRoRo,
+		LanguageCodeRuRu,
+		LanguageCodeSvSe,
+		LanguageCodeTrTr,
+	}
+}
+
 const (
 	// OutputFormatJson is a OutputFormat enum value
 	OutputFormatJson = "json"
@@ -3588,6 +3639,16 @@ const (
 	// OutputFormatPcm is a OutputFormat enum value
 	OutputFormatPcm = "pcm"
 )
+
+// OutputFormat_Values returns all elements of the OutputFormat enum
+func OutputFormat_Values() []string {
+	return []string{
+		OutputFormatJson,
+		OutputFormatMp3,
+		OutputFormatOggVorbis,
+		OutputFormatPcm,
+	}
+}
 
 const (
 	// SpeechMarkTypeSentence is a SpeechMarkType enum value
@@ -3603,6 +3664,16 @@ const (
 	SpeechMarkTypeWord = "word"
 )
 
+// SpeechMarkType_Values returns all elements of the SpeechMarkType enum
+func SpeechMarkType_Values() []string {
+	return []string{
+		SpeechMarkTypeSentence,
+		SpeechMarkTypeSsml,
+		SpeechMarkTypeViseme,
+		SpeechMarkTypeWord,
+	}
+}
+
 const (
 	// TaskStatusScheduled is a TaskStatus enum value
 	TaskStatusScheduled = "scheduled"
@@ -3617,6 +3688,16 @@ const (
 	TaskStatusFailed = "failed"
 )
 
+// TaskStatus_Values returns all elements of the TaskStatus enum
+func TaskStatus_Values() []string {
+	return []string{
+		TaskStatusScheduled,
+		TaskStatusInProgress,
+		TaskStatusCompleted,
+		TaskStatusFailed,
+	}
+}
+
 const (
 	// TextTypeSsml is a TextType enum value
 	TextTypeSsml = "ssml"
@@ -3624,6 +3705,14 @@ const (
 	// TextTypeText is a TextType enum value
 	TextTypeText = "text"
 )
+
+// TextType_Values returns all elements of the TextType enum
+func TextType_Values() []string {
+	return []string{
+		TextTypeSsml,
+		TextTypeText,
+	}
+}
 
 const (
 	// VoiceIdAditi is a VoiceId enum value
@@ -3809,3 +3898,70 @@ const (
 	// VoiceIdZhiyu is a VoiceId enum value
 	VoiceIdZhiyu = "Zhiyu"
 )
+
+// VoiceId_Values returns all elements of the VoiceId enum
+func VoiceId_Values() []string {
+	return []string{
+		VoiceIdAditi,
+		VoiceIdAmy,
+		VoiceIdAstrid,
+		VoiceIdBianca,
+		VoiceIdBrian,
+		VoiceIdCamila,
+		VoiceIdCarla,
+		VoiceIdCarmen,
+		VoiceIdCeline,
+		VoiceIdChantal,
+		VoiceIdConchita,
+		VoiceIdCristiano,
+		VoiceIdDora,
+		VoiceIdEmma,
+		VoiceIdEnrique,
+		VoiceIdEwa,
+		VoiceIdFiliz,
+		VoiceIdGeraint,
+		VoiceIdGiorgio,
+		VoiceIdGwyneth,
+		VoiceIdHans,
+		VoiceIdInes,
+		VoiceIdIvy,
+		VoiceIdJacek,
+		VoiceIdJan,
+		VoiceIdJoanna,
+		VoiceIdJoey,
+		VoiceIdJustin,
+		VoiceIdKarl,
+		VoiceIdKendra,
+		VoiceIdKevin,
+		VoiceIdKimberly,
+		VoiceIdLea,
+		VoiceIdLiv,
+		VoiceIdLotte,
+		VoiceIdLucia,
+		VoiceIdLupe,
+		VoiceIdMads,
+		VoiceIdMaja,
+		VoiceIdMarlene,
+		VoiceIdMathieu,
+		VoiceIdMatthew,
+		VoiceIdMaxim,
+		VoiceIdMia,
+		VoiceIdMiguel,
+		VoiceIdMizuki,
+		VoiceIdNaja,
+		VoiceIdNicole,
+		VoiceIdPenelope,
+		VoiceIdRaveena,
+		VoiceIdRicardo,
+		VoiceIdRuben,
+		VoiceIdRussell,
+		VoiceIdSalli,
+		VoiceIdSeoyeon,
+		VoiceIdTakumi,
+		VoiceIdTatyana,
+		VoiceIdVicki,
+		VoiceIdVitoria,
+		VoiceIdZeina,
+		VoiceIdZhiyu,
+	}
+}

--- a/service/pricing/api.go
+++ b/service/pricing/api.go
@@ -1241,3 +1241,10 @@ const (
 	// FilterTypeTermMatch is a FilterType enum value
 	FilterTypeTermMatch = "TERM_MATCH"
 )
+
+// FilterType_Values returns all elements of the FilterType enum
+func FilterType_Values() []string {
+	return []string{
+		FilterTypeTermMatch,
+	}
+}

--- a/service/qldb/api.go
+++ b/service/qldb/api.go
@@ -4759,6 +4759,14 @@ const (
 	ErrorCauseIamPermissionRevoked = "IAM_PERMISSION_REVOKED"
 )
 
+// ErrorCause_Values returns all elements of the ErrorCause enum
+func ErrorCause_Values() []string {
+	return []string{
+		ErrorCauseKinesisStreamNotFound,
+		ErrorCauseIamPermissionRevoked,
+	}
+}
+
 const (
 	// ExportStatusInProgress is a ExportStatus enum value
 	ExportStatusInProgress = "IN_PROGRESS"
@@ -4769,6 +4777,15 @@ const (
 	// ExportStatusCancelled is a ExportStatus enum value
 	ExportStatusCancelled = "CANCELLED"
 )
+
+// ExportStatus_Values returns all elements of the ExportStatus enum
+func ExportStatus_Values() []string {
+	return []string{
+		ExportStatusInProgress,
+		ExportStatusCompleted,
+		ExportStatusCancelled,
+	}
+}
 
 const (
 	// LedgerStateCreating is a LedgerState enum value
@@ -4784,10 +4801,27 @@ const (
 	LedgerStateDeleted = "DELETED"
 )
 
+// LedgerState_Values returns all elements of the LedgerState enum
+func LedgerState_Values() []string {
+	return []string{
+		LedgerStateCreating,
+		LedgerStateActive,
+		LedgerStateDeleting,
+		LedgerStateDeleted,
+	}
+}
+
 const (
 	// PermissionsModeAllowAll is a PermissionsMode enum value
 	PermissionsModeAllowAll = "ALLOW_ALL"
 )
+
+// PermissionsMode_Values returns all elements of the PermissionsMode enum
+func PermissionsMode_Values() []string {
+	return []string{
+		PermissionsModeAllowAll,
+	}
+}
 
 const (
 	// S3ObjectEncryptionTypeSseKms is a S3ObjectEncryptionType enum value
@@ -4799,6 +4833,15 @@ const (
 	// S3ObjectEncryptionTypeNoEncryption is a S3ObjectEncryptionType enum value
 	S3ObjectEncryptionTypeNoEncryption = "NO_ENCRYPTION"
 )
+
+// S3ObjectEncryptionType_Values returns all elements of the S3ObjectEncryptionType enum
+func S3ObjectEncryptionType_Values() []string {
+	return []string{
+		S3ObjectEncryptionTypeSseKms,
+		S3ObjectEncryptionTypeSseS3,
+		S3ObjectEncryptionTypeNoEncryption,
+	}
+}
 
 const (
 	// StreamStatusActive is a StreamStatus enum value
@@ -4816,3 +4859,14 @@ const (
 	// StreamStatusImpaired is a StreamStatus enum value
 	StreamStatusImpaired = "IMPAIRED"
 )
+
+// StreamStatus_Values returns all elements of the StreamStatus enum
+func StreamStatus_Values() []string {
+	return []string{
+		StreamStatusActive,
+		StreamStatusCompleted,
+		StreamStatusCanceled,
+		StreamStatusFailed,
+		StreamStatusImpaired,
+	}
+}

--- a/service/quicksight/api.go
+++ b/service/quicksight/api.go
@@ -30229,6 +30229,15 @@ const (
 	AssignmentStatusDisabled = "DISABLED"
 )
 
+// AssignmentStatus_Values returns all elements of the AssignmentStatus enum
+func AssignmentStatus_Values() []string {
+	return []string{
+		AssignmentStatusEnabled,
+		AssignmentStatusDraft,
+		AssignmentStatusDisabled,
+	}
+}
+
 const (
 	// ColumnDataTypeString is a ColumnDataType enum value
 	ColumnDataTypeString = "STRING"
@@ -30243,6 +30252,16 @@ const (
 	ColumnDataTypeDatetime = "DATETIME"
 )
 
+// ColumnDataType_Values returns all elements of the ColumnDataType enum
+func ColumnDataType_Values() []string {
+	return []string{
+		ColumnDataTypeString,
+		ColumnDataTypeInteger,
+		ColumnDataTypeDecimal,
+		ColumnDataTypeDatetime,
+	}
+}
+
 const (
 	// DashboardBehaviorEnabled is a DashboardBehavior enum value
 	DashboardBehaviorEnabled = "ENABLED"
@@ -30250,6 +30269,14 @@ const (
 	// DashboardBehaviorDisabled is a DashboardBehavior enum value
 	DashboardBehaviorDisabled = "DISABLED"
 )
+
+// DashboardBehavior_Values returns all elements of the DashboardBehavior enum
+func DashboardBehavior_Values() []string {
+	return []string{
+		DashboardBehaviorEnabled,
+		DashboardBehaviorDisabled,
+	}
+}
 
 const (
 	// DashboardErrorTypeAccessDenied is a DashboardErrorType enum value
@@ -30283,10 +30310,33 @@ const (
 	DashboardErrorTypeColumnReplacementMissing = "COLUMN_REPLACEMENT_MISSING"
 )
 
+// DashboardErrorType_Values returns all elements of the DashboardErrorType enum
+func DashboardErrorType_Values() []string {
+	return []string{
+		DashboardErrorTypeAccessDenied,
+		DashboardErrorTypeSourceNotFound,
+		DashboardErrorTypeDataSetNotFound,
+		DashboardErrorTypeInternalFailure,
+		DashboardErrorTypeParameterValueIncompatible,
+		DashboardErrorTypeParameterTypeInvalid,
+		DashboardErrorTypeParameterNotFound,
+		DashboardErrorTypeColumnTypeMismatch,
+		DashboardErrorTypeColumnGeographicRoleMismatch,
+		DashboardErrorTypeColumnReplacementMissing,
+	}
+}
+
 const (
 	// DashboardFilterAttributeQuicksightUser is a DashboardFilterAttribute enum value
 	DashboardFilterAttributeQuicksightUser = "QUICKSIGHT_USER"
 )
+
+// DashboardFilterAttribute_Values returns all elements of the DashboardFilterAttribute enum
+func DashboardFilterAttribute_Values() []string {
+	return []string{
+		DashboardFilterAttributeQuicksightUser,
+	}
+}
 
 const (
 	// DashboardUIStateExpanded is a DashboardUIState enum value
@@ -30296,6 +30346,14 @@ const (
 	DashboardUIStateCollapsed = "COLLAPSED"
 )
 
+// DashboardUIState_Values returns all elements of the DashboardUIState enum
+func DashboardUIState_Values() []string {
+	return []string{
+		DashboardUIStateExpanded,
+		DashboardUIStateCollapsed,
+	}
+}
+
 const (
 	// DataSetImportModeSpice is a DataSetImportMode enum value
 	DataSetImportModeSpice = "SPICE"
@@ -30303,6 +30361,14 @@ const (
 	// DataSetImportModeDirectQuery is a DataSetImportMode enum value
 	DataSetImportModeDirectQuery = "DIRECT_QUERY"
 )
+
+// DataSetImportMode_Values returns all elements of the DataSetImportMode enum
+func DataSetImportMode_Values() []string {
+	return []string{
+		DataSetImportModeSpice,
+		DataSetImportModeDirectQuery,
+	}
+}
 
 const (
 	// DataSourceErrorInfoTypeAccessDenied is a DataSourceErrorInfoType enum value
@@ -30329,6 +30395,20 @@ const (
 	// DataSourceErrorInfoTypeUnknown is a DataSourceErrorInfoType enum value
 	DataSourceErrorInfoTypeUnknown = "UNKNOWN"
 )
+
+// DataSourceErrorInfoType_Values returns all elements of the DataSourceErrorInfoType enum
+func DataSourceErrorInfoType_Values() []string {
+	return []string{
+		DataSourceErrorInfoTypeAccessDenied,
+		DataSourceErrorInfoTypeCopySourceNotFound,
+		DataSourceErrorInfoTypeTimeout,
+		DataSourceErrorInfoTypeEngineVersionNotSupported,
+		DataSourceErrorInfoTypeUnknownHost,
+		DataSourceErrorInfoTypeGenericSqlFailure,
+		DataSourceErrorInfoTypeConflict,
+		DataSourceErrorInfoTypeUnknown,
+	}
+}
 
 const (
 	// DataSourceTypeAdobeAnalytics is a DataSourceType enum value
@@ -30395,6 +30475,33 @@ const (
 	DataSourceTypeTwitter = "TWITTER"
 )
 
+// DataSourceType_Values returns all elements of the DataSourceType enum
+func DataSourceType_Values() []string {
+	return []string{
+		DataSourceTypeAdobeAnalytics,
+		DataSourceTypeAmazonElasticsearch,
+		DataSourceTypeAthena,
+		DataSourceTypeAurora,
+		DataSourceTypeAuroraPostgresql,
+		DataSourceTypeAwsIotAnalytics,
+		DataSourceTypeGithub,
+		DataSourceTypeJira,
+		DataSourceTypeMariadb,
+		DataSourceTypeMysql,
+		DataSourceTypePostgresql,
+		DataSourceTypePresto,
+		DataSourceTypeRedshift,
+		DataSourceTypeS3,
+		DataSourceTypeSalesforce,
+		DataSourceTypeServicenow,
+		DataSourceTypeSnowflake,
+		DataSourceTypeSpark,
+		DataSourceTypeSqlserver,
+		DataSourceTypeTeradata,
+		DataSourceTypeTwitter,
+	}
+}
+
 const (
 	// EditionStandard is a Edition enum value
 	EditionStandard = "STANDARD"
@@ -30402,6 +30509,14 @@ const (
 	// EditionEnterprise is a Edition enum value
 	EditionEnterprise = "ENTERPRISE"
 )
+
+// Edition_Values returns all elements of the Edition enum
+func Edition_Values() []string {
+	return []string{
+		EditionStandard,
+		EditionEnterprise,
+	}
+}
 
 const (
 	// ExceptionResourceTypeUser is a ExceptionResourceType enum value
@@ -30432,6 +30547,21 @@ const (
 	ExceptionResourceTypeIngestion = "INGESTION"
 )
 
+// ExceptionResourceType_Values returns all elements of the ExceptionResourceType enum
+func ExceptionResourceType_Values() []string {
+	return []string{
+		ExceptionResourceTypeUser,
+		ExceptionResourceTypeGroup,
+		ExceptionResourceTypeNamespace,
+		ExceptionResourceTypeAccountSettings,
+		ExceptionResourceTypeIampolicyAssignment,
+		ExceptionResourceTypeDataSource,
+		ExceptionResourceTypeDataSet,
+		ExceptionResourceTypeVpcConnection,
+		ExceptionResourceTypeIngestion,
+	}
+}
+
 const (
 	// FileFormatCsv is a FileFormat enum value
 	FileFormatCsv = "CSV"
@@ -30452,15 +30582,41 @@ const (
 	FileFormatJson = "JSON"
 )
 
+// FileFormat_Values returns all elements of the FileFormat enum
+func FileFormat_Values() []string {
+	return []string{
+		FileFormatCsv,
+		FileFormatTsv,
+		FileFormatClf,
+		FileFormatElf,
+		FileFormatXlsx,
+		FileFormatJson,
+	}
+}
+
 const (
 	// FilterOperatorStringEquals is a FilterOperator enum value
 	FilterOperatorStringEquals = "StringEquals"
 )
 
+// FilterOperator_Values returns all elements of the FilterOperator enum
+func FilterOperator_Values() []string {
+	return []string{
+		FilterOperatorStringEquals,
+	}
+}
+
 const (
 	// GeoSpatialCountryCodeUs is a GeoSpatialCountryCode enum value
 	GeoSpatialCountryCodeUs = "US"
 )
+
+// GeoSpatialCountryCode_Values returns all elements of the GeoSpatialCountryCode enum
+func GeoSpatialCountryCode_Values() []string {
+	return []string{
+		GeoSpatialCountryCodeUs,
+	}
+}
 
 const (
 	// GeoSpatialDataRoleCountry is a GeoSpatialDataRole enum value
@@ -30485,10 +30641,30 @@ const (
 	GeoSpatialDataRoleLatitude = "LATITUDE"
 )
 
+// GeoSpatialDataRole_Values returns all elements of the GeoSpatialDataRole enum
+func GeoSpatialDataRole_Values() []string {
+	return []string{
+		GeoSpatialDataRoleCountry,
+		GeoSpatialDataRoleState,
+		GeoSpatialDataRoleCounty,
+		GeoSpatialDataRoleCity,
+		GeoSpatialDataRolePostcode,
+		GeoSpatialDataRoleLongitude,
+		GeoSpatialDataRoleLatitude,
+	}
+}
+
 const (
 	// IdentityStoreQuicksight is a IdentityStore enum value
 	IdentityStoreQuicksight = "QUICKSIGHT"
 )
+
+// IdentityStore_Values returns all elements of the IdentityStore enum
+func IdentityStore_Values() []string {
+	return []string{
+		IdentityStoreQuicksight,
+	}
+}
 
 const (
 	// IdentityTypeIam is a IdentityType enum value
@@ -30497,6 +30673,14 @@ const (
 	// IdentityTypeQuicksight is a IdentityType enum value
 	IdentityTypeQuicksight = "QUICKSIGHT"
 )
+
+// IdentityType_Values returns all elements of the IdentityType enum
+func IdentityType_Values() []string {
+	return []string{
+		IdentityTypeIam,
+		IdentityTypeQuicksight,
+	}
+}
 
 const (
 	// IngestionErrorTypeFailureToAssumeRole is a IngestionErrorType enum value
@@ -30620,6 +30804,52 @@ const (
 	IngestionErrorTypeInternalServiceError = "INTERNAL_SERVICE_ERROR"
 )
 
+// IngestionErrorType_Values returns all elements of the IngestionErrorType enum
+func IngestionErrorType_Values() []string {
+	return []string{
+		IngestionErrorTypeFailureToAssumeRole,
+		IngestionErrorTypeIngestionSuperseded,
+		IngestionErrorTypeIngestionCanceled,
+		IngestionErrorTypeDataSetDeleted,
+		IngestionErrorTypeDataSetNotSpice,
+		IngestionErrorTypeS3UploadedFileDeleted,
+		IngestionErrorTypeS3ManifestError,
+		IngestionErrorTypeDataToleranceException,
+		IngestionErrorTypeSpiceTableNotFound,
+		IngestionErrorTypeDataSetSizeLimitExceeded,
+		IngestionErrorTypeRowSizeLimitExceeded,
+		IngestionErrorTypeAccountCapacityLimitExceeded,
+		IngestionErrorTypeCustomerError,
+		IngestionErrorTypeDataSourceNotFound,
+		IngestionErrorTypeIamRoleNotAvailable,
+		IngestionErrorTypeConnectionFailure,
+		IngestionErrorTypeSqlTableNotFound,
+		IngestionErrorTypePermissionDenied,
+		IngestionErrorTypeSslCertificateValidationFailure,
+		IngestionErrorTypeOauthTokenFailure,
+		IngestionErrorTypeSourceApiLimitExceededFailure,
+		IngestionErrorTypePasswordAuthenticationFailure,
+		IngestionErrorTypeSqlSchemaMismatchError,
+		IngestionErrorTypeInvalidDateFormat,
+		IngestionErrorTypeInvalidDataprepSyntax,
+		IngestionErrorTypeSourceResourceLimitExceeded,
+		IngestionErrorTypeSqlInvalidParameterValue,
+		IngestionErrorTypeQueryTimeout,
+		IngestionErrorTypeSqlNumericOverflow,
+		IngestionErrorTypeUnresolvableHost,
+		IngestionErrorTypeUnroutableHost,
+		IngestionErrorTypeSqlException,
+		IngestionErrorTypeS3FileInaccessible,
+		IngestionErrorTypeIotFileNotFound,
+		IngestionErrorTypeIotDataSetFileEmpty,
+		IngestionErrorTypeInvalidDataSourceConfig,
+		IngestionErrorTypeDataSourceAuthFailed,
+		IngestionErrorTypeDataSourceConnectionFailed,
+		IngestionErrorTypeFailureToProcessJsonFile,
+		IngestionErrorTypeInternalServiceError,
+	}
+}
+
 const (
 	// IngestionRequestSourceManual is a IngestionRequestSource enum value
 	IngestionRequestSourceManual = "MANUAL"
@@ -30627,6 +30857,14 @@ const (
 	// IngestionRequestSourceScheduled is a IngestionRequestSource enum value
 	IngestionRequestSourceScheduled = "SCHEDULED"
 )
+
+// IngestionRequestSource_Values returns all elements of the IngestionRequestSource enum
+func IngestionRequestSource_Values() []string {
+	return []string{
+		IngestionRequestSourceManual,
+		IngestionRequestSourceScheduled,
+	}
+}
 
 const (
 	// IngestionRequestTypeInitialIngestion is a IngestionRequestType enum value
@@ -30641,6 +30879,16 @@ const (
 	// IngestionRequestTypeFullRefresh is a IngestionRequestType enum value
 	IngestionRequestTypeFullRefresh = "FULL_REFRESH"
 )
+
+// IngestionRequestType_Values returns all elements of the IngestionRequestType enum
+func IngestionRequestType_Values() []string {
+	return []string{
+		IngestionRequestTypeInitialIngestion,
+		IngestionRequestTypeEdit,
+		IngestionRequestTypeIncrementalRefresh,
+		IngestionRequestTypeFullRefresh,
+	}
+}
 
 const (
 	// IngestionStatusInitialized is a IngestionStatus enum value
@@ -30661,6 +30909,18 @@ const (
 	// IngestionStatusCancelled is a IngestionStatus enum value
 	IngestionStatusCancelled = "CANCELLED"
 )
+
+// IngestionStatus_Values returns all elements of the IngestionStatus enum
+func IngestionStatus_Values() []string {
+	return []string{
+		IngestionStatusInitialized,
+		IngestionStatusQueued,
+		IngestionStatusRunning,
+		IngestionStatusFailed,
+		IngestionStatusCompleted,
+		IngestionStatusCancelled,
+	}
+}
 
 const (
 	// InputColumnDataTypeString is a InputColumnDataType enum value
@@ -30685,6 +30945,19 @@ const (
 	InputColumnDataTypeJson = "JSON"
 )
 
+// InputColumnDataType_Values returns all elements of the InputColumnDataType enum
+func InputColumnDataType_Values() []string {
+	return []string{
+		InputColumnDataTypeString,
+		InputColumnDataTypeInteger,
+		InputColumnDataTypeDecimal,
+		InputColumnDataTypeDatetime,
+		InputColumnDataTypeBit,
+		InputColumnDataTypeBoolean,
+		InputColumnDataTypeJson,
+	}
+}
+
 const (
 	// JoinTypeInner is a JoinType enum value
 	JoinTypeInner = "INNER"
@@ -30699,6 +30972,16 @@ const (
 	JoinTypeRight = "RIGHT"
 )
 
+// JoinType_Values returns all elements of the JoinType enum
+func JoinType_Values() []string {
+	return []string{
+		JoinTypeInner,
+		JoinTypeOuter,
+		JoinTypeLeft,
+		JoinTypeRight,
+	}
+}
+
 const (
 	// NamespaceErrorTypePermissionDenied is a NamespaceErrorType enum value
 	NamespaceErrorTypePermissionDenied = "PERMISSION_DENIED"
@@ -30706,6 +30989,14 @@ const (
 	// NamespaceErrorTypeInternalServiceError is a NamespaceErrorType enum value
 	NamespaceErrorTypeInternalServiceError = "INTERNAL_SERVICE_ERROR"
 )
+
+// NamespaceErrorType_Values returns all elements of the NamespaceErrorType enum
+func NamespaceErrorType_Values() []string {
+	return []string{
+		NamespaceErrorTypePermissionDenied,
+		NamespaceErrorTypeInternalServiceError,
+	}
+}
 
 const (
 	// NamespaceStatusCreated is a NamespaceStatus enum value
@@ -30723,6 +31014,17 @@ const (
 	// NamespaceStatusNonRetryableFailure is a NamespaceStatus enum value
 	NamespaceStatusNonRetryableFailure = "NON_RETRYABLE_FAILURE"
 )
+
+// NamespaceStatus_Values returns all elements of the NamespaceStatus enum
+func NamespaceStatus_Values() []string {
+	return []string{
+		NamespaceStatusCreated,
+		NamespaceStatusCreating,
+		NamespaceStatusDeleting,
+		NamespaceStatusRetryableFailure,
+		NamespaceStatusNonRetryableFailure,
+	}
+}
 
 const (
 	// ResourceStatusCreationInProgress is a ResourceStatus enum value
@@ -30744,6 +31046,18 @@ const (
 	ResourceStatusUpdateFailed = "UPDATE_FAILED"
 )
 
+// ResourceStatus_Values returns all elements of the ResourceStatus enum
+func ResourceStatus_Values() []string {
+	return []string{
+		ResourceStatusCreationInProgress,
+		ResourceStatusCreationSuccessful,
+		ResourceStatusCreationFailed,
+		ResourceStatusUpdateInProgress,
+		ResourceStatusUpdateSuccessful,
+		ResourceStatusUpdateFailed,
+	}
+}
+
 const (
 	// RowLevelPermissionPolicyGrantAccess is a RowLevelPermissionPolicy enum value
 	RowLevelPermissionPolicyGrantAccess = "GRANT_ACCESS"
@@ -30751,6 +31065,14 @@ const (
 	// RowLevelPermissionPolicyDenyAccess is a RowLevelPermissionPolicy enum value
 	RowLevelPermissionPolicyDenyAccess = "DENY_ACCESS"
 )
+
+// RowLevelPermissionPolicy_Values returns all elements of the RowLevelPermissionPolicy enum
+func RowLevelPermissionPolicy_Values() []string {
+	return []string{
+		RowLevelPermissionPolicyGrantAccess,
+		RowLevelPermissionPolicyDenyAccess,
+	}
+}
 
 const (
 	// TemplateErrorTypeSourceNotFound is a TemplateErrorType enum value
@@ -30763,6 +31085,15 @@ const (
 	TemplateErrorTypeInternalFailure = "INTERNAL_FAILURE"
 )
 
+// TemplateErrorType_Values returns all elements of the TemplateErrorType enum
+func TemplateErrorType_Values() []string {
+	return []string{
+		TemplateErrorTypeSourceNotFound,
+		TemplateErrorTypeDataSetNotFound,
+		TemplateErrorTypeInternalFailure,
+	}
+}
+
 const (
 	// TextQualifierDoubleQuote is a TextQualifier enum value
 	TextQualifierDoubleQuote = "DOUBLE_QUOTE"
@@ -30771,10 +31102,25 @@ const (
 	TextQualifierSingleQuote = "SINGLE_QUOTE"
 )
 
+// TextQualifier_Values returns all elements of the TextQualifier enum
+func TextQualifier_Values() []string {
+	return []string{
+		TextQualifierDoubleQuote,
+		TextQualifierSingleQuote,
+	}
+}
+
 const (
 	// ThemeErrorTypeInternalFailure is a ThemeErrorType enum value
 	ThemeErrorTypeInternalFailure = "INTERNAL_FAILURE"
 )
+
+// ThemeErrorType_Values returns all elements of the ThemeErrorType enum
+func ThemeErrorType_Values() []string {
+	return []string{
+		ThemeErrorTypeInternalFailure,
+	}
+}
 
 const (
 	// ThemeTypeQuicksight is a ThemeType enum value
@@ -30786,6 +31132,15 @@ const (
 	// ThemeTypeAll is a ThemeType enum value
 	ThemeTypeAll = "ALL"
 )
+
+// ThemeType_Values returns all elements of the ThemeType enum
+func ThemeType_Values() []string {
+	return []string{
+		ThemeTypeQuicksight,
+		ThemeTypeCustom,
+		ThemeTypeAll,
+	}
+}
 
 const (
 	// UserRoleAdmin is a UserRole enum value
@@ -30803,3 +31158,14 @@ const (
 	// UserRoleRestrictedReader is a UserRole enum value
 	UserRoleRestrictedReader = "RESTRICTED_READER"
 )
+
+// UserRole_Values returns all elements of the UserRole enum
+func UserRole_Values() []string {
+	return []string{
+		UserRoleAdmin,
+		UserRoleAuthor,
+		UserRoleReader,
+		UserRoleRestrictedAuthor,
+		UserRoleRestrictedReader,
+	}
+}

--- a/service/ram/api.go
+++ b/service/ram/api.go
@@ -6982,6 +6982,14 @@ const (
 	ResourceOwnerOtherAccounts = "OTHER-ACCOUNTS"
 )
 
+// ResourceOwner_Values returns all elements of the ResourceOwner enum
+func ResourceOwner_Values() []string {
+	return []string{
+		ResourceOwnerSelf,
+		ResourceOwnerOtherAccounts,
+	}
+}
+
 const (
 	// ResourceShareAssociationStatusAssociating is a ResourceShareAssociationStatus enum value
 	ResourceShareAssociationStatusAssociating = "ASSOCIATING"
@@ -6999,6 +7007,17 @@ const (
 	ResourceShareAssociationStatusDisassociated = "DISASSOCIATED"
 )
 
+// ResourceShareAssociationStatus_Values returns all elements of the ResourceShareAssociationStatus enum
+func ResourceShareAssociationStatus_Values() []string {
+	return []string{
+		ResourceShareAssociationStatusAssociating,
+		ResourceShareAssociationStatusAssociated,
+		ResourceShareAssociationStatusFailed,
+		ResourceShareAssociationStatusDisassociating,
+		ResourceShareAssociationStatusDisassociated,
+	}
+}
+
 const (
 	// ResourceShareAssociationTypePrincipal is a ResourceShareAssociationType enum value
 	ResourceShareAssociationTypePrincipal = "PRINCIPAL"
@@ -7006,6 +7025,14 @@ const (
 	// ResourceShareAssociationTypeResource is a ResourceShareAssociationType enum value
 	ResourceShareAssociationTypeResource = "RESOURCE"
 )
+
+// ResourceShareAssociationType_Values returns all elements of the ResourceShareAssociationType enum
+func ResourceShareAssociationType_Values() []string {
+	return []string{
+		ResourceShareAssociationTypePrincipal,
+		ResourceShareAssociationTypeResource,
+	}
+}
 
 const (
 	// ResourceShareFeatureSetCreatedFromPolicy is a ResourceShareFeatureSet enum value
@@ -7017,6 +7044,15 @@ const (
 	// ResourceShareFeatureSetStandard is a ResourceShareFeatureSet enum value
 	ResourceShareFeatureSetStandard = "STANDARD"
 )
+
+// ResourceShareFeatureSet_Values returns all elements of the ResourceShareFeatureSet enum
+func ResourceShareFeatureSet_Values() []string {
+	return []string{
+		ResourceShareFeatureSetCreatedFromPolicy,
+		ResourceShareFeatureSetPromotingToStandard,
+		ResourceShareFeatureSetStandard,
+	}
+}
 
 const (
 	// ResourceShareInvitationStatusPending is a ResourceShareInvitationStatus enum value
@@ -7031,6 +7067,16 @@ const (
 	// ResourceShareInvitationStatusExpired is a ResourceShareInvitationStatus enum value
 	ResourceShareInvitationStatusExpired = "EXPIRED"
 )
+
+// ResourceShareInvitationStatus_Values returns all elements of the ResourceShareInvitationStatus enum
+func ResourceShareInvitationStatus_Values() []string {
+	return []string{
+		ResourceShareInvitationStatusPending,
+		ResourceShareInvitationStatusAccepted,
+		ResourceShareInvitationStatusRejected,
+		ResourceShareInvitationStatusExpired,
+	}
+}
 
 const (
 	// ResourceShareStatusPending is a ResourceShareStatus enum value
@@ -7049,6 +7095,17 @@ const (
 	ResourceShareStatusDeleted = "DELETED"
 )
 
+// ResourceShareStatus_Values returns all elements of the ResourceShareStatus enum
+func ResourceShareStatus_Values() []string {
+	return []string{
+		ResourceShareStatusPending,
+		ResourceShareStatusActive,
+		ResourceShareStatusFailed,
+		ResourceShareStatusDeleting,
+		ResourceShareStatusDeleted,
+	}
+}
+
 const (
 	// ResourceStatusAvailable is a ResourceStatus enum value
 	ResourceStatusAvailable = "AVAILABLE"
@@ -7065,3 +7122,14 @@ const (
 	// ResourceStatusPending is a ResourceStatus enum value
 	ResourceStatusPending = "PENDING"
 )
+
+// ResourceStatus_Values returns all elements of the ResourceStatus enum
+func ResourceStatus_Values() []string {
+	return []string{
+		ResourceStatusAvailable,
+		ResourceStatusZonalResourceInaccessible,
+		ResourceStatusLimitExceeded,
+		ResourceStatusUnavailable,
+		ResourceStatusPending,
+	}
+}

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -42025,6 +42025,14 @@ const (
 	ActivityStreamModeAsync = "async"
 )
 
+// ActivityStreamMode_Values returns all elements of the ActivityStreamMode enum
+func ActivityStreamMode_Values() []string {
+	return []string{
+		ActivityStreamModeSync,
+		ActivityStreamModeAsync,
+	}
+}
+
 const (
 	// ActivityStreamStatusStopped is a ActivityStreamStatus enum value
 	ActivityStreamStatusStopped = "stopped"
@@ -42039,6 +42047,16 @@ const (
 	ActivityStreamStatusStopping = "stopping"
 )
 
+// ActivityStreamStatus_Values returns all elements of the ActivityStreamStatus enum
+func ActivityStreamStatus_Values() []string {
+	return []string{
+		ActivityStreamStatusStopped,
+		ActivityStreamStatusStarting,
+		ActivityStreamStatusStarted,
+		ActivityStreamStatusStopping,
+	}
+}
+
 const (
 	// ApplyMethodImmediate is a ApplyMethod enum value
 	ApplyMethodImmediate = "immediate"
@@ -42047,10 +42065,25 @@ const (
 	ApplyMethodPendingReboot = "pending-reboot"
 )
 
+// ApplyMethod_Values returns all elements of the ApplyMethod enum
+func ApplyMethod_Values() []string {
+	return []string{
+		ApplyMethodImmediate,
+		ApplyMethodPendingReboot,
+	}
+}
+
 const (
 	// AuthSchemeSecrets is a AuthScheme enum value
 	AuthSchemeSecrets = "SECRETS"
 )
+
+// AuthScheme_Values returns all elements of the AuthScheme enum
+func AuthScheme_Values() []string {
+	return []string{
+		AuthSchemeSecrets,
+	}
+}
 
 const (
 	// DBProxyStatusAvailable is a DBProxyStatus enum value
@@ -42081,6 +42114,21 @@ const (
 	DBProxyStatusReactivating = "reactivating"
 )
 
+// DBProxyStatus_Values returns all elements of the DBProxyStatus enum
+func DBProxyStatus_Values() []string {
+	return []string{
+		DBProxyStatusAvailable,
+		DBProxyStatusModifying,
+		DBProxyStatusIncompatibleNetwork,
+		DBProxyStatusInsufficientResourceLimits,
+		DBProxyStatusCreating,
+		DBProxyStatusDeleting,
+		DBProxyStatusSuspended,
+		DBProxyStatusSuspending,
+		DBProxyStatusReactivating,
+	}
+}
+
 const (
 	// EngineFamilyMysql is a EngineFamily enum value
 	EngineFamilyMysql = "MYSQL"
@@ -42089,6 +42137,14 @@ const (
 	EngineFamilyPostgresql = "POSTGRESQL"
 )
 
+// EngineFamily_Values returns all elements of the EngineFamily enum
+func EngineFamily_Values() []string {
+	return []string{
+		EngineFamilyMysql,
+		EngineFamilyPostgresql,
+	}
+}
+
 const (
 	// IAMAuthModeDisabled is a IAMAuthMode enum value
 	IAMAuthModeDisabled = "DISABLED"
@@ -42096,6 +42152,14 @@ const (
 	// IAMAuthModeRequired is a IAMAuthMode enum value
 	IAMAuthModeRequired = "REQUIRED"
 )
+
+// IAMAuthMode_Values returns all elements of the IAMAuthMode enum
+func IAMAuthMode_Values() []string {
+	return []string{
+		IAMAuthModeDisabled,
+		IAMAuthModeRequired,
+	}
+}
 
 const (
 	// SourceTypeDbInstance is a SourceType enum value
@@ -42117,6 +42181,18 @@ const (
 	SourceTypeDbClusterSnapshot = "db-cluster-snapshot"
 )
 
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeDbInstance,
+		SourceTypeDbParameterGroup,
+		SourceTypeDbSecurityGroup,
+		SourceTypeDbSnapshot,
+		SourceTypeDbCluster,
+		SourceTypeDbClusterSnapshot,
+	}
+}
+
 const (
 	// TargetHealthReasonUnreachable is a TargetHealthReason enum value
 	TargetHealthReasonUnreachable = "UNREACHABLE"
@@ -42131,6 +42207,16 @@ const (
 	TargetHealthReasonPendingProxyCapacity = "PENDING_PROXY_CAPACITY"
 )
 
+// TargetHealthReason_Values returns all elements of the TargetHealthReason enum
+func TargetHealthReason_Values() []string {
+	return []string{
+		TargetHealthReasonUnreachable,
+		TargetHealthReasonConnectionFailed,
+		TargetHealthReasonAuthFailure,
+		TargetHealthReasonPendingProxyCapacity,
+	}
+}
+
 const (
 	// TargetStateRegistering is a TargetState enum value
 	TargetStateRegistering = "REGISTERING"
@@ -42142,6 +42228,15 @@ const (
 	TargetStateUnavailable = "UNAVAILABLE"
 )
 
+// TargetState_Values returns all elements of the TargetState enum
+func TargetState_Values() []string {
+	return []string{
+		TargetStateRegistering,
+		TargetStateAvailable,
+		TargetStateUnavailable,
+	}
+}
+
 const (
 	// TargetTypeRdsInstance is a TargetType enum value
 	TargetTypeRdsInstance = "RDS_INSTANCE"
@@ -42152,6 +42247,15 @@ const (
 	// TargetTypeTrackedCluster is a TargetType enum value
 	TargetTypeTrackedCluster = "TRACKED_CLUSTER"
 )
+
+// TargetType_Values returns all elements of the TargetType enum
+func TargetType_Values() []string {
+	return []string{
+		TargetTypeRdsInstance,
+		TargetTypeRdsServerlessEndpoint,
+		TargetTypeTrackedCluster,
+	}
+}
 
 const (
 	// WriteForwardingStatusEnabled is a WriteForwardingStatus enum value
@@ -42169,3 +42273,14 @@ const (
 	// WriteForwardingStatusUnknown is a WriteForwardingStatus enum value
 	WriteForwardingStatusUnknown = "unknown"
 )
+
+// WriteForwardingStatus_Values returns all elements of the WriteForwardingStatus enum
+func WriteForwardingStatus_Values() []string {
+	return []string{
+		WriteForwardingStatusEnabled,
+		WriteForwardingStatusDisabled,
+		WriteForwardingStatusEnabling,
+		WriteForwardingStatusDisabling,
+		WriteForwardingStatusUnknown,
+	}
+}

--- a/service/rdsdataservice/api.go
+++ b/service/rdsdataservice/api.go
@@ -2371,6 +2371,14 @@ const (
 	DecimalReturnTypeString = "STRING"
 )
 
+// DecimalReturnType_Values returns all elements of the DecimalReturnType enum
+func DecimalReturnType_Values() []string {
+	return []string{
+		DecimalReturnTypeDoubleOrLong,
+		DecimalReturnTypeString,
+	}
+}
+
 const (
 	// TypeHintDate is a TypeHint enum value
 	TypeHintDate = "DATE"
@@ -2384,3 +2392,13 @@ const (
 	// TypeHintTimestamp is a TypeHint enum value
 	TypeHintTimestamp = "TIMESTAMP"
 )
+
+// TypeHint_Values returns all elements of the TypeHint enum
+func TypeHint_Values() []string {
+	return []string{
+		TypeHintDate,
+		TypeHintDecimal,
+		TypeHintTime,
+		TypeHintTimestamp,
+	}
+}

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -24830,6 +24830,15 @@ const (
 	ActionTypeResizeCluster = "resize-cluster"
 )
 
+// ActionType_Values returns all elements of the ActionType enum
+func ActionType_Values() []string {
+	return []string{
+		ActionTypeRestoreCluster,
+		ActionTypeRecommendNodeConfig,
+		ActionTypeResizeCluster,
+	}
+}
+
 const (
 	// ModeStandard is a Mode enum value
 	ModeStandard = "standard"
@@ -24837,6 +24846,14 @@ const (
 	// ModeHighPerformance is a Mode enum value
 	ModeHighPerformance = "high-performance"
 )
+
+// Mode_Values returns all elements of the Mode enum
+func Mode_Values() []string {
+	return []string{
+		ModeStandard,
+		ModeHighPerformance,
+	}
+}
 
 const (
 	// NodeConfigurationOptionsFilterNameNodeType is a NodeConfigurationOptionsFilterName enum value
@@ -24851,6 +24868,16 @@ const (
 	// NodeConfigurationOptionsFilterNameMode is a NodeConfigurationOptionsFilterName enum value
 	NodeConfigurationOptionsFilterNameMode = "Mode"
 )
+
+// NodeConfigurationOptionsFilterName_Values returns all elements of the NodeConfigurationOptionsFilterName enum
+func NodeConfigurationOptionsFilterName_Values() []string {
+	return []string{
+		NodeConfigurationOptionsFilterNameNodeType,
+		NodeConfigurationOptionsFilterNameNumberOfNodes,
+		NodeConfigurationOptionsFilterNameEstimatedDiskUtilizationPercent,
+		NodeConfigurationOptionsFilterNameMode,
+	}
+}
 
 const (
 	// OperatorTypeEq is a OperatorType enum value
@@ -24875,6 +24902,19 @@ const (
 	OperatorTypeBetween = "between"
 )
 
+// OperatorType_Values returns all elements of the OperatorType enum
+func OperatorType_Values() []string {
+	return []string{
+		OperatorTypeEq,
+		OperatorTypeLt,
+		OperatorTypeGt,
+		OperatorTypeLe,
+		OperatorTypeGe,
+		OperatorTypeIn,
+		OperatorTypeBetween,
+	}
+}
+
 const (
 	// ParameterApplyTypeStatic is a ParameterApplyType enum value
 	ParameterApplyTypeStatic = "static"
@@ -24883,6 +24923,14 @@ const (
 	ParameterApplyTypeDynamic = "dynamic"
 )
 
+// ParameterApplyType_Values returns all elements of the ParameterApplyType enum
+func ParameterApplyType_Values() []string {
+	return []string{
+		ParameterApplyTypeStatic,
+		ParameterApplyTypeDynamic,
+	}
+}
+
 const (
 	// ReservedNodeOfferingTypeRegular is a ReservedNodeOfferingType enum value
 	ReservedNodeOfferingTypeRegular = "Regular"
@@ -24890,6 +24938,14 @@ const (
 	// ReservedNodeOfferingTypeUpgradable is a ReservedNodeOfferingType enum value
 	ReservedNodeOfferingTypeUpgradable = "Upgradable"
 )
+
+// ReservedNodeOfferingType_Values returns all elements of the ReservedNodeOfferingType enum
+func ReservedNodeOfferingType_Values() []string {
+	return []string{
+		ReservedNodeOfferingTypeRegular,
+		ReservedNodeOfferingTypeUpgradable,
+	}
+}
 
 const (
 	// ScheduleStateModifying is a ScheduleState enum value
@@ -24902,6 +24958,15 @@ const (
 	ScheduleStateFailed = "FAILED"
 )
 
+// ScheduleState_Values returns all elements of the ScheduleState enum
+func ScheduleState_Values() []string {
+	return []string{
+		ScheduleStateModifying,
+		ScheduleStateActive,
+		ScheduleStateFailed,
+	}
+}
+
 const (
 	// ScheduledActionFilterNameClusterIdentifier is a ScheduledActionFilterName enum value
 	ScheduledActionFilterNameClusterIdentifier = "cluster-identifier"
@@ -24910,6 +24975,14 @@ const (
 	ScheduledActionFilterNameIamRole = "iam-role"
 )
 
+// ScheduledActionFilterName_Values returns all elements of the ScheduledActionFilterName enum
+func ScheduledActionFilterName_Values() []string {
+	return []string{
+		ScheduledActionFilterNameClusterIdentifier,
+		ScheduledActionFilterNameIamRole,
+	}
+}
+
 const (
 	// ScheduledActionStateActive is a ScheduledActionState enum value
 	ScheduledActionStateActive = "ACTIVE"
@@ -24917,6 +24990,14 @@ const (
 	// ScheduledActionStateDisabled is a ScheduledActionState enum value
 	ScheduledActionStateDisabled = "DISABLED"
 )
+
+// ScheduledActionState_Values returns all elements of the ScheduledActionState enum
+func ScheduledActionState_Values() []string {
+	return []string{
+		ScheduledActionStateActive,
+		ScheduledActionStateDisabled,
+	}
+}
 
 const (
 	// ScheduledActionTypeValuesResizeCluster is a ScheduledActionTypeValues enum value
@@ -24929,6 +25010,15 @@ const (
 	ScheduledActionTypeValuesResumeCluster = "ResumeCluster"
 )
 
+// ScheduledActionTypeValues_Values returns all elements of the ScheduledActionTypeValues enum
+func ScheduledActionTypeValues_Values() []string {
+	return []string{
+		ScheduledActionTypeValuesResizeCluster,
+		ScheduledActionTypeValuesPauseCluster,
+		ScheduledActionTypeValuesResumeCluster,
+	}
+}
+
 const (
 	// SnapshotAttributeToSortBySourceType is a SnapshotAttributeToSortBy enum value
 	SnapshotAttributeToSortBySourceType = "SOURCE_TYPE"
@@ -24940,6 +25030,15 @@ const (
 	SnapshotAttributeToSortByCreateTime = "CREATE_TIME"
 )
 
+// SnapshotAttributeToSortBy_Values returns all elements of the SnapshotAttributeToSortBy enum
+func SnapshotAttributeToSortBy_Values() []string {
+	return []string{
+		SnapshotAttributeToSortBySourceType,
+		SnapshotAttributeToSortByTotalSize,
+		SnapshotAttributeToSortByCreateTime,
+	}
+}
+
 const (
 	// SortByOrderAsc is a SortByOrder enum value
 	SortByOrderAsc = "ASC"
@@ -24947,6 +25046,14 @@ const (
 	// SortByOrderDesc is a SortByOrder enum value
 	SortByOrderDesc = "DESC"
 )
+
+// SortByOrder_Values returns all elements of the SortByOrder enum
+func SortByOrder_Values() []string {
+	return []string{
+		SortByOrderAsc,
+		SortByOrderDesc,
+	}
+}
 
 const (
 	// SourceTypeCluster is a SourceType enum value
@@ -24965,6 +25072,17 @@ const (
 	SourceTypeScheduledAction = "scheduled-action"
 )
 
+// SourceType_Values returns all elements of the SourceType enum
+func SourceType_Values() []string {
+	return []string{
+		SourceTypeCluster,
+		SourceTypeClusterParameterGroup,
+		SourceTypeClusterSecurityGroup,
+		SourceTypeClusterSnapshot,
+		SourceTypeScheduledAction,
+	}
+}
+
 const (
 	// TableRestoreStatusTypePending is a TableRestoreStatusType enum value
 	TableRestoreStatusTypePending = "PENDING"
@@ -24982,6 +25100,17 @@ const (
 	TableRestoreStatusTypeCanceled = "CANCELED"
 )
 
+// TableRestoreStatusType_Values returns all elements of the TableRestoreStatusType enum
+func TableRestoreStatusType_Values() []string {
+	return []string{
+		TableRestoreStatusTypePending,
+		TableRestoreStatusTypeInProgress,
+		TableRestoreStatusTypeSucceeded,
+		TableRestoreStatusTypeFailed,
+		TableRestoreStatusTypeCanceled,
+	}
+}
+
 const (
 	// UsageLimitBreachActionLog is a UsageLimitBreachAction enum value
 	UsageLimitBreachActionLog = "log"
@@ -24993,6 +25122,15 @@ const (
 	UsageLimitBreachActionDisable = "disable"
 )
 
+// UsageLimitBreachAction_Values returns all elements of the UsageLimitBreachAction enum
+func UsageLimitBreachAction_Values() []string {
+	return []string{
+		UsageLimitBreachActionLog,
+		UsageLimitBreachActionEmitMetric,
+		UsageLimitBreachActionDisable,
+	}
+}
+
 const (
 	// UsageLimitFeatureTypeSpectrum is a UsageLimitFeatureType enum value
 	UsageLimitFeatureTypeSpectrum = "spectrum"
@@ -25001,6 +25139,14 @@ const (
 	UsageLimitFeatureTypeConcurrencyScaling = "concurrency-scaling"
 )
 
+// UsageLimitFeatureType_Values returns all elements of the UsageLimitFeatureType enum
+func UsageLimitFeatureType_Values() []string {
+	return []string{
+		UsageLimitFeatureTypeSpectrum,
+		UsageLimitFeatureTypeConcurrencyScaling,
+	}
+}
+
 const (
 	// UsageLimitLimitTypeTime is a UsageLimitLimitType enum value
 	UsageLimitLimitTypeTime = "time"
@@ -25008,6 +25154,14 @@ const (
 	// UsageLimitLimitTypeDataScanned is a UsageLimitLimitType enum value
 	UsageLimitLimitTypeDataScanned = "data-scanned"
 )
+
+// UsageLimitLimitType_Values returns all elements of the UsageLimitLimitType enum
+func UsageLimitLimitType_Values() []string {
+	return []string{
+		UsageLimitLimitTypeTime,
+		UsageLimitLimitTypeDataScanned,
+	}
+}
 
 const (
 	// UsageLimitPeriodDaily is a UsageLimitPeriod enum value
@@ -25019,3 +25173,12 @@ const (
 	// UsageLimitPeriodMonthly is a UsageLimitPeriod enum value
 	UsageLimitPeriodMonthly = "monthly"
 )
+
+// UsageLimitPeriod_Values returns all elements of the UsageLimitPeriod enum
+func UsageLimitPeriod_Values() []string {
+	return []string{
+		UsageLimitPeriodDaily,
+		UsageLimitPeriodWeekly,
+		UsageLimitPeriodMonthly,
+	}
+}

--- a/service/rekognition/api.go
+++ b/service/rekognition/api.go
@@ -16330,6 +16330,14 @@ const (
 	AttributeAll = "ALL"
 )
 
+// Attribute_Values returns all elements of the Attribute enum
+func Attribute_Values() []string {
+	return []string{
+		AttributeDefault,
+		AttributeAll,
+	}
+}
+
 const (
 	// CelebrityRecognitionSortById is a CelebrityRecognitionSortBy enum value
 	CelebrityRecognitionSortById = "ID"
@@ -16337,6 +16345,14 @@ const (
 	// CelebrityRecognitionSortByTimestamp is a CelebrityRecognitionSortBy enum value
 	CelebrityRecognitionSortByTimestamp = "TIMESTAMP"
 )
+
+// CelebrityRecognitionSortBy_Values returns all elements of the CelebrityRecognitionSortBy enum
+func CelebrityRecognitionSortBy_Values() []string {
+	return []string{
+		CelebrityRecognitionSortById,
+		CelebrityRecognitionSortByTimestamp,
+	}
+}
 
 const (
 	// ContentClassifierFreeOfPersonallyIdentifiableInformation is a ContentClassifier enum value
@@ -16346,6 +16362,14 @@ const (
 	ContentClassifierFreeOfAdultContent = "FreeOfAdultContent"
 )
 
+// ContentClassifier_Values returns all elements of the ContentClassifier enum
+func ContentClassifier_Values() []string {
+	return []string{
+		ContentClassifierFreeOfPersonallyIdentifiableInformation,
+		ContentClassifierFreeOfAdultContent,
+	}
+}
+
 const (
 	// ContentModerationSortByName is a ContentModerationSortBy enum value
 	ContentModerationSortByName = "NAME"
@@ -16353,6 +16377,14 @@ const (
 	// ContentModerationSortByTimestamp is a ContentModerationSortBy enum value
 	ContentModerationSortByTimestamp = "TIMESTAMP"
 )
+
+// ContentModerationSortBy_Values returns all elements of the ContentModerationSortBy enum
+func ContentModerationSortBy_Values() []string {
+	return []string{
+		ContentModerationSortByName,
+		ContentModerationSortByTimestamp,
+	}
+}
 
 const (
 	// EmotionNameHappy is a EmotionName enum value
@@ -16383,6 +16415,21 @@ const (
 	EmotionNameFear = "FEAR"
 )
 
+// EmotionName_Values returns all elements of the EmotionName enum
+func EmotionName_Values() []string {
+	return []string{
+		EmotionNameHappy,
+		EmotionNameSad,
+		EmotionNameAngry,
+		EmotionNameConfused,
+		EmotionNameDisgusted,
+		EmotionNameSurprised,
+		EmotionNameCalm,
+		EmotionNameUnknown,
+		EmotionNameFear,
+	}
+}
+
 const (
 	// FaceAttributesDefault is a FaceAttributes enum value
 	FaceAttributesDefault = "DEFAULT"
@@ -16390,6 +16437,14 @@ const (
 	// FaceAttributesAll is a FaceAttributes enum value
 	FaceAttributesAll = "ALL"
 )
+
+// FaceAttributes_Values returns all elements of the FaceAttributes enum
+func FaceAttributes_Values() []string {
+	return []string{
+		FaceAttributesDefault,
+		FaceAttributesAll,
+	}
+}
 
 const (
 	// FaceSearchSortByIndex is a FaceSearchSortBy enum value
@@ -16399,6 +16454,14 @@ const (
 	FaceSearchSortByTimestamp = "TIMESTAMP"
 )
 
+// FaceSearchSortBy_Values returns all elements of the FaceSearchSortBy enum
+func FaceSearchSortBy_Values() []string {
+	return []string{
+		FaceSearchSortByIndex,
+		FaceSearchSortByTimestamp,
+	}
+}
+
 const (
 	// GenderTypeMale is a GenderType enum value
 	GenderTypeMale = "Male"
@@ -16407,6 +16470,14 @@ const (
 	GenderTypeFemale = "Female"
 )
 
+// GenderType_Values returns all elements of the GenderType enum
+func GenderType_Values() []string {
+	return []string{
+		GenderTypeMale,
+		GenderTypeFemale,
+	}
+}
+
 const (
 	// LabelDetectionSortByName is a LabelDetectionSortBy enum value
 	LabelDetectionSortByName = "NAME"
@@ -16414,6 +16485,14 @@ const (
 	// LabelDetectionSortByTimestamp is a LabelDetectionSortBy enum value
 	LabelDetectionSortByTimestamp = "TIMESTAMP"
 )
+
+// LabelDetectionSortBy_Values returns all elements of the LabelDetectionSortBy enum
+func LabelDetectionSortBy_Values() []string {
+	return []string{
+		LabelDetectionSortByName,
+		LabelDetectionSortByTimestamp,
+	}
+}
 
 const (
 	// LandmarkTypeEyeLeft is a LandmarkType enum value
@@ -16507,6 +16586,42 @@ const (
 	LandmarkTypeUpperJawlineRight = "upperJawlineRight"
 )
 
+// LandmarkType_Values returns all elements of the LandmarkType enum
+func LandmarkType_Values() []string {
+	return []string{
+		LandmarkTypeEyeLeft,
+		LandmarkTypeEyeRight,
+		LandmarkTypeNose,
+		LandmarkTypeMouthLeft,
+		LandmarkTypeMouthRight,
+		LandmarkTypeLeftEyeBrowLeft,
+		LandmarkTypeLeftEyeBrowRight,
+		LandmarkTypeLeftEyeBrowUp,
+		LandmarkTypeRightEyeBrowLeft,
+		LandmarkTypeRightEyeBrowRight,
+		LandmarkTypeRightEyeBrowUp,
+		LandmarkTypeLeftEyeLeft,
+		LandmarkTypeLeftEyeRight,
+		LandmarkTypeLeftEyeUp,
+		LandmarkTypeLeftEyeDown,
+		LandmarkTypeRightEyeLeft,
+		LandmarkTypeRightEyeRight,
+		LandmarkTypeRightEyeUp,
+		LandmarkTypeRightEyeDown,
+		LandmarkTypeNoseLeft,
+		LandmarkTypeNoseRight,
+		LandmarkTypeMouthUp,
+		LandmarkTypeMouthDown,
+		LandmarkTypeLeftPupil,
+		LandmarkTypeRightPupil,
+		LandmarkTypeUpperJawlineLeft,
+		LandmarkTypeMidJawlineLeft,
+		LandmarkTypeChinBottom,
+		LandmarkTypeMidJawlineRight,
+		LandmarkTypeUpperJawlineRight,
+	}
+}
+
 const (
 	// OrientationCorrectionRotate0 is a OrientationCorrection enum value
 	OrientationCorrectionRotate0 = "ROTATE_0"
@@ -16521,6 +16636,16 @@ const (
 	OrientationCorrectionRotate270 = "ROTATE_270"
 )
 
+// OrientationCorrection_Values returns all elements of the OrientationCorrection enum
+func OrientationCorrection_Values() []string {
+	return []string{
+		OrientationCorrectionRotate0,
+		OrientationCorrectionRotate90,
+		OrientationCorrectionRotate180,
+		OrientationCorrectionRotate270,
+	}
+}
+
 const (
 	// PersonTrackingSortByIndex is a PersonTrackingSortBy enum value
 	PersonTrackingSortByIndex = "INDEX"
@@ -16528,6 +16653,14 @@ const (
 	// PersonTrackingSortByTimestamp is a PersonTrackingSortBy enum value
 	PersonTrackingSortByTimestamp = "TIMESTAMP"
 )
+
+// PersonTrackingSortBy_Values returns all elements of the PersonTrackingSortBy enum
+func PersonTrackingSortBy_Values() []string {
+	return []string{
+		PersonTrackingSortByIndex,
+		PersonTrackingSortByTimestamp,
+	}
+}
 
 const (
 	// ProjectStatusCreating is a ProjectStatus enum value
@@ -16539,6 +16672,15 @@ const (
 	// ProjectStatusDeleting is a ProjectStatus enum value
 	ProjectStatusDeleting = "DELETING"
 )
+
+// ProjectStatus_Values returns all elements of the ProjectStatus enum
+func ProjectStatus_Values() []string {
+	return []string{
+		ProjectStatusCreating,
+		ProjectStatusCreated,
+		ProjectStatusDeleting,
+	}
+}
 
 const (
 	// ProjectVersionStatusTrainingInProgress is a ProjectVersionStatus enum value
@@ -16569,6 +16711,21 @@ const (
 	ProjectVersionStatusDeleting = "DELETING"
 )
 
+// ProjectVersionStatus_Values returns all elements of the ProjectVersionStatus enum
+func ProjectVersionStatus_Values() []string {
+	return []string{
+		ProjectVersionStatusTrainingInProgress,
+		ProjectVersionStatusTrainingCompleted,
+		ProjectVersionStatusTrainingFailed,
+		ProjectVersionStatusStarting,
+		ProjectVersionStatusRunning,
+		ProjectVersionStatusFailed,
+		ProjectVersionStatusStopping,
+		ProjectVersionStatusStopped,
+		ProjectVersionStatusDeleting,
+	}
+}
+
 const (
 	// QualityFilterNone is a QualityFilter enum value
 	QualityFilterNone = "NONE"
@@ -16585,6 +16742,17 @@ const (
 	// QualityFilterHigh is a QualityFilter enum value
 	QualityFilterHigh = "HIGH"
 )
+
+// QualityFilter_Values returns all elements of the QualityFilter enum
+func QualityFilter_Values() []string {
+	return []string{
+		QualityFilterNone,
+		QualityFilterAuto,
+		QualityFilterLow,
+		QualityFilterMedium,
+		QualityFilterHigh,
+	}
+}
 
 const (
 	// ReasonExceedsMaxFaces is a Reason enum value
@@ -16609,6 +16777,19 @@ const (
 	ReasonLowFaceQuality = "LOW_FACE_QUALITY"
 )
 
+// Reason_Values returns all elements of the Reason enum
+func Reason_Values() []string {
+	return []string{
+		ReasonExceedsMaxFaces,
+		ReasonExtremePose,
+		ReasonLowBrightness,
+		ReasonLowSharpness,
+		ReasonLowConfidence,
+		ReasonSmallBoundingBox,
+		ReasonLowFaceQuality,
+	}
+}
+
 const (
 	// SegmentTypeTechnicalCue is a SegmentType enum value
 	SegmentTypeTechnicalCue = "TECHNICAL_CUE"
@@ -16616,6 +16797,14 @@ const (
 	// SegmentTypeShot is a SegmentType enum value
 	SegmentTypeShot = "SHOT"
 )
+
+// SegmentType_Values returns all elements of the SegmentType enum
+func SegmentType_Values() []string {
+	return []string{
+		SegmentTypeTechnicalCue,
+		SegmentTypeShot,
+	}
+}
 
 const (
 	// StreamProcessorStatusStopped is a StreamProcessorStatus enum value
@@ -16634,6 +16823,17 @@ const (
 	StreamProcessorStatusStopping = "STOPPING"
 )
 
+// StreamProcessorStatus_Values returns all elements of the StreamProcessorStatus enum
+func StreamProcessorStatus_Values() []string {
+	return []string{
+		StreamProcessorStatusStopped,
+		StreamProcessorStatusStarting,
+		StreamProcessorStatusRunning,
+		StreamProcessorStatusFailed,
+		StreamProcessorStatusStopping,
+	}
+}
+
 const (
 	// TechnicalCueTypeColorBars is a TechnicalCueType enum value
 	TechnicalCueTypeColorBars = "ColorBars"
@@ -16645,6 +16845,15 @@ const (
 	TechnicalCueTypeBlackFrames = "BlackFrames"
 )
 
+// TechnicalCueType_Values returns all elements of the TechnicalCueType enum
+func TechnicalCueType_Values() []string {
+	return []string{
+		TechnicalCueTypeColorBars,
+		TechnicalCueTypeEndCredits,
+		TechnicalCueTypeBlackFrames,
+	}
+}
+
 const (
 	// TextTypesLine is a TextTypes enum value
 	TextTypesLine = "LINE"
@@ -16652,6 +16861,14 @@ const (
 	// TextTypesWord is a TextTypes enum value
 	TextTypesWord = "WORD"
 )
+
+// TextTypes_Values returns all elements of the TextTypes enum
+func TextTypes_Values() []string {
+	return []string{
+		TextTypesLine,
+		TextTypesWord,
+	}
+}
 
 const (
 	// VideoJobStatusInProgress is a VideoJobStatus enum value
@@ -16663,3 +16880,12 @@ const (
 	// VideoJobStatusFailed is a VideoJobStatus enum value
 	VideoJobStatusFailed = "FAILED"
 )
+
+// VideoJobStatus_Values returns all elements of the VideoJobStatus enum
+func VideoJobStatus_Values() []string {
+	return []string{
+		VideoJobStatusInProgress,
+		VideoJobStatusSucceeded,
+		VideoJobStatusFailed,
+	}
+}

--- a/service/resourcegroups/api.go
+++ b/service/resourcegroups/api.go
@@ -4140,6 +4140,15 @@ const (
 	GroupConfigurationStatusUpdateFailed = "UPDATE_FAILED"
 )
 
+// GroupConfigurationStatus_Values returns all elements of the GroupConfigurationStatus enum
+func GroupConfigurationStatus_Values() []string {
+	return []string{
+		GroupConfigurationStatusUpdating,
+		GroupConfigurationStatusUpdateComplete,
+		GroupConfigurationStatusUpdateFailed,
+	}
+}
+
 const (
 	// GroupFilterNameResourceType is a GroupFilterName enum value
 	GroupFilterNameResourceType = "resource-type"
@@ -4147,6 +4156,14 @@ const (
 	// GroupFilterNameConfigurationType is a GroupFilterName enum value
 	GroupFilterNameConfigurationType = "configuration-type"
 )
+
+// GroupFilterName_Values returns all elements of the GroupFilterName enum
+func GroupFilterName_Values() []string {
+	return []string{
+		GroupFilterNameResourceType,
+		GroupFilterNameConfigurationType,
+	}
+}
 
 const (
 	// QueryErrorCodeCloudformationStackInactive is a QueryErrorCode enum value
@@ -4156,6 +4173,14 @@ const (
 	QueryErrorCodeCloudformationStackNotExisting = "CLOUDFORMATION_STACK_NOT_EXISTING"
 )
 
+// QueryErrorCode_Values returns all elements of the QueryErrorCode enum
+func QueryErrorCode_Values() []string {
+	return []string{
+		QueryErrorCodeCloudformationStackInactive,
+		QueryErrorCodeCloudformationStackNotExisting,
+	}
+}
+
 const (
 	// QueryTypeTagFilters10 is a QueryType enum value
 	QueryTypeTagFilters10 = "TAG_FILTERS_1_0"
@@ -4164,7 +4189,22 @@ const (
 	QueryTypeCloudformationStack10 = "CLOUDFORMATION_STACK_1_0"
 )
 
+// QueryType_Values returns all elements of the QueryType enum
+func QueryType_Values() []string {
+	return []string{
+		QueryTypeTagFilters10,
+		QueryTypeCloudformationStack10,
+	}
+}
+
 const (
 	// ResourceFilterNameResourceType is a ResourceFilterName enum value
 	ResourceFilterNameResourceType = "resource-type"
 )
+
+// ResourceFilterName_Values returns all elements of the ResourceFilterName enum
+func ResourceFilterName_Values() []string {
+	return []string{
+		ResourceFilterNameResourceType,
+	}
+}

--- a/service/resourcegroupstaggingapi/api.go
+++ b/service/resourcegroupstaggingapi/api.go
@@ -2673,6 +2673,14 @@ const (
 	ErrorCodeInvalidParameterException = "InvalidParameterException"
 )
 
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeInternalServiceException,
+		ErrorCodeInvalidParameterException,
+	}
+}
+
 const (
 	// GroupByAttributeTargetId is a GroupByAttribute enum value
 	GroupByAttributeTargetId = "TARGET_ID"
@@ -2684,6 +2692,15 @@ const (
 	GroupByAttributeResourceType = "RESOURCE_TYPE"
 )
 
+// GroupByAttribute_Values returns all elements of the GroupByAttribute enum
+func GroupByAttribute_Values() []string {
+	return []string{
+		GroupByAttributeTargetId,
+		GroupByAttributeRegion,
+		GroupByAttributeResourceType,
+	}
+}
+
 const (
 	// TargetIdTypeAccount is a TargetIdType enum value
 	TargetIdTypeAccount = "ACCOUNT"
@@ -2694,3 +2711,12 @@ const (
 	// TargetIdTypeRoot is a TargetIdType enum value
 	TargetIdTypeRoot = "ROOT"
 )
+
+// TargetIdType_Values returns all elements of the TargetIdType enum
+func TargetIdType_Values() []string {
+	return []string{
+		TargetIdTypeAccount,
+		TargetIdTypeOu,
+		TargetIdTypeRoot,
+	}
+}

--- a/service/robomaker/api.go
+++ b/service/robomaker/api.go
@@ -12788,6 +12788,15 @@ const (
 	ArchitectureArmhf = "ARMHF"
 )
 
+// Architecture_Values returns all elements of the Architecture enum
+func Architecture_Values() []string {
+	return []string{
+		ArchitectureX8664,
+		ArchitectureArm64,
+		ArchitectureArmhf,
+	}
+}
+
 const (
 	// DeploymentJobErrorCodeResourceNotFound is a DeploymentJobErrorCode enum value
 	DeploymentJobErrorCodeResourceNotFound = "ResourceNotFound"
@@ -12850,6 +12859,32 @@ const (
 	DeploymentJobErrorCodeInternalServerError = "InternalServerError"
 )
 
+// DeploymentJobErrorCode_Values returns all elements of the DeploymentJobErrorCode enum
+func DeploymentJobErrorCode_Values() []string {
+	return []string{
+		DeploymentJobErrorCodeResourceNotFound,
+		DeploymentJobErrorCodeEnvironmentSetupError,
+		DeploymentJobErrorCodeEtagMismatch,
+		DeploymentJobErrorCodeFailureThresholdBreached,
+		DeploymentJobErrorCodeRobotDeploymentAborted,
+		DeploymentJobErrorCodeRobotDeploymentNoResponse,
+		DeploymentJobErrorCodeRobotAgentConnectionTimeout,
+		DeploymentJobErrorCodeGreengrassDeploymentFailed,
+		DeploymentJobErrorCodeInvalidGreengrassGroup,
+		DeploymentJobErrorCodeMissingRobotArchitecture,
+		DeploymentJobErrorCodeMissingRobotApplicationArchitecture,
+		DeploymentJobErrorCodeMissingRobotDeploymentResource,
+		DeploymentJobErrorCodeGreengrassGroupVersionDoesNotExist,
+		DeploymentJobErrorCodeLambdaDeleted,
+		DeploymentJobErrorCodeExtractingBundleFailure,
+		DeploymentJobErrorCodePreLaunchFileFailure,
+		DeploymentJobErrorCodePostLaunchFileFailure,
+		DeploymentJobErrorCodeBadPermissionError,
+		DeploymentJobErrorCodeDownloadConditionFailed,
+		DeploymentJobErrorCodeInternalServerError,
+	}
+}
+
 const (
 	// DeploymentStatusPending is a DeploymentStatus enum value
 	DeploymentStatusPending = "Pending"
@@ -12870,6 +12905,18 @@ const (
 	DeploymentStatusCanceled = "Canceled"
 )
 
+// DeploymentStatus_Values returns all elements of the DeploymentStatus enum
+func DeploymentStatus_Values() []string {
+	return []string{
+		DeploymentStatusPending,
+		DeploymentStatusPreparing,
+		DeploymentStatusInProgress,
+		DeploymentStatusFailed,
+		DeploymentStatusSucceeded,
+		DeploymentStatusCanceled,
+	}
+}
+
 const (
 	// FailureBehaviorFail is a FailureBehavior enum value
 	FailureBehaviorFail = "Fail"
@@ -12878,10 +12925,25 @@ const (
 	FailureBehaviorContinue = "Continue"
 )
 
+// FailureBehavior_Values returns all elements of the FailureBehavior enum
+func FailureBehavior_Values() []string {
+	return []string{
+		FailureBehaviorFail,
+		FailureBehaviorContinue,
+	}
+}
+
 const (
 	// RenderingEngineTypeOgre is a RenderingEngineType enum value
 	RenderingEngineTypeOgre = "OGRE"
 )
+
+// RenderingEngineType_Values returns all elements of the RenderingEngineType enum
+func RenderingEngineType_Values() []string {
+	return []string{
+		RenderingEngineTypeOgre,
+	}
+}
 
 const (
 	// RobotDeploymentStepValidating is a RobotDeploymentStep enum value
@@ -12906,6 +12968,19 @@ const (
 	RobotDeploymentStepFinished = "Finished"
 )
 
+// RobotDeploymentStep_Values returns all elements of the RobotDeploymentStep enum
+func RobotDeploymentStep_Values() []string {
+	return []string{
+		RobotDeploymentStepValidating,
+		RobotDeploymentStepDownloadingExtracting,
+		RobotDeploymentStepExecutingDownloadCondition,
+		RobotDeploymentStepExecutingPreLaunch,
+		RobotDeploymentStepLaunching,
+		RobotDeploymentStepExecutingPostLaunch,
+		RobotDeploymentStepFinished,
+	}
+}
+
 const (
 	// RobotSoftwareSuiteTypeRos is a RobotSoftwareSuiteType enum value
 	RobotSoftwareSuiteTypeRos = "ROS"
@@ -12913,6 +12988,14 @@ const (
 	// RobotSoftwareSuiteTypeRos2 is a RobotSoftwareSuiteType enum value
 	RobotSoftwareSuiteTypeRos2 = "ROS2"
 )
+
+// RobotSoftwareSuiteType_Values returns all elements of the RobotSoftwareSuiteType enum
+func RobotSoftwareSuiteType_Values() []string {
+	return []string{
+		RobotSoftwareSuiteTypeRos,
+		RobotSoftwareSuiteTypeRos2,
+	}
+}
 
 const (
 	// RobotSoftwareSuiteVersionTypeKinetic is a RobotSoftwareSuiteVersionType enum value
@@ -12924,6 +13007,15 @@ const (
 	// RobotSoftwareSuiteVersionTypeDashing is a RobotSoftwareSuiteVersionType enum value
 	RobotSoftwareSuiteVersionTypeDashing = "Dashing"
 )
+
+// RobotSoftwareSuiteVersionType_Values returns all elements of the RobotSoftwareSuiteVersionType enum
+func RobotSoftwareSuiteVersionType_Values() []string {
+	return []string{
+		RobotSoftwareSuiteVersionTypeKinetic,
+		RobotSoftwareSuiteVersionTypeMelodic,
+		RobotSoftwareSuiteVersionTypeDashing,
+	}
+}
 
 const (
 	// RobotStatusAvailable is a RobotStatus enum value
@@ -12948,10 +13040,30 @@ const (
 	RobotStatusNoResponse = "NoResponse"
 )
 
+// RobotStatus_Values returns all elements of the RobotStatus enum
+func RobotStatus_Values() []string {
+	return []string{
+		RobotStatusAvailable,
+		RobotStatusRegistered,
+		RobotStatusPendingNewDeployment,
+		RobotStatusDeploying,
+		RobotStatusFailed,
+		RobotStatusInSync,
+		RobotStatusNoResponse,
+	}
+}
+
 const (
 	// SimulationJobBatchErrorCodeInternalServiceError is a SimulationJobBatchErrorCode enum value
 	SimulationJobBatchErrorCodeInternalServiceError = "InternalServiceError"
 )
+
+// SimulationJobBatchErrorCode_Values returns all elements of the SimulationJobBatchErrorCode enum
+func SimulationJobBatchErrorCode_Values() []string {
+	return []string{
+		SimulationJobBatchErrorCodeInternalServiceError,
+	}
+}
 
 const (
 	// SimulationJobBatchStatusPending is a SimulationJobBatchStatus enum value
@@ -12981,6 +13093,21 @@ const (
 	// SimulationJobBatchStatusTimedOut is a SimulationJobBatchStatus enum value
 	SimulationJobBatchStatusTimedOut = "TimedOut"
 )
+
+// SimulationJobBatchStatus_Values returns all elements of the SimulationJobBatchStatus enum
+func SimulationJobBatchStatus_Values() []string {
+	return []string{
+		SimulationJobBatchStatusPending,
+		SimulationJobBatchStatusInProgress,
+		SimulationJobBatchStatusFailed,
+		SimulationJobBatchStatusCompleted,
+		SimulationJobBatchStatusCanceled,
+		SimulationJobBatchStatusCanceling,
+		SimulationJobBatchStatusCompleting,
+		SimulationJobBatchStatusTimingOut,
+		SimulationJobBatchStatusTimedOut,
+	}
+}
 
 const (
 	// SimulationJobErrorCodeInternalServiceError is a SimulationJobErrorCode enum value
@@ -13065,6 +13192,39 @@ const (
 	SimulationJobErrorCodeWrongRegionSimulationApplication = "WrongRegionSimulationApplication"
 )
 
+// SimulationJobErrorCode_Values returns all elements of the SimulationJobErrorCode enum
+func SimulationJobErrorCode_Values() []string {
+	return []string{
+		SimulationJobErrorCodeInternalServiceError,
+		SimulationJobErrorCodeRobotApplicationCrash,
+		SimulationJobErrorCodeSimulationApplicationCrash,
+		SimulationJobErrorCodeBadPermissionsRobotApplication,
+		SimulationJobErrorCodeBadPermissionsSimulationApplication,
+		SimulationJobErrorCodeBadPermissionsS3object,
+		SimulationJobErrorCodeBadPermissionsS3output,
+		SimulationJobErrorCodeBadPermissionsCloudwatchLogs,
+		SimulationJobErrorCodeSubnetIpLimitExceeded,
+		SimulationJobErrorCodeEnilimitExceeded,
+		SimulationJobErrorCodeBadPermissionsUserCredentials,
+		SimulationJobErrorCodeInvalidBundleRobotApplication,
+		SimulationJobErrorCodeInvalidBundleSimulationApplication,
+		SimulationJobErrorCodeInvalidS3resource,
+		SimulationJobErrorCodeLimitExceeded,
+		SimulationJobErrorCodeMismatchedEtag,
+		SimulationJobErrorCodeRobotApplicationVersionMismatchedEtag,
+		SimulationJobErrorCodeSimulationApplicationVersionMismatchedEtag,
+		SimulationJobErrorCodeResourceNotFound,
+		SimulationJobErrorCodeRequestThrottled,
+		SimulationJobErrorCodeBatchTimedOut,
+		SimulationJobErrorCodeBatchCanceled,
+		SimulationJobErrorCodeInvalidInput,
+		SimulationJobErrorCodeWrongRegionS3bucket,
+		SimulationJobErrorCodeWrongRegionS3output,
+		SimulationJobErrorCodeWrongRegionRobotApplication,
+		SimulationJobErrorCodeWrongRegionSimulationApplication,
+	}
+}
+
 const (
 	// SimulationJobStatusPending is a SimulationJobStatus enum value
 	SimulationJobStatusPending = "Pending"
@@ -13097,6 +13257,22 @@ const (
 	SimulationJobStatusCanceled = "Canceled"
 )
 
+// SimulationJobStatus_Values returns all elements of the SimulationJobStatus enum
+func SimulationJobStatus_Values() []string {
+	return []string{
+		SimulationJobStatusPending,
+		SimulationJobStatusPreparing,
+		SimulationJobStatusRunning,
+		SimulationJobStatusRestarting,
+		SimulationJobStatusCompleted,
+		SimulationJobStatusFailed,
+		SimulationJobStatusRunningFailed,
+		SimulationJobStatusTerminating,
+		SimulationJobStatusTerminated,
+		SimulationJobStatusCanceled,
+	}
+}
+
 const (
 	// SimulationSoftwareSuiteTypeGazebo is a SimulationSoftwareSuiteType enum value
 	SimulationSoftwareSuiteTypeGazebo = "Gazebo"
@@ -13104,3 +13280,11 @@ const (
 	// SimulationSoftwareSuiteTypeRosbagPlay is a SimulationSoftwareSuiteType enum value
 	SimulationSoftwareSuiteTypeRosbagPlay = "RosbagPlay"
 )
+
+// SimulationSoftwareSuiteType_Values returns all elements of the SimulationSoftwareSuiteType enum
+func SimulationSoftwareSuiteType_Values() []string {
+	return []string{
+		SimulationSoftwareSuiteTypeGazebo,
+		SimulationSoftwareSuiteTypeRosbagPlay,
+	}
+}

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -15452,6 +15452,17 @@ const (
 	AccountLimitTypeMaxTrafficPoliciesByOwner = "MAX_TRAFFIC_POLICIES_BY_OWNER"
 )
 
+// AccountLimitType_Values returns all elements of the AccountLimitType enum
+func AccountLimitType_Values() []string {
+	return []string{
+		AccountLimitTypeMaxHealthChecksByOwner,
+		AccountLimitTypeMaxHostedZonesByOwner,
+		AccountLimitTypeMaxTrafficPolicyInstancesByOwner,
+		AccountLimitTypeMaxReusableDelegationSetsByOwner,
+		AccountLimitTypeMaxTrafficPoliciesByOwner,
+	}
+}
+
 const (
 	// ChangeActionCreate is a ChangeAction enum value
 	ChangeActionCreate = "CREATE"
@@ -15463,6 +15474,15 @@ const (
 	ChangeActionUpsert = "UPSERT"
 )
 
+// ChangeAction_Values returns all elements of the ChangeAction enum
+func ChangeAction_Values() []string {
+	return []string{
+		ChangeActionCreate,
+		ChangeActionDelete,
+		ChangeActionUpsert,
+	}
+}
+
 const (
 	// ChangeStatusPending is a ChangeStatus enum value
 	ChangeStatusPending = "PENDING"
@@ -15470,6 +15490,14 @@ const (
 	// ChangeStatusInsync is a ChangeStatus enum value
 	ChangeStatusInsync = "INSYNC"
 )
+
+// ChangeStatus_Values returns all elements of the ChangeStatus enum
+func ChangeStatus_Values() []string {
+	return []string{
+		ChangeStatusPending,
+		ChangeStatusInsync,
+	}
+}
 
 const (
 	// CloudWatchRegionUsEast1 is a CloudWatchRegion enum value
@@ -15554,6 +15582,39 @@ const (
 	CloudWatchRegionUsIsobEast1 = "us-isob-east-1"
 )
 
+// CloudWatchRegion_Values returns all elements of the CloudWatchRegion enum
+func CloudWatchRegion_Values() []string {
+	return []string{
+		CloudWatchRegionUsEast1,
+		CloudWatchRegionUsEast2,
+		CloudWatchRegionUsWest1,
+		CloudWatchRegionUsWest2,
+		CloudWatchRegionCaCentral1,
+		CloudWatchRegionEuCentral1,
+		CloudWatchRegionEuWest1,
+		CloudWatchRegionEuWest2,
+		CloudWatchRegionEuWest3,
+		CloudWatchRegionApEast1,
+		CloudWatchRegionMeSouth1,
+		CloudWatchRegionApSouth1,
+		CloudWatchRegionApSoutheast1,
+		CloudWatchRegionApSoutheast2,
+		CloudWatchRegionApNortheast1,
+		CloudWatchRegionApNortheast2,
+		CloudWatchRegionApNortheast3,
+		CloudWatchRegionEuNorth1,
+		CloudWatchRegionSaEast1,
+		CloudWatchRegionCnNorthwest1,
+		CloudWatchRegionCnNorth1,
+		CloudWatchRegionAfSouth1,
+		CloudWatchRegionEuSouth1,
+		CloudWatchRegionUsGovWest1,
+		CloudWatchRegionUsGovEast1,
+		CloudWatchRegionUsIsoEast1,
+		CloudWatchRegionUsIsobEast1,
+	}
+}
+
 const (
 	// ComparisonOperatorGreaterThanOrEqualToThreshold is a ComparisonOperator enum value
 	ComparisonOperatorGreaterThanOrEqualToThreshold = "GreaterThanOrEqualToThreshold"
@@ -15567,6 +15628,16 @@ const (
 	// ComparisonOperatorLessThanOrEqualToThreshold is a ComparisonOperator enum value
 	ComparisonOperatorLessThanOrEqualToThreshold = "LessThanOrEqualToThreshold"
 )
+
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorGreaterThanOrEqualToThreshold,
+		ComparisonOperatorGreaterThanThreshold,
+		ComparisonOperatorLessThanThreshold,
+		ComparisonOperatorLessThanOrEqualToThreshold,
+	}
+}
 
 const (
 	// HealthCheckRegionUsEast1 is a HealthCheckRegion enum value
@@ -15594,6 +15665,20 @@ const (
 	HealthCheckRegionSaEast1 = "sa-east-1"
 )
 
+// HealthCheckRegion_Values returns all elements of the HealthCheckRegion enum
+func HealthCheckRegion_Values() []string {
+	return []string{
+		HealthCheckRegionUsEast1,
+		HealthCheckRegionUsWest1,
+		HealthCheckRegionUsWest2,
+		HealthCheckRegionEuWest1,
+		HealthCheckRegionApSoutheast1,
+		HealthCheckRegionApSoutheast2,
+		HealthCheckRegionApNortheast1,
+		HealthCheckRegionSaEast1,
+	}
+}
+
 const (
 	// HealthCheckTypeHttp is a HealthCheckType enum value
 	HealthCheckTypeHttp = "HTTP"
@@ -15617,6 +15702,19 @@ const (
 	HealthCheckTypeCloudwatchMetric = "CLOUDWATCH_METRIC"
 )
 
+// HealthCheckType_Values returns all elements of the HealthCheckType enum
+func HealthCheckType_Values() []string {
+	return []string{
+		HealthCheckTypeHttp,
+		HealthCheckTypeHttps,
+		HealthCheckTypeHttpStrMatch,
+		HealthCheckTypeHttpsStrMatch,
+		HealthCheckTypeTcp,
+		HealthCheckTypeCalculated,
+		HealthCheckTypeCloudwatchMetric,
+	}
+}
+
 const (
 	// HostedZoneLimitTypeMaxRrsetsByZone is a HostedZoneLimitType enum value
 	HostedZoneLimitTypeMaxRrsetsByZone = "MAX_RRSETS_BY_ZONE"
@@ -15624,6 +15722,14 @@ const (
 	// HostedZoneLimitTypeMaxVpcsAssociatedByZone is a HostedZoneLimitType enum value
 	HostedZoneLimitTypeMaxVpcsAssociatedByZone = "MAX_VPCS_ASSOCIATED_BY_ZONE"
 )
+
+// HostedZoneLimitType_Values returns all elements of the HostedZoneLimitType enum
+func HostedZoneLimitType_Values() []string {
+	return []string{
+		HostedZoneLimitTypeMaxRrsetsByZone,
+		HostedZoneLimitTypeMaxVpcsAssociatedByZone,
+	}
+}
 
 const (
 	// InsufficientDataHealthStatusHealthy is a InsufficientDataHealthStatus enum value
@@ -15635,6 +15741,15 @@ const (
 	// InsufficientDataHealthStatusLastKnownStatus is a InsufficientDataHealthStatus enum value
 	InsufficientDataHealthStatusLastKnownStatus = "LastKnownStatus"
 )
+
+// InsufficientDataHealthStatus_Values returns all elements of the InsufficientDataHealthStatus enum
+func InsufficientDataHealthStatus_Values() []string {
+	return []string{
+		InsufficientDataHealthStatusHealthy,
+		InsufficientDataHealthStatusUnhealthy,
+		InsufficientDataHealthStatusLastKnownStatus,
+	}
+}
 
 const (
 	// RRTypeSoa is a RRType enum value
@@ -15674,6 +15789,24 @@ const (
 	RRTypeCaa = "CAA"
 )
 
+// RRType_Values returns all elements of the RRType enum
+func RRType_Values() []string {
+	return []string{
+		RRTypeSoa,
+		RRTypeA,
+		RRTypeTxt,
+		RRTypeNs,
+		RRTypeCname,
+		RRTypeMx,
+		RRTypeNaptr,
+		RRTypePtr,
+		RRTypeSrv,
+		RRTypeSpf,
+		RRTypeAaaa,
+		RRTypeCaa,
+	}
+}
+
 const (
 	// ResettableElementNameFullyQualifiedDomainName is a ResettableElementName enum value
 	ResettableElementNameFullyQualifiedDomainName = "FullyQualifiedDomainName"
@@ -15688,6 +15821,16 @@ const (
 	ResettableElementNameChildHealthChecks = "ChildHealthChecks"
 )
 
+// ResettableElementName_Values returns all elements of the ResettableElementName enum
+func ResettableElementName_Values() []string {
+	return []string{
+		ResettableElementNameFullyQualifiedDomainName,
+		ResettableElementNameRegions,
+		ResettableElementNameResourcePath,
+		ResettableElementNameChildHealthChecks,
+	}
+}
+
 const (
 	// ResourceRecordSetFailoverPrimary is a ResourceRecordSetFailover enum value
 	ResourceRecordSetFailoverPrimary = "PRIMARY"
@@ -15695,6 +15838,14 @@ const (
 	// ResourceRecordSetFailoverSecondary is a ResourceRecordSetFailover enum value
 	ResourceRecordSetFailoverSecondary = "SECONDARY"
 )
+
+// ResourceRecordSetFailover_Values returns all elements of the ResourceRecordSetFailover enum
+func ResourceRecordSetFailover_Values() []string {
+	return []string{
+		ResourceRecordSetFailoverPrimary,
+		ResourceRecordSetFailoverSecondary,
+	}
+}
 
 const (
 	// ResourceRecordSetRegionUsEast1 is a ResourceRecordSetRegion enum value
@@ -15767,10 +15918,46 @@ const (
 	ResourceRecordSetRegionEuSouth1 = "eu-south-1"
 )
 
+// ResourceRecordSetRegion_Values returns all elements of the ResourceRecordSetRegion enum
+func ResourceRecordSetRegion_Values() []string {
+	return []string{
+		ResourceRecordSetRegionUsEast1,
+		ResourceRecordSetRegionUsEast2,
+		ResourceRecordSetRegionUsWest1,
+		ResourceRecordSetRegionUsWest2,
+		ResourceRecordSetRegionCaCentral1,
+		ResourceRecordSetRegionEuWest1,
+		ResourceRecordSetRegionEuWest2,
+		ResourceRecordSetRegionEuWest3,
+		ResourceRecordSetRegionEuCentral1,
+		ResourceRecordSetRegionApSoutheast1,
+		ResourceRecordSetRegionApSoutheast2,
+		ResourceRecordSetRegionApNortheast1,
+		ResourceRecordSetRegionApNortheast2,
+		ResourceRecordSetRegionApNortheast3,
+		ResourceRecordSetRegionEuNorth1,
+		ResourceRecordSetRegionSaEast1,
+		ResourceRecordSetRegionCnNorth1,
+		ResourceRecordSetRegionCnNorthwest1,
+		ResourceRecordSetRegionApEast1,
+		ResourceRecordSetRegionMeSouth1,
+		ResourceRecordSetRegionApSouth1,
+		ResourceRecordSetRegionAfSouth1,
+		ResourceRecordSetRegionEuSouth1,
+	}
+}
+
 const (
 	// ReusableDelegationSetLimitTypeMaxZonesByReusableDelegationSet is a ReusableDelegationSetLimitType enum value
 	ReusableDelegationSetLimitTypeMaxZonesByReusableDelegationSet = "MAX_ZONES_BY_REUSABLE_DELEGATION_SET"
 )
+
+// ReusableDelegationSetLimitType_Values returns all elements of the ReusableDelegationSetLimitType enum
+func ReusableDelegationSetLimitType_Values() []string {
+	return []string{
+		ReusableDelegationSetLimitTypeMaxZonesByReusableDelegationSet,
+	}
+}
 
 const (
 	// StatisticAverage is a Statistic enum value
@@ -15789,6 +15976,17 @@ const (
 	StatisticMinimum = "Minimum"
 )
 
+// Statistic_Values returns all elements of the Statistic enum
+func Statistic_Values() []string {
+	return []string{
+		StatisticAverage,
+		StatisticSum,
+		StatisticSampleCount,
+		StatisticMaximum,
+		StatisticMinimum,
+	}
+}
+
 const (
 	// TagResourceTypeHealthcheck is a TagResourceType enum value
 	TagResourceTypeHealthcheck = "healthcheck"
@@ -15796,6 +15994,14 @@ const (
 	// TagResourceTypeHostedzone is a TagResourceType enum value
 	TagResourceTypeHostedzone = "hostedzone"
 )
+
+// TagResourceType_Values returns all elements of the TagResourceType enum
+func TagResourceType_Values() []string {
+	return []string{
+		TagResourceTypeHealthcheck,
+		TagResourceTypeHostedzone,
+	}
+}
 
 const (
 	// VPCRegionUsEast1 is a VPCRegion enum value
@@ -15876,3 +16082,35 @@ const (
 	// VPCRegionEuSouth1 is a VPCRegion enum value
 	VPCRegionEuSouth1 = "eu-south-1"
 )
+
+// VPCRegion_Values returns all elements of the VPCRegion enum
+func VPCRegion_Values() []string {
+	return []string{
+		VPCRegionUsEast1,
+		VPCRegionUsEast2,
+		VPCRegionUsWest1,
+		VPCRegionUsWest2,
+		VPCRegionEuWest1,
+		VPCRegionEuWest2,
+		VPCRegionEuWest3,
+		VPCRegionEuCentral1,
+		VPCRegionApEast1,
+		VPCRegionMeSouth1,
+		VPCRegionUsGovWest1,
+		VPCRegionUsGovEast1,
+		VPCRegionUsIsoEast1,
+		VPCRegionUsIsobEast1,
+		VPCRegionApSoutheast1,
+		VPCRegionApSoutheast2,
+		VPCRegionApSouth1,
+		VPCRegionApNortheast1,
+		VPCRegionApNortheast2,
+		VPCRegionApNortheast3,
+		VPCRegionEuNorth1,
+		VPCRegionSaEast1,
+		VPCRegionCaCentral1,
+		VPCRegionCnNorth1,
+		VPCRegionAfSouth1,
+		VPCRegionEuSouth1,
+	}
+}

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -6814,6 +6814,17 @@ const (
 	ContactTypeReseller = "RESELLER"
 )
 
+// ContactType_Values returns all elements of the ContactType enum
+func ContactType_Values() []string {
+	return []string{
+		ContactTypePerson,
+		ContactTypeCompany,
+		ContactTypeAssociation,
+		ContactTypePublicBody,
+		ContactTypeReseller,
+	}
+}
+
 const (
 	// CountryCodeAd is a CountryCode enum value
 	CountryCodeAd = "AD"
@@ -7503,6 +7514,241 @@ const (
 	CountryCodeZw = "ZW"
 )
 
+// CountryCode_Values returns all elements of the CountryCode enum
+func CountryCode_Values() []string {
+	return []string{
+		CountryCodeAd,
+		CountryCodeAe,
+		CountryCodeAf,
+		CountryCodeAg,
+		CountryCodeAi,
+		CountryCodeAl,
+		CountryCodeAm,
+		CountryCodeAn,
+		CountryCodeAo,
+		CountryCodeAq,
+		CountryCodeAr,
+		CountryCodeAs,
+		CountryCodeAt,
+		CountryCodeAu,
+		CountryCodeAw,
+		CountryCodeAz,
+		CountryCodeBa,
+		CountryCodeBb,
+		CountryCodeBd,
+		CountryCodeBe,
+		CountryCodeBf,
+		CountryCodeBg,
+		CountryCodeBh,
+		CountryCodeBi,
+		CountryCodeBj,
+		CountryCodeBl,
+		CountryCodeBm,
+		CountryCodeBn,
+		CountryCodeBo,
+		CountryCodeBr,
+		CountryCodeBs,
+		CountryCodeBt,
+		CountryCodeBw,
+		CountryCodeBy,
+		CountryCodeBz,
+		CountryCodeCa,
+		CountryCodeCc,
+		CountryCodeCd,
+		CountryCodeCf,
+		CountryCodeCg,
+		CountryCodeCh,
+		CountryCodeCi,
+		CountryCodeCk,
+		CountryCodeCl,
+		CountryCodeCm,
+		CountryCodeCn,
+		CountryCodeCo,
+		CountryCodeCr,
+		CountryCodeCu,
+		CountryCodeCv,
+		CountryCodeCx,
+		CountryCodeCy,
+		CountryCodeCz,
+		CountryCodeDe,
+		CountryCodeDj,
+		CountryCodeDk,
+		CountryCodeDm,
+		CountryCodeDo,
+		CountryCodeDz,
+		CountryCodeEc,
+		CountryCodeEe,
+		CountryCodeEg,
+		CountryCodeEr,
+		CountryCodeEs,
+		CountryCodeEt,
+		CountryCodeFi,
+		CountryCodeFj,
+		CountryCodeFk,
+		CountryCodeFm,
+		CountryCodeFo,
+		CountryCodeFr,
+		CountryCodeGa,
+		CountryCodeGb,
+		CountryCodeGd,
+		CountryCodeGe,
+		CountryCodeGh,
+		CountryCodeGi,
+		CountryCodeGl,
+		CountryCodeGm,
+		CountryCodeGn,
+		CountryCodeGq,
+		CountryCodeGr,
+		CountryCodeGt,
+		CountryCodeGu,
+		CountryCodeGw,
+		CountryCodeGy,
+		CountryCodeHk,
+		CountryCodeHn,
+		CountryCodeHr,
+		CountryCodeHt,
+		CountryCodeHu,
+		CountryCodeId,
+		CountryCodeIe,
+		CountryCodeIl,
+		CountryCodeIm,
+		CountryCodeIn,
+		CountryCodeIq,
+		CountryCodeIr,
+		CountryCodeIs,
+		CountryCodeIt,
+		CountryCodeJm,
+		CountryCodeJo,
+		CountryCodeJp,
+		CountryCodeKe,
+		CountryCodeKg,
+		CountryCodeKh,
+		CountryCodeKi,
+		CountryCodeKm,
+		CountryCodeKn,
+		CountryCodeKp,
+		CountryCodeKr,
+		CountryCodeKw,
+		CountryCodeKy,
+		CountryCodeKz,
+		CountryCodeLa,
+		CountryCodeLb,
+		CountryCodeLc,
+		CountryCodeLi,
+		CountryCodeLk,
+		CountryCodeLr,
+		CountryCodeLs,
+		CountryCodeLt,
+		CountryCodeLu,
+		CountryCodeLv,
+		CountryCodeLy,
+		CountryCodeMa,
+		CountryCodeMc,
+		CountryCodeMd,
+		CountryCodeMe,
+		CountryCodeMf,
+		CountryCodeMg,
+		CountryCodeMh,
+		CountryCodeMk,
+		CountryCodeMl,
+		CountryCodeMm,
+		CountryCodeMn,
+		CountryCodeMo,
+		CountryCodeMp,
+		CountryCodeMr,
+		CountryCodeMs,
+		CountryCodeMt,
+		CountryCodeMu,
+		CountryCodeMv,
+		CountryCodeMw,
+		CountryCodeMx,
+		CountryCodeMy,
+		CountryCodeMz,
+		CountryCodeNa,
+		CountryCodeNc,
+		CountryCodeNe,
+		CountryCodeNg,
+		CountryCodeNi,
+		CountryCodeNl,
+		CountryCodeNo,
+		CountryCodeNp,
+		CountryCodeNr,
+		CountryCodeNu,
+		CountryCodeNz,
+		CountryCodeOm,
+		CountryCodePa,
+		CountryCodePe,
+		CountryCodePf,
+		CountryCodePg,
+		CountryCodePh,
+		CountryCodePk,
+		CountryCodePl,
+		CountryCodePm,
+		CountryCodePn,
+		CountryCodePr,
+		CountryCodePt,
+		CountryCodePw,
+		CountryCodePy,
+		CountryCodeQa,
+		CountryCodeRo,
+		CountryCodeRs,
+		CountryCodeRu,
+		CountryCodeRw,
+		CountryCodeSa,
+		CountryCodeSb,
+		CountryCodeSc,
+		CountryCodeSd,
+		CountryCodeSe,
+		CountryCodeSg,
+		CountryCodeSh,
+		CountryCodeSi,
+		CountryCodeSk,
+		CountryCodeSl,
+		CountryCodeSm,
+		CountryCodeSn,
+		CountryCodeSo,
+		CountryCodeSr,
+		CountryCodeSt,
+		CountryCodeSv,
+		CountryCodeSy,
+		CountryCodeSz,
+		CountryCodeTc,
+		CountryCodeTd,
+		CountryCodeTg,
+		CountryCodeTh,
+		CountryCodeTj,
+		CountryCodeTk,
+		CountryCodeTl,
+		CountryCodeTm,
+		CountryCodeTn,
+		CountryCodeTo,
+		CountryCodeTr,
+		CountryCodeTt,
+		CountryCodeTv,
+		CountryCodeTw,
+		CountryCodeTz,
+		CountryCodeUa,
+		CountryCodeUg,
+		CountryCodeUs,
+		CountryCodeUy,
+		CountryCodeUz,
+		CountryCodeVa,
+		CountryCodeVc,
+		CountryCodeVe,
+		CountryCodeVg,
+		CountryCodeVi,
+		CountryCodeVn,
+		CountryCodeVu,
+		CountryCodeWf,
+		CountryCodeWs,
+		CountryCodeYe,
+		CountryCodeYt,
+		CountryCodeZa,
+		CountryCodeZm,
+		CountryCodeZw,
+	}
+}
+
 const (
 	// DomainAvailabilityAvailable is a DomainAvailability enum value
 	DomainAvailabilityAvailable = "AVAILABLE"
@@ -7528,6 +7774,20 @@ const (
 	// DomainAvailabilityDontKnow is a DomainAvailability enum value
 	DomainAvailabilityDontKnow = "DONT_KNOW"
 )
+
+// DomainAvailability_Values returns all elements of the DomainAvailability enum
+func DomainAvailability_Values() []string {
+	return []string{
+		DomainAvailabilityAvailable,
+		DomainAvailabilityAvailableReserved,
+		DomainAvailabilityAvailablePreorder,
+		DomainAvailabilityUnavailable,
+		DomainAvailabilityUnavailablePremium,
+		DomainAvailabilityUnavailableRestricted,
+		DomainAvailabilityReserved,
+		DomainAvailabilityDontKnow,
+	}
+}
 
 const (
 	// ExtraParamNameDunsNumber is a ExtraParamName enum value
@@ -7618,6 +7878,41 @@ const (
 	ExtraParamNameUkCompanyNumber = "UK_COMPANY_NUMBER"
 )
 
+// ExtraParamName_Values returns all elements of the ExtraParamName enum
+func ExtraParamName_Values() []string {
+	return []string{
+		ExtraParamNameDunsNumber,
+		ExtraParamNameBrandNumber,
+		ExtraParamNameBirthDepartment,
+		ExtraParamNameBirthDateInYyyyMmDd,
+		ExtraParamNameBirthCountry,
+		ExtraParamNameBirthCity,
+		ExtraParamNameDocumentNumber,
+		ExtraParamNameAuIdNumber,
+		ExtraParamNameAuIdType,
+		ExtraParamNameCaLegalType,
+		ExtraParamNameCaBusinessEntityType,
+		ExtraParamNameCaLegalRepresentative,
+		ExtraParamNameCaLegalRepresentativeCapacity,
+		ExtraParamNameEsIdentification,
+		ExtraParamNameEsIdentificationType,
+		ExtraParamNameEsLegalForm,
+		ExtraParamNameFiBusinessNumber,
+		ExtraParamNameFiIdNumber,
+		ExtraParamNameFiNationality,
+		ExtraParamNameFiOrganizationType,
+		ExtraParamNameItNationality,
+		ExtraParamNameItPin,
+		ExtraParamNameItRegistrantEntityType,
+		ExtraParamNameRuPassportData,
+		ExtraParamNameSeIdNumber,
+		ExtraParamNameSgIdNumber,
+		ExtraParamNameVatNumber,
+		ExtraParamNameUkContactType,
+		ExtraParamNameUkCompanyNumber,
+	}
+}
+
 const (
 	// OperationStatusSubmitted is a OperationStatus enum value
 	OperationStatusSubmitted = "SUBMITTED"
@@ -7634,6 +7929,17 @@ const (
 	// OperationStatusFailed is a OperationStatus enum value
 	OperationStatusFailed = "FAILED"
 )
+
+// OperationStatus_Values returns all elements of the OperationStatus enum
+func OperationStatus_Values() []string {
+	return []string{
+		OperationStatusSubmitted,
+		OperationStatusInProgress,
+		OperationStatusError,
+		OperationStatusSuccessful,
+		OperationStatusFailed,
+	}
+}
 
 const (
 	// OperationTypeRegisterDomain is a OperationType enum value
@@ -7691,6 +7997,30 @@ const (
 	OperationTypeInternalTransferInDomain = "INTERNAL_TRANSFER_IN_DOMAIN"
 )
 
+// OperationType_Values returns all elements of the OperationType enum
+func OperationType_Values() []string {
+	return []string{
+		OperationTypeRegisterDomain,
+		OperationTypeDeleteDomain,
+		OperationTypeTransferInDomain,
+		OperationTypeUpdateDomainContact,
+		OperationTypeUpdateNameserver,
+		OperationTypeChangePrivacyProtection,
+		OperationTypeDomainLock,
+		OperationTypeEnableAutorenew,
+		OperationTypeDisableAutorenew,
+		OperationTypeAddDnssec,
+		OperationTypeRemoveDnssec,
+		OperationTypeExpireDomain,
+		OperationTypeTransferOutDomain,
+		OperationTypeChangeDomainOwner,
+		OperationTypeRenewDomain,
+		OperationTypePushDomain,
+		OperationTypeInternalTransferOutDomain,
+		OperationTypeInternalTransferInDomain,
+	}
+}
+
 const (
 	// ReachabilityStatusPending is a ReachabilityStatus enum value
 	ReachabilityStatusPending = "PENDING"
@@ -7701,6 +8031,15 @@ const (
 	// ReachabilityStatusExpired is a ReachabilityStatus enum value
 	ReachabilityStatusExpired = "EXPIRED"
 )
+
+// ReachabilityStatus_Values returns all elements of the ReachabilityStatus enum
+func ReachabilityStatus_Values() []string {
+	return []string{
+		ReachabilityStatusPending,
+		ReachabilityStatusDone,
+		ReachabilityStatusExpired,
+	}
+}
 
 // Whether the domain name can be transferred to Route 53.
 //
@@ -7729,3 +8068,12 @@ const (
 	// TransferableDontKnow is a Transferable enum value
 	TransferableDontKnow = "DONT_KNOW"
 )
+
+// Transferable_Values returns all elements of the Transferable enum
+func Transferable_Values() []string {
+	return []string{
+		TransferableTransferable,
+		TransferableUntransferable,
+		TransferableDontKnow,
+	}
+}

--- a/service/route53resolver/api.go
+++ b/service/route53resolver/api.go
@@ -5880,6 +5880,22 @@ const (
 	IpAddressStatusDeleteFailedFasExpired = "DELETE_FAILED_FAS_EXPIRED"
 )
 
+// IpAddressStatus_Values returns all elements of the IpAddressStatus enum
+func IpAddressStatus_Values() []string {
+	return []string{
+		IpAddressStatusCreating,
+		IpAddressStatusFailedCreation,
+		IpAddressStatusAttaching,
+		IpAddressStatusAttached,
+		IpAddressStatusRemapDetaching,
+		IpAddressStatusRemapAttaching,
+		IpAddressStatusDetaching,
+		IpAddressStatusFailedResourceGone,
+		IpAddressStatusDeleting,
+		IpAddressStatusDeleteFailedFasExpired,
+	}
+}
+
 const (
 	// ResolverEndpointDirectionInbound is a ResolverEndpointDirection enum value
 	ResolverEndpointDirectionInbound = "INBOUND"
@@ -5887,6 +5903,14 @@ const (
 	// ResolverEndpointDirectionOutbound is a ResolverEndpointDirection enum value
 	ResolverEndpointDirectionOutbound = "OUTBOUND"
 )
+
+// ResolverEndpointDirection_Values returns all elements of the ResolverEndpointDirection enum
+func ResolverEndpointDirection_Values() []string {
+	return []string{
+		ResolverEndpointDirectionInbound,
+		ResolverEndpointDirectionOutbound,
+	}
+}
 
 const (
 	// ResolverEndpointStatusCreating is a ResolverEndpointStatus enum value
@@ -5908,6 +5932,18 @@ const (
 	ResolverEndpointStatusDeleting = "DELETING"
 )
 
+// ResolverEndpointStatus_Values returns all elements of the ResolverEndpointStatus enum
+func ResolverEndpointStatus_Values() []string {
+	return []string{
+		ResolverEndpointStatusCreating,
+		ResolverEndpointStatusOperational,
+		ResolverEndpointStatusUpdating,
+		ResolverEndpointStatusAutoRecovering,
+		ResolverEndpointStatusActionNeeded,
+		ResolverEndpointStatusDeleting,
+	}
+}
+
 const (
 	// ResolverRuleAssociationStatusCreating is a ResolverRuleAssociationStatus enum value
 	ResolverRuleAssociationStatusCreating = "CREATING"
@@ -5925,6 +5961,17 @@ const (
 	ResolverRuleAssociationStatusOverridden = "OVERRIDDEN"
 )
 
+// ResolverRuleAssociationStatus_Values returns all elements of the ResolverRuleAssociationStatus enum
+func ResolverRuleAssociationStatus_Values() []string {
+	return []string{
+		ResolverRuleAssociationStatusCreating,
+		ResolverRuleAssociationStatusComplete,
+		ResolverRuleAssociationStatusDeleting,
+		ResolverRuleAssociationStatusFailed,
+		ResolverRuleAssociationStatusOverridden,
+	}
+}
+
 const (
 	// ResolverRuleStatusComplete is a ResolverRuleStatus enum value
 	ResolverRuleStatusComplete = "COMPLETE"
@@ -5939,6 +5986,16 @@ const (
 	ResolverRuleStatusFailed = "FAILED"
 )
 
+// ResolverRuleStatus_Values returns all elements of the ResolverRuleStatus enum
+func ResolverRuleStatus_Values() []string {
+	return []string{
+		ResolverRuleStatusComplete,
+		ResolverRuleStatusDeleting,
+		ResolverRuleStatusUpdating,
+		ResolverRuleStatusFailed,
+	}
+}
+
 const (
 	// RuleTypeOptionForward is a RuleTypeOption enum value
 	RuleTypeOptionForward = "FORWARD"
@@ -5950,6 +6007,15 @@ const (
 	RuleTypeOptionRecursive = "RECURSIVE"
 )
 
+// RuleTypeOption_Values returns all elements of the RuleTypeOption enum
+func RuleTypeOption_Values() []string {
+	return []string{
+		RuleTypeOptionForward,
+		RuleTypeOptionSystem,
+		RuleTypeOptionRecursive,
+	}
+}
+
 const (
 	// ShareStatusNotShared is a ShareStatus enum value
 	ShareStatusNotShared = "NOT_SHARED"
@@ -5960,3 +6026,12 @@ const (
 	// ShareStatusSharedByMe is a ShareStatus enum value
 	ShareStatusSharedByMe = "SHARED_BY_ME"
 )
+
+// ShareStatus_Values returns all elements of the ShareStatus enum
+func ShareStatus_Values() []string {
+	return []string{
+		ShareStatusNotShared,
+		ShareStatusSharedWithMe,
+		ShareStatusSharedByMe,
+	}
+}

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -30355,17 +30355,31 @@ const (
 // BucketLocationConstraint_Values returns all elements of the BucketLocationConstraint enum
 func BucketLocationConstraint_Values() []string {
 	return []string{
-		BucketLocationConstraintEu,
-		BucketLocationConstraintEuWest1,
-		BucketLocationConstraintUsWest1,
-		BucketLocationConstraintUsWest2,
+		BucketLocationConstraintAfSouth1,
+		BucketLocationConstraintApEast1,
+		BucketLocationConstraintApNortheast1,
+		BucketLocationConstraintApNortheast2,
+		BucketLocationConstraintApNortheast3,
 		BucketLocationConstraintApSouth1,
 		BucketLocationConstraintApSoutheast1,
 		BucketLocationConstraintApSoutheast2,
-		BucketLocationConstraintApNortheast1,
-		BucketLocationConstraintSaEast1,
+		BucketLocationConstraintCaCentral1,
 		BucketLocationConstraintCnNorth1,
+		BucketLocationConstraintCnNorthwest1,
+		BucketLocationConstraintEu,
 		BucketLocationConstraintEuCentral1,
+		BucketLocationConstraintEuNorth1,
+		BucketLocationConstraintEuSouth1,
+		BucketLocationConstraintEuWest1,
+		BucketLocationConstraintEuWest2,
+		BucketLocationConstraintEuWest3,
+		BucketLocationConstraintMeSouth1,
+		BucketLocationConstraintSaEast1,
+		BucketLocationConstraintUsEast2,
+		BucketLocationConstraintUsGovEast1,
+		BucketLocationConstraintUsGovWest1,
+		BucketLocationConstraintUsWest1,
+		BucketLocationConstraintUsWest2,
 	}
 }
 

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -30228,6 +30228,13 @@ const (
 	AnalyticsS3ExportFileFormatCsv = "CSV"
 )
 
+// AnalyticsS3ExportFileFormat_Values returns all elements of the AnalyticsS3ExportFileFormat enum
+func AnalyticsS3ExportFileFormat_Values() []string {
+	return []string{
+		AnalyticsS3ExportFileFormatCsv,
+	}
+}
+
 const (
 	// BucketAccelerateStatusEnabled is a BucketAccelerateStatus enum value
 	BucketAccelerateStatusEnabled = "Enabled"
@@ -30235,6 +30242,14 @@ const (
 	// BucketAccelerateStatusSuspended is a BucketAccelerateStatus enum value
 	BucketAccelerateStatusSuspended = "Suspended"
 )
+
+// BucketAccelerateStatus_Values returns all elements of the BucketAccelerateStatus enum
+func BucketAccelerateStatus_Values() []string {
+	return []string{
+		BucketAccelerateStatusEnabled,
+		BucketAccelerateStatusSuspended,
+	}
+}
 
 const (
 	// BucketCannedACLPrivate is a BucketCannedACL enum value
@@ -30249,6 +30264,16 @@ const (
 	// BucketCannedACLAuthenticatedRead is a BucketCannedACL enum value
 	BucketCannedACLAuthenticatedRead = "authenticated-read"
 )
+
+// BucketCannedACL_Values returns all elements of the BucketCannedACL enum
+func BucketCannedACL_Values() []string {
+	return []string{
+		BucketCannedACLPrivate,
+		BucketCannedACLPublicRead,
+		BucketCannedACLPublicReadWrite,
+		BucketCannedACLAuthenticatedRead,
+	}
+}
 
 const (
 	// BucketLocationConstraintAfSouth1 is a BucketLocationConstraint enum value
@@ -30327,6 +30352,23 @@ const (
 	BucketLocationConstraintUsWest2 = "us-west-2"
 )
 
+// BucketLocationConstraint_Values returns all elements of the BucketLocationConstraint enum
+func BucketLocationConstraint_Values() []string {
+	return []string{
+		BucketLocationConstraintEu,
+		BucketLocationConstraintEuWest1,
+		BucketLocationConstraintUsWest1,
+		BucketLocationConstraintUsWest2,
+		BucketLocationConstraintApSouth1,
+		BucketLocationConstraintApSoutheast1,
+		BucketLocationConstraintApSoutheast2,
+		BucketLocationConstraintApNortheast1,
+		BucketLocationConstraintSaEast1,
+		BucketLocationConstraintCnNorth1,
+		BucketLocationConstraintEuCentral1,
+	}
+}
+
 const (
 	// BucketLogsPermissionFullControl is a BucketLogsPermission enum value
 	BucketLogsPermissionFullControl = "FULL_CONTROL"
@@ -30338,6 +30380,15 @@ const (
 	BucketLogsPermissionWrite = "WRITE"
 )
 
+// BucketLogsPermission_Values returns all elements of the BucketLogsPermission enum
+func BucketLogsPermission_Values() []string {
+	return []string{
+		BucketLogsPermissionFullControl,
+		BucketLogsPermissionRead,
+		BucketLogsPermissionWrite,
+	}
+}
+
 const (
 	// BucketVersioningStatusEnabled is a BucketVersioningStatus enum value
 	BucketVersioningStatusEnabled = "Enabled"
@@ -30345,6 +30396,14 @@ const (
 	// BucketVersioningStatusSuspended is a BucketVersioningStatus enum value
 	BucketVersioningStatusSuspended = "Suspended"
 )
+
+// BucketVersioningStatus_Values returns all elements of the BucketVersioningStatus enum
+func BucketVersioningStatus_Values() []string {
+	return []string{
+		BucketVersioningStatusEnabled,
+		BucketVersioningStatusSuspended,
+	}
+}
 
 const (
 	// CompressionTypeNone is a CompressionType enum value
@@ -30357,6 +30416,15 @@ const (
 	CompressionTypeBzip2 = "BZIP2"
 )
 
+// CompressionType_Values returns all elements of the CompressionType enum
+func CompressionType_Values() []string {
+	return []string{
+		CompressionTypeNone,
+		CompressionTypeGzip,
+		CompressionTypeBzip2,
+	}
+}
+
 const (
 	// DeleteMarkerReplicationStatusEnabled is a DeleteMarkerReplicationStatus enum value
 	DeleteMarkerReplicationStatusEnabled = "Enabled"
@@ -30364,6 +30432,14 @@ const (
 	// DeleteMarkerReplicationStatusDisabled is a DeleteMarkerReplicationStatus enum value
 	DeleteMarkerReplicationStatusDisabled = "Disabled"
 )
+
+// DeleteMarkerReplicationStatus_Values returns all elements of the DeleteMarkerReplicationStatus enum
+func DeleteMarkerReplicationStatus_Values() []string {
+	return []string{
+		DeleteMarkerReplicationStatusEnabled,
+		DeleteMarkerReplicationStatusDisabled,
+	}
+}
 
 // Requests Amazon S3 to encode the object keys in the response and specifies
 // the encoding method to use. An object key may contain any Unicode character;
@@ -30375,6 +30451,13 @@ const (
 	// EncodingTypeUrl is a EncodingType enum value
 	EncodingTypeUrl = "url"
 )
+
+// EncodingType_Values returns all elements of the EncodingType enum
+func EncodingType_Values() []string {
+	return []string{
+		EncodingTypeUrl,
+	}
+}
 
 // The bucket event for which to send notifications.
 const (
@@ -30430,6 +30513,29 @@ const (
 	EventS3ReplicationOperationReplicatedAfterThreshold = "s3:Replication:OperationReplicatedAfterThreshold"
 )
 
+// Event_Values returns all elements of the Event enum
+func Event_Values() []string {
+	return []string{
+		EventS3ReducedRedundancyLostObject,
+		EventS3ObjectCreated,
+		EventS3ObjectCreatedPut,
+		EventS3ObjectCreatedPost,
+		EventS3ObjectCreatedCopy,
+		EventS3ObjectCreatedCompleteMultipartUpload,
+		EventS3ObjectRemoved,
+		EventS3ObjectRemovedDelete,
+		EventS3ObjectRemovedDeleteMarkerCreated,
+		EventS3ObjectRestore,
+		EventS3ObjectRestorePost,
+		EventS3ObjectRestoreCompleted,
+		EventS3Replication,
+		EventS3ReplicationOperationFailedReplication,
+		EventS3ReplicationOperationNotTracked,
+		EventS3ReplicationOperationMissedThreshold,
+		EventS3ReplicationOperationReplicatedAfterThreshold,
+	}
+}
+
 const (
 	// ExistingObjectReplicationStatusEnabled is a ExistingObjectReplicationStatus enum value
 	ExistingObjectReplicationStatusEnabled = "Enabled"
@@ -30437,6 +30543,14 @@ const (
 	// ExistingObjectReplicationStatusDisabled is a ExistingObjectReplicationStatus enum value
 	ExistingObjectReplicationStatusDisabled = "Disabled"
 )
+
+// ExistingObjectReplicationStatus_Values returns all elements of the ExistingObjectReplicationStatus enum
+func ExistingObjectReplicationStatus_Values() []string {
+	return []string{
+		ExistingObjectReplicationStatusEnabled,
+		ExistingObjectReplicationStatusDisabled,
+	}
+}
 
 const (
 	// ExpirationStatusEnabled is a ExpirationStatus enum value
@@ -30446,10 +30560,25 @@ const (
 	ExpirationStatusDisabled = "Disabled"
 )
 
+// ExpirationStatus_Values returns all elements of the ExpirationStatus enum
+func ExpirationStatus_Values() []string {
+	return []string{
+		ExpirationStatusEnabled,
+		ExpirationStatusDisabled,
+	}
+}
+
 const (
 	// ExpressionTypeSql is a ExpressionType enum value
 	ExpressionTypeSql = "SQL"
 )
+
+// ExpressionType_Values returns all elements of the ExpressionType enum
+func ExpressionType_Values() []string {
+	return []string{
+		ExpressionTypeSql,
+	}
+}
 
 const (
 	// FileHeaderInfoUse is a FileHeaderInfo enum value
@@ -30462,6 +30591,15 @@ const (
 	FileHeaderInfoNone = "NONE"
 )
 
+// FileHeaderInfo_Values returns all elements of the FileHeaderInfo enum
+func FileHeaderInfo_Values() []string {
+	return []string{
+		FileHeaderInfoUse,
+		FileHeaderInfoIgnore,
+		FileHeaderInfoNone,
+	}
+}
+
 const (
 	// FilterRuleNamePrefix is a FilterRuleName enum value
 	FilterRuleNamePrefix = "prefix"
@@ -30469,6 +30607,14 @@ const (
 	// FilterRuleNameSuffix is a FilterRuleName enum value
 	FilterRuleNameSuffix = "suffix"
 )
+
+// FilterRuleName_Values returns all elements of the FilterRuleName enum
+func FilterRuleName_Values() []string {
+	return []string{
+		FilterRuleNamePrefix,
+		FilterRuleNameSuffix,
+	}
+}
 
 const (
 	// InventoryFormatCsv is a InventoryFormat enum value
@@ -30481,6 +30627,15 @@ const (
 	InventoryFormatParquet = "Parquet"
 )
 
+// InventoryFormat_Values returns all elements of the InventoryFormat enum
+func InventoryFormat_Values() []string {
+	return []string{
+		InventoryFormatCsv,
+		InventoryFormatOrc,
+		InventoryFormatParquet,
+	}
+}
+
 const (
 	// InventoryFrequencyDaily is a InventoryFrequency enum value
 	InventoryFrequencyDaily = "Daily"
@@ -30489,6 +30644,14 @@ const (
 	InventoryFrequencyWeekly = "Weekly"
 )
 
+// InventoryFrequency_Values returns all elements of the InventoryFrequency enum
+func InventoryFrequency_Values() []string {
+	return []string{
+		InventoryFrequencyDaily,
+		InventoryFrequencyWeekly,
+	}
+}
+
 const (
 	// InventoryIncludedObjectVersionsAll is a InventoryIncludedObjectVersions enum value
 	InventoryIncludedObjectVersionsAll = "All"
@@ -30496,6 +30659,14 @@ const (
 	// InventoryIncludedObjectVersionsCurrent is a InventoryIncludedObjectVersions enum value
 	InventoryIncludedObjectVersionsCurrent = "Current"
 )
+
+// InventoryIncludedObjectVersions_Values returns all elements of the InventoryIncludedObjectVersions enum
+func InventoryIncludedObjectVersions_Values() []string {
+	return []string{
+		InventoryIncludedObjectVersionsAll,
+		InventoryIncludedObjectVersionsCurrent,
+	}
+}
 
 const (
 	// InventoryOptionalFieldSize is a InventoryOptionalField enum value
@@ -30532,6 +30703,23 @@ const (
 	InventoryOptionalFieldIntelligentTieringAccessTier = "IntelligentTieringAccessTier"
 )
 
+// InventoryOptionalField_Values returns all elements of the InventoryOptionalField enum
+func InventoryOptionalField_Values() []string {
+	return []string{
+		InventoryOptionalFieldSize,
+		InventoryOptionalFieldLastModifiedDate,
+		InventoryOptionalFieldStorageClass,
+		InventoryOptionalFieldEtag,
+		InventoryOptionalFieldIsMultipartUploaded,
+		InventoryOptionalFieldReplicationStatus,
+		InventoryOptionalFieldEncryptionStatus,
+		InventoryOptionalFieldObjectLockRetainUntilDate,
+		InventoryOptionalFieldObjectLockMode,
+		InventoryOptionalFieldObjectLockLegalHoldStatus,
+		InventoryOptionalFieldIntelligentTieringAccessTier,
+	}
+}
+
 const (
 	// JSONTypeDocument is a JSONType enum value
 	JSONTypeDocument = "DOCUMENT"
@@ -30539,6 +30727,14 @@ const (
 	// JSONTypeLines is a JSONType enum value
 	JSONTypeLines = "LINES"
 )
+
+// JSONType_Values returns all elements of the JSONType enum
+func JSONType_Values() []string {
+	return []string{
+		JSONTypeDocument,
+		JSONTypeLines,
+	}
+}
 
 const (
 	// MFADeleteEnabled is a MFADelete enum value
@@ -30548,6 +30744,14 @@ const (
 	MFADeleteDisabled = "Disabled"
 )
 
+// MFADelete_Values returns all elements of the MFADelete enum
+func MFADelete_Values() []string {
+	return []string{
+		MFADeleteEnabled,
+		MFADeleteDisabled,
+	}
+}
+
 const (
 	// MFADeleteStatusEnabled is a MFADeleteStatus enum value
 	MFADeleteStatusEnabled = "Enabled"
@@ -30555,6 +30759,14 @@ const (
 	// MFADeleteStatusDisabled is a MFADeleteStatus enum value
 	MFADeleteStatusDisabled = "Disabled"
 )
+
+// MFADeleteStatus_Values returns all elements of the MFADeleteStatus enum
+func MFADeleteStatus_Values() []string {
+	return []string{
+		MFADeleteStatusEnabled,
+		MFADeleteStatusDisabled,
+	}
+}
 
 const (
 	// MetadataDirectiveCopy is a MetadataDirective enum value
@@ -30564,6 +30776,14 @@ const (
 	MetadataDirectiveReplace = "REPLACE"
 )
 
+// MetadataDirective_Values returns all elements of the MetadataDirective enum
+func MetadataDirective_Values() []string {
+	return []string{
+		MetadataDirectiveCopy,
+		MetadataDirectiveReplace,
+	}
+}
+
 const (
 	// MetricsStatusEnabled is a MetricsStatus enum value
 	MetricsStatusEnabled = "Enabled"
@@ -30571,6 +30791,14 @@ const (
 	// MetricsStatusDisabled is a MetricsStatus enum value
 	MetricsStatusDisabled = "Disabled"
 )
+
+// MetricsStatus_Values returns all elements of the MetricsStatus enum
+func MetricsStatus_Values() []string {
+	return []string{
+		MetricsStatusEnabled,
+		MetricsStatusDisabled,
+	}
+}
 
 const (
 	// ObjectCannedACLPrivate is a ObjectCannedACL enum value
@@ -30595,10 +30823,30 @@ const (
 	ObjectCannedACLBucketOwnerFullControl = "bucket-owner-full-control"
 )
 
+// ObjectCannedACL_Values returns all elements of the ObjectCannedACL enum
+func ObjectCannedACL_Values() []string {
+	return []string{
+		ObjectCannedACLPrivate,
+		ObjectCannedACLPublicRead,
+		ObjectCannedACLPublicReadWrite,
+		ObjectCannedACLAuthenticatedRead,
+		ObjectCannedACLAwsExecRead,
+		ObjectCannedACLBucketOwnerRead,
+		ObjectCannedACLBucketOwnerFullControl,
+	}
+}
+
 const (
 	// ObjectLockEnabledEnabled is a ObjectLockEnabled enum value
 	ObjectLockEnabledEnabled = "Enabled"
 )
+
+// ObjectLockEnabled_Values returns all elements of the ObjectLockEnabled enum
+func ObjectLockEnabled_Values() []string {
+	return []string{
+		ObjectLockEnabledEnabled,
+	}
+}
 
 const (
 	// ObjectLockLegalHoldStatusOn is a ObjectLockLegalHoldStatus enum value
@@ -30608,6 +30856,14 @@ const (
 	ObjectLockLegalHoldStatusOff = "OFF"
 )
 
+// ObjectLockLegalHoldStatus_Values returns all elements of the ObjectLockLegalHoldStatus enum
+func ObjectLockLegalHoldStatus_Values() []string {
+	return []string{
+		ObjectLockLegalHoldStatusOn,
+		ObjectLockLegalHoldStatusOff,
+	}
+}
+
 const (
 	// ObjectLockModeGovernance is a ObjectLockMode enum value
 	ObjectLockModeGovernance = "GOVERNANCE"
@@ -30616,6 +30872,14 @@ const (
 	ObjectLockModeCompliance = "COMPLIANCE"
 )
 
+// ObjectLockMode_Values returns all elements of the ObjectLockMode enum
+func ObjectLockMode_Values() []string {
+	return []string{
+		ObjectLockModeGovernance,
+		ObjectLockModeCompliance,
+	}
+}
+
 const (
 	// ObjectLockRetentionModeGovernance is a ObjectLockRetentionMode enum value
 	ObjectLockRetentionModeGovernance = "GOVERNANCE"
@@ -30623,6 +30887,14 @@ const (
 	// ObjectLockRetentionModeCompliance is a ObjectLockRetentionMode enum value
 	ObjectLockRetentionModeCompliance = "COMPLIANCE"
 )
+
+// ObjectLockRetentionMode_Values returns all elements of the ObjectLockRetentionMode enum
+func ObjectLockRetentionMode_Values() []string {
+	return []string{
+		ObjectLockRetentionModeGovernance,
+		ObjectLockRetentionModeCompliance,
+	}
+}
 
 const (
 	// ObjectStorageClassStandard is a ObjectStorageClass enum value
@@ -30647,15 +30919,42 @@ const (
 	ObjectStorageClassDeepArchive = "DEEP_ARCHIVE"
 )
 
+// ObjectStorageClass_Values returns all elements of the ObjectStorageClass enum
+func ObjectStorageClass_Values() []string {
+	return []string{
+		ObjectStorageClassStandard,
+		ObjectStorageClassReducedRedundancy,
+		ObjectStorageClassGlacier,
+		ObjectStorageClassStandardIa,
+		ObjectStorageClassOnezoneIa,
+		ObjectStorageClassIntelligentTiering,
+		ObjectStorageClassDeepArchive,
+	}
+}
+
 const (
 	// ObjectVersionStorageClassStandard is a ObjectVersionStorageClass enum value
 	ObjectVersionStorageClassStandard = "STANDARD"
 )
 
+// ObjectVersionStorageClass_Values returns all elements of the ObjectVersionStorageClass enum
+func ObjectVersionStorageClass_Values() []string {
+	return []string{
+		ObjectVersionStorageClassStandard,
+	}
+}
+
 const (
 	// OwnerOverrideDestination is a OwnerOverride enum value
 	OwnerOverrideDestination = "Destination"
 )
+
+// OwnerOverride_Values returns all elements of the OwnerOverride enum
+func OwnerOverride_Values() []string {
+	return []string{
+		OwnerOverrideDestination,
+	}
+}
 
 const (
 	// PayerRequester is a Payer enum value
@@ -30664,6 +30963,14 @@ const (
 	// PayerBucketOwner is a Payer enum value
 	PayerBucketOwner = "BucketOwner"
 )
+
+// Payer_Values returns all elements of the Payer enum
+func Payer_Values() []string {
+	return []string{
+		PayerRequester,
+		PayerBucketOwner,
+	}
+}
 
 const (
 	// PermissionFullControl is a Permission enum value
@@ -30682,6 +30989,17 @@ const (
 	PermissionReadAcp = "READ_ACP"
 )
 
+// Permission_Values returns all elements of the Permission enum
+func Permission_Values() []string {
+	return []string{
+		PermissionFullControl,
+		PermissionWrite,
+		PermissionWriteAcp,
+		PermissionRead,
+		PermissionReadAcp,
+	}
+}
+
 const (
 	// ProtocolHttp is a Protocol enum value
 	ProtocolHttp = "http"
@@ -30689,6 +31007,14 @@ const (
 	// ProtocolHttps is a Protocol enum value
 	ProtocolHttps = "https"
 )
+
+// Protocol_Values returns all elements of the Protocol enum
+func Protocol_Values() []string {
+	return []string{
+		ProtocolHttp,
+		ProtocolHttps,
+	}
+}
 
 const (
 	// QuoteFieldsAlways is a QuoteFields enum value
@@ -30698,6 +31024,14 @@ const (
 	QuoteFieldsAsneeded = "ASNEEDED"
 )
 
+// QuoteFields_Values returns all elements of the QuoteFields enum
+func QuoteFields_Values() []string {
+	return []string{
+		QuoteFieldsAlways,
+		QuoteFieldsAsneeded,
+	}
+}
+
 const (
 	// ReplicationRuleStatusEnabled is a ReplicationRuleStatus enum value
 	ReplicationRuleStatusEnabled = "Enabled"
@@ -30705,6 +31039,14 @@ const (
 	// ReplicationRuleStatusDisabled is a ReplicationRuleStatus enum value
 	ReplicationRuleStatusDisabled = "Disabled"
 )
+
+// ReplicationRuleStatus_Values returns all elements of the ReplicationRuleStatus enum
+func ReplicationRuleStatus_Values() []string {
+	return []string{
+		ReplicationRuleStatusEnabled,
+		ReplicationRuleStatusDisabled,
+	}
+}
 
 const (
 	// ReplicationStatusComplete is a ReplicationStatus enum value
@@ -30720,6 +31062,16 @@ const (
 	ReplicationStatusReplica = "REPLICA"
 )
 
+// ReplicationStatus_Values returns all elements of the ReplicationStatus enum
+func ReplicationStatus_Values() []string {
+	return []string{
+		ReplicationStatusComplete,
+		ReplicationStatusPending,
+		ReplicationStatusFailed,
+		ReplicationStatusReplica,
+	}
+}
+
 const (
 	// ReplicationTimeStatusEnabled is a ReplicationTimeStatus enum value
 	ReplicationTimeStatusEnabled = "Enabled"
@@ -30728,12 +31080,27 @@ const (
 	ReplicationTimeStatusDisabled = "Disabled"
 )
 
+// ReplicationTimeStatus_Values returns all elements of the ReplicationTimeStatus enum
+func ReplicationTimeStatus_Values() []string {
+	return []string{
+		ReplicationTimeStatusEnabled,
+		ReplicationTimeStatusDisabled,
+	}
+}
+
 // If present, indicates that the requester was successfully charged for the
 // request.
 const (
 	// RequestChargedRequester is a RequestCharged enum value
 	RequestChargedRequester = "requester"
 )
+
+// RequestCharged_Values returns all elements of the RequestCharged enum
+func RequestCharged_Values() []string {
+	return []string{
+		RequestChargedRequester,
+	}
+}
 
 // Confirms that the requester knows that they will be charged for the request.
 // Bucket owners need not specify this parameter in their requests. For information
@@ -30745,10 +31112,24 @@ const (
 	RequestPayerRequester = "requester"
 )
 
+// RequestPayer_Values returns all elements of the RequestPayer enum
+func RequestPayer_Values() []string {
+	return []string{
+		RequestPayerRequester,
+	}
+}
+
 const (
 	// RestoreRequestTypeSelect is a RestoreRequestType enum value
 	RestoreRequestTypeSelect = "SELECT"
 )
+
+// RestoreRequestType_Values returns all elements of the RestoreRequestType enum
+func RestoreRequestType_Values() []string {
+	return []string{
+		RestoreRequestTypeSelect,
+	}
+}
 
 const (
 	// ServerSideEncryptionAes256 is a ServerSideEncryption enum value
@@ -30758,6 +31139,14 @@ const (
 	ServerSideEncryptionAwsKms = "aws:kms"
 )
 
+// ServerSideEncryption_Values returns all elements of the ServerSideEncryption enum
+func ServerSideEncryption_Values() []string {
+	return []string{
+		ServerSideEncryptionAes256,
+		ServerSideEncryptionAwsKms,
+	}
+}
+
 const (
 	// SseKmsEncryptedObjectsStatusEnabled is a SseKmsEncryptedObjectsStatus enum value
 	SseKmsEncryptedObjectsStatusEnabled = "Enabled"
@@ -30765,6 +31154,14 @@ const (
 	// SseKmsEncryptedObjectsStatusDisabled is a SseKmsEncryptedObjectsStatus enum value
 	SseKmsEncryptedObjectsStatusDisabled = "Disabled"
 )
+
+// SseKmsEncryptedObjectsStatus_Values returns all elements of the SseKmsEncryptedObjectsStatus enum
+func SseKmsEncryptedObjectsStatus_Values() []string {
+	return []string{
+		SseKmsEncryptedObjectsStatusEnabled,
+		SseKmsEncryptedObjectsStatusDisabled,
+	}
+}
 
 const (
 	// StorageClassStandard is a StorageClass enum value
@@ -30789,10 +31186,30 @@ const (
 	StorageClassDeepArchive = "DEEP_ARCHIVE"
 )
 
+// StorageClass_Values returns all elements of the StorageClass enum
+func StorageClass_Values() []string {
+	return []string{
+		StorageClassStandard,
+		StorageClassReducedRedundancy,
+		StorageClassStandardIa,
+		StorageClassOnezoneIa,
+		StorageClassIntelligentTiering,
+		StorageClassGlacier,
+		StorageClassDeepArchive,
+	}
+}
+
 const (
 	// StorageClassAnalysisSchemaVersionV1 is a StorageClassAnalysisSchemaVersion enum value
 	StorageClassAnalysisSchemaVersionV1 = "V_1"
 )
+
+// StorageClassAnalysisSchemaVersion_Values returns all elements of the StorageClassAnalysisSchemaVersion enum
+func StorageClassAnalysisSchemaVersion_Values() []string {
+	return []string{
+		StorageClassAnalysisSchemaVersionV1,
+	}
+}
 
 const (
 	// TaggingDirectiveCopy is a TaggingDirective enum value
@@ -30801,6 +31218,14 @@ const (
 	// TaggingDirectiveReplace is a TaggingDirective enum value
 	TaggingDirectiveReplace = "REPLACE"
 )
+
+// TaggingDirective_Values returns all elements of the TaggingDirective enum
+func TaggingDirective_Values() []string {
+	return []string{
+		TaggingDirectiveCopy,
+		TaggingDirectiveReplace,
+	}
+}
 
 const (
 	// TierStandard is a Tier enum value
@@ -30812,6 +31237,15 @@ const (
 	// TierExpedited is a Tier enum value
 	TierExpedited = "Expedited"
 )
+
+// Tier_Values returns all elements of the Tier enum
+func Tier_Values() []string {
+	return []string{
+		TierStandard,
+		TierBulk,
+		TierExpedited,
+	}
+}
 
 const (
 	// TransitionStorageClassGlacier is a TransitionStorageClass enum value
@@ -30830,6 +31264,17 @@ const (
 	TransitionStorageClassDeepArchive = "DEEP_ARCHIVE"
 )
 
+// TransitionStorageClass_Values returns all elements of the TransitionStorageClass enum
+func TransitionStorageClass_Values() []string {
+	return []string{
+		TransitionStorageClassGlacier,
+		TransitionStorageClassStandardIa,
+		TransitionStorageClassOnezoneIa,
+		TransitionStorageClassIntelligentTiering,
+		TransitionStorageClassDeepArchive,
+	}
+}
+
 const (
 	// TypeCanonicalUser is a Type enum value
 	TypeCanonicalUser = "CanonicalUser"
@@ -30840,3 +31285,12 @@ const (
 	// TypeGroup is a Type enum value
 	TypeGroup = "Group"
 )
+
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypeCanonicalUser,
+		TypeAmazonCustomerByEmail,
+		TypeGroup,
+	}
+}

--- a/service/s3control/api.go
+++ b/service/s3control/api.go
@@ -5690,6 +5690,16 @@ const (
 	JobManifestFieldNameVersionId = "VersionId"
 )
 
+// JobManifestFieldName_Values returns all elements of the JobManifestFieldName enum
+func JobManifestFieldName_Values() []string {
+	return []string{
+		JobManifestFieldNameIgnore,
+		JobManifestFieldNameBucket,
+		JobManifestFieldNameKey,
+		JobManifestFieldNameVersionId,
+	}
+}
+
 const (
 	// JobManifestFormatS3batchOperationsCsv20180820 is a JobManifestFormat enum value
 	JobManifestFormatS3batchOperationsCsv20180820 = "S3BatchOperations_CSV_20180820"
@@ -5698,10 +5708,25 @@ const (
 	JobManifestFormatS3inventoryReportCsv20161130 = "S3InventoryReport_CSV_20161130"
 )
 
+// JobManifestFormat_Values returns all elements of the JobManifestFormat enum
+func JobManifestFormat_Values() []string {
+	return []string{
+		JobManifestFormatS3batchOperationsCsv20180820,
+		JobManifestFormatS3inventoryReportCsv20161130,
+	}
+}
+
 const (
 	// JobReportFormatReportCsv20180820 is a JobReportFormat enum value
 	JobReportFormatReportCsv20180820 = "Report_CSV_20180820"
 )
+
+// JobReportFormat_Values returns all elements of the JobReportFormat enum
+func JobReportFormat_Values() []string {
+	return []string{
+		JobReportFormatReportCsv20180820,
+	}
+}
 
 const (
 	// JobReportScopeAllTasks is a JobReportScope enum value
@@ -5710,6 +5735,14 @@ const (
 	// JobReportScopeFailedTasksOnly is a JobReportScope enum value
 	JobReportScopeFailedTasksOnly = "FailedTasksOnly"
 )
+
+// JobReportScope_Values returns all elements of the JobReportScope enum
+func JobReportScope_Values() []string {
+	return []string{
+		JobReportScopeAllTasks,
+		JobReportScopeFailedTasksOnly,
+	}
+}
 
 const (
 	// JobStatusActive is a JobStatus enum value
@@ -5752,6 +5785,25 @@ const (
 	JobStatusSuspended = "Suspended"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusActive,
+		JobStatusCancelled,
+		JobStatusCancelling,
+		JobStatusComplete,
+		JobStatusCompleting,
+		JobStatusFailed,
+		JobStatusFailing,
+		JobStatusNew,
+		JobStatusPaused,
+		JobStatusPausing,
+		JobStatusPreparing,
+		JobStatusReady,
+		JobStatusSuspended,
+	}
+}
+
 const (
 	// NetworkOriginInternet is a NetworkOrigin enum value
 	NetworkOriginInternet = "Internet"
@@ -5759,6 +5811,14 @@ const (
 	// NetworkOriginVpc is a NetworkOrigin enum value
 	NetworkOriginVpc = "VPC"
 )
+
+// NetworkOrigin_Values returns all elements of the NetworkOrigin enum
+func NetworkOrigin_Values() []string {
+	return []string{
+		NetworkOriginInternet,
+		NetworkOriginVpc,
+	}
+}
 
 const (
 	// OperationNameLambdaInvoke is a OperationName enum value
@@ -5783,6 +5843,19 @@ const (
 	OperationNameS3putObjectRetention = "S3PutObjectRetention"
 )
 
+// OperationName_Values returns all elements of the OperationName enum
+func OperationName_Values() []string {
+	return []string{
+		OperationNameLambdaInvoke,
+		OperationNameS3putObjectCopy,
+		OperationNameS3putObjectAcl,
+		OperationNameS3putObjectTagging,
+		OperationNameS3initiateRestoreObject,
+		OperationNameS3putObjectLegalHold,
+		OperationNameS3putObjectRetention,
+	}
+}
+
 const (
 	// RequestedJobStatusCancelled is a RequestedJobStatus enum value
 	RequestedJobStatusCancelled = "Cancelled"
@@ -5790,6 +5863,14 @@ const (
 	// RequestedJobStatusReady is a RequestedJobStatus enum value
 	RequestedJobStatusReady = "Ready"
 )
+
+// RequestedJobStatus_Values returns all elements of the RequestedJobStatus enum
+func RequestedJobStatus_Values() []string {
+	return []string{
+		RequestedJobStatusCancelled,
+		RequestedJobStatusReady,
+	}
+}
 
 const (
 	// S3CannedAccessControlListPrivate is a S3CannedAccessControlList enum value
@@ -5814,6 +5895,19 @@ const (
 	S3CannedAccessControlListBucketOwnerFullControl = "bucket-owner-full-control"
 )
 
+// S3CannedAccessControlList_Values returns all elements of the S3CannedAccessControlList enum
+func S3CannedAccessControlList_Values() []string {
+	return []string{
+		S3CannedAccessControlListPrivate,
+		S3CannedAccessControlListPublicRead,
+		S3CannedAccessControlListPublicReadWrite,
+		S3CannedAccessControlListAwsExecRead,
+		S3CannedAccessControlListAuthenticatedRead,
+		S3CannedAccessControlListBucketOwnerRead,
+		S3CannedAccessControlListBucketOwnerFullControl,
+	}
+}
+
 const (
 	// S3GlacierJobTierBulk is a S3GlacierJobTier enum value
 	S3GlacierJobTierBulk = "BULK"
@@ -5821,6 +5915,14 @@ const (
 	// S3GlacierJobTierStandard is a S3GlacierJobTier enum value
 	S3GlacierJobTierStandard = "STANDARD"
 )
+
+// S3GlacierJobTier_Values returns all elements of the S3GlacierJobTier enum
+func S3GlacierJobTier_Values() []string {
+	return []string{
+		S3GlacierJobTierBulk,
+		S3GlacierJobTierStandard,
+	}
+}
 
 const (
 	// S3GranteeTypeIdentifierId is a S3GranteeTypeIdentifier enum value
@@ -5833,6 +5935,15 @@ const (
 	S3GranteeTypeIdentifierUri = "uri"
 )
 
+// S3GranteeTypeIdentifier_Values returns all elements of the S3GranteeTypeIdentifier enum
+func S3GranteeTypeIdentifier_Values() []string {
+	return []string{
+		S3GranteeTypeIdentifierId,
+		S3GranteeTypeIdentifierEmailAddress,
+		S3GranteeTypeIdentifierUri,
+	}
+}
+
 const (
 	// S3MetadataDirectiveCopy is a S3MetadataDirective enum value
 	S3MetadataDirectiveCopy = "COPY"
@@ -5840,6 +5951,14 @@ const (
 	// S3MetadataDirectiveReplace is a S3MetadataDirective enum value
 	S3MetadataDirectiveReplace = "REPLACE"
 )
+
+// S3MetadataDirective_Values returns all elements of the S3MetadataDirective enum
+func S3MetadataDirective_Values() []string {
+	return []string{
+		S3MetadataDirectiveCopy,
+		S3MetadataDirectiveReplace,
+	}
+}
 
 const (
 	// S3ObjectLockLegalHoldStatusOff is a S3ObjectLockLegalHoldStatus enum value
@@ -5849,6 +5968,14 @@ const (
 	S3ObjectLockLegalHoldStatusOn = "ON"
 )
 
+// S3ObjectLockLegalHoldStatus_Values returns all elements of the S3ObjectLockLegalHoldStatus enum
+func S3ObjectLockLegalHoldStatus_Values() []string {
+	return []string{
+		S3ObjectLockLegalHoldStatusOff,
+		S3ObjectLockLegalHoldStatusOn,
+	}
+}
+
 const (
 	// S3ObjectLockModeCompliance is a S3ObjectLockMode enum value
 	S3ObjectLockModeCompliance = "COMPLIANCE"
@@ -5857,6 +5984,14 @@ const (
 	S3ObjectLockModeGovernance = "GOVERNANCE"
 )
 
+// S3ObjectLockMode_Values returns all elements of the S3ObjectLockMode enum
+func S3ObjectLockMode_Values() []string {
+	return []string{
+		S3ObjectLockModeCompliance,
+		S3ObjectLockModeGovernance,
+	}
+}
+
 const (
 	// S3ObjectLockRetentionModeCompliance is a S3ObjectLockRetentionMode enum value
 	S3ObjectLockRetentionModeCompliance = "COMPLIANCE"
@@ -5864,6 +5999,14 @@ const (
 	// S3ObjectLockRetentionModeGovernance is a S3ObjectLockRetentionMode enum value
 	S3ObjectLockRetentionModeGovernance = "GOVERNANCE"
 )
+
+// S3ObjectLockRetentionMode_Values returns all elements of the S3ObjectLockRetentionMode enum
+func S3ObjectLockRetentionMode_Values() []string {
+	return []string{
+		S3ObjectLockRetentionModeCompliance,
+		S3ObjectLockRetentionModeGovernance,
+	}
+}
 
 const (
 	// S3PermissionFullControl is a S3Permission enum value
@@ -5882,6 +6025,17 @@ const (
 	S3PermissionWriteAcp = "WRITE_ACP"
 )
 
+// S3Permission_Values returns all elements of the S3Permission enum
+func S3Permission_Values() []string {
+	return []string{
+		S3PermissionFullControl,
+		S3PermissionRead,
+		S3PermissionWrite,
+		S3PermissionReadAcp,
+		S3PermissionWriteAcp,
+	}
+}
+
 const (
 	// S3SSEAlgorithmAes256 is a S3SSEAlgorithm enum value
 	S3SSEAlgorithmAes256 = "AES256"
@@ -5889,6 +6043,14 @@ const (
 	// S3SSEAlgorithmKms is a S3SSEAlgorithm enum value
 	S3SSEAlgorithmKms = "KMS"
 )
+
+// S3SSEAlgorithm_Values returns all elements of the S3SSEAlgorithm enum
+func S3SSEAlgorithm_Values() []string {
+	return []string{
+		S3SSEAlgorithmAes256,
+		S3SSEAlgorithmKms,
+	}
+}
 
 const (
 	// S3StorageClassStandard is a S3StorageClass enum value
@@ -5909,3 +6071,15 @@ const (
 	// S3StorageClassDeepArchive is a S3StorageClass enum value
 	S3StorageClassDeepArchive = "DEEP_ARCHIVE"
 )
+
+// S3StorageClass_Values returns all elements of the S3StorageClass enum
+func S3StorageClass_Values() []string {
+	return []string{
+		S3StorageClassStandard,
+		S3StorageClassStandardIa,
+		S3StorageClassOnezoneIa,
+		S3StorageClassGlacier,
+		S3StorageClassIntelligentTiering,
+		S3StorageClassDeepArchive,
+	}
+}

--- a/service/sagemaker/api.go
+++ b/service/sagemaker/api.go
@@ -48592,6 +48592,14 @@ const (
 	AlgorithmSortByCreationTime = "CreationTime"
 )
 
+// AlgorithmSortBy_Values returns all elements of the AlgorithmSortBy enum
+func AlgorithmSortBy_Values() []string {
+	return []string{
+		AlgorithmSortByName,
+		AlgorithmSortByCreationTime,
+	}
+}
+
 const (
 	// AlgorithmStatusPending is a AlgorithmStatus enum value
 	AlgorithmStatusPending = "Pending"
@@ -48608,6 +48616,17 @@ const (
 	// AlgorithmStatusDeleting is a AlgorithmStatus enum value
 	AlgorithmStatusDeleting = "Deleting"
 )
+
+// AlgorithmStatus_Values returns all elements of the AlgorithmStatus enum
+func AlgorithmStatus_Values() []string {
+	return []string{
+		AlgorithmStatusPending,
+		AlgorithmStatusInProgress,
+		AlgorithmStatusCompleted,
+		AlgorithmStatusFailed,
+		AlgorithmStatusDeleting,
+	}
+}
 
 const (
 	// AppInstanceTypeSystem is a AppInstanceType enum value
@@ -48707,10 +48726,55 @@ const (
 	AppInstanceTypeMlG4dn16xlarge = "ml.g4dn.16xlarge"
 )
 
+// AppInstanceType_Values returns all elements of the AppInstanceType enum
+func AppInstanceType_Values() []string {
+	return []string{
+		AppInstanceTypeSystem,
+		AppInstanceTypeMlT3Micro,
+		AppInstanceTypeMlT3Small,
+		AppInstanceTypeMlT3Medium,
+		AppInstanceTypeMlT3Large,
+		AppInstanceTypeMlT3Xlarge,
+		AppInstanceTypeMlT32xlarge,
+		AppInstanceTypeMlM5Large,
+		AppInstanceTypeMlM5Xlarge,
+		AppInstanceTypeMlM52xlarge,
+		AppInstanceTypeMlM54xlarge,
+		AppInstanceTypeMlM58xlarge,
+		AppInstanceTypeMlM512xlarge,
+		AppInstanceTypeMlM516xlarge,
+		AppInstanceTypeMlM524xlarge,
+		AppInstanceTypeMlC5Large,
+		AppInstanceTypeMlC5Xlarge,
+		AppInstanceTypeMlC52xlarge,
+		AppInstanceTypeMlC54xlarge,
+		AppInstanceTypeMlC59xlarge,
+		AppInstanceTypeMlC512xlarge,
+		AppInstanceTypeMlC518xlarge,
+		AppInstanceTypeMlC524xlarge,
+		AppInstanceTypeMlP32xlarge,
+		AppInstanceTypeMlP38xlarge,
+		AppInstanceTypeMlP316xlarge,
+		AppInstanceTypeMlG4dnXlarge,
+		AppInstanceTypeMlG4dn2xlarge,
+		AppInstanceTypeMlG4dn4xlarge,
+		AppInstanceTypeMlG4dn8xlarge,
+		AppInstanceTypeMlG4dn12xlarge,
+		AppInstanceTypeMlG4dn16xlarge,
+	}
+}
+
 const (
 	// AppSortKeyCreationTime is a AppSortKey enum value
 	AppSortKeyCreationTime = "CreationTime"
 )
+
+// AppSortKey_Values returns all elements of the AppSortKey enum
+func AppSortKey_Values() []string {
+	return []string{
+		AppSortKeyCreationTime,
+	}
+}
 
 const (
 	// AppStatusDeleted is a AppStatus enum value
@@ -48729,6 +48793,17 @@ const (
 	AppStatusPending = "Pending"
 )
 
+// AppStatus_Values returns all elements of the AppStatus enum
+func AppStatus_Values() []string {
+	return []string{
+		AppStatusDeleted,
+		AppStatusDeleting,
+		AppStatusFailed,
+		AppStatusInService,
+		AppStatusPending,
+	}
+}
+
 const (
 	// AppTypeJupyterServer is a AppType enum value
 	AppTypeJupyterServer = "JupyterServer"
@@ -48740,6 +48815,15 @@ const (
 	AppTypeTensorBoard = "TensorBoard"
 )
 
+// AppType_Values returns all elements of the AppType enum
+func AppType_Values() []string {
+	return []string{
+		AppTypeJupyterServer,
+		AppTypeKernelGateway,
+		AppTypeTensorBoard,
+	}
+}
+
 const (
 	// AssemblyTypeNone is a AssemblyType enum value
 	AssemblyTypeNone = "None"
@@ -48747,6 +48831,14 @@ const (
 	// AssemblyTypeLine is a AssemblyType enum value
 	AssemblyTypeLine = "Line"
 )
+
+// AssemblyType_Values returns all elements of the AssemblyType enum
+func AssemblyType_Values() []string {
+	return []string{
+		AssemblyTypeNone,
+		AssemblyTypeLine,
+	}
+}
 
 const (
 	// AuthModeSso is a AuthMode enum value
@@ -48756,6 +48848,14 @@ const (
 	AuthModeIam = "IAM"
 )
 
+// AuthMode_Values returns all elements of the AuthMode enum
+func AuthMode_Values() []string {
+	return []string{
+		AuthModeSso,
+		AuthModeIam,
+	}
+}
+
 const (
 	// AutoMLJobObjectiveTypeMaximize is a AutoMLJobObjectiveType enum value
 	AutoMLJobObjectiveTypeMaximize = "Maximize"
@@ -48763,6 +48863,14 @@ const (
 	// AutoMLJobObjectiveTypeMinimize is a AutoMLJobObjectiveType enum value
 	AutoMLJobObjectiveTypeMinimize = "Minimize"
 )
+
+// AutoMLJobObjectiveType_Values returns all elements of the AutoMLJobObjectiveType enum
+func AutoMLJobObjectiveType_Values() []string {
+	return []string{
+		AutoMLJobObjectiveTypeMaximize,
+		AutoMLJobObjectiveTypeMinimize,
+	}
+}
 
 const (
 	// AutoMLJobSecondaryStatusStarting is a AutoMLJobSecondaryStatus enum value
@@ -48796,6 +48904,22 @@ const (
 	AutoMLJobSecondaryStatusCandidateDefinitionsGenerated = "CandidateDefinitionsGenerated"
 )
 
+// AutoMLJobSecondaryStatus_Values returns all elements of the AutoMLJobSecondaryStatus enum
+func AutoMLJobSecondaryStatus_Values() []string {
+	return []string{
+		AutoMLJobSecondaryStatusStarting,
+		AutoMLJobSecondaryStatusAnalyzingData,
+		AutoMLJobSecondaryStatusFeatureEngineering,
+		AutoMLJobSecondaryStatusModelTuning,
+		AutoMLJobSecondaryStatusMaxCandidatesReached,
+		AutoMLJobSecondaryStatusFailed,
+		AutoMLJobSecondaryStatusStopped,
+		AutoMLJobSecondaryStatusMaxAutoMljobRuntimeReached,
+		AutoMLJobSecondaryStatusStopping,
+		AutoMLJobSecondaryStatusCandidateDefinitionsGenerated,
+	}
+}
+
 const (
 	// AutoMLJobStatusCompleted is a AutoMLJobStatus enum value
 	AutoMLJobStatusCompleted = "Completed"
@@ -48813,6 +48937,17 @@ const (
 	AutoMLJobStatusStopping = "Stopping"
 )
 
+// AutoMLJobStatus_Values returns all elements of the AutoMLJobStatus enum
+func AutoMLJobStatus_Values() []string {
+	return []string{
+		AutoMLJobStatusCompleted,
+		AutoMLJobStatusInProgress,
+		AutoMLJobStatusFailed,
+		AutoMLJobStatusStopped,
+		AutoMLJobStatusStopping,
+	}
+}
+
 const (
 	// AutoMLMetricEnumAccuracy is a AutoMLMetricEnum enum value
 	AutoMLMetricEnumAccuracy = "Accuracy"
@@ -48827,6 +48962,16 @@ const (
 	AutoMLMetricEnumF1macro = "F1macro"
 )
 
+// AutoMLMetricEnum_Values returns all elements of the AutoMLMetricEnum enum
+func AutoMLMetricEnum_Values() []string {
+	return []string{
+		AutoMLMetricEnumAccuracy,
+		AutoMLMetricEnumMse,
+		AutoMLMetricEnumF1,
+		AutoMLMetricEnumF1macro,
+	}
+}
+
 const (
 	// AutoMLS3DataTypeManifestFile is a AutoMLS3DataType enum value
 	AutoMLS3DataTypeManifestFile = "ManifestFile"
@@ -48834,6 +48979,14 @@ const (
 	// AutoMLS3DataTypeS3prefix is a AutoMLS3DataType enum value
 	AutoMLS3DataTypeS3prefix = "S3Prefix"
 )
+
+// AutoMLS3DataType_Values returns all elements of the AutoMLS3DataType enum
+func AutoMLS3DataType_Values() []string {
+	return []string{
+		AutoMLS3DataTypeManifestFile,
+		AutoMLS3DataTypeS3prefix,
+	}
+}
 
 const (
 	// AutoMLSortByName is a AutoMLSortBy enum value
@@ -48846,6 +48999,15 @@ const (
 	AutoMLSortByStatus = "Status"
 )
 
+// AutoMLSortBy_Values returns all elements of the AutoMLSortBy enum
+func AutoMLSortBy_Values() []string {
+	return []string{
+		AutoMLSortByName,
+		AutoMLSortByCreationTime,
+		AutoMLSortByStatus,
+	}
+}
+
 const (
 	// AutoMLSortOrderAscending is a AutoMLSortOrder enum value
 	AutoMLSortOrderAscending = "Ascending"
@@ -48853,6 +49015,14 @@ const (
 	// AutoMLSortOrderDescending is a AutoMLSortOrder enum value
 	AutoMLSortOrderDescending = "Descending"
 )
+
+// AutoMLSortOrder_Values returns all elements of the AutoMLSortOrder enum
+func AutoMLSortOrder_Values() []string {
+	return []string{
+		AutoMLSortOrderAscending,
+		AutoMLSortOrderDescending,
+	}
+}
 
 const (
 	// AwsManagedHumanLoopRequestSourceAwsRekognitionDetectModerationLabelsImageV3 is a AwsManagedHumanLoopRequestSource enum value
@@ -48862,6 +49032,14 @@ const (
 	AwsManagedHumanLoopRequestSourceAwsTextractAnalyzeDocumentFormsV1 = "AWS/Textract/AnalyzeDocument/Forms/V1"
 )
 
+// AwsManagedHumanLoopRequestSource_Values returns all elements of the AwsManagedHumanLoopRequestSource enum
+func AwsManagedHumanLoopRequestSource_Values() []string {
+	return []string{
+		AwsManagedHumanLoopRequestSourceAwsRekognitionDetectModerationLabelsImageV3,
+		AwsManagedHumanLoopRequestSourceAwsTextractAnalyzeDocumentFormsV1,
+	}
+}
+
 const (
 	// BatchStrategyMultiRecord is a BatchStrategy enum value
 	BatchStrategyMultiRecord = "MultiRecord"
@@ -48870,6 +49048,14 @@ const (
 	BatchStrategySingleRecord = "SingleRecord"
 )
 
+// BatchStrategy_Values returns all elements of the BatchStrategy enum
+func BatchStrategy_Values() []string {
+	return []string{
+		BatchStrategyMultiRecord,
+		BatchStrategySingleRecord,
+	}
+}
+
 const (
 	// BooleanOperatorAnd is a BooleanOperator enum value
 	BooleanOperatorAnd = "And"
@@ -48877,6 +49063,14 @@ const (
 	// BooleanOperatorOr is a BooleanOperator enum value
 	BooleanOperatorOr = "Or"
 )
+
+// BooleanOperator_Values returns all elements of the BooleanOperator enum
+func BooleanOperator_Values() []string {
+	return []string{
+		BooleanOperatorAnd,
+		BooleanOperatorOr,
+	}
+}
 
 const (
 	// CandidateSortByCreationTime is a CandidateSortBy enum value
@@ -48888,6 +49082,15 @@ const (
 	// CandidateSortByFinalObjectiveMetricValue is a CandidateSortBy enum value
 	CandidateSortByFinalObjectiveMetricValue = "FinalObjectiveMetricValue"
 )
+
+// CandidateSortBy_Values returns all elements of the CandidateSortBy enum
+func CandidateSortBy_Values() []string {
+	return []string{
+		CandidateSortByCreationTime,
+		CandidateSortByStatus,
+		CandidateSortByFinalObjectiveMetricValue,
+	}
+}
 
 const (
 	// CandidateStatusCompleted is a CandidateStatus enum value
@@ -48906,6 +49109,17 @@ const (
 	CandidateStatusStopping = "Stopping"
 )
 
+// CandidateStatus_Values returns all elements of the CandidateStatus enum
+func CandidateStatus_Values() []string {
+	return []string{
+		CandidateStatusCompleted,
+		CandidateStatusInProgress,
+		CandidateStatusFailed,
+		CandidateStatusStopped,
+		CandidateStatusStopping,
+	}
+}
+
 const (
 	// CandidateStepTypeAwsSageMakerTrainingJob is a CandidateStepType enum value
 	CandidateStepTypeAwsSageMakerTrainingJob = "AWS::SageMaker::TrainingJob"
@@ -48917,6 +49131,15 @@ const (
 	CandidateStepTypeAwsSageMakerProcessingJob = "AWS::SageMaker::ProcessingJob"
 )
 
+// CandidateStepType_Values returns all elements of the CandidateStepType enum
+func CandidateStepType_Values() []string {
+	return []string{
+		CandidateStepTypeAwsSageMakerTrainingJob,
+		CandidateStepTypeAwsSageMakerTransformJob,
+		CandidateStepTypeAwsSageMakerProcessingJob,
+	}
+}
+
 const (
 	// CaptureModeInput is a CaptureMode enum value
 	CaptureModeInput = "Input"
@@ -48925,6 +49148,14 @@ const (
 	CaptureModeOutput = "Output"
 )
 
+// CaptureMode_Values returns all elements of the CaptureMode enum
+func CaptureMode_Values() []string {
+	return []string{
+		CaptureModeInput,
+		CaptureModeOutput,
+	}
+}
+
 const (
 	// CaptureStatusStarted is a CaptureStatus enum value
 	CaptureStatusStarted = "Started"
@@ -48932,6 +49163,14 @@ const (
 	// CaptureStatusStopped is a CaptureStatus enum value
 	CaptureStatusStopped = "Stopped"
 )
+
+// CaptureStatus_Values returns all elements of the CaptureStatus enum
+func CaptureStatus_Values() []string {
+	return []string{
+		CaptureStatusStarted,
+		CaptureStatusStopped,
+	}
+}
 
 const (
 	// CodeRepositorySortByName is a CodeRepositorySortBy enum value
@@ -48944,6 +49183,15 @@ const (
 	CodeRepositorySortByLastModifiedTime = "LastModifiedTime"
 )
 
+// CodeRepositorySortBy_Values returns all elements of the CodeRepositorySortBy enum
+func CodeRepositorySortBy_Values() []string {
+	return []string{
+		CodeRepositorySortByName,
+		CodeRepositorySortByCreationTime,
+		CodeRepositorySortByLastModifiedTime,
+	}
+}
+
 const (
 	// CodeRepositorySortOrderAscending is a CodeRepositorySortOrder enum value
 	CodeRepositorySortOrderAscending = "Ascending"
@@ -48951,6 +49199,14 @@ const (
 	// CodeRepositorySortOrderDescending is a CodeRepositorySortOrder enum value
 	CodeRepositorySortOrderDescending = "Descending"
 )
+
+// CodeRepositorySortOrder_Values returns all elements of the CodeRepositorySortOrder enum
+func CodeRepositorySortOrder_Values() []string {
+	return []string{
+		CodeRepositorySortOrderAscending,
+		CodeRepositorySortOrderDescending,
+	}
+}
 
 const (
 	// CompilationJobStatusInprogress is a CompilationJobStatus enum value
@@ -48972,6 +49228,18 @@ const (
 	CompilationJobStatusStopped = "STOPPED"
 )
 
+// CompilationJobStatus_Values returns all elements of the CompilationJobStatus enum
+func CompilationJobStatus_Values() []string {
+	return []string{
+		CompilationJobStatusInprogress,
+		CompilationJobStatusCompleted,
+		CompilationJobStatusFailed,
+		CompilationJobStatusStarting,
+		CompilationJobStatusStopping,
+		CompilationJobStatusStopped,
+	}
+}
+
 const (
 	// CompressionTypeNone is a CompressionType enum value
 	CompressionTypeNone = "None"
@@ -48979,6 +49247,14 @@ const (
 	// CompressionTypeGzip is a CompressionType enum value
 	CompressionTypeGzip = "Gzip"
 )
+
+// CompressionType_Values returns all elements of the CompressionType enum
+func CompressionType_Values() []string {
+	return []string{
+		CompressionTypeNone,
+		CompressionTypeGzip,
+	}
+}
 
 const (
 	// ContainerModeSingleModel is a ContainerMode enum value
@@ -48988,6 +49264,14 @@ const (
 	ContainerModeMultiModel = "MultiModel"
 )
 
+// ContainerMode_Values returns all elements of the ContainerMode enum
+func ContainerMode_Values() []string {
+	return []string{
+		ContainerModeSingleModel,
+		ContainerModeMultiModel,
+	}
+}
+
 const (
 	// ContentClassifierFreeOfPersonallyIdentifiableInformation is a ContentClassifier enum value
 	ContentClassifierFreeOfPersonallyIdentifiableInformation = "FreeOfPersonallyIdentifiableInformation"
@@ -48995,6 +49279,14 @@ const (
 	// ContentClassifierFreeOfAdultContent is a ContentClassifier enum value
 	ContentClassifierFreeOfAdultContent = "FreeOfAdultContent"
 )
+
+// ContentClassifier_Values returns all elements of the ContentClassifier enum
+func ContentClassifier_Values() []string {
+	return []string{
+		ContentClassifierFreeOfPersonallyIdentifiableInformation,
+		ContentClassifierFreeOfAdultContent,
+	}
+}
 
 const (
 	// DetailedAlgorithmStatusNotStarted is a DetailedAlgorithmStatus enum value
@@ -49010,6 +49302,16 @@ const (
 	DetailedAlgorithmStatusFailed = "Failed"
 )
 
+// DetailedAlgorithmStatus_Values returns all elements of the DetailedAlgorithmStatus enum
+func DetailedAlgorithmStatus_Values() []string {
+	return []string{
+		DetailedAlgorithmStatusNotStarted,
+		DetailedAlgorithmStatusInProgress,
+		DetailedAlgorithmStatusCompleted,
+		DetailedAlgorithmStatusFailed,
+	}
+}
+
 const (
 	// DetailedModelPackageStatusNotStarted is a DetailedModelPackageStatus enum value
 	DetailedModelPackageStatusNotStarted = "NotStarted"
@@ -49024,6 +49326,16 @@ const (
 	DetailedModelPackageStatusFailed = "Failed"
 )
 
+// DetailedModelPackageStatus_Values returns all elements of the DetailedModelPackageStatus enum
+func DetailedModelPackageStatus_Values() []string {
+	return []string{
+		DetailedModelPackageStatusNotStarted,
+		DetailedModelPackageStatusInProgress,
+		DetailedModelPackageStatusCompleted,
+		DetailedModelPackageStatusFailed,
+	}
+}
+
 const (
 	// DirectInternetAccessEnabled is a DirectInternetAccess enum value
 	DirectInternetAccessEnabled = "Enabled"
@@ -49031,6 +49343,14 @@ const (
 	// DirectInternetAccessDisabled is a DirectInternetAccess enum value
 	DirectInternetAccessDisabled = "Disabled"
 )
+
+// DirectInternetAccess_Values returns all elements of the DirectInternetAccess enum
+func DirectInternetAccess_Values() []string {
+	return []string{
+		DirectInternetAccessEnabled,
+		DirectInternetAccessDisabled,
+	}
+}
 
 const (
 	// DomainStatusDeleting is a DomainStatus enum value
@@ -49046,6 +49366,16 @@ const (
 	DomainStatusPending = "Pending"
 )
 
+// DomainStatus_Values returns all elements of the DomainStatus enum
+func DomainStatus_Values() []string {
+	return []string{
+		DomainStatusDeleting,
+		DomainStatusFailed,
+		DomainStatusInService,
+		DomainStatusPending,
+	}
+}
+
 const (
 	// EndpointConfigSortKeyName is a EndpointConfigSortKey enum value
 	EndpointConfigSortKeyName = "Name"
@@ -49053,6 +49383,14 @@ const (
 	// EndpointConfigSortKeyCreationTime is a EndpointConfigSortKey enum value
 	EndpointConfigSortKeyCreationTime = "CreationTime"
 )
+
+// EndpointConfigSortKey_Values returns all elements of the EndpointConfigSortKey enum
+func EndpointConfigSortKey_Values() []string {
+	return []string{
+		EndpointConfigSortKeyName,
+		EndpointConfigSortKeyCreationTime,
+	}
+}
 
 const (
 	// EndpointSortKeyName is a EndpointSortKey enum value
@@ -49064,6 +49402,15 @@ const (
 	// EndpointSortKeyStatus is a EndpointSortKey enum value
 	EndpointSortKeyStatus = "Status"
 )
+
+// EndpointSortKey_Values returns all elements of the EndpointSortKey enum
+func EndpointSortKey_Values() []string {
+	return []string{
+		EndpointSortKeyName,
+		EndpointSortKeyCreationTime,
+		EndpointSortKeyStatus,
+	}
+}
 
 const (
 	// EndpointStatusOutOfService is a EndpointStatus enum value
@@ -49091,6 +49438,20 @@ const (
 	EndpointStatusFailed = "Failed"
 )
 
+// EndpointStatus_Values returns all elements of the EndpointStatus enum
+func EndpointStatus_Values() []string {
+	return []string{
+		EndpointStatusOutOfService,
+		EndpointStatusCreating,
+		EndpointStatusUpdating,
+		EndpointStatusSystemUpdating,
+		EndpointStatusRollingBack,
+		EndpointStatusInService,
+		EndpointStatusDeleting,
+		EndpointStatusFailed,
+	}
+}
+
 const (
 	// ExecutionStatusPending is a ExecutionStatus enum value
 	ExecutionStatusPending = "Pending"
@@ -49114,6 +49475,19 @@ const (
 	ExecutionStatusStopped = "Stopped"
 )
 
+// ExecutionStatus_Values returns all elements of the ExecutionStatus enum
+func ExecutionStatus_Values() []string {
+	return []string{
+		ExecutionStatusPending,
+		ExecutionStatusCompleted,
+		ExecutionStatusCompletedWithViolations,
+		ExecutionStatusInProgress,
+		ExecutionStatusFailed,
+		ExecutionStatusStopping,
+		ExecutionStatusStopped,
+	}
+}
+
 const (
 	// FileSystemAccessModeRw is a FileSystemAccessMode enum value
 	FileSystemAccessModeRw = "rw"
@@ -49122,6 +49496,14 @@ const (
 	FileSystemAccessModeRo = "ro"
 )
 
+// FileSystemAccessMode_Values returns all elements of the FileSystemAccessMode enum
+func FileSystemAccessMode_Values() []string {
+	return []string{
+		FileSystemAccessModeRw,
+		FileSystemAccessModeRo,
+	}
+}
+
 const (
 	// FileSystemTypeEfs is a FileSystemType enum value
 	FileSystemTypeEfs = "EFS"
@@ -49129,6 +49511,14 @@ const (
 	// FileSystemTypeFsxLustre is a FileSystemType enum value
 	FileSystemTypeFsxLustre = "FSxLustre"
 )
+
+// FileSystemType_Values returns all elements of the FileSystemType enum
+func FileSystemType_Values() []string {
+	return []string{
+		FileSystemTypeEfs,
+		FileSystemTypeFsxLustre,
+	}
+}
 
 const (
 	// FlowDefinitionStatusInitializing is a FlowDefinitionStatus enum value
@@ -49143,6 +49533,16 @@ const (
 	// FlowDefinitionStatusDeleting is a FlowDefinitionStatus enum value
 	FlowDefinitionStatusDeleting = "Deleting"
 )
+
+// FlowDefinitionStatus_Values returns all elements of the FlowDefinitionStatus enum
+func FlowDefinitionStatus_Values() []string {
+	return []string{
+		FlowDefinitionStatusInitializing,
+		FlowDefinitionStatusActive,
+		FlowDefinitionStatusFailed,
+		FlowDefinitionStatusDeleting,
+	}
+}
 
 const (
 	// FrameworkTensorflow is a Framework enum value
@@ -49167,6 +49567,19 @@ const (
 	FrameworkTflite = "TFLITE"
 )
 
+// Framework_Values returns all elements of the Framework enum
+func Framework_Values() []string {
+	return []string{
+		FrameworkTensorflow,
+		FrameworkKeras,
+		FrameworkMxnet,
+		FrameworkOnnx,
+		FrameworkPytorch,
+		FrameworkXgboost,
+		FrameworkTflite,
+	}
+}
+
 const (
 	// HumanTaskUiStatusActive is a HumanTaskUiStatus enum value
 	HumanTaskUiStatusActive = "Active"
@@ -49174,6 +49587,14 @@ const (
 	// HumanTaskUiStatusDeleting is a HumanTaskUiStatus enum value
 	HumanTaskUiStatusDeleting = "Deleting"
 )
+
+// HumanTaskUiStatus_Values returns all elements of the HumanTaskUiStatus enum
+func HumanTaskUiStatus_Values() []string {
+	return []string{
+		HumanTaskUiStatusActive,
+		HumanTaskUiStatusDeleting,
+	}
+}
 
 const (
 	// HyperParameterScalingTypeAuto is a HyperParameterScalingType enum value
@@ -49189,6 +49610,16 @@ const (
 	HyperParameterScalingTypeReverseLogarithmic = "ReverseLogarithmic"
 )
 
+// HyperParameterScalingType_Values returns all elements of the HyperParameterScalingType enum
+func HyperParameterScalingType_Values() []string {
+	return []string{
+		HyperParameterScalingTypeAuto,
+		HyperParameterScalingTypeLinear,
+		HyperParameterScalingTypeLogarithmic,
+		HyperParameterScalingTypeReverseLogarithmic,
+	}
+}
+
 const (
 	// HyperParameterTuningJobObjectiveTypeMaximize is a HyperParameterTuningJobObjectiveType enum value
 	HyperParameterTuningJobObjectiveTypeMaximize = "Maximize"
@@ -49196,6 +49627,14 @@ const (
 	// HyperParameterTuningJobObjectiveTypeMinimize is a HyperParameterTuningJobObjectiveType enum value
 	HyperParameterTuningJobObjectiveTypeMinimize = "Minimize"
 )
+
+// HyperParameterTuningJobObjectiveType_Values returns all elements of the HyperParameterTuningJobObjectiveType enum
+func HyperParameterTuningJobObjectiveType_Values() []string {
+	return []string{
+		HyperParameterTuningJobObjectiveTypeMaximize,
+		HyperParameterTuningJobObjectiveTypeMinimize,
+	}
+}
 
 const (
 	// HyperParameterTuningJobSortByOptionsName is a HyperParameterTuningJobSortByOptions enum value
@@ -49207,6 +49646,15 @@ const (
 	// HyperParameterTuningJobSortByOptionsCreationTime is a HyperParameterTuningJobSortByOptions enum value
 	HyperParameterTuningJobSortByOptionsCreationTime = "CreationTime"
 )
+
+// HyperParameterTuningJobSortByOptions_Values returns all elements of the HyperParameterTuningJobSortByOptions enum
+func HyperParameterTuningJobSortByOptions_Values() []string {
+	return []string{
+		HyperParameterTuningJobSortByOptionsName,
+		HyperParameterTuningJobSortByOptionsStatus,
+		HyperParameterTuningJobSortByOptionsCreationTime,
+	}
+}
 
 const (
 	// HyperParameterTuningJobStatusCompleted is a HyperParameterTuningJobStatus enum value
@@ -49225,6 +49673,17 @@ const (
 	HyperParameterTuningJobStatusStopping = "Stopping"
 )
 
+// HyperParameterTuningJobStatus_Values returns all elements of the HyperParameterTuningJobStatus enum
+func HyperParameterTuningJobStatus_Values() []string {
+	return []string{
+		HyperParameterTuningJobStatusCompleted,
+		HyperParameterTuningJobStatusInProgress,
+		HyperParameterTuningJobStatusFailed,
+		HyperParameterTuningJobStatusStopped,
+		HyperParameterTuningJobStatusStopping,
+	}
+}
+
 // The strategy hyperparameter tuning uses to find the best combination of hyperparameters
 // for your model. Currently, the only supported value is Bayesian.
 const (
@@ -49235,6 +49694,14 @@ const (
 	HyperParameterTuningJobStrategyTypeRandom = "Random"
 )
 
+// HyperParameterTuningJobStrategyType_Values returns all elements of the HyperParameterTuningJobStrategyType enum
+func HyperParameterTuningJobStrategyType_Values() []string {
+	return []string{
+		HyperParameterTuningJobStrategyTypeBayesian,
+		HyperParameterTuningJobStrategyTypeRandom,
+	}
+}
+
 const (
 	// HyperParameterTuningJobWarmStartTypeIdenticalDataAndAlgorithm is a HyperParameterTuningJobWarmStartType enum value
 	HyperParameterTuningJobWarmStartTypeIdenticalDataAndAlgorithm = "IdenticalDataAndAlgorithm"
@@ -49242,6 +49709,14 @@ const (
 	// HyperParameterTuningJobWarmStartTypeTransferLearning is a HyperParameterTuningJobWarmStartType enum value
 	HyperParameterTuningJobWarmStartTypeTransferLearning = "TransferLearning"
 )
+
+// HyperParameterTuningJobWarmStartType_Values returns all elements of the HyperParameterTuningJobWarmStartType enum
+func HyperParameterTuningJobWarmStartType_Values() []string {
+	return []string{
+		HyperParameterTuningJobWarmStartTypeIdenticalDataAndAlgorithm,
+		HyperParameterTuningJobWarmStartTypeTransferLearning,
+	}
+}
 
 const (
 	// InstanceTypeMlT2Medium is a InstanceType enum value
@@ -49359,6 +49834,50 @@ const (
 	InstanceTypeMlP316xlarge = "ml.p3.16xlarge"
 )
 
+// InstanceType_Values returns all elements of the InstanceType enum
+func InstanceType_Values() []string {
+	return []string{
+		InstanceTypeMlT2Medium,
+		InstanceTypeMlT2Large,
+		InstanceTypeMlT2Xlarge,
+		InstanceTypeMlT22xlarge,
+		InstanceTypeMlT3Medium,
+		InstanceTypeMlT3Large,
+		InstanceTypeMlT3Xlarge,
+		InstanceTypeMlT32xlarge,
+		InstanceTypeMlM4Xlarge,
+		InstanceTypeMlM42xlarge,
+		InstanceTypeMlM44xlarge,
+		InstanceTypeMlM410xlarge,
+		InstanceTypeMlM416xlarge,
+		InstanceTypeMlM5Xlarge,
+		InstanceTypeMlM52xlarge,
+		InstanceTypeMlM54xlarge,
+		InstanceTypeMlM512xlarge,
+		InstanceTypeMlM524xlarge,
+		InstanceTypeMlC4Xlarge,
+		InstanceTypeMlC42xlarge,
+		InstanceTypeMlC44xlarge,
+		InstanceTypeMlC48xlarge,
+		InstanceTypeMlC5Xlarge,
+		InstanceTypeMlC52xlarge,
+		InstanceTypeMlC54xlarge,
+		InstanceTypeMlC59xlarge,
+		InstanceTypeMlC518xlarge,
+		InstanceTypeMlC5dXlarge,
+		InstanceTypeMlC5d2xlarge,
+		InstanceTypeMlC5d4xlarge,
+		InstanceTypeMlC5d9xlarge,
+		InstanceTypeMlC5d18xlarge,
+		InstanceTypeMlP2Xlarge,
+		InstanceTypeMlP28xlarge,
+		InstanceTypeMlP216xlarge,
+		InstanceTypeMlP32xlarge,
+		InstanceTypeMlP38xlarge,
+		InstanceTypeMlP316xlarge,
+	}
+}
+
 const (
 	// JoinSourceInput is a JoinSource enum value
 	JoinSourceInput = "Input"
@@ -49366,6 +49885,14 @@ const (
 	// JoinSourceNone is a JoinSource enum value
 	JoinSourceNone = "None"
 )
+
+// JoinSource_Values returns all elements of the JoinSource enum
+func JoinSource_Values() []string {
+	return []string{
+		JoinSourceInput,
+		JoinSourceNone,
+	}
+}
 
 const (
 	// LabelingJobStatusInitializing is a LabelingJobStatus enum value
@@ -49387,6 +49914,18 @@ const (
 	LabelingJobStatusStopped = "Stopped"
 )
 
+// LabelingJobStatus_Values returns all elements of the LabelingJobStatus enum
+func LabelingJobStatus_Values() []string {
+	return []string{
+		LabelingJobStatusInitializing,
+		LabelingJobStatusInProgress,
+		LabelingJobStatusCompleted,
+		LabelingJobStatusFailed,
+		LabelingJobStatusStopping,
+		LabelingJobStatusStopped,
+	}
+}
+
 const (
 	// ListCompilationJobsSortByName is a ListCompilationJobsSortBy enum value
 	ListCompilationJobsSortByName = "Name"
@@ -49398,10 +49937,26 @@ const (
 	ListCompilationJobsSortByStatus = "Status"
 )
 
+// ListCompilationJobsSortBy_Values returns all elements of the ListCompilationJobsSortBy enum
+func ListCompilationJobsSortBy_Values() []string {
+	return []string{
+		ListCompilationJobsSortByName,
+		ListCompilationJobsSortByCreationTime,
+		ListCompilationJobsSortByStatus,
+	}
+}
+
 const (
 	// ListLabelingJobsForWorkteamSortByOptionsCreationTime is a ListLabelingJobsForWorkteamSortByOptions enum value
 	ListLabelingJobsForWorkteamSortByOptionsCreationTime = "CreationTime"
 )
+
+// ListLabelingJobsForWorkteamSortByOptions_Values returns all elements of the ListLabelingJobsForWorkteamSortByOptions enum
+func ListLabelingJobsForWorkteamSortByOptions_Values() []string {
+	return []string{
+		ListLabelingJobsForWorkteamSortByOptionsCreationTime,
+	}
+}
 
 const (
 	// ListWorkforcesSortByOptionsName is a ListWorkforcesSortByOptions enum value
@@ -49411,6 +49966,14 @@ const (
 	ListWorkforcesSortByOptionsCreateDate = "CreateDate"
 )
 
+// ListWorkforcesSortByOptions_Values returns all elements of the ListWorkforcesSortByOptions enum
+func ListWorkforcesSortByOptions_Values() []string {
+	return []string{
+		ListWorkforcesSortByOptionsName,
+		ListWorkforcesSortByOptionsCreateDate,
+	}
+}
+
 const (
 	// ListWorkteamsSortByOptionsName is a ListWorkteamsSortByOptions enum value
 	ListWorkteamsSortByOptionsName = "Name"
@@ -49419,6 +49982,14 @@ const (
 	ListWorkteamsSortByOptionsCreateDate = "CreateDate"
 )
 
+// ListWorkteamsSortByOptions_Values returns all elements of the ListWorkteamsSortByOptions enum
+func ListWorkteamsSortByOptions_Values() []string {
+	return []string{
+		ListWorkteamsSortByOptionsName,
+		ListWorkteamsSortByOptionsCreateDate,
+	}
+}
+
 const (
 	// ModelPackageSortByName is a ModelPackageSortBy enum value
 	ModelPackageSortByName = "Name"
@@ -49426,6 +49997,14 @@ const (
 	// ModelPackageSortByCreationTime is a ModelPackageSortBy enum value
 	ModelPackageSortByCreationTime = "CreationTime"
 )
+
+// ModelPackageSortBy_Values returns all elements of the ModelPackageSortBy enum
+func ModelPackageSortBy_Values() []string {
+	return []string{
+		ModelPackageSortByName,
+		ModelPackageSortByCreationTime,
+	}
+}
 
 const (
 	// ModelPackageStatusPending is a ModelPackageStatus enum value
@@ -49444,6 +50023,17 @@ const (
 	ModelPackageStatusDeleting = "Deleting"
 )
 
+// ModelPackageStatus_Values returns all elements of the ModelPackageStatus enum
+func ModelPackageStatus_Values() []string {
+	return []string{
+		ModelPackageStatusPending,
+		ModelPackageStatusInProgress,
+		ModelPackageStatusCompleted,
+		ModelPackageStatusFailed,
+		ModelPackageStatusDeleting,
+	}
+}
+
 const (
 	// ModelSortKeyName is a ModelSortKey enum value
 	ModelSortKeyName = "Name"
@@ -49451,6 +50041,14 @@ const (
 	// ModelSortKeyCreationTime is a ModelSortKey enum value
 	ModelSortKeyCreationTime = "CreationTime"
 )
+
+// ModelSortKey_Values returns all elements of the ModelSortKey enum
+func ModelSortKey_Values() []string {
+	return []string{
+		ModelSortKeyName,
+		ModelSortKeyCreationTime,
+	}
+}
 
 const (
 	// MonitoringExecutionSortKeyCreationTime is a MonitoringExecutionSortKey enum value
@@ -49463,6 +50061,15 @@ const (
 	MonitoringExecutionSortKeyStatus = "Status"
 )
 
+// MonitoringExecutionSortKey_Values returns all elements of the MonitoringExecutionSortKey enum
+func MonitoringExecutionSortKey_Values() []string {
+	return []string{
+		MonitoringExecutionSortKeyCreationTime,
+		MonitoringExecutionSortKeyScheduledTime,
+		MonitoringExecutionSortKeyStatus,
+	}
+}
+
 const (
 	// MonitoringScheduleSortKeyName is a MonitoringScheduleSortKey enum value
 	MonitoringScheduleSortKeyName = "Name"
@@ -49473,6 +50080,15 @@ const (
 	// MonitoringScheduleSortKeyStatus is a MonitoringScheduleSortKey enum value
 	MonitoringScheduleSortKeyStatus = "Status"
 )
+
+// MonitoringScheduleSortKey_Values returns all elements of the MonitoringScheduleSortKey enum
+func MonitoringScheduleSortKey_Values() []string {
+	return []string{
+		MonitoringScheduleSortKeyName,
+		MonitoringScheduleSortKeyCreationTime,
+		MonitoringScheduleSortKeyStatus,
+	}
+}
 
 const (
 	// NotebookInstanceAcceleratorTypeMlEia1Medium is a NotebookInstanceAcceleratorType enum value
@@ -49494,6 +50110,18 @@ const (
 	NotebookInstanceAcceleratorTypeMlEia2Xlarge = "ml.eia2.xlarge"
 )
 
+// NotebookInstanceAcceleratorType_Values returns all elements of the NotebookInstanceAcceleratorType enum
+func NotebookInstanceAcceleratorType_Values() []string {
+	return []string{
+		NotebookInstanceAcceleratorTypeMlEia1Medium,
+		NotebookInstanceAcceleratorTypeMlEia1Large,
+		NotebookInstanceAcceleratorTypeMlEia1Xlarge,
+		NotebookInstanceAcceleratorTypeMlEia2Medium,
+		NotebookInstanceAcceleratorTypeMlEia2Large,
+		NotebookInstanceAcceleratorTypeMlEia2Xlarge,
+	}
+}
+
 const (
 	// NotebookInstanceLifecycleConfigSortKeyName is a NotebookInstanceLifecycleConfigSortKey enum value
 	NotebookInstanceLifecycleConfigSortKeyName = "Name"
@@ -49505,6 +50133,15 @@ const (
 	NotebookInstanceLifecycleConfigSortKeyLastModifiedTime = "LastModifiedTime"
 )
 
+// NotebookInstanceLifecycleConfigSortKey_Values returns all elements of the NotebookInstanceLifecycleConfigSortKey enum
+func NotebookInstanceLifecycleConfigSortKey_Values() []string {
+	return []string{
+		NotebookInstanceLifecycleConfigSortKeyName,
+		NotebookInstanceLifecycleConfigSortKeyCreationTime,
+		NotebookInstanceLifecycleConfigSortKeyLastModifiedTime,
+	}
+}
+
 const (
 	// NotebookInstanceLifecycleConfigSortOrderAscending is a NotebookInstanceLifecycleConfigSortOrder enum value
 	NotebookInstanceLifecycleConfigSortOrderAscending = "Ascending"
@@ -49512,6 +50149,14 @@ const (
 	// NotebookInstanceLifecycleConfigSortOrderDescending is a NotebookInstanceLifecycleConfigSortOrder enum value
 	NotebookInstanceLifecycleConfigSortOrderDescending = "Descending"
 )
+
+// NotebookInstanceLifecycleConfigSortOrder_Values returns all elements of the NotebookInstanceLifecycleConfigSortOrder enum
+func NotebookInstanceLifecycleConfigSortOrder_Values() []string {
+	return []string{
+		NotebookInstanceLifecycleConfigSortOrderAscending,
+		NotebookInstanceLifecycleConfigSortOrderDescending,
+	}
+}
 
 const (
 	// NotebookInstanceSortKeyName is a NotebookInstanceSortKey enum value
@@ -49524,6 +50169,15 @@ const (
 	NotebookInstanceSortKeyStatus = "Status"
 )
 
+// NotebookInstanceSortKey_Values returns all elements of the NotebookInstanceSortKey enum
+func NotebookInstanceSortKey_Values() []string {
+	return []string{
+		NotebookInstanceSortKeyName,
+		NotebookInstanceSortKeyCreationTime,
+		NotebookInstanceSortKeyStatus,
+	}
+}
+
 const (
 	// NotebookInstanceSortOrderAscending is a NotebookInstanceSortOrder enum value
 	NotebookInstanceSortOrderAscending = "Ascending"
@@ -49531,6 +50185,14 @@ const (
 	// NotebookInstanceSortOrderDescending is a NotebookInstanceSortOrder enum value
 	NotebookInstanceSortOrderDescending = "Descending"
 )
+
+// NotebookInstanceSortOrder_Values returns all elements of the NotebookInstanceSortOrder enum
+func NotebookInstanceSortOrder_Values() []string {
+	return []string{
+		NotebookInstanceSortOrderAscending,
+		NotebookInstanceSortOrderDescending,
+	}
+}
 
 const (
 	// NotebookInstanceStatusPending is a NotebookInstanceStatus enum value
@@ -49555,6 +50217,19 @@ const (
 	NotebookInstanceStatusUpdating = "Updating"
 )
 
+// NotebookInstanceStatus_Values returns all elements of the NotebookInstanceStatus enum
+func NotebookInstanceStatus_Values() []string {
+	return []string{
+		NotebookInstanceStatusPending,
+		NotebookInstanceStatusInService,
+		NotebookInstanceStatusStopping,
+		NotebookInstanceStatusStopped,
+		NotebookInstanceStatusFailed,
+		NotebookInstanceStatusDeleting,
+		NotebookInstanceStatusUpdating,
+	}
+}
+
 const (
 	// NotebookOutputOptionAllowed is a NotebookOutputOption enum value
 	NotebookOutputOptionAllowed = "Allowed"
@@ -49562,6 +50237,14 @@ const (
 	// NotebookOutputOptionDisabled is a NotebookOutputOption enum value
 	NotebookOutputOptionDisabled = "Disabled"
 )
+
+// NotebookOutputOption_Values returns all elements of the NotebookOutputOption enum
+func NotebookOutputOption_Values() []string {
+	return []string{
+		NotebookOutputOptionAllowed,
+		NotebookOutputOptionDisabled,
+	}
+}
 
 const (
 	// ObjectiveStatusSucceeded is a ObjectiveStatus enum value
@@ -49573,6 +50256,15 @@ const (
 	// ObjectiveStatusFailed is a ObjectiveStatus enum value
 	ObjectiveStatusFailed = "Failed"
 )
+
+// ObjectiveStatus_Values returns all elements of the ObjectiveStatus enum
+func ObjectiveStatus_Values() []string {
+	return []string{
+		ObjectiveStatusSucceeded,
+		ObjectiveStatusPending,
+		ObjectiveStatusFailed,
+	}
+}
 
 const (
 	// OperatorEquals is a Operator enum value
@@ -49606,6 +50298,22 @@ const (
 	OperatorIn = "In"
 )
 
+// Operator_Values returns all elements of the Operator enum
+func Operator_Values() []string {
+	return []string{
+		OperatorEquals,
+		OperatorNotEquals,
+		OperatorGreaterThan,
+		OperatorGreaterThanOrEqualTo,
+		OperatorLessThan,
+		OperatorLessThanOrEqualTo,
+		OperatorContains,
+		OperatorExists,
+		OperatorNotExists,
+		OperatorIn,
+	}
+}
+
 const (
 	// OrderKeyAscending is a OrderKey enum value
 	OrderKeyAscending = "Ascending"
@@ -49613,6 +50321,14 @@ const (
 	// OrderKeyDescending is a OrderKey enum value
 	OrderKeyDescending = "Descending"
 )
+
+// OrderKey_Values returns all elements of the OrderKey enum
+func OrderKey_Values() []string {
+	return []string{
+		OrderKeyAscending,
+		OrderKeyDescending,
+	}
+}
 
 const (
 	// ParameterTypeInteger is a ParameterType enum value
@@ -49628,6 +50344,16 @@ const (
 	ParameterTypeFreeText = "FreeText"
 )
 
+// ParameterType_Values returns all elements of the ParameterType enum
+func ParameterType_Values() []string {
+	return []string{
+		ParameterTypeInteger,
+		ParameterTypeContinuous,
+		ParameterTypeCategorical,
+		ParameterTypeFreeText,
+	}
+}
+
 const (
 	// ProblemTypeBinaryClassification is a ProblemType enum value
 	ProblemTypeBinaryClassification = "BinaryClassification"
@@ -49638,6 +50364,15 @@ const (
 	// ProblemTypeRegression is a ProblemType enum value
 	ProblemTypeRegression = "Regression"
 )
+
+// ProblemType_Values returns all elements of the ProblemType enum
+func ProblemType_Values() []string {
+	return []string{
+		ProblemTypeBinaryClassification,
+		ProblemTypeMulticlassClassification,
+		ProblemTypeRegression,
+	}
+}
 
 const (
 	// ProcessingInstanceTypeMlT3Medium is a ProcessingInstanceType enum value
@@ -49755,6 +50490,50 @@ const (
 	ProcessingInstanceTypeMlR524xlarge = "ml.r5.24xlarge"
 )
 
+// ProcessingInstanceType_Values returns all elements of the ProcessingInstanceType enum
+func ProcessingInstanceType_Values() []string {
+	return []string{
+		ProcessingInstanceTypeMlT3Medium,
+		ProcessingInstanceTypeMlT3Large,
+		ProcessingInstanceTypeMlT3Xlarge,
+		ProcessingInstanceTypeMlT32xlarge,
+		ProcessingInstanceTypeMlM4Xlarge,
+		ProcessingInstanceTypeMlM42xlarge,
+		ProcessingInstanceTypeMlM44xlarge,
+		ProcessingInstanceTypeMlM410xlarge,
+		ProcessingInstanceTypeMlM416xlarge,
+		ProcessingInstanceTypeMlC4Xlarge,
+		ProcessingInstanceTypeMlC42xlarge,
+		ProcessingInstanceTypeMlC44xlarge,
+		ProcessingInstanceTypeMlC48xlarge,
+		ProcessingInstanceTypeMlP2Xlarge,
+		ProcessingInstanceTypeMlP28xlarge,
+		ProcessingInstanceTypeMlP216xlarge,
+		ProcessingInstanceTypeMlP32xlarge,
+		ProcessingInstanceTypeMlP38xlarge,
+		ProcessingInstanceTypeMlP316xlarge,
+		ProcessingInstanceTypeMlC5Xlarge,
+		ProcessingInstanceTypeMlC52xlarge,
+		ProcessingInstanceTypeMlC54xlarge,
+		ProcessingInstanceTypeMlC59xlarge,
+		ProcessingInstanceTypeMlC518xlarge,
+		ProcessingInstanceTypeMlM5Large,
+		ProcessingInstanceTypeMlM5Xlarge,
+		ProcessingInstanceTypeMlM52xlarge,
+		ProcessingInstanceTypeMlM54xlarge,
+		ProcessingInstanceTypeMlM512xlarge,
+		ProcessingInstanceTypeMlM524xlarge,
+		ProcessingInstanceTypeMlR5Large,
+		ProcessingInstanceTypeMlR5Xlarge,
+		ProcessingInstanceTypeMlR52xlarge,
+		ProcessingInstanceTypeMlR54xlarge,
+		ProcessingInstanceTypeMlR58xlarge,
+		ProcessingInstanceTypeMlR512xlarge,
+		ProcessingInstanceTypeMlR516xlarge,
+		ProcessingInstanceTypeMlR524xlarge,
+	}
+}
+
 const (
 	// ProcessingJobStatusInProgress is a ProcessingJobStatus enum value
 	ProcessingJobStatusInProgress = "InProgress"
@@ -49772,6 +50551,17 @@ const (
 	ProcessingJobStatusStopped = "Stopped"
 )
 
+// ProcessingJobStatus_Values returns all elements of the ProcessingJobStatus enum
+func ProcessingJobStatus_Values() []string {
+	return []string{
+		ProcessingJobStatusInProgress,
+		ProcessingJobStatusCompleted,
+		ProcessingJobStatusFailed,
+		ProcessingJobStatusStopping,
+		ProcessingJobStatusStopped,
+	}
+}
+
 const (
 	// ProcessingS3CompressionTypeNone is a ProcessingS3CompressionType enum value
 	ProcessingS3CompressionTypeNone = "None"
@@ -49779,6 +50569,14 @@ const (
 	// ProcessingS3CompressionTypeGzip is a ProcessingS3CompressionType enum value
 	ProcessingS3CompressionTypeGzip = "Gzip"
 )
+
+// ProcessingS3CompressionType_Values returns all elements of the ProcessingS3CompressionType enum
+func ProcessingS3CompressionType_Values() []string {
+	return []string{
+		ProcessingS3CompressionTypeNone,
+		ProcessingS3CompressionTypeGzip,
+	}
+}
 
 const (
 	// ProcessingS3DataDistributionTypeFullyReplicated is a ProcessingS3DataDistributionType enum value
@@ -49788,6 +50586,14 @@ const (
 	ProcessingS3DataDistributionTypeShardedByS3key = "ShardedByS3Key"
 )
 
+// ProcessingS3DataDistributionType_Values returns all elements of the ProcessingS3DataDistributionType enum
+func ProcessingS3DataDistributionType_Values() []string {
+	return []string{
+		ProcessingS3DataDistributionTypeFullyReplicated,
+		ProcessingS3DataDistributionTypeShardedByS3key,
+	}
+}
+
 const (
 	// ProcessingS3DataTypeManifestFile is a ProcessingS3DataType enum value
 	ProcessingS3DataTypeManifestFile = "ManifestFile"
@@ -49795,6 +50601,14 @@ const (
 	// ProcessingS3DataTypeS3prefix is a ProcessingS3DataType enum value
 	ProcessingS3DataTypeS3prefix = "S3Prefix"
 )
+
+// ProcessingS3DataType_Values returns all elements of the ProcessingS3DataType enum
+func ProcessingS3DataType_Values() []string {
+	return []string{
+		ProcessingS3DataTypeManifestFile,
+		ProcessingS3DataTypeS3prefix,
+	}
+}
 
 const (
 	// ProcessingS3InputModePipe is a ProcessingS3InputMode enum value
@@ -49804,6 +50618,14 @@ const (
 	ProcessingS3InputModeFile = "File"
 )
 
+// ProcessingS3InputMode_Values returns all elements of the ProcessingS3InputMode enum
+func ProcessingS3InputMode_Values() []string {
+	return []string{
+		ProcessingS3InputModePipe,
+		ProcessingS3InputModeFile,
+	}
+}
+
 const (
 	// ProcessingS3UploadModeContinuous is a ProcessingS3UploadMode enum value
 	ProcessingS3UploadModeContinuous = "Continuous"
@@ -49811,6 +50633,14 @@ const (
 	// ProcessingS3UploadModeEndOfJob is a ProcessingS3UploadMode enum value
 	ProcessingS3UploadModeEndOfJob = "EndOfJob"
 )
+
+// ProcessingS3UploadMode_Values returns all elements of the ProcessingS3UploadMode enum
+func ProcessingS3UploadMode_Values() []string {
+	return []string{
+		ProcessingS3UploadModeContinuous,
+		ProcessingS3UploadModeEndOfJob,
+	}
+}
 
 const (
 	// ProductionVariantAcceleratorTypeMlEia1Medium is a ProductionVariantAcceleratorType enum value
@@ -49831,6 +50661,18 @@ const (
 	// ProductionVariantAcceleratorTypeMlEia2Xlarge is a ProductionVariantAcceleratorType enum value
 	ProductionVariantAcceleratorTypeMlEia2Xlarge = "ml.eia2.xlarge"
 )
+
+// ProductionVariantAcceleratorType_Values returns all elements of the ProductionVariantAcceleratorType enum
+func ProductionVariantAcceleratorType_Values() []string {
+	return []string{
+		ProductionVariantAcceleratorTypeMlEia1Medium,
+		ProductionVariantAcceleratorTypeMlEia1Large,
+		ProductionVariantAcceleratorTypeMlEia1Xlarge,
+		ProductionVariantAcceleratorTypeMlEia2Medium,
+		ProductionVariantAcceleratorTypeMlEia2Large,
+		ProductionVariantAcceleratorTypeMlEia2Xlarge,
+	}
+}
 
 const (
 	// ProductionVariantInstanceTypeMlT2Medium is a ProductionVariantInstanceType enum value
@@ -50032,6 +50874,78 @@ const (
 	ProductionVariantInstanceTypeMlInf124xlarge = "ml.inf1.24xlarge"
 )
 
+// ProductionVariantInstanceType_Values returns all elements of the ProductionVariantInstanceType enum
+func ProductionVariantInstanceType_Values() []string {
+	return []string{
+		ProductionVariantInstanceTypeMlT2Medium,
+		ProductionVariantInstanceTypeMlT2Large,
+		ProductionVariantInstanceTypeMlT2Xlarge,
+		ProductionVariantInstanceTypeMlT22xlarge,
+		ProductionVariantInstanceTypeMlM4Xlarge,
+		ProductionVariantInstanceTypeMlM42xlarge,
+		ProductionVariantInstanceTypeMlM44xlarge,
+		ProductionVariantInstanceTypeMlM410xlarge,
+		ProductionVariantInstanceTypeMlM416xlarge,
+		ProductionVariantInstanceTypeMlM5Large,
+		ProductionVariantInstanceTypeMlM5Xlarge,
+		ProductionVariantInstanceTypeMlM52xlarge,
+		ProductionVariantInstanceTypeMlM54xlarge,
+		ProductionVariantInstanceTypeMlM512xlarge,
+		ProductionVariantInstanceTypeMlM524xlarge,
+		ProductionVariantInstanceTypeMlM5dLarge,
+		ProductionVariantInstanceTypeMlM5dXlarge,
+		ProductionVariantInstanceTypeMlM5d2xlarge,
+		ProductionVariantInstanceTypeMlM5d4xlarge,
+		ProductionVariantInstanceTypeMlM5d12xlarge,
+		ProductionVariantInstanceTypeMlM5d24xlarge,
+		ProductionVariantInstanceTypeMlC4Large,
+		ProductionVariantInstanceTypeMlC4Xlarge,
+		ProductionVariantInstanceTypeMlC42xlarge,
+		ProductionVariantInstanceTypeMlC44xlarge,
+		ProductionVariantInstanceTypeMlC48xlarge,
+		ProductionVariantInstanceTypeMlP2Xlarge,
+		ProductionVariantInstanceTypeMlP28xlarge,
+		ProductionVariantInstanceTypeMlP216xlarge,
+		ProductionVariantInstanceTypeMlP32xlarge,
+		ProductionVariantInstanceTypeMlP38xlarge,
+		ProductionVariantInstanceTypeMlP316xlarge,
+		ProductionVariantInstanceTypeMlC5Large,
+		ProductionVariantInstanceTypeMlC5Xlarge,
+		ProductionVariantInstanceTypeMlC52xlarge,
+		ProductionVariantInstanceTypeMlC54xlarge,
+		ProductionVariantInstanceTypeMlC59xlarge,
+		ProductionVariantInstanceTypeMlC518xlarge,
+		ProductionVariantInstanceTypeMlC5dLarge,
+		ProductionVariantInstanceTypeMlC5dXlarge,
+		ProductionVariantInstanceTypeMlC5d2xlarge,
+		ProductionVariantInstanceTypeMlC5d4xlarge,
+		ProductionVariantInstanceTypeMlC5d9xlarge,
+		ProductionVariantInstanceTypeMlC5d18xlarge,
+		ProductionVariantInstanceTypeMlG4dnXlarge,
+		ProductionVariantInstanceTypeMlG4dn2xlarge,
+		ProductionVariantInstanceTypeMlG4dn4xlarge,
+		ProductionVariantInstanceTypeMlG4dn8xlarge,
+		ProductionVariantInstanceTypeMlG4dn12xlarge,
+		ProductionVariantInstanceTypeMlG4dn16xlarge,
+		ProductionVariantInstanceTypeMlR5Large,
+		ProductionVariantInstanceTypeMlR5Xlarge,
+		ProductionVariantInstanceTypeMlR52xlarge,
+		ProductionVariantInstanceTypeMlR54xlarge,
+		ProductionVariantInstanceTypeMlR512xlarge,
+		ProductionVariantInstanceTypeMlR524xlarge,
+		ProductionVariantInstanceTypeMlR5dLarge,
+		ProductionVariantInstanceTypeMlR5dXlarge,
+		ProductionVariantInstanceTypeMlR5d2xlarge,
+		ProductionVariantInstanceTypeMlR5d4xlarge,
+		ProductionVariantInstanceTypeMlR5d12xlarge,
+		ProductionVariantInstanceTypeMlR5d24xlarge,
+		ProductionVariantInstanceTypeMlInf1Xlarge,
+		ProductionVariantInstanceTypeMlInf12xlarge,
+		ProductionVariantInstanceTypeMlInf16xlarge,
+		ProductionVariantInstanceTypeMlInf124xlarge,
+	}
+}
+
 const (
 	// RecordWrapperNone is a RecordWrapper enum value
 	RecordWrapperNone = "None"
@@ -50039,6 +50953,14 @@ const (
 	// RecordWrapperRecordIo is a RecordWrapper enum value
 	RecordWrapperRecordIo = "RecordIO"
 )
+
+// RecordWrapper_Values returns all elements of the RecordWrapper enum
+func RecordWrapper_Values() []string {
+	return []string{
+		RecordWrapperNone,
+		RecordWrapperRecordIo,
+	}
+}
 
 const (
 	// ResourceTypeTrainingJob is a ResourceType enum value
@@ -50054,6 +50976,16 @@ const (
 	ResourceTypeExperimentTrialComponent = "ExperimentTrialComponent"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeTrainingJob,
+		ResourceTypeExperiment,
+		ResourceTypeExperimentTrial,
+		ResourceTypeExperimentTrialComponent,
+	}
+}
+
 const (
 	// RetentionTypeRetain is a RetentionType enum value
 	RetentionTypeRetain = "Retain"
@@ -50062,6 +50994,14 @@ const (
 	RetentionTypeDelete = "Delete"
 )
 
+// RetentionType_Values returns all elements of the RetentionType enum
+func RetentionType_Values() []string {
+	return []string{
+		RetentionTypeRetain,
+		RetentionTypeDelete,
+	}
+}
+
 const (
 	// RootAccessEnabled is a RootAccess enum value
 	RootAccessEnabled = "Enabled"
@@ -50069,6 +51009,14 @@ const (
 	// RootAccessDisabled is a RootAccess enum value
 	RootAccessDisabled = "Disabled"
 )
+
+// RootAccess_Values returns all elements of the RootAccess enum
+func RootAccess_Values() []string {
+	return []string{
+		RootAccessEnabled,
+		RootAccessDisabled,
+	}
+}
 
 const (
 	// RuleEvaluationStatusInProgress is a RuleEvaluationStatus enum value
@@ -50090,6 +51038,18 @@ const (
 	RuleEvaluationStatusStopped = "Stopped"
 )
 
+// RuleEvaluationStatus_Values returns all elements of the RuleEvaluationStatus enum
+func RuleEvaluationStatus_Values() []string {
+	return []string{
+		RuleEvaluationStatusInProgress,
+		RuleEvaluationStatusNoIssuesFound,
+		RuleEvaluationStatusIssuesFound,
+		RuleEvaluationStatusError,
+		RuleEvaluationStatusStopping,
+		RuleEvaluationStatusStopped,
+	}
+}
+
 const (
 	// S3DataDistributionFullyReplicated is a S3DataDistribution enum value
 	S3DataDistributionFullyReplicated = "FullyReplicated"
@@ -50097,6 +51057,14 @@ const (
 	// S3DataDistributionShardedByS3key is a S3DataDistribution enum value
 	S3DataDistributionShardedByS3key = "ShardedByS3Key"
 )
+
+// S3DataDistribution_Values returns all elements of the S3DataDistribution enum
+func S3DataDistribution_Values() []string {
+	return []string{
+		S3DataDistributionFullyReplicated,
+		S3DataDistributionShardedByS3key,
+	}
+}
 
 const (
 	// S3DataTypeManifestFile is a S3DataType enum value
@@ -50108,6 +51076,15 @@ const (
 	// S3DataTypeAugmentedManifestFile is a S3DataType enum value
 	S3DataTypeAugmentedManifestFile = "AugmentedManifestFile"
 )
+
+// S3DataType_Values returns all elements of the S3DataType enum
+func S3DataType_Values() []string {
+	return []string{
+		S3DataTypeManifestFile,
+		S3DataTypeS3prefix,
+		S3DataTypeAugmentedManifestFile,
+	}
+}
 
 const (
 	// ScheduleStatusPending is a ScheduleStatus enum value
@@ -50123,6 +51100,16 @@ const (
 	ScheduleStatusStopped = "Stopped"
 )
 
+// ScheduleStatus_Values returns all elements of the ScheduleStatus enum
+func ScheduleStatus_Values() []string {
+	return []string{
+		ScheduleStatusPending,
+		ScheduleStatusFailed,
+		ScheduleStatusScheduled,
+		ScheduleStatusStopped,
+	}
+}
+
 const (
 	// SearchSortOrderAscending is a SearchSortOrder enum value
 	SearchSortOrderAscending = "Ascending"
@@ -50130,6 +51117,14 @@ const (
 	// SearchSortOrderDescending is a SearchSortOrder enum value
 	SearchSortOrderDescending = "Descending"
 )
+
+// SearchSortOrder_Values returns all elements of the SearchSortOrder enum
+func SearchSortOrder_Values() []string {
+	return []string{
+		SearchSortOrderAscending,
+		SearchSortOrderDescending,
+	}
+}
 
 const (
 	// SecondaryStatusStarting is a SecondaryStatus enum value
@@ -50175,6 +51170,26 @@ const (
 	SecondaryStatusMaxWaitTimeExceeded = "MaxWaitTimeExceeded"
 )
 
+// SecondaryStatus_Values returns all elements of the SecondaryStatus enum
+func SecondaryStatus_Values() []string {
+	return []string{
+		SecondaryStatusStarting,
+		SecondaryStatusLaunchingMlinstances,
+		SecondaryStatusPreparingTrainingStack,
+		SecondaryStatusDownloading,
+		SecondaryStatusDownloadingTrainingImage,
+		SecondaryStatusTraining,
+		SecondaryStatusUploading,
+		SecondaryStatusStopping,
+		SecondaryStatusStopped,
+		SecondaryStatusMaxRuntimeExceeded,
+		SecondaryStatusCompleted,
+		SecondaryStatusFailed,
+		SecondaryStatusInterrupted,
+		SecondaryStatusMaxWaitTimeExceeded,
+	}
+}
+
 const (
 	// SortByName is a SortBy enum value
 	SortByName = "Name"
@@ -50186,6 +51201,15 @@ const (
 	SortByStatus = "Status"
 )
 
+// SortBy_Values returns all elements of the SortBy enum
+func SortBy_Values() []string {
+	return []string{
+		SortByName,
+		SortByCreationTime,
+		SortByStatus,
+	}
+}
+
 const (
 	// SortExperimentsByName is a SortExperimentsBy enum value
 	SortExperimentsByName = "Name"
@@ -50193,6 +51217,14 @@ const (
 	// SortExperimentsByCreationTime is a SortExperimentsBy enum value
 	SortExperimentsByCreationTime = "CreationTime"
 )
+
+// SortExperimentsBy_Values returns all elements of the SortExperimentsBy enum
+func SortExperimentsBy_Values() []string {
+	return []string{
+		SortExperimentsByName,
+		SortExperimentsByCreationTime,
+	}
+}
 
 const (
 	// SortOrderAscending is a SortOrder enum value
@@ -50202,6 +51234,14 @@ const (
 	SortOrderDescending = "Descending"
 )
 
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderAscending,
+		SortOrderDescending,
+	}
+}
+
 const (
 	// SortTrialComponentsByName is a SortTrialComponentsBy enum value
 	SortTrialComponentsByName = "Name"
@@ -50210,6 +51250,14 @@ const (
 	SortTrialComponentsByCreationTime = "CreationTime"
 )
 
+// SortTrialComponentsBy_Values returns all elements of the SortTrialComponentsBy enum
+func SortTrialComponentsBy_Values() []string {
+	return []string{
+		SortTrialComponentsByName,
+		SortTrialComponentsByCreationTime,
+	}
+}
+
 const (
 	// SortTrialsByName is a SortTrialsBy enum value
 	SortTrialsByName = "Name"
@@ -50217,6 +51265,14 @@ const (
 	// SortTrialsByCreationTime is a SortTrialsBy enum value
 	SortTrialsByCreationTime = "CreationTime"
 )
+
+// SortTrialsBy_Values returns all elements of the SortTrialsBy enum
+func SortTrialsBy_Values() []string {
+	return []string{
+		SortTrialsByName,
+		SortTrialsByCreationTime,
+	}
+}
 
 const (
 	// SplitTypeNone is a SplitType enum value
@@ -50231,6 +51287,16 @@ const (
 	// SplitTypeTfrecord is a SplitType enum value
 	SplitTypeTfrecord = "TFRecord"
 )
+
+// SplitType_Values returns all elements of the SplitType enum
+func SplitType_Values() []string {
+	return []string{
+		SplitTypeNone,
+		SplitTypeLine,
+		SplitTypeRecordIo,
+		SplitTypeTfrecord,
+	}
+}
 
 const (
 	// TargetDeviceLambda is a TargetDevice enum value
@@ -50312,6 +51378,38 @@ const (
 	TargetDeviceX86Win64 = "x86_win64"
 )
 
+// TargetDevice_Values returns all elements of the TargetDevice enum
+func TargetDevice_Values() []string {
+	return []string{
+		TargetDeviceLambda,
+		TargetDeviceMlM4,
+		TargetDeviceMlM5,
+		TargetDeviceMlC4,
+		TargetDeviceMlC5,
+		TargetDeviceMlP2,
+		TargetDeviceMlP3,
+		TargetDeviceMlG4dn,
+		TargetDeviceMlInf1,
+		TargetDeviceJetsonTx1,
+		TargetDeviceJetsonTx2,
+		TargetDeviceJetsonNano,
+		TargetDeviceJetsonXavier,
+		TargetDeviceRasp3b,
+		TargetDeviceImx8qm,
+		TargetDeviceDeeplens,
+		TargetDeviceRk3399,
+		TargetDeviceRk3288,
+		TargetDeviceAisage,
+		TargetDeviceSbeC,
+		TargetDeviceQcs605,
+		TargetDeviceQcs603,
+		TargetDeviceSitaraAm57x,
+		TargetDeviceAmbaCv22,
+		TargetDeviceX86Win32,
+		TargetDeviceX86Win64,
+	}
+}
+
 const (
 	// TargetPlatformAcceleratorIntelGraphics is a TargetPlatformAccelerator enum value
 	TargetPlatformAcceleratorIntelGraphics = "INTEL_GRAPHICS"
@@ -50322,6 +51420,15 @@ const (
 	// TargetPlatformAcceleratorNvidia is a TargetPlatformAccelerator enum value
 	TargetPlatformAcceleratorNvidia = "NVIDIA"
 )
+
+// TargetPlatformAccelerator_Values returns all elements of the TargetPlatformAccelerator enum
+func TargetPlatformAccelerator_Values() []string {
+	return []string{
+		TargetPlatformAcceleratorIntelGraphics,
+		TargetPlatformAcceleratorMali,
+		TargetPlatformAcceleratorNvidia,
+	}
+}
 
 const (
 	// TargetPlatformArchX8664 is a TargetPlatformArch enum value
@@ -50340,6 +51447,17 @@ const (
 	TargetPlatformArchArmEabihf = "ARM_EABIHF"
 )
 
+// TargetPlatformArch_Values returns all elements of the TargetPlatformArch enum
+func TargetPlatformArch_Values() []string {
+	return []string{
+		TargetPlatformArchX8664,
+		TargetPlatformArchX86,
+		TargetPlatformArchArm64,
+		TargetPlatformArchArmEabi,
+		TargetPlatformArchArmEabihf,
+	}
+}
+
 const (
 	// TargetPlatformOsAndroid is a TargetPlatformOs enum value
 	TargetPlatformOsAndroid = "ANDROID"
@@ -50348,6 +51466,14 @@ const (
 	TargetPlatformOsLinux = "LINUX"
 )
 
+// TargetPlatformOs_Values returns all elements of the TargetPlatformOs enum
+func TargetPlatformOs_Values() []string {
+	return []string{
+		TargetPlatformOsAndroid,
+		TargetPlatformOsLinux,
+	}
+}
+
 const (
 	// TrainingInputModePipe is a TrainingInputMode enum value
 	TrainingInputModePipe = "Pipe"
@@ -50355,6 +51481,14 @@ const (
 	// TrainingInputModeFile is a TrainingInputMode enum value
 	TrainingInputModeFile = "File"
 )
+
+// TrainingInputMode_Values returns all elements of the TrainingInputMode enum
+func TrainingInputMode_Values() []string {
+	return []string{
+		TrainingInputModePipe,
+		TrainingInputModeFile,
+	}
+}
 
 const (
 	// TrainingInstanceTypeMlM4Xlarge is a TrainingInstanceType enum value
@@ -50472,6 +51606,50 @@ const (
 	TrainingInstanceTypeMlC5n18xlarge = "ml.c5n.18xlarge"
 )
 
+// TrainingInstanceType_Values returns all elements of the TrainingInstanceType enum
+func TrainingInstanceType_Values() []string {
+	return []string{
+		TrainingInstanceTypeMlM4Xlarge,
+		TrainingInstanceTypeMlM42xlarge,
+		TrainingInstanceTypeMlM44xlarge,
+		TrainingInstanceTypeMlM410xlarge,
+		TrainingInstanceTypeMlM416xlarge,
+		TrainingInstanceTypeMlG4dnXlarge,
+		TrainingInstanceTypeMlG4dn2xlarge,
+		TrainingInstanceTypeMlG4dn4xlarge,
+		TrainingInstanceTypeMlG4dn8xlarge,
+		TrainingInstanceTypeMlG4dn12xlarge,
+		TrainingInstanceTypeMlG4dn16xlarge,
+		TrainingInstanceTypeMlM5Large,
+		TrainingInstanceTypeMlM5Xlarge,
+		TrainingInstanceTypeMlM52xlarge,
+		TrainingInstanceTypeMlM54xlarge,
+		TrainingInstanceTypeMlM512xlarge,
+		TrainingInstanceTypeMlM524xlarge,
+		TrainingInstanceTypeMlC4Xlarge,
+		TrainingInstanceTypeMlC42xlarge,
+		TrainingInstanceTypeMlC44xlarge,
+		TrainingInstanceTypeMlC48xlarge,
+		TrainingInstanceTypeMlP2Xlarge,
+		TrainingInstanceTypeMlP28xlarge,
+		TrainingInstanceTypeMlP216xlarge,
+		TrainingInstanceTypeMlP32xlarge,
+		TrainingInstanceTypeMlP38xlarge,
+		TrainingInstanceTypeMlP316xlarge,
+		TrainingInstanceTypeMlP3dn24xlarge,
+		TrainingInstanceTypeMlC5Xlarge,
+		TrainingInstanceTypeMlC52xlarge,
+		TrainingInstanceTypeMlC54xlarge,
+		TrainingInstanceTypeMlC59xlarge,
+		TrainingInstanceTypeMlC518xlarge,
+		TrainingInstanceTypeMlC5nXlarge,
+		TrainingInstanceTypeMlC5n2xlarge,
+		TrainingInstanceTypeMlC5n4xlarge,
+		TrainingInstanceTypeMlC5n9xlarge,
+		TrainingInstanceTypeMlC5n18xlarge,
+	}
+}
+
 const (
 	// TrainingJobEarlyStoppingTypeOff is a TrainingJobEarlyStoppingType enum value
 	TrainingJobEarlyStoppingTypeOff = "Off"
@@ -50479,6 +51657,14 @@ const (
 	// TrainingJobEarlyStoppingTypeAuto is a TrainingJobEarlyStoppingType enum value
 	TrainingJobEarlyStoppingTypeAuto = "Auto"
 )
+
+// TrainingJobEarlyStoppingType_Values returns all elements of the TrainingJobEarlyStoppingType enum
+func TrainingJobEarlyStoppingType_Values() []string {
+	return []string{
+		TrainingJobEarlyStoppingTypeOff,
+		TrainingJobEarlyStoppingTypeAuto,
+	}
+}
 
 const (
 	// TrainingJobSortByOptionsName is a TrainingJobSortByOptions enum value
@@ -50493,6 +51679,16 @@ const (
 	// TrainingJobSortByOptionsFinalObjectiveMetricValue is a TrainingJobSortByOptions enum value
 	TrainingJobSortByOptionsFinalObjectiveMetricValue = "FinalObjectiveMetricValue"
 )
+
+// TrainingJobSortByOptions_Values returns all elements of the TrainingJobSortByOptions enum
+func TrainingJobSortByOptions_Values() []string {
+	return []string{
+		TrainingJobSortByOptionsName,
+		TrainingJobSortByOptionsCreationTime,
+		TrainingJobSortByOptionsStatus,
+		TrainingJobSortByOptionsFinalObjectiveMetricValue,
+	}
+}
 
 const (
 	// TrainingJobStatusInProgress is a TrainingJobStatus enum value
@@ -50510,6 +51706,17 @@ const (
 	// TrainingJobStatusStopped is a TrainingJobStatus enum value
 	TrainingJobStatusStopped = "Stopped"
 )
+
+// TrainingJobStatus_Values returns all elements of the TrainingJobStatus enum
+func TrainingJobStatus_Values() []string {
+	return []string{
+		TrainingJobStatusInProgress,
+		TrainingJobStatusCompleted,
+		TrainingJobStatusFailed,
+		TrainingJobStatusStopping,
+		TrainingJobStatusStopped,
+	}
+}
 
 const (
 	// TransformInstanceTypeMlM4Xlarge is a TransformInstanceType enum value
@@ -50591,6 +51798,38 @@ const (
 	TransformInstanceTypeMlM524xlarge = "ml.m5.24xlarge"
 )
 
+// TransformInstanceType_Values returns all elements of the TransformInstanceType enum
+func TransformInstanceType_Values() []string {
+	return []string{
+		TransformInstanceTypeMlM4Xlarge,
+		TransformInstanceTypeMlM42xlarge,
+		TransformInstanceTypeMlM44xlarge,
+		TransformInstanceTypeMlM410xlarge,
+		TransformInstanceTypeMlM416xlarge,
+		TransformInstanceTypeMlC4Xlarge,
+		TransformInstanceTypeMlC42xlarge,
+		TransformInstanceTypeMlC44xlarge,
+		TransformInstanceTypeMlC48xlarge,
+		TransformInstanceTypeMlP2Xlarge,
+		TransformInstanceTypeMlP28xlarge,
+		TransformInstanceTypeMlP216xlarge,
+		TransformInstanceTypeMlP32xlarge,
+		TransformInstanceTypeMlP38xlarge,
+		TransformInstanceTypeMlP316xlarge,
+		TransformInstanceTypeMlC5Xlarge,
+		TransformInstanceTypeMlC52xlarge,
+		TransformInstanceTypeMlC54xlarge,
+		TransformInstanceTypeMlC59xlarge,
+		TransformInstanceTypeMlC518xlarge,
+		TransformInstanceTypeMlM5Large,
+		TransformInstanceTypeMlM5Xlarge,
+		TransformInstanceTypeMlM52xlarge,
+		TransformInstanceTypeMlM54xlarge,
+		TransformInstanceTypeMlM512xlarge,
+		TransformInstanceTypeMlM524xlarge,
+	}
+}
+
 const (
 	// TransformJobStatusInProgress is a TransformJobStatus enum value
 	TransformJobStatusInProgress = "InProgress"
@@ -50607,6 +51846,17 @@ const (
 	// TransformJobStatusStopped is a TransformJobStatus enum value
 	TransformJobStatusStopped = "Stopped"
 )
+
+// TransformJobStatus_Values returns all elements of the TransformJobStatus enum
+func TransformJobStatus_Values() []string {
+	return []string{
+		TransformJobStatusInProgress,
+		TransformJobStatusCompleted,
+		TransformJobStatusFailed,
+		TransformJobStatusStopping,
+		TransformJobStatusStopped,
+	}
+}
 
 const (
 	// TrialComponentPrimaryStatusInProgress is a TrialComponentPrimaryStatus enum value
@@ -50625,6 +51875,17 @@ const (
 	TrialComponentPrimaryStatusStopped = "Stopped"
 )
 
+// TrialComponentPrimaryStatus_Values returns all elements of the TrialComponentPrimaryStatus enum
+func TrialComponentPrimaryStatus_Values() []string {
+	return []string{
+		TrialComponentPrimaryStatusInProgress,
+		TrialComponentPrimaryStatusCompleted,
+		TrialComponentPrimaryStatusFailed,
+		TrialComponentPrimaryStatusStopping,
+		TrialComponentPrimaryStatusStopped,
+	}
+}
+
 const (
 	// UserProfileSortKeyCreationTime is a UserProfileSortKey enum value
 	UserProfileSortKeyCreationTime = "CreationTime"
@@ -50632,6 +51893,14 @@ const (
 	// UserProfileSortKeyLastModifiedTime is a UserProfileSortKey enum value
 	UserProfileSortKeyLastModifiedTime = "LastModifiedTime"
 )
+
+// UserProfileSortKey_Values returns all elements of the UserProfileSortKey enum
+func UserProfileSortKey_Values() []string {
+	return []string{
+		UserProfileSortKeyCreationTime,
+		UserProfileSortKeyLastModifiedTime,
+	}
+}
 
 const (
 	// UserProfileStatusDeleting is a UserProfileStatus enum value
@@ -50647,6 +51916,16 @@ const (
 	UserProfileStatusPending = "Pending"
 )
 
+// UserProfileStatus_Values returns all elements of the UserProfileStatus enum
+func UserProfileStatus_Values() []string {
+	return []string{
+		UserProfileStatusDeleting,
+		UserProfileStatusFailed,
+		UserProfileStatusInService,
+		UserProfileStatusPending,
+	}
+}
+
 const (
 	// VariantPropertyTypeDesiredInstanceCount is a VariantPropertyType enum value
 	VariantPropertyTypeDesiredInstanceCount = "DesiredInstanceCount"
@@ -50657,3 +51936,12 @@ const (
 	// VariantPropertyTypeDataCaptureConfig is a VariantPropertyType enum value
 	VariantPropertyTypeDataCaptureConfig = "DataCaptureConfig"
 )
+
+// VariantPropertyType_Values returns all elements of the VariantPropertyType enum
+func VariantPropertyType_Values() []string {
+	return []string{
+		VariantPropertyTypeDesiredInstanceCount,
+		VariantPropertyTypeDesiredWeight,
+		VariantPropertyTypeDataCaptureConfig,
+	}
+}

--- a/service/savingsplans/api.go
+++ b/service/savingsplans/api.go
@@ -2514,6 +2514,14 @@ const (
 	CurrencyCodeUsd = "USD"
 )
 
+// CurrencyCode_Values returns all elements of the CurrencyCode enum
+func CurrencyCode_Values() []string {
+	return []string{
+		CurrencyCodeCny,
+		CurrencyCodeUsd,
+	}
+}
+
 const (
 	// SavingsPlanOfferingFilterAttributeRegion is a SavingsPlanOfferingFilterAttribute enum value
 	SavingsPlanOfferingFilterAttributeRegion = "region"
@@ -2522,6 +2530,14 @@ const (
 	SavingsPlanOfferingFilterAttributeInstanceFamily = "instanceFamily"
 )
 
+// SavingsPlanOfferingFilterAttribute_Values returns all elements of the SavingsPlanOfferingFilterAttribute enum
+func SavingsPlanOfferingFilterAttribute_Values() []string {
+	return []string{
+		SavingsPlanOfferingFilterAttributeRegion,
+		SavingsPlanOfferingFilterAttributeInstanceFamily,
+	}
+}
+
 const (
 	// SavingsPlanOfferingPropertyKeyRegion is a SavingsPlanOfferingPropertyKey enum value
 	SavingsPlanOfferingPropertyKeyRegion = "region"
@@ -2529,6 +2545,14 @@ const (
 	// SavingsPlanOfferingPropertyKeyInstanceFamily is a SavingsPlanOfferingPropertyKey enum value
 	SavingsPlanOfferingPropertyKeyInstanceFamily = "instanceFamily"
 )
+
+// SavingsPlanOfferingPropertyKey_Values returns all elements of the SavingsPlanOfferingPropertyKey enum
+func SavingsPlanOfferingPropertyKey_Values() []string {
+	return []string{
+		SavingsPlanOfferingPropertyKeyRegion,
+		SavingsPlanOfferingPropertyKeyInstanceFamily,
+	}
+}
 
 const (
 	// SavingsPlanPaymentOptionAllUpfront is a SavingsPlanPaymentOption enum value
@@ -2541,6 +2565,15 @@ const (
 	SavingsPlanPaymentOptionNoUpfront = "No Upfront"
 )
 
+// SavingsPlanPaymentOption_Values returns all elements of the SavingsPlanPaymentOption enum
+func SavingsPlanPaymentOption_Values() []string {
+	return []string{
+		SavingsPlanPaymentOptionAllUpfront,
+		SavingsPlanPaymentOptionPartialUpfront,
+		SavingsPlanPaymentOptionNoUpfront,
+	}
+}
+
 const (
 	// SavingsPlanProductTypeEc2 is a SavingsPlanProductType enum value
 	SavingsPlanProductTypeEc2 = "EC2"
@@ -2551,6 +2584,15 @@ const (
 	// SavingsPlanProductTypeLambda is a SavingsPlanProductType enum value
 	SavingsPlanProductTypeLambda = "Lambda"
 )
+
+// SavingsPlanProductType_Values returns all elements of the SavingsPlanProductType enum
+func SavingsPlanProductType_Values() []string {
+	return []string{
+		SavingsPlanProductTypeEc2,
+		SavingsPlanProductTypeFargate,
+		SavingsPlanProductTypeLambda,
+	}
+}
 
 const (
 	// SavingsPlanRateFilterAttributeRegion is a SavingsPlanRateFilterAttribute enum value
@@ -2571,6 +2613,18 @@ const (
 	// SavingsPlanRateFilterAttributeProductId is a SavingsPlanRateFilterAttribute enum value
 	SavingsPlanRateFilterAttributeProductId = "productId"
 )
+
+// SavingsPlanRateFilterAttribute_Values returns all elements of the SavingsPlanRateFilterAttribute enum
+func SavingsPlanRateFilterAttribute_Values() []string {
+	return []string{
+		SavingsPlanRateFilterAttributeRegion,
+		SavingsPlanRateFilterAttributeInstanceFamily,
+		SavingsPlanRateFilterAttributeInstanceType,
+		SavingsPlanRateFilterAttributeProductDescription,
+		SavingsPlanRateFilterAttributeTenancy,
+		SavingsPlanRateFilterAttributeProductId,
+	}
+}
 
 const (
 	// SavingsPlanRateFilterNameRegion is a SavingsPlanRateFilterName enum value
@@ -2598,6 +2652,20 @@ const (
 	SavingsPlanRateFilterNameOperation = "operation"
 )
 
+// SavingsPlanRateFilterName_Values returns all elements of the SavingsPlanRateFilterName enum
+func SavingsPlanRateFilterName_Values() []string {
+	return []string{
+		SavingsPlanRateFilterNameRegion,
+		SavingsPlanRateFilterNameInstanceType,
+		SavingsPlanRateFilterNameProductDescription,
+		SavingsPlanRateFilterNameTenancy,
+		SavingsPlanRateFilterNameProductType,
+		SavingsPlanRateFilterNameServiceCode,
+		SavingsPlanRateFilterNameUsageType,
+		SavingsPlanRateFilterNameOperation,
+	}
+}
+
 const (
 	// SavingsPlanRatePropertyKeyRegion is a SavingsPlanRatePropertyKey enum value
 	SavingsPlanRatePropertyKeyRegion = "region"
@@ -2615,6 +2683,17 @@ const (
 	SavingsPlanRatePropertyKeyTenancy = "tenancy"
 )
 
+// SavingsPlanRatePropertyKey_Values returns all elements of the SavingsPlanRatePropertyKey enum
+func SavingsPlanRatePropertyKey_Values() []string {
+	return []string{
+		SavingsPlanRatePropertyKeyRegion,
+		SavingsPlanRatePropertyKeyInstanceType,
+		SavingsPlanRatePropertyKeyInstanceFamily,
+		SavingsPlanRatePropertyKeyProductDescription,
+		SavingsPlanRatePropertyKeyTenancy,
+	}
+}
+
 const (
 	// SavingsPlanRateServiceCodeAmazonEc2 is a SavingsPlanRateServiceCode enum value
 	SavingsPlanRateServiceCodeAmazonEc2 = "AmazonEC2"
@@ -2629,6 +2708,15 @@ const (
 	SavingsPlanRateServiceCodeAwslambda = "AWSLambda"
 )
 
+// SavingsPlanRateServiceCode_Values returns all elements of the SavingsPlanRateServiceCode enum
+func SavingsPlanRateServiceCode_Values() []string {
+	return []string{
+		SavingsPlanRateServiceCodeAmazonEc2,
+		SavingsPlanRateServiceCodeAmazonEcs,
+		SavingsPlanRateServiceCodeAwslambda,
+	}
+}
+
 const (
 	// SavingsPlanRateUnitHrs is a SavingsPlanRateUnit enum value
 	SavingsPlanRateUnitHrs = "Hrs"
@@ -2639,6 +2727,15 @@ const (
 	// SavingsPlanRateUnitRequest is a SavingsPlanRateUnit enum value
 	SavingsPlanRateUnitRequest = "Request"
 )
+
+// SavingsPlanRateUnit_Values returns all elements of the SavingsPlanRateUnit enum
+func SavingsPlanRateUnit_Values() []string {
+	return []string{
+		SavingsPlanRateUnitHrs,
+		SavingsPlanRateUnitLambdaGbSecond,
+		SavingsPlanRateUnitRequest,
+	}
+}
 
 const (
 	// SavingsPlanStatePaymentPending is a SavingsPlanState enum value
@@ -2654,6 +2751,16 @@ const (
 	SavingsPlanStateRetired = "retired"
 )
 
+// SavingsPlanState_Values returns all elements of the SavingsPlanState enum
+func SavingsPlanState_Values() []string {
+	return []string{
+		SavingsPlanStatePaymentPending,
+		SavingsPlanStatePaymentFailed,
+		SavingsPlanStateActive,
+		SavingsPlanStateRetired,
+	}
+}
+
 const (
 	// SavingsPlanTypeCompute is a SavingsPlanType enum value
 	SavingsPlanTypeCompute = "Compute"
@@ -2661,6 +2768,14 @@ const (
 	// SavingsPlanTypeEc2instance is a SavingsPlanType enum value
 	SavingsPlanTypeEc2instance = "EC2Instance"
 )
+
+// SavingsPlanType_Values returns all elements of the SavingsPlanType enum
+func SavingsPlanType_Values() []string {
+	return []string{
+		SavingsPlanTypeCompute,
+		SavingsPlanTypeEc2instance,
+	}
+}
 
 const (
 	// SavingsPlansFilterNameRegion is a SavingsPlansFilterName enum value
@@ -2690,3 +2805,18 @@ const (
 	// SavingsPlansFilterNameEnd is a SavingsPlansFilterName enum value
 	SavingsPlansFilterNameEnd = "end"
 )
+
+// SavingsPlansFilterName_Values returns all elements of the SavingsPlansFilterName enum
+func SavingsPlansFilterName_Values() []string {
+	return []string{
+		SavingsPlansFilterNameRegion,
+		SavingsPlansFilterNameEc2InstanceFamily,
+		SavingsPlansFilterNameCommitment,
+		SavingsPlansFilterNameUpfront,
+		SavingsPlansFilterNameTerm,
+		SavingsPlansFilterNameSavingsPlanType,
+		SavingsPlansFilterNamePaymentOption,
+		SavingsPlansFilterNameStart,
+		SavingsPlansFilterNameEnd,
+	}
+}

--- a/service/savingsplans/api.go
+++ b/service/savingsplans/api.go
@@ -2713,6 +2713,7 @@ func SavingsPlanRateServiceCode_Values() []string {
 	return []string{
 		SavingsPlanRateServiceCodeAmazonEc2,
 		SavingsPlanRateServiceCodeAmazonEcs,
+		SavingsPlanRateServiceCodeAmazonEks,
 		SavingsPlanRateServiceCodeAwslambda,
 	}
 }

--- a/service/schemas/api.go
+++ b/service/schemas/api.go
@@ -6521,6 +6521,15 @@ const (
 	CodeGenerationStatusCreateFailed = "CREATE_FAILED"
 )
 
+// CodeGenerationStatus_Values returns all elements of the CodeGenerationStatus enum
+func CodeGenerationStatus_Values() []string {
+	return []string{
+		CodeGenerationStatusCreateInProgress,
+		CodeGenerationStatusCreateComplete,
+		CodeGenerationStatusCreateFailed,
+	}
+}
+
 const (
 	// DiscovererStateStarted is a DiscovererState enum value
 	DiscovererStateStarted = "STARTED"
@@ -6529,7 +6538,22 @@ const (
 	DiscovererStateStopped = "STOPPED"
 )
 
+// DiscovererState_Values returns all elements of the DiscovererState enum
+func DiscovererState_Values() []string {
+	return []string{
+		DiscovererStateStarted,
+		DiscovererStateStopped,
+	}
+}
+
 const (
 	// TypeOpenApi3 is a Type enum value
 	TypeOpenApi3 = "OpenApi3"
 )
+
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypeOpenApi3,
+	}
+}

--- a/service/secretsmanager/api.go
+++ b/service/secretsmanager/api.go
@@ -6549,6 +6549,17 @@ const (
 	FilterNameStringTypeAll = "all"
 )
 
+// FilterNameStringType_Values returns all elements of the FilterNameStringType enum
+func FilterNameStringType_Values() []string {
+	return []string{
+		FilterNameStringTypeDescription,
+		FilterNameStringTypeName,
+		FilterNameStringTypeTagKey,
+		FilterNameStringTypeTagValue,
+		FilterNameStringTypeAll,
+	}
+}
+
 const (
 	// SortOrderTypeAsc is a SortOrderType enum value
 	SortOrderTypeAsc = "asc"
@@ -6556,3 +6567,11 @@ const (
 	// SortOrderTypeDesc is a SortOrderType enum value
 	SortOrderTypeDesc = "desc"
 )
+
+// SortOrderType_Values returns all elements of the SortOrderType enum
+func SortOrderType_Values() []string {
+	return []string{
+		SortOrderTypeAsc,
+		SortOrderTypeDesc,
+	}
+}

--- a/service/securityhub/api.go
+++ b/service/securityhub/api.go
@@ -15984,6 +15984,14 @@ const (
 	AwsIamAccessKeyStatusInactive = "Inactive"
 )
 
+// AwsIamAccessKeyStatus_Values returns all elements of the AwsIamAccessKeyStatus enum
+func AwsIamAccessKeyStatus_Values() []string {
+	return []string{
+		AwsIamAccessKeyStatusActive,
+		AwsIamAccessKeyStatusInactive,
+	}
+}
+
 const (
 	// ComplianceStatusPassed is a ComplianceStatus enum value
 	ComplianceStatusPassed = "PASSED"
@@ -15998,6 +16006,16 @@ const (
 	ComplianceStatusNotAvailable = "NOT_AVAILABLE"
 )
 
+// ComplianceStatus_Values returns all elements of the ComplianceStatus enum
+func ComplianceStatus_Values() []string {
+	return []string{
+		ComplianceStatusPassed,
+		ComplianceStatusWarning,
+		ComplianceStatusFailed,
+		ComplianceStatusNotAvailable,
+	}
+}
+
 const (
 	// ControlStatusEnabled is a ControlStatus enum value
 	ControlStatusEnabled = "ENABLED"
@@ -16006,10 +16024,25 @@ const (
 	ControlStatusDisabled = "DISABLED"
 )
 
+// ControlStatus_Values returns all elements of the ControlStatus enum
+func ControlStatus_Values() []string {
+	return []string{
+		ControlStatusEnabled,
+		ControlStatusDisabled,
+	}
+}
+
 const (
 	// DateRangeUnitDays is a DateRangeUnit enum value
 	DateRangeUnitDays = "DAYS"
 )
+
+// DateRangeUnit_Values returns all elements of the DateRangeUnit enum
+func DateRangeUnit_Values() []string {
+	return []string{
+		DateRangeUnitDays,
+	}
+}
 
 const (
 	// IntegrationTypeSendFindingsToSecurityHub is a IntegrationType enum value
@@ -16018,6 +16051,14 @@ const (
 	// IntegrationTypeReceiveFindingsFromSecurityHub is a IntegrationType enum value
 	IntegrationTypeReceiveFindingsFromSecurityHub = "RECEIVE_FINDINGS_FROM_SECURITY_HUB"
 )
+
+// IntegrationType_Values returns all elements of the IntegrationType enum
+func IntegrationType_Values() []string {
+	return []string{
+		IntegrationTypeSendFindingsToSecurityHub,
+		IntegrationTypeReceiveFindingsFromSecurityHub,
+	}
+}
 
 const (
 	// MalwareStateObserved is a MalwareState enum value
@@ -16029,6 +16070,15 @@ const (
 	// MalwareStateRemoved is a MalwareState enum value
 	MalwareStateRemoved = "REMOVED"
 )
+
+// MalwareState_Values returns all elements of the MalwareState enum
+func MalwareState_Values() []string {
+	return []string{
+		MalwareStateObserved,
+		MalwareStateRemovalFailed,
+		MalwareStateRemoved,
+	}
+}
 
 const (
 	// MalwareTypeAdware is a MalwareType enum value
@@ -16077,10 +16127,38 @@ const (
 	MalwareTypeWorm = "WORM"
 )
 
+// MalwareType_Values returns all elements of the MalwareType enum
+func MalwareType_Values() []string {
+	return []string{
+		MalwareTypeAdware,
+		MalwareTypeBlendedThreat,
+		MalwareTypeBotnetAgent,
+		MalwareTypeCoinMiner,
+		MalwareTypeExploitKit,
+		MalwareTypeKeylogger,
+		MalwareTypeMacro,
+		MalwareTypePotentiallyUnwanted,
+		MalwareTypeSpyware,
+		MalwareTypeRansomware,
+		MalwareTypeRemoteAccess,
+		MalwareTypeRootkit,
+		MalwareTypeTrojan,
+		MalwareTypeVirus,
+		MalwareTypeWorm,
+	}
+}
+
 const (
 	// MapFilterComparisonEquals is a MapFilterComparison enum value
 	MapFilterComparisonEquals = "EQUALS"
 )
+
+// MapFilterComparison_Values returns all elements of the MapFilterComparison enum
+func MapFilterComparison_Values() []string {
+	return []string{
+		MapFilterComparisonEquals,
+	}
+}
 
 const (
 	// NetworkDirectionIn is a NetworkDirection enum value
@@ -16089,6 +16167,14 @@ const (
 	// NetworkDirectionOut is a NetworkDirection enum value
 	NetworkDirectionOut = "OUT"
 )
+
+// NetworkDirection_Values returns all elements of the NetworkDirection enum
+func NetworkDirection_Values() []string {
+	return []string{
+		NetworkDirectionIn,
+		NetworkDirectionOut,
+	}
+}
 
 const (
 	// PartitionAws is a Partition enum value
@@ -16101,6 +16187,15 @@ const (
 	PartitionAwsUsGov = "aws-us-gov"
 )
 
+// Partition_Values returns all elements of the Partition enum
+func Partition_Values() []string {
+	return []string{
+		PartitionAws,
+		PartitionAwsCn,
+		PartitionAwsUsGov,
+	}
+}
+
 const (
 	// RecordStateActive is a RecordState enum value
 	RecordStateActive = "ACTIVE"
@@ -16108,6 +16203,14 @@ const (
 	// RecordStateArchived is a RecordState enum value
 	RecordStateArchived = "ARCHIVED"
 )
+
+// RecordState_Values returns all elements of the RecordState enum
+func RecordState_Values() []string {
+	return []string{
+		RecordStateActive,
+		RecordStateArchived,
+	}
+}
 
 const (
 	// SeverityLabelInformational is a SeverityLabel enum value
@@ -16126,6 +16229,17 @@ const (
 	SeverityLabelCritical = "CRITICAL"
 )
 
+// SeverityLabel_Values returns all elements of the SeverityLabel enum
+func SeverityLabel_Values() []string {
+	return []string{
+		SeverityLabelInformational,
+		SeverityLabelLow,
+		SeverityLabelMedium,
+		SeverityLabelHigh,
+		SeverityLabelCritical,
+	}
+}
+
 const (
 	// SeverityRatingLow is a SeverityRating enum value
 	SeverityRatingLow = "LOW"
@@ -16140,6 +16254,16 @@ const (
 	SeverityRatingCritical = "CRITICAL"
 )
 
+// SeverityRating_Values returns all elements of the SeverityRating enum
+func SeverityRating_Values() []string {
+	return []string{
+		SeverityRatingLow,
+		SeverityRatingMedium,
+		SeverityRatingHigh,
+		SeverityRatingCritical,
+	}
+}
+
 const (
 	// SortOrderAsc is a SortOrder enum value
 	SortOrderAsc = "asc"
@@ -16147,6 +16271,14 @@ const (
 	// SortOrderDesc is a SortOrder enum value
 	SortOrderDesc = "desc"
 )
+
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderAsc,
+		SortOrderDesc,
+	}
+}
 
 const (
 	// StandardsStatusPending is a StandardsStatus enum value
@@ -16165,6 +16297,17 @@ const (
 	StandardsStatusIncomplete = "INCOMPLETE"
 )
 
+// StandardsStatus_Values returns all elements of the StandardsStatus enum
+func StandardsStatus_Values() []string {
+	return []string{
+		StandardsStatusPending,
+		StandardsStatusReady,
+		StandardsStatusFailed,
+		StandardsStatusDeleting,
+		StandardsStatusIncomplete,
+	}
+}
+
 const (
 	// StringFilterComparisonEquals is a StringFilterComparison enum value
 	StringFilterComparisonEquals = "EQUALS"
@@ -16172,6 +16315,14 @@ const (
 	// StringFilterComparisonPrefix is a StringFilterComparison enum value
 	StringFilterComparisonPrefix = "PREFIX"
 )
+
+// StringFilterComparison_Values returns all elements of the StringFilterComparison enum
+func StringFilterComparison_Values() []string {
+	return []string{
+		StringFilterComparisonEquals,
+		StringFilterComparisonPrefix,
+	}
+}
 
 const (
 	// ThreatIntelIndicatorCategoryBackdoor is a ThreatIntelIndicatorCategory enum value
@@ -16192,6 +16343,18 @@ const (
 	// ThreatIntelIndicatorCategoryKeylogger is a ThreatIntelIndicatorCategory enum value
 	ThreatIntelIndicatorCategoryKeylogger = "KEYLOGGER"
 )
+
+// ThreatIntelIndicatorCategory_Values returns all elements of the ThreatIntelIndicatorCategory enum
+func ThreatIntelIndicatorCategory_Values() []string {
+	return []string{
+		ThreatIntelIndicatorCategoryBackdoor,
+		ThreatIntelIndicatorCategoryCardStealer,
+		ThreatIntelIndicatorCategoryCommandAndControl,
+		ThreatIntelIndicatorCategoryDropSite,
+		ThreatIntelIndicatorCategoryExploitSite,
+		ThreatIntelIndicatorCategoryKeylogger,
+	}
+}
 
 const (
 	// ThreatIntelIndicatorTypeDomain is a ThreatIntelIndicatorType enum value
@@ -16228,6 +16391,23 @@ const (
 	ThreatIntelIndicatorTypeUrl = "URL"
 )
 
+// ThreatIntelIndicatorType_Values returns all elements of the ThreatIntelIndicatorType enum
+func ThreatIntelIndicatorType_Values() []string {
+	return []string{
+		ThreatIntelIndicatorTypeDomain,
+		ThreatIntelIndicatorTypeEmailAddress,
+		ThreatIntelIndicatorTypeHashMd5,
+		ThreatIntelIndicatorTypeHashSha1,
+		ThreatIntelIndicatorTypeHashSha256,
+		ThreatIntelIndicatorTypeHashSha512,
+		ThreatIntelIndicatorTypeIpv4Address,
+		ThreatIntelIndicatorTypeIpv6Address,
+		ThreatIntelIndicatorTypeMutex,
+		ThreatIntelIndicatorTypeProcess,
+		ThreatIntelIndicatorTypeUrl,
+	}
+}
+
 const (
 	// VerificationStateUnknown is a VerificationState enum value
 	VerificationStateUnknown = "UNKNOWN"
@@ -16241,6 +16421,16 @@ const (
 	// VerificationStateBenignPositive is a VerificationState enum value
 	VerificationStateBenignPositive = "BENIGN_POSITIVE"
 )
+
+// VerificationState_Values returns all elements of the VerificationState enum
+func VerificationState_Values() []string {
+	return []string{
+		VerificationStateUnknown,
+		VerificationStateTruePositive,
+		VerificationStateFalsePositive,
+		VerificationStateBenignPositive,
+	}
+}
 
 const (
 	// WorkflowStateNew is a WorkflowState enum value
@@ -16259,6 +16449,17 @@ const (
 	WorkflowStateResolved = "RESOLVED"
 )
 
+// WorkflowState_Values returns all elements of the WorkflowState enum
+func WorkflowState_Values() []string {
+	return []string{
+		WorkflowStateNew,
+		WorkflowStateAssigned,
+		WorkflowStateInProgress,
+		WorkflowStateDeferred,
+		WorkflowStateResolved,
+	}
+}
+
 const (
 	// WorkflowStatusNew is a WorkflowStatus enum value
 	WorkflowStatusNew = "NEW"
@@ -16272,3 +16473,13 @@ const (
 	// WorkflowStatusSuppressed is a WorkflowStatus enum value
 	WorkflowStatusSuppressed = "SUPPRESSED"
 )
+
+// WorkflowStatus_Values returns all elements of the WorkflowStatus enum
+func WorkflowStatus_Values() []string {
+	return []string{
+		WorkflowStatusNew,
+		WorkflowStatusNotified,
+		WorkflowStatusResolved,
+		WorkflowStatusSuppressed,
+	}
+}

--- a/service/serverlessapplicationrepository/api.go
+++ b/service/serverlessapplicationrepository/api.go
@@ -4520,6 +4520,16 @@ const (
 	CapabilityCapabilityResourcePolicy = "CAPABILITY_RESOURCE_POLICY"
 )
 
+// Capability_Values returns all elements of the Capability enum
+func Capability_Values() []string {
+	return []string{
+		CapabilityCapabilityIam,
+		CapabilityCapabilityNamedIam,
+		CapabilityCapabilityAutoExpand,
+		CapabilityCapabilityResourcePolicy,
+	}
+}
+
 const (
 	// StatusPreparing is a Status enum value
 	StatusPreparing = "PREPARING"
@@ -4530,3 +4540,12 @@ const (
 	// StatusExpired is a Status enum value
 	StatusExpired = "EXPIRED"
 )
+
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusPreparing,
+		StatusActive,
+		StatusExpired,
+	}
+}

--- a/service/servicecatalog/api.go
+++ b/service/servicecatalog/api.go
@@ -21047,6 +21047,15 @@ const (
 	AccessLevelFilterKeyUser = "User"
 )
 
+// AccessLevelFilterKey_Values returns all elements of the AccessLevelFilterKey enum
+func AccessLevelFilterKey_Values() []string {
+	return []string{
+		AccessLevelFilterKeyAccount,
+		AccessLevelFilterKeyRole,
+		AccessLevelFilterKeyUser,
+	}
+}
+
 const (
 	// AccessStatusEnabled is a AccessStatus enum value
 	AccessStatusEnabled = "ENABLED"
@@ -21057,6 +21066,15 @@ const (
 	// AccessStatusDisabled is a AccessStatus enum value
 	AccessStatusDisabled = "DISABLED"
 )
+
+// AccessStatus_Values returns all elements of the AccessStatus enum
+func AccessStatus_Values() []string {
+	return []string{
+		AccessStatusEnabled,
+		AccessStatusUnderChange,
+		AccessStatusDisabled,
+	}
+}
 
 const (
 	// ChangeActionAdd is a ChangeAction enum value
@@ -21069,10 +21087,26 @@ const (
 	ChangeActionRemove = "REMOVE"
 )
 
+// ChangeAction_Values returns all elements of the ChangeAction enum
+func ChangeAction_Values() []string {
+	return []string{
+		ChangeActionAdd,
+		ChangeActionModify,
+		ChangeActionRemove,
+	}
+}
+
 const (
 	// CopyOptionCopyTags is a CopyOption enum value
 	CopyOptionCopyTags = "CopyTags"
 )
+
+// CopyOption_Values returns all elements of the CopyOption enum
+func CopyOption_Values() []string {
+	return []string{
+		CopyOptionCopyTags,
+	}
+}
 
 const (
 	// CopyProductStatusSucceeded is a CopyProductStatus enum value
@@ -21085,6 +21119,15 @@ const (
 	CopyProductStatusFailed = "FAILED"
 )
 
+// CopyProductStatus_Values returns all elements of the CopyProductStatus enum
+func CopyProductStatus_Values() []string {
+	return []string{
+		CopyProductStatusSucceeded,
+		CopyProductStatusInProgress,
+		CopyProductStatusFailed,
+	}
+}
+
 const (
 	// EvaluationTypeStatic is a EvaluationType enum value
 	EvaluationTypeStatic = "STATIC"
@@ -21092,6 +21135,14 @@ const (
 	// EvaluationTypeDynamic is a EvaluationType enum value
 	EvaluationTypeDynamic = "DYNAMIC"
 )
+
+// EvaluationType_Values returns all elements of the EvaluationType enum
+func EvaluationType_Values() []string {
+	return []string{
+		EvaluationTypeStatic,
+		EvaluationTypeDynamic,
+	}
+}
 
 const (
 	// OrganizationNodeTypeOrganization is a OrganizationNodeType enum value
@@ -21104,6 +21155,15 @@ const (
 	OrganizationNodeTypeAccount = "ACCOUNT"
 )
 
+// OrganizationNodeType_Values returns all elements of the OrganizationNodeType enum
+func OrganizationNodeType_Values() []string {
+	return []string{
+		OrganizationNodeTypeOrganization,
+		OrganizationNodeTypeOrganizationalUnit,
+		OrganizationNodeTypeAccount,
+	}
+}
+
 const (
 	// PortfolioShareTypeImported is a PortfolioShareType enum value
 	PortfolioShareTypeImported = "IMPORTED"
@@ -21115,15 +21175,38 @@ const (
 	PortfolioShareTypeAwsOrganizations = "AWS_ORGANIZATIONS"
 )
 
+// PortfolioShareType_Values returns all elements of the PortfolioShareType enum
+func PortfolioShareType_Values() []string {
+	return []string{
+		PortfolioShareTypeImported,
+		PortfolioShareTypeAwsServicecatalog,
+		PortfolioShareTypeAwsOrganizations,
+	}
+}
+
 const (
 	// PrincipalTypeIam is a PrincipalType enum value
 	PrincipalTypeIam = "IAM"
 )
 
+// PrincipalType_Values returns all elements of the PrincipalType enum
+func PrincipalType_Values() []string {
+	return []string{
+		PrincipalTypeIam,
+	}
+}
+
 const (
 	// ProductSourceAccount is a ProductSource enum value
 	ProductSourceAccount = "ACCOUNT"
 )
+
+// ProductSource_Values returns all elements of the ProductSource enum
+func ProductSource_Values() []string {
+	return []string{
+		ProductSourceAccount,
+	}
+}
 
 const (
 	// ProductTypeCloudFormationTemplate is a ProductType enum value
@@ -21132,6 +21215,14 @@ const (
 	// ProductTypeMarketplace is a ProductType enum value
 	ProductTypeMarketplace = "MARKETPLACE"
 )
+
+// ProductType_Values returns all elements of the ProductType enum
+func ProductType_Values() []string {
+	return []string{
+		ProductTypeCloudFormationTemplate,
+		ProductTypeMarketplace,
+	}
+}
 
 const (
 	// ProductViewFilterByFullTextSearch is a ProductViewFilterBy enum value
@@ -21147,6 +21238,16 @@ const (
 	ProductViewFilterBySourceProductId = "SourceProductId"
 )
 
+// ProductViewFilterBy_Values returns all elements of the ProductViewFilterBy enum
+func ProductViewFilterBy_Values() []string {
+	return []string{
+		ProductViewFilterByFullTextSearch,
+		ProductViewFilterByOwner,
+		ProductViewFilterByProductType,
+		ProductViewFilterBySourceProductId,
+	}
+}
+
 const (
 	// ProductViewSortByTitle is a ProductViewSortBy enum value
 	ProductViewSortByTitle = "Title"
@@ -21158,10 +21259,26 @@ const (
 	ProductViewSortByCreationDate = "CreationDate"
 )
 
+// ProductViewSortBy_Values returns all elements of the ProductViewSortBy enum
+func ProductViewSortBy_Values() []string {
+	return []string{
+		ProductViewSortByTitle,
+		ProductViewSortByVersionCount,
+		ProductViewSortByCreationDate,
+	}
+}
+
 const (
 	// PropertyKeyOwner is a PropertyKey enum value
 	PropertyKeyOwner = "OWNER"
 )
+
+// PropertyKey_Values returns all elements of the PropertyKey enum
+func PropertyKey_Values() []string {
+	return []string{
+		PropertyKeyOwner,
+	}
+}
 
 const (
 	// ProvisionedProductPlanStatusCreateInProgress is a ProvisionedProductPlanStatus enum value
@@ -21183,10 +21300,29 @@ const (
 	ProvisionedProductPlanStatusExecuteFailed = "EXECUTE_FAILED"
 )
 
+// ProvisionedProductPlanStatus_Values returns all elements of the ProvisionedProductPlanStatus enum
+func ProvisionedProductPlanStatus_Values() []string {
+	return []string{
+		ProvisionedProductPlanStatusCreateInProgress,
+		ProvisionedProductPlanStatusCreateSuccess,
+		ProvisionedProductPlanStatusCreateFailed,
+		ProvisionedProductPlanStatusExecuteInProgress,
+		ProvisionedProductPlanStatusExecuteSuccess,
+		ProvisionedProductPlanStatusExecuteFailed,
+	}
+}
+
 const (
 	// ProvisionedProductPlanTypeCloudformation is a ProvisionedProductPlanType enum value
 	ProvisionedProductPlanTypeCloudformation = "CLOUDFORMATION"
 )
+
+// ProvisionedProductPlanType_Values returns all elements of the ProvisionedProductPlanType enum
+func ProvisionedProductPlanType_Values() []string {
+	return []string{
+		ProvisionedProductPlanTypeCloudformation,
+	}
+}
 
 const (
 	// ProvisionedProductStatusAvailable is a ProvisionedProductStatus enum value
@@ -21205,10 +21341,28 @@ const (
 	ProvisionedProductStatusPlanInProgress = "PLAN_IN_PROGRESS"
 )
 
+// ProvisionedProductStatus_Values returns all elements of the ProvisionedProductStatus enum
+func ProvisionedProductStatus_Values() []string {
+	return []string{
+		ProvisionedProductStatusAvailable,
+		ProvisionedProductStatusUnderChange,
+		ProvisionedProductStatusTainted,
+		ProvisionedProductStatusError,
+		ProvisionedProductStatusPlanInProgress,
+	}
+}
+
 const (
 	// ProvisionedProductViewFilterBySearchQuery is a ProvisionedProductViewFilterBy enum value
 	ProvisionedProductViewFilterBySearchQuery = "SearchQuery"
 )
+
+// ProvisionedProductViewFilterBy_Values returns all elements of the ProvisionedProductViewFilterBy enum
+func ProvisionedProductViewFilterBy_Values() []string {
+	return []string{
+		ProvisionedProductViewFilterBySearchQuery,
+	}
+}
 
 const (
 	// ProvisioningArtifactGuidanceDefault is a ProvisioningArtifactGuidance enum value
@@ -21218,10 +21372,25 @@ const (
 	ProvisioningArtifactGuidanceDeprecated = "DEPRECATED"
 )
 
+// ProvisioningArtifactGuidance_Values returns all elements of the ProvisioningArtifactGuidance enum
+func ProvisioningArtifactGuidance_Values() []string {
+	return []string{
+		ProvisioningArtifactGuidanceDefault,
+		ProvisioningArtifactGuidanceDeprecated,
+	}
+}
+
 const (
 	// ProvisioningArtifactPropertyNameId is a ProvisioningArtifactPropertyName enum value
 	ProvisioningArtifactPropertyNameId = "Id"
 )
+
+// ProvisioningArtifactPropertyName_Values returns all elements of the ProvisioningArtifactPropertyName enum
+func ProvisioningArtifactPropertyName_Values() []string {
+	return []string{
+		ProvisioningArtifactPropertyNameId,
+	}
+}
 
 const (
 	// ProvisioningArtifactTypeCloudFormationTemplate is a ProvisioningArtifactType enum value
@@ -21233,6 +21402,15 @@ const (
 	// ProvisioningArtifactTypeMarketplaceCar is a ProvisioningArtifactType enum value
 	ProvisioningArtifactTypeMarketplaceCar = "MARKETPLACE_CAR"
 )
+
+// ProvisioningArtifactType_Values returns all elements of the ProvisioningArtifactType enum
+func ProvisioningArtifactType_Values() []string {
+	return []string{
+		ProvisioningArtifactTypeCloudFormationTemplate,
+		ProvisioningArtifactTypeMarketplaceAmi,
+		ProvisioningArtifactTypeMarketplaceCar,
+	}
+}
 
 const (
 	// RecordStatusCreated is a RecordStatus enum value
@@ -21251,6 +21429,17 @@ const (
 	RecordStatusFailed = "FAILED"
 )
 
+// RecordStatus_Values returns all elements of the RecordStatus enum
+func RecordStatus_Values() []string {
+	return []string{
+		RecordStatusCreated,
+		RecordStatusInProgress,
+		RecordStatusInProgressInError,
+		RecordStatusSucceeded,
+		RecordStatusFailed,
+	}
+}
+
 const (
 	// ReplacementTrue is a Replacement enum value
 	ReplacementTrue = "TRUE"
@@ -21262,6 +21451,15 @@ const (
 	ReplacementConditional = "CONDITIONAL"
 )
 
+// Replacement_Values returns all elements of the Replacement enum
+func Replacement_Values() []string {
+	return []string{
+		ReplacementTrue,
+		ReplacementFalse,
+		ReplacementConditional,
+	}
+}
+
 const (
 	// RequiresRecreationNever is a RequiresRecreation enum value
 	RequiresRecreationNever = "NEVER"
@@ -21272,6 +21470,15 @@ const (
 	// RequiresRecreationAlways is a RequiresRecreation enum value
 	RequiresRecreationAlways = "ALWAYS"
 )
+
+// RequiresRecreation_Values returns all elements of the RequiresRecreation enum
+func RequiresRecreation_Values() []string {
+	return []string{
+		RequiresRecreationNever,
+		RequiresRecreationConditionally,
+		RequiresRecreationAlways,
+	}
+}
 
 const (
 	// ResourceAttributeProperties is a ResourceAttribute enum value
@@ -21293,6 +21500,18 @@ const (
 	ResourceAttributeTags = "TAGS"
 )
 
+// ResourceAttribute_Values returns all elements of the ResourceAttribute enum
+func ResourceAttribute_Values() []string {
+	return []string{
+		ResourceAttributeProperties,
+		ResourceAttributeMetadata,
+		ResourceAttributeCreationpolicy,
+		ResourceAttributeUpdatepolicy,
+		ResourceAttributeDeletionpolicy,
+		ResourceAttributeTags,
+	}
+}
+
 const (
 	// ServiceActionAssociationErrorCodeDuplicateResource is a ServiceActionAssociationErrorCode enum value
 	ServiceActionAssociationErrorCodeDuplicateResource = "DUPLICATE_RESOURCE"
@@ -21310,6 +21529,17 @@ const (
 	ServiceActionAssociationErrorCodeThrottling = "THROTTLING"
 )
 
+// ServiceActionAssociationErrorCode_Values returns all elements of the ServiceActionAssociationErrorCode enum
+func ServiceActionAssociationErrorCode_Values() []string {
+	return []string{
+		ServiceActionAssociationErrorCodeDuplicateResource,
+		ServiceActionAssociationErrorCodeInternalFailure,
+		ServiceActionAssociationErrorCodeLimitExceeded,
+		ServiceActionAssociationErrorCodeResourceNotFound,
+		ServiceActionAssociationErrorCodeThrottling,
+	}
+}
+
 const (
 	// ServiceActionDefinitionKeyName is a ServiceActionDefinitionKey enum value
 	ServiceActionDefinitionKeyName = "Name"
@@ -21324,10 +21554,27 @@ const (
 	ServiceActionDefinitionKeyParameters = "Parameters"
 )
 
+// ServiceActionDefinitionKey_Values returns all elements of the ServiceActionDefinitionKey enum
+func ServiceActionDefinitionKey_Values() []string {
+	return []string{
+		ServiceActionDefinitionKeyName,
+		ServiceActionDefinitionKeyVersion,
+		ServiceActionDefinitionKeyAssumeRole,
+		ServiceActionDefinitionKeyParameters,
+	}
+}
+
 const (
 	// ServiceActionDefinitionTypeSsmAutomation is a ServiceActionDefinitionType enum value
 	ServiceActionDefinitionTypeSsmAutomation = "SSM_AUTOMATION"
 )
+
+// ServiceActionDefinitionType_Values returns all elements of the ServiceActionDefinitionType enum
+func ServiceActionDefinitionType_Values() []string {
+	return []string{
+		ServiceActionDefinitionTypeSsmAutomation,
+	}
+}
 
 const (
 	// ShareStatusNotStarted is a ShareStatus enum value
@@ -21346,6 +21593,17 @@ const (
 	ShareStatusError = "ERROR"
 )
 
+// ShareStatus_Values returns all elements of the ShareStatus enum
+func ShareStatus_Values() []string {
+	return []string{
+		ShareStatusNotStarted,
+		ShareStatusInProgress,
+		ShareStatusCompleted,
+		ShareStatusCompletedWithErrors,
+		ShareStatusError,
+	}
+}
+
 const (
 	// SortOrderAscending is a SortOrder enum value
 	SortOrderAscending = "ASCENDING"
@@ -21353,6 +21611,14 @@ const (
 	// SortOrderDescending is a SortOrder enum value
 	SortOrderDescending = "DESCENDING"
 )
+
+// SortOrder_Values returns all elements of the SortOrder enum
+func SortOrder_Values() []string {
+	return []string{
+		SortOrderAscending,
+		SortOrderDescending,
+	}
+}
 
 const (
 	// StackInstanceStatusCurrent is a StackInstanceStatus enum value
@@ -21365,6 +21631,15 @@ const (
 	StackInstanceStatusInoperable = "INOPERABLE"
 )
 
+// StackInstanceStatus_Values returns all elements of the StackInstanceStatus enum
+func StackInstanceStatus_Values() []string {
+	return []string{
+		StackInstanceStatusCurrent,
+		StackInstanceStatusOutdated,
+		StackInstanceStatusInoperable,
+	}
+}
+
 const (
 	// StackSetOperationTypeCreate is a StackSetOperationType enum value
 	StackSetOperationTypeCreate = "CREATE"
@@ -21376,6 +21651,15 @@ const (
 	StackSetOperationTypeDelete = "DELETE"
 )
 
+// StackSetOperationType_Values returns all elements of the StackSetOperationType enum
+func StackSetOperationType_Values() []string {
+	return []string{
+		StackSetOperationTypeCreate,
+		StackSetOperationTypeUpdate,
+		StackSetOperationTypeDelete,
+	}
+}
+
 const (
 	// StatusAvailable is a Status enum value
 	StatusAvailable = "AVAILABLE"
@@ -21386,3 +21670,12 @@ const (
 	// StatusFailed is a Status enum value
 	StatusFailed = "FAILED"
 )
+
+// Status_Values returns all elements of the Status enum
+func Status_Values() []string {
+	return []string{
+		StatusAvailable,
+		StatusCreating,
+		StatusFailed,
+	}
+}

--- a/service/servicediscovery/api.go
+++ b/service/servicediscovery/api.go
@@ -7544,6 +7544,14 @@ const (
 	CustomHealthStatusUnhealthy = "UNHEALTHY"
 )
 
+// CustomHealthStatus_Values returns all elements of the CustomHealthStatus enum
+func CustomHealthStatus_Values() []string {
+	return []string{
+		CustomHealthStatusHealthy,
+		CustomHealthStatusUnhealthy,
+	}
+}
+
 const (
 	// FilterConditionEq is a FilterCondition enum value
 	FilterConditionEq = "EQ"
@@ -7554,6 +7562,15 @@ const (
 	// FilterConditionBetween is a FilterCondition enum value
 	FilterConditionBetween = "BETWEEN"
 )
+
+// FilterCondition_Values returns all elements of the FilterCondition enum
+func FilterCondition_Values() []string {
+	return []string{
+		FilterConditionEq,
+		FilterConditionIn,
+		FilterConditionBetween,
+	}
+}
 
 const (
 	// HealthCheckTypeHttp is a HealthCheckType enum value
@@ -7566,6 +7583,15 @@ const (
 	HealthCheckTypeTcp = "TCP"
 )
 
+// HealthCheckType_Values returns all elements of the HealthCheckType enum
+func HealthCheckType_Values() []string {
+	return []string{
+		HealthCheckTypeHttp,
+		HealthCheckTypeHttps,
+		HealthCheckTypeTcp,
+	}
+}
+
 const (
 	// HealthStatusHealthy is a HealthStatus enum value
 	HealthStatusHealthy = "HEALTHY"
@@ -7576,6 +7602,15 @@ const (
 	// HealthStatusUnknown is a HealthStatus enum value
 	HealthStatusUnknown = "UNKNOWN"
 )
+
+// HealthStatus_Values returns all elements of the HealthStatus enum
+func HealthStatus_Values() []string {
+	return []string{
+		HealthStatusHealthy,
+		HealthStatusUnhealthy,
+		HealthStatusUnknown,
+	}
+}
 
 const (
 	// HealthStatusFilterHealthy is a HealthStatusFilter enum value
@@ -7588,10 +7623,26 @@ const (
 	HealthStatusFilterAll = "ALL"
 )
 
+// HealthStatusFilter_Values returns all elements of the HealthStatusFilter enum
+func HealthStatusFilter_Values() []string {
+	return []string{
+		HealthStatusFilterHealthy,
+		HealthStatusFilterUnhealthy,
+		HealthStatusFilterAll,
+	}
+}
+
 const (
 	// NamespaceFilterNameType is a NamespaceFilterName enum value
 	NamespaceFilterNameType = "TYPE"
 )
+
+// NamespaceFilterName_Values returns all elements of the NamespaceFilterName enum
+func NamespaceFilterName_Values() []string {
+	return []string{
+		NamespaceFilterNameType,
+	}
+}
 
 const (
 	// NamespaceTypeDnsPublic is a NamespaceType enum value
@@ -7603,6 +7654,15 @@ const (
 	// NamespaceTypeHttp is a NamespaceType enum value
 	NamespaceTypeHttp = "HTTP"
 )
+
+// NamespaceType_Values returns all elements of the NamespaceType enum
+func NamespaceType_Values() []string {
+	return []string{
+		NamespaceTypeDnsPublic,
+		NamespaceTypeDnsPrivate,
+		NamespaceTypeHttp,
+	}
+}
 
 const (
 	// OperationFilterNameNamespaceId is a OperationFilterName enum value
@@ -7621,6 +7681,17 @@ const (
 	OperationFilterNameUpdateDate = "UPDATE_DATE"
 )
 
+// OperationFilterName_Values returns all elements of the OperationFilterName enum
+func OperationFilterName_Values() []string {
+	return []string{
+		OperationFilterNameNamespaceId,
+		OperationFilterNameServiceId,
+		OperationFilterNameStatus,
+		OperationFilterNameType,
+		OperationFilterNameUpdateDate,
+	}
+}
+
 const (
 	// OperationStatusSubmitted is a OperationStatus enum value
 	OperationStatusSubmitted = "SUBMITTED"
@@ -7635,6 +7706,16 @@ const (
 	OperationStatusFail = "FAIL"
 )
 
+// OperationStatus_Values returns all elements of the OperationStatus enum
+func OperationStatus_Values() []string {
+	return []string{
+		OperationStatusSubmitted,
+		OperationStatusPending,
+		OperationStatusSuccess,
+		OperationStatusFail,
+	}
+}
+
 const (
 	// OperationTargetTypeNamespace is a OperationTargetType enum value
 	OperationTargetTypeNamespace = "NAMESPACE"
@@ -7645,6 +7726,15 @@ const (
 	// OperationTargetTypeInstance is a OperationTargetType enum value
 	OperationTargetTypeInstance = "INSTANCE"
 )
+
+// OperationTargetType_Values returns all elements of the OperationTargetType enum
+func OperationTargetType_Values() []string {
+	return []string{
+		OperationTargetTypeNamespace,
+		OperationTargetTypeService,
+		OperationTargetTypeInstance,
+	}
+}
 
 const (
 	// OperationTypeCreateNamespace is a OperationType enum value
@@ -7663,6 +7753,17 @@ const (
 	OperationTypeDeregisterInstance = "DEREGISTER_INSTANCE"
 )
 
+// OperationType_Values returns all elements of the OperationType enum
+func OperationType_Values() []string {
+	return []string{
+		OperationTypeCreateNamespace,
+		OperationTypeDeleteNamespace,
+		OperationTypeUpdateService,
+		OperationTypeRegisterInstance,
+		OperationTypeDeregisterInstance,
+	}
+}
+
 const (
 	// RecordTypeSrv is a RecordType enum value
 	RecordTypeSrv = "SRV"
@@ -7677,6 +7778,16 @@ const (
 	RecordTypeCname = "CNAME"
 )
 
+// RecordType_Values returns all elements of the RecordType enum
+func RecordType_Values() []string {
+	return []string{
+		RecordTypeSrv,
+		RecordTypeA,
+		RecordTypeAaaa,
+		RecordTypeCname,
+	}
+}
+
 const (
 	// RoutingPolicyMultivalue is a RoutingPolicy enum value
 	RoutingPolicyMultivalue = "MULTIVALUE"
@@ -7685,7 +7796,22 @@ const (
 	RoutingPolicyWeighted = "WEIGHTED"
 )
 
+// RoutingPolicy_Values returns all elements of the RoutingPolicy enum
+func RoutingPolicy_Values() []string {
+	return []string{
+		RoutingPolicyMultivalue,
+		RoutingPolicyWeighted,
+	}
+}
+
 const (
 	// ServiceFilterNameNamespaceId is a ServiceFilterName enum value
 	ServiceFilterNameNamespaceId = "NAMESPACE_ID"
 )
+
+// ServiceFilterName_Values returns all elements of the ServiceFilterName enum
+func ServiceFilterName_Values() []string {
+	return []string{
+		ServiceFilterNameNamespaceId,
+	}
+}

--- a/service/servicequotas/api.go
+++ b/service/servicequotas/api.go
@@ -4791,6 +4791,16 @@ const (
 	ErrorCodeServiceQuotaNotAvailableError = "SERVICE_QUOTA_NOT_AVAILABLE_ERROR"
 )
 
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeDependencyAccessDeniedError,
+		ErrorCodeDependencyThrottlingError,
+		ErrorCodeDependencyServiceError,
+		ErrorCodeServiceQuotaNotAvailableError,
+	}
+}
+
 const (
 	// PeriodUnitMicrosecond is a PeriodUnit enum value
 	PeriodUnitMicrosecond = "MICROSECOND"
@@ -4814,6 +4824,19 @@ const (
 	PeriodUnitWeek = "WEEK"
 )
 
+// PeriodUnit_Values returns all elements of the PeriodUnit enum
+func PeriodUnit_Values() []string {
+	return []string{
+		PeriodUnitMicrosecond,
+		PeriodUnitMillisecond,
+		PeriodUnitSecond,
+		PeriodUnitMinute,
+		PeriodUnitHour,
+		PeriodUnitDay,
+		PeriodUnitWeek,
+	}
+}
+
 const (
 	// RequestStatusPending is a RequestStatus enum value
 	RequestStatusPending = "PENDING"
@@ -4831,6 +4854,17 @@ const (
 	RequestStatusCaseClosed = "CASE_CLOSED"
 )
 
+// RequestStatus_Values returns all elements of the RequestStatus enum
+func RequestStatus_Values() []string {
+	return []string{
+		RequestStatusPending,
+		RequestStatusCaseOpened,
+		RequestStatusApproved,
+		RequestStatusDenied,
+		RequestStatusCaseClosed,
+	}
+}
+
 const (
 	// ServiceQuotaTemplateAssociationStatusAssociated is a ServiceQuotaTemplateAssociationStatus enum value
 	ServiceQuotaTemplateAssociationStatusAssociated = "ASSOCIATED"
@@ -4838,3 +4872,11 @@ const (
 	// ServiceQuotaTemplateAssociationStatusDisassociated is a ServiceQuotaTemplateAssociationStatus enum value
 	ServiceQuotaTemplateAssociationStatusDisassociated = "DISASSOCIATED"
 )
+
+// ServiceQuotaTemplateAssociationStatus_Values returns all elements of the ServiceQuotaTemplateAssociationStatus enum
+func ServiceQuotaTemplateAssociationStatus_Values() []string {
+	return []string{
+		ServiceQuotaTemplateAssociationStatusAssociated,
+		ServiceQuotaTemplateAssociationStatusDisassociated,
+	}
+}

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -15124,6 +15124,14 @@ const (
 	BehaviorOnMXFailureRejectMessage = "RejectMessage"
 )
 
+// BehaviorOnMXFailure_Values returns all elements of the BehaviorOnMXFailure enum
+func BehaviorOnMXFailure_Values() []string {
+	return []string{
+		BehaviorOnMXFailureUseDefaultValue,
+		BehaviorOnMXFailureRejectMessage,
+	}
+}
+
 const (
 	// BounceTypeDoesNotExist is a BounceType enum value
 	BounceTypeDoesNotExist = "DoesNotExist"
@@ -15143,6 +15151,18 @@ const (
 	// BounceTypeTemporaryFailure is a BounceType enum value
 	BounceTypeTemporaryFailure = "TemporaryFailure"
 )
+
+// BounceType_Values returns all elements of the BounceType enum
+func BounceType_Values() []string {
+	return []string{
+		BounceTypeDoesNotExist,
+		BounceTypeMessageTooLarge,
+		BounceTypeExceededQuota,
+		BounceTypeContentRejected,
+		BounceTypeUndefined,
+		BounceTypeTemporaryFailure,
+	}
+}
 
 const (
 	// BulkEmailStatusSuccess is a BulkEmailStatus enum value
@@ -15188,6 +15208,26 @@ const (
 	BulkEmailStatusFailed = "Failed"
 )
 
+// BulkEmailStatus_Values returns all elements of the BulkEmailStatus enum
+func BulkEmailStatus_Values() []string {
+	return []string{
+		BulkEmailStatusSuccess,
+		BulkEmailStatusMessageRejected,
+		BulkEmailStatusMailFromDomainNotVerified,
+		BulkEmailStatusConfigurationSetDoesNotExist,
+		BulkEmailStatusTemplateDoesNotExist,
+		BulkEmailStatusAccountSuspended,
+		BulkEmailStatusAccountThrottled,
+		BulkEmailStatusAccountDailyQuotaExceeded,
+		BulkEmailStatusInvalidSendingPoolName,
+		BulkEmailStatusAccountSendingPaused,
+		BulkEmailStatusConfigurationSetSendingPaused,
+		BulkEmailStatusInvalidParameterValue,
+		BulkEmailStatusTransientFailure,
+		BulkEmailStatusFailed,
+	}
+}
+
 const (
 	// ConfigurationSetAttributeEventDestinations is a ConfigurationSetAttribute enum value
 	ConfigurationSetAttributeEventDestinations = "eventDestinations"
@@ -15201,6 +15241,16 @@ const (
 	// ConfigurationSetAttributeReputationOptions is a ConfigurationSetAttribute enum value
 	ConfigurationSetAttributeReputationOptions = "reputationOptions"
 )
+
+// ConfigurationSetAttribute_Values returns all elements of the ConfigurationSetAttribute enum
+func ConfigurationSetAttribute_Values() []string {
+	return []string{
+		ConfigurationSetAttributeEventDestinations,
+		ConfigurationSetAttributeTrackingOptions,
+		ConfigurationSetAttributeDeliveryOptions,
+		ConfigurationSetAttributeReputationOptions,
+	}
+}
 
 const (
 	// CustomMailFromStatusPending is a CustomMailFromStatus enum value
@@ -15216,6 +15266,16 @@ const (
 	CustomMailFromStatusTemporaryFailure = "TemporaryFailure"
 )
 
+// CustomMailFromStatus_Values returns all elements of the CustomMailFromStatus enum
+func CustomMailFromStatus_Values() []string {
+	return []string{
+		CustomMailFromStatusPending,
+		CustomMailFromStatusSuccess,
+		CustomMailFromStatusFailed,
+		CustomMailFromStatusTemporaryFailure,
+	}
+}
+
 const (
 	// DimensionValueSourceMessageTag is a DimensionValueSource enum value
 	DimensionValueSourceMessageTag = "messageTag"
@@ -15226,6 +15286,15 @@ const (
 	// DimensionValueSourceLinkTag is a DimensionValueSource enum value
 	DimensionValueSourceLinkTag = "linkTag"
 )
+
+// DimensionValueSource_Values returns all elements of the DimensionValueSource enum
+func DimensionValueSource_Values() []string {
+	return []string{
+		DimensionValueSourceMessageTag,
+		DimensionValueSourceEmailHeader,
+		DimensionValueSourceLinkTag,
+	}
+}
 
 const (
 	// DsnActionFailed is a DsnAction enum value
@@ -15243,6 +15312,17 @@ const (
 	// DsnActionExpanded is a DsnAction enum value
 	DsnActionExpanded = "expanded"
 )
+
+// DsnAction_Values returns all elements of the DsnAction enum
+func DsnAction_Values() []string {
+	return []string{
+		DsnActionFailed,
+		DsnActionDelayed,
+		DsnActionDelivered,
+		DsnActionRelayed,
+		DsnActionExpanded,
+	}
+}
 
 const (
 	// EventTypeSend is a EventType enum value
@@ -15270,6 +15350,20 @@ const (
 	EventTypeRenderingFailure = "renderingFailure"
 )
 
+// EventType_Values returns all elements of the EventType enum
+func EventType_Values() []string {
+	return []string{
+		EventTypeSend,
+		EventTypeReject,
+		EventTypeBounce,
+		EventTypeComplaint,
+		EventTypeDelivery,
+		EventTypeOpen,
+		EventTypeClick,
+		EventTypeRenderingFailure,
+	}
+}
+
 const (
 	// IdentityTypeEmailAddress is a IdentityType enum value
 	IdentityTypeEmailAddress = "EmailAddress"
@@ -15278,6 +15372,14 @@ const (
 	IdentityTypeDomain = "Domain"
 )
 
+// IdentityType_Values returns all elements of the IdentityType enum
+func IdentityType_Values() []string {
+	return []string{
+		IdentityTypeEmailAddress,
+		IdentityTypeDomain,
+	}
+}
+
 const (
 	// InvocationTypeEvent is a InvocationType enum value
 	InvocationTypeEvent = "Event"
@@ -15285,6 +15387,14 @@ const (
 	// InvocationTypeRequestResponse is a InvocationType enum value
 	InvocationTypeRequestResponse = "RequestResponse"
 )
+
+// InvocationType_Values returns all elements of the InvocationType enum
+func InvocationType_Values() []string {
+	return []string{
+		InvocationTypeEvent,
+		InvocationTypeRequestResponse,
+	}
+}
 
 const (
 	// NotificationTypeBounce is a NotificationType enum value
@@ -15297,6 +15407,15 @@ const (
 	NotificationTypeDelivery = "Delivery"
 )
 
+// NotificationType_Values returns all elements of the NotificationType enum
+func NotificationType_Values() []string {
+	return []string{
+		NotificationTypeBounce,
+		NotificationTypeComplaint,
+		NotificationTypeDelivery,
+	}
+}
+
 const (
 	// ReceiptFilterPolicyBlock is a ReceiptFilterPolicy enum value
 	ReceiptFilterPolicyBlock = "Block"
@@ -15304,6 +15423,14 @@ const (
 	// ReceiptFilterPolicyAllow is a ReceiptFilterPolicy enum value
 	ReceiptFilterPolicyAllow = "Allow"
 )
+
+// ReceiptFilterPolicy_Values returns all elements of the ReceiptFilterPolicy enum
+func ReceiptFilterPolicy_Values() []string {
+	return []string{
+		ReceiptFilterPolicyBlock,
+		ReceiptFilterPolicyAllow,
+	}
+}
 
 const (
 	// SNSActionEncodingUtf8 is a SNSActionEncoding enum value
@@ -15313,10 +15440,25 @@ const (
 	SNSActionEncodingBase64 = "Base64"
 )
 
+// SNSActionEncoding_Values returns all elements of the SNSActionEncoding enum
+func SNSActionEncoding_Values() []string {
+	return []string{
+		SNSActionEncodingUtf8,
+		SNSActionEncodingBase64,
+	}
+}
+
 const (
 	// StopScopeRuleSet is a StopScope enum value
 	StopScopeRuleSet = "RuleSet"
 )
+
+// StopScope_Values returns all elements of the StopScope enum
+func StopScope_Values() []string {
+	return []string{
+		StopScopeRuleSet,
+	}
+}
 
 const (
 	// TlsPolicyRequire is a TlsPolicy enum value
@@ -15325,6 +15467,14 @@ const (
 	// TlsPolicyOptional is a TlsPolicy enum value
 	TlsPolicyOptional = "Optional"
 )
+
+// TlsPolicy_Values returns all elements of the TlsPolicy enum
+func TlsPolicy_Values() []string {
+	return []string{
+		TlsPolicyRequire,
+		TlsPolicyOptional,
+	}
+}
 
 const (
 	// VerificationStatusPending is a VerificationStatus enum value
@@ -15342,3 +15492,14 @@ const (
 	// VerificationStatusNotStarted is a VerificationStatus enum value
 	VerificationStatusNotStarted = "NotStarted"
 )
+
+// VerificationStatus_Values returns all elements of the VerificationStatus enum
+func VerificationStatus_Values() []string {
+	return []string{
+		VerificationStatusPending,
+		VerificationStatusSuccess,
+		VerificationStatusFailed,
+		VerificationStatusTemporaryFailure,
+		VerificationStatusNotStarted,
+	}
+}

--- a/service/sesv2/api.go
+++ b/service/sesv2/api.go
@@ -16349,6 +16349,14 @@ const (
 	BehaviorOnMxFailureRejectMessage = "REJECT_MESSAGE"
 )
 
+// BehaviorOnMxFailure_Values returns all elements of the BehaviorOnMxFailure enum
+func BehaviorOnMxFailure_Values() []string {
+	return []string{
+		BehaviorOnMxFailureUseDefaultValue,
+		BehaviorOnMxFailureRejectMessage,
+	}
+}
+
 const (
 	// BulkEmailStatusSuccess is a BulkEmailStatus enum value
 	BulkEmailStatusSuccess = "SUCCESS"
@@ -16393,6 +16401,26 @@ const (
 	BulkEmailStatusFailed = "FAILED"
 )
 
+// BulkEmailStatus_Values returns all elements of the BulkEmailStatus enum
+func BulkEmailStatus_Values() []string {
+	return []string{
+		BulkEmailStatusSuccess,
+		BulkEmailStatusMessageRejected,
+		BulkEmailStatusMailFromDomainNotVerified,
+		BulkEmailStatusConfigurationSetNotFound,
+		BulkEmailStatusTemplateNotFound,
+		BulkEmailStatusAccountSuspended,
+		BulkEmailStatusAccountThrottled,
+		BulkEmailStatusAccountDailyQuotaExceeded,
+		BulkEmailStatusInvalidSendingPoolName,
+		BulkEmailStatusAccountSendingPaused,
+		BulkEmailStatusConfigurationSetSendingPaused,
+		BulkEmailStatusInvalidParameter,
+		BulkEmailStatusTransientFailure,
+		BulkEmailStatusFailed,
+	}
+}
+
 const (
 	// ContactLanguageEn is a ContactLanguage enum value
 	ContactLanguageEn = "EN"
@@ -16400,6 +16428,14 @@ const (
 	// ContactLanguageJa is a ContactLanguage enum value
 	ContactLanguageJa = "JA"
 )
+
+// ContactLanguage_Values returns all elements of the ContactLanguage enum
+func ContactLanguage_Values() []string {
+	return []string{
+		ContactLanguageEn,
+		ContactLanguageJa,
+	}
+}
 
 // The current status of your Deliverability dashboard subscription. If this
 // value is PENDING_EXPIRATION, your subscription is scheduled to expire at
@@ -16415,6 +16451,15 @@ const (
 	DeliverabilityDashboardAccountStatusDisabled = "DISABLED"
 )
 
+// DeliverabilityDashboardAccountStatus_Values returns all elements of the DeliverabilityDashboardAccountStatus enum
+func DeliverabilityDashboardAccountStatus_Values() []string {
+	return []string{
+		DeliverabilityDashboardAccountStatusActive,
+		DeliverabilityDashboardAccountStatusPendingExpiration,
+		DeliverabilityDashboardAccountStatusDisabled,
+	}
+}
+
 // The status of a predictive inbox placement test. If the status is IN_PROGRESS,
 // then the predictive inbox placement test is currently running. Predictive
 // inbox placement tests are usually complete within 24 hours of creating the
@@ -16427,6 +16472,14 @@ const (
 	// DeliverabilityTestStatusCompleted is a DeliverabilityTestStatus enum value
 	DeliverabilityTestStatusCompleted = "COMPLETED"
 )
+
+// DeliverabilityTestStatus_Values returns all elements of the DeliverabilityTestStatus enum
+func DeliverabilityTestStatus_Values() []string {
+	return []string{
+		DeliverabilityTestStatusInProgress,
+		DeliverabilityTestStatusCompleted,
+	}
+}
 
 // The location where the Amazon SES API v2 finds the value of a dimension to
 // publish to Amazon CloudWatch. If you want to use the message tags that you
@@ -16444,6 +16497,15 @@ const (
 	DimensionValueSourceLinkTag = "LINK_TAG"
 )
 
+// DimensionValueSource_Values returns all elements of the DimensionValueSource enum
+func DimensionValueSource_Values() []string {
+	return []string{
+		DimensionValueSourceMessageTag,
+		DimensionValueSourceEmailHeader,
+		DimensionValueSourceLinkTag,
+	}
+}
+
 const (
 	// DkimSigningAttributesOriginAwsSes is a DkimSigningAttributesOrigin enum value
 	DkimSigningAttributesOriginAwsSes = "AWS_SES"
@@ -16451,6 +16513,14 @@ const (
 	// DkimSigningAttributesOriginExternal is a DkimSigningAttributesOrigin enum value
 	DkimSigningAttributesOriginExternal = "EXTERNAL"
 )
+
+// DkimSigningAttributesOrigin_Values returns all elements of the DkimSigningAttributesOrigin enum
+func DkimSigningAttributesOrigin_Values() []string {
+	return []string{
+		DkimSigningAttributesOriginAwsSes,
+		DkimSigningAttributesOriginExternal,
+	}
+}
 
 // The DKIM authentication status of the identity. The status can be one of
 // the following:
@@ -16486,6 +16556,17 @@ const (
 	DkimStatusNotStarted = "NOT_STARTED"
 )
 
+// DkimStatus_Values returns all elements of the DkimStatus enum
+func DkimStatus_Values() []string {
+	return []string{
+		DkimStatusPending,
+		DkimStatusSuccess,
+		DkimStatusFailed,
+		DkimStatusTemporaryFailure,
+		DkimStatusNotStarted,
+	}
+}
+
 // An email sending event type. For example, email sends, opens, and bounces
 // are all email events.
 const (
@@ -16517,6 +16598,21 @@ const (
 	EventTypeDeliveryDelay = "DELIVERY_DELAY"
 )
 
+// EventType_Values returns all elements of the EventType enum
+func EventType_Values() []string {
+	return []string{
+		EventTypeSend,
+		EventTypeReject,
+		EventTypeBounce,
+		EventTypeComplaint,
+		EventTypeDelivery,
+		EventTypeOpen,
+		EventTypeClick,
+		EventTypeRenderingFailure,
+		EventTypeDeliveryDelay,
+	}
+}
+
 // The email identity type. The identity type can be one of the following:
 //
 //    * EMAIL_ADDRESS – The identity is an email address.
@@ -16532,6 +16628,15 @@ const (
 	// IdentityTypeManagedDomain is a IdentityType enum value
 	IdentityTypeManagedDomain = "MANAGED_DOMAIN"
 )
+
+// IdentityType_Values returns all elements of the IdentityType enum
+func IdentityType_Values() []string {
+	return []string{
+		IdentityTypeEmailAddress,
+		IdentityTypeDomain,
+		IdentityTypeManagedDomain,
+	}
+}
 
 // The status of the MAIL FROM domain. This status can have the following values:
 //
@@ -16559,6 +16664,16 @@ const (
 	MailFromDomainStatusTemporaryFailure = "TEMPORARY_FAILURE"
 )
 
+// MailFromDomainStatus_Values returns all elements of the MailFromDomainStatus enum
+func MailFromDomainStatus_Values() []string {
+	return []string{
+		MailFromDomainStatusPending,
+		MailFromDomainStatusSuccess,
+		MailFromDomainStatusFailed,
+		MailFromDomainStatusTemporaryFailure,
+	}
+}
+
 const (
 	// MailTypeMarketing is a MailType enum value
 	MailTypeMarketing = "MARKETING"
@@ -16566,6 +16681,14 @@ const (
 	// MailTypeTransactional is a MailType enum value
 	MailTypeTransactional = "TRANSACTIONAL"
 )
+
+// MailType_Values returns all elements of the MailType enum
+func MailType_Values() []string {
+	return []string{
+		MailTypeMarketing,
+		MailTypeTransactional,
+	}
+}
 
 const (
 	// ReviewStatusPending is a ReviewStatus enum value
@@ -16580,6 +16703,16 @@ const (
 	// ReviewStatusDenied is a ReviewStatus enum value
 	ReviewStatusDenied = "DENIED"
 )
+
+// ReviewStatus_Values returns all elements of the ReviewStatus enum
+func ReviewStatus_Values() []string {
+	return []string{
+		ReviewStatusPending,
+		ReviewStatusFailed,
+		ReviewStatusGranted,
+		ReviewStatusDenied,
+	}
+}
 
 // The reason that the address was added to the suppression list for your account.
 // The value can be one of the following:
@@ -16598,6 +16731,14 @@ const (
 	SuppressionListReasonComplaint = "COMPLAINT"
 )
 
+// SuppressionListReason_Values returns all elements of the SuppressionListReason enum
+func SuppressionListReason_Values() []string {
+	return []string{
+		SuppressionListReasonBounce,
+		SuppressionListReasonComplaint,
+	}
+}
+
 // Specifies whether messages that use the configuration set are required to
 // use Transport Layer Security (TLS). If the value is Require, messages are
 // only delivered if a TLS connection can be established. If the value is Optional,
@@ -16610,6 +16751,14 @@ const (
 	TlsPolicyOptional = "OPTIONAL"
 )
 
+// TlsPolicy_Values returns all elements of the TlsPolicy enum
+func TlsPolicy_Values() []string {
+	return []string{
+		TlsPolicyRequire,
+		TlsPolicyOptional,
+	}
+}
+
 // The warmup status of a dedicated IP.
 const (
 	// WarmupStatusInProgress is a WarmupStatus enum value
@@ -16618,3 +16767,11 @@ const (
 	// WarmupStatusDone is a WarmupStatus enum value
 	WarmupStatusDone = "DONE"
 )
+
+// WarmupStatus_Values returns all elements of the WarmupStatus enum
+func WarmupStatus_Values() []string {
+	return []string{
+		WarmupStatusInProgress,
+		WarmupStatusDone,
+	}
+}

--- a/service/sfn/api.go
+++ b/service/sfn/api.go
@@ -7678,6 +7678,17 @@ const (
 	ExecutionStatusAborted = "ABORTED"
 )
 
+// ExecutionStatus_Values returns all elements of the ExecutionStatus enum
+func ExecutionStatus_Values() []string {
+	return []string{
+		ExecutionStatusRunning,
+		ExecutionStatusSucceeded,
+		ExecutionStatusFailed,
+		ExecutionStatusTimedOut,
+		ExecutionStatusAborted,
+	}
+}
+
 const (
 	// HistoryEventTypeActivityFailed is a HistoryEventType enum value
 	HistoryEventTypeActivityFailed = "ActivityFailed"
@@ -7845,6 +7856,67 @@ const (
 	HistoryEventTypeWaitStateExited = "WaitStateExited"
 )
 
+// HistoryEventType_Values returns all elements of the HistoryEventType enum
+func HistoryEventType_Values() []string {
+	return []string{
+		HistoryEventTypeActivityFailed,
+		HistoryEventTypeActivityScheduled,
+		HistoryEventTypeActivityScheduleFailed,
+		HistoryEventTypeActivityStarted,
+		HistoryEventTypeActivitySucceeded,
+		HistoryEventTypeActivityTimedOut,
+		HistoryEventTypeChoiceStateEntered,
+		HistoryEventTypeChoiceStateExited,
+		HistoryEventTypeExecutionAborted,
+		HistoryEventTypeExecutionFailed,
+		HistoryEventTypeExecutionStarted,
+		HistoryEventTypeExecutionSucceeded,
+		HistoryEventTypeExecutionTimedOut,
+		HistoryEventTypeFailStateEntered,
+		HistoryEventTypeLambdaFunctionFailed,
+		HistoryEventTypeLambdaFunctionScheduled,
+		HistoryEventTypeLambdaFunctionScheduleFailed,
+		HistoryEventTypeLambdaFunctionStarted,
+		HistoryEventTypeLambdaFunctionStartFailed,
+		HistoryEventTypeLambdaFunctionSucceeded,
+		HistoryEventTypeLambdaFunctionTimedOut,
+		HistoryEventTypeMapIterationAborted,
+		HistoryEventTypeMapIterationFailed,
+		HistoryEventTypeMapIterationStarted,
+		HistoryEventTypeMapIterationSucceeded,
+		HistoryEventTypeMapStateAborted,
+		HistoryEventTypeMapStateEntered,
+		HistoryEventTypeMapStateExited,
+		HistoryEventTypeMapStateFailed,
+		HistoryEventTypeMapStateStarted,
+		HistoryEventTypeMapStateSucceeded,
+		HistoryEventTypeParallelStateAborted,
+		HistoryEventTypeParallelStateEntered,
+		HistoryEventTypeParallelStateExited,
+		HistoryEventTypeParallelStateFailed,
+		HistoryEventTypeParallelStateStarted,
+		HistoryEventTypeParallelStateSucceeded,
+		HistoryEventTypePassStateEntered,
+		HistoryEventTypePassStateExited,
+		HistoryEventTypeSucceedStateEntered,
+		HistoryEventTypeSucceedStateExited,
+		HistoryEventTypeTaskFailed,
+		HistoryEventTypeTaskScheduled,
+		HistoryEventTypeTaskStarted,
+		HistoryEventTypeTaskStartFailed,
+		HistoryEventTypeTaskStateAborted,
+		HistoryEventTypeTaskStateEntered,
+		HistoryEventTypeTaskStateExited,
+		HistoryEventTypeTaskSubmitFailed,
+		HistoryEventTypeTaskSubmitted,
+		HistoryEventTypeTaskSucceeded,
+		HistoryEventTypeTaskTimedOut,
+		HistoryEventTypeWaitStateAborted,
+		HistoryEventTypeWaitStateEntered,
+		HistoryEventTypeWaitStateExited,
+	}
+}
+
 const (
 	// LogLevelAll is a LogLevel enum value
 	LogLevelAll = "ALL"
@@ -7859,6 +7931,16 @@ const (
 	LogLevelOff = "OFF"
 )
 
+// LogLevel_Values returns all elements of the LogLevel enum
+func LogLevel_Values() []string {
+	return []string{
+		LogLevelAll,
+		LogLevelError,
+		LogLevelFatal,
+		LogLevelOff,
+	}
+}
+
 const (
 	// StateMachineStatusActive is a StateMachineStatus enum value
 	StateMachineStatusActive = "ACTIVE"
@@ -7867,6 +7949,14 @@ const (
 	StateMachineStatusDeleting = "DELETING"
 )
 
+// StateMachineStatus_Values returns all elements of the StateMachineStatus enum
+func StateMachineStatus_Values() []string {
+	return []string{
+		StateMachineStatusActive,
+		StateMachineStatusDeleting,
+	}
+}
+
 const (
 	// StateMachineTypeStandard is a StateMachineType enum value
 	StateMachineTypeStandard = "STANDARD"
@@ -7874,3 +7964,11 @@ const (
 	// StateMachineTypeExpress is a StateMachineType enum value
 	StateMachineTypeExpress = "EXPRESS"
 )
+
+// StateMachineType_Values returns all elements of the StateMachineType enum
+func StateMachineType_Values() []string {
+	return []string{
+		StateMachineTypeStandard,
+		StateMachineTypeExpress,
+	}
+}

--- a/service/shield/api.go
+++ b/service/shield/api.go
@@ -5178,6 +5178,14 @@ const (
 	AttackLayerApplication = "APPLICATION"
 )
 
+// AttackLayer_Values returns all elements of the AttackLayer enum
+func AttackLayer_Values() []string {
+	return []string{
+		AttackLayerNetwork,
+		AttackLayerApplication,
+	}
+}
+
 const (
 	// AttackPropertyIdentifierDestinationUrl is a AttackPropertyIdentifier enum value
 	AttackPropertyIdentifierDestinationUrl = "DESTINATION_URL"
@@ -5204,6 +5212,20 @@ const (
 	AttackPropertyIdentifierWordpressPingbackSource = "WORDPRESS_PINGBACK_SOURCE"
 )
 
+// AttackPropertyIdentifier_Values returns all elements of the AttackPropertyIdentifier enum
+func AttackPropertyIdentifier_Values() []string {
+	return []string{
+		AttackPropertyIdentifierDestinationUrl,
+		AttackPropertyIdentifierReferrer,
+		AttackPropertyIdentifierSourceAsn,
+		AttackPropertyIdentifierSourceCountry,
+		AttackPropertyIdentifierSourceIpAddress,
+		AttackPropertyIdentifierSourceUserAgent,
+		AttackPropertyIdentifierWordpressPingbackReflector,
+		AttackPropertyIdentifierWordpressPingbackSource,
+	}
+}
+
 const (
 	// AutoRenewEnabled is a AutoRenew enum value
 	AutoRenewEnabled = "ENABLED"
@@ -5211,6 +5233,14 @@ const (
 	// AutoRenewDisabled is a AutoRenew enum value
 	AutoRenewDisabled = "DISABLED"
 )
+
+// AutoRenew_Values returns all elements of the AutoRenew enum
+func AutoRenew_Values() []string {
+	return []string{
+		AutoRenewEnabled,
+		AutoRenewDisabled,
+	}
+}
 
 const (
 	// ProactiveEngagementStatusEnabled is a ProactiveEngagementStatus enum value
@@ -5223,6 +5253,15 @@ const (
 	ProactiveEngagementStatusPending = "PENDING"
 )
 
+// ProactiveEngagementStatus_Values returns all elements of the ProactiveEngagementStatus enum
+func ProactiveEngagementStatus_Values() []string {
+	return []string{
+		ProactiveEngagementStatusEnabled,
+		ProactiveEngagementStatusDisabled,
+		ProactiveEngagementStatusPending,
+	}
+}
+
 const (
 	// SubResourceTypeIp is a SubResourceType enum value
 	SubResourceTypeIp = "IP"
@@ -5231,6 +5270,14 @@ const (
 	SubResourceTypeUrl = "URL"
 )
 
+// SubResourceType_Values returns all elements of the SubResourceType enum
+func SubResourceType_Values() []string {
+	return []string{
+		SubResourceTypeIp,
+		SubResourceTypeUrl,
+	}
+}
+
 const (
 	// SubscriptionStateActive is a SubscriptionState enum value
 	SubscriptionStateActive = "ACTIVE"
@@ -5238,6 +5285,14 @@ const (
 	// SubscriptionStateInactive is a SubscriptionState enum value
 	SubscriptionStateInactive = "INACTIVE"
 )
+
+// SubscriptionState_Values returns all elements of the SubscriptionState enum
+func SubscriptionState_Values() []string {
+	return []string{
+		SubscriptionStateActive,
+		SubscriptionStateInactive,
+	}
+}
 
 const (
 	// UnitBits is a Unit enum value
@@ -5252,3 +5307,13 @@ const (
 	// UnitRequests is a Unit enum value
 	UnitRequests = "REQUESTS"
 )
+
+// Unit_Values returns all elements of the Unit enum
+func Unit_Values() []string {
+	return []string{
+		UnitBits,
+		UnitBytes,
+		UnitPackets,
+		UnitRequests,
+	}
+}

--- a/service/signer/api.go
+++ b/service/signer/api.go
@@ -3648,6 +3648,13 @@ const (
 	CategoryAwsioT = "AWSIoT"
 )
 
+// Category_Values returns all elements of the Category enum
+func Category_Values() []string {
+	return []string{
+		CategoryAwsioT,
+	}
+}
+
 const (
 	// EncryptionAlgorithmRsa is a EncryptionAlgorithm enum value
 	EncryptionAlgorithmRsa = "RSA"
@@ -3656,6 +3663,14 @@ const (
 	EncryptionAlgorithmEcdsa = "ECDSA"
 )
 
+// EncryptionAlgorithm_Values returns all elements of the EncryptionAlgorithm enum
+func EncryptionAlgorithm_Values() []string {
+	return []string{
+		EncryptionAlgorithmRsa,
+		EncryptionAlgorithmEcdsa,
+	}
+}
+
 const (
 	// HashAlgorithmSha1 is a HashAlgorithm enum value
 	HashAlgorithmSha1 = "SHA1"
@@ -3663,6 +3678,14 @@ const (
 	// HashAlgorithmSha256 is a HashAlgorithm enum value
 	HashAlgorithmSha256 = "SHA256"
 )
+
+// HashAlgorithm_Values returns all elements of the HashAlgorithm enum
+func HashAlgorithm_Values() []string {
+	return []string{
+		HashAlgorithmSha1,
+		HashAlgorithmSha256,
+	}
+}
 
 const (
 	// ImageFormatJson is a ImageFormat enum value
@@ -3675,6 +3698,15 @@ const (
 	ImageFormatJsondetached = "JSONDetached"
 )
 
+// ImageFormat_Values returns all elements of the ImageFormat enum
+func ImageFormat_Values() []string {
+	return []string{
+		ImageFormatJson,
+		ImageFormatJsonembedded,
+		ImageFormatJsondetached,
+	}
+}
+
 const (
 	// SigningProfileStatusActive is a SigningProfileStatus enum value
 	SigningProfileStatusActive = "Active"
@@ -3682,6 +3714,14 @@ const (
 	// SigningProfileStatusCanceled is a SigningProfileStatus enum value
 	SigningProfileStatusCanceled = "Canceled"
 )
+
+// SigningProfileStatus_Values returns all elements of the SigningProfileStatus enum
+func SigningProfileStatus_Values() []string {
+	return []string{
+		SigningProfileStatusActive,
+		SigningProfileStatusCanceled,
+	}
+}
 
 const (
 	// SigningStatusInProgress is a SigningStatus enum value
@@ -3693,3 +3733,12 @@ const (
 	// SigningStatusSucceeded is a SigningStatus enum value
 	SigningStatusSucceeded = "Succeeded"
 )
+
+// SigningStatus_Values returns all elements of the SigningStatus enum
+func SigningStatus_Values() []string {
+	return []string{
+		SigningStatusInProgress,
+		SigningStatusFailed,
+		SigningStatusSucceeded,
+	}
+}

--- a/service/sms/api.go
+++ b/service/sms/api.go
@@ -8424,6 +8424,14 @@ const (
 	AppLaunchConfigurationStatusConfigured = "CONFIGURED"
 )
 
+// AppLaunchConfigurationStatus_Values returns all elements of the AppLaunchConfigurationStatus enum
+func AppLaunchConfigurationStatus_Values() []string {
+	return []string{
+		AppLaunchConfigurationStatusNotConfigured,
+		AppLaunchConfigurationStatusConfigured,
+	}
+}
+
 const (
 	// AppLaunchStatusReadyForConfiguration is a AppLaunchStatus enum value
 	AppLaunchStatusReadyForConfiguration = "READY_FOR_CONFIGURATION"
@@ -8471,6 +8479,27 @@ const (
 	AppLaunchStatusTerminated = "TERMINATED"
 )
 
+// AppLaunchStatus_Values returns all elements of the AppLaunchStatus enum
+func AppLaunchStatus_Values() []string {
+	return []string{
+		AppLaunchStatusReadyForConfiguration,
+		AppLaunchStatusConfigurationInProgress,
+		AppLaunchStatusConfigurationInvalid,
+		AppLaunchStatusReadyForLaunch,
+		AppLaunchStatusValidationInProgress,
+		AppLaunchStatusLaunchPending,
+		AppLaunchStatusLaunchInProgress,
+		AppLaunchStatusLaunched,
+		AppLaunchStatusPartiallyLaunched,
+		AppLaunchStatusDeltaLaunchInProgress,
+		AppLaunchStatusDeltaLaunchFailed,
+		AppLaunchStatusLaunchFailed,
+		AppLaunchStatusTerminateInProgress,
+		AppLaunchStatusTerminateFailed,
+		AppLaunchStatusTerminated,
+	}
+}
+
 const (
 	// AppReplicationConfigurationStatusNotConfigured is a AppReplicationConfigurationStatus enum value
 	AppReplicationConfigurationStatusNotConfigured = "NOT_CONFIGURED"
@@ -8478,6 +8507,14 @@ const (
 	// AppReplicationConfigurationStatusConfigured is a AppReplicationConfigurationStatus enum value
 	AppReplicationConfigurationStatusConfigured = "CONFIGURED"
 )
+
+// AppReplicationConfigurationStatus_Values returns all elements of the AppReplicationConfigurationStatus enum
+func AppReplicationConfigurationStatus_Values() []string {
+	return []string{
+		AppReplicationConfigurationStatusNotConfigured,
+		AppReplicationConfigurationStatusConfigured,
+	}
+}
 
 const (
 	// AppReplicationStatusReadyForConfiguration is a AppReplicationStatus enum value
@@ -8529,6 +8566,28 @@ const (
 	AppReplicationStatusReplicationStopped = "REPLICATION_STOPPED"
 )
 
+// AppReplicationStatus_Values returns all elements of the AppReplicationStatus enum
+func AppReplicationStatus_Values() []string {
+	return []string{
+		AppReplicationStatusReadyForConfiguration,
+		AppReplicationStatusConfigurationInProgress,
+		AppReplicationStatusConfigurationInvalid,
+		AppReplicationStatusReadyForReplication,
+		AppReplicationStatusValidationInProgress,
+		AppReplicationStatusReplicationPending,
+		AppReplicationStatusReplicationInProgress,
+		AppReplicationStatusReplicated,
+		AppReplicationStatusPartiallyReplicated,
+		AppReplicationStatusDeltaReplicationInProgress,
+		AppReplicationStatusDeltaReplicated,
+		AppReplicationStatusDeltaReplicationFailed,
+		AppReplicationStatusReplicationFailed,
+		AppReplicationStatusReplicationStopping,
+		AppReplicationStatusReplicationStopFailed,
+		AppReplicationStatusReplicationStopped,
+	}
+}
+
 const (
 	// AppStatusCreating is a AppStatus enum value
 	AppStatusCreating = "CREATING"
@@ -8549,10 +8608,29 @@ const (
 	AppStatusDeleteFailed = "DELETE_FAILED"
 )
 
+// AppStatus_Values returns all elements of the AppStatus enum
+func AppStatus_Values() []string {
+	return []string{
+		AppStatusCreating,
+		AppStatusActive,
+		AppStatusUpdating,
+		AppStatusDeleting,
+		AppStatusDeleted,
+		AppStatusDeleteFailed,
+	}
+}
+
 const (
 	// AppValidationStrategySsm is a AppValidationStrategy enum value
 	AppValidationStrategySsm = "SSM"
 )
+
+// AppValidationStrategy_Values returns all elements of the AppValidationStrategy enum
+func AppValidationStrategy_Values() []string {
+	return []string{
+		AppValidationStrategySsm,
+	}
+}
 
 const (
 	// ConnectorCapabilityVsphere is a ConnectorCapability enum value
@@ -8571,6 +8649,17 @@ const (
 	ConnectorCapabilitySmsOptimized = "SMS_OPTIMIZED"
 )
 
+// ConnectorCapability_Values returns all elements of the ConnectorCapability enum
+func ConnectorCapability_Values() []string {
+	return []string{
+		ConnectorCapabilityVsphere,
+		ConnectorCapabilityScvmm,
+		ConnectorCapabilityHypervManager,
+		ConnectorCapabilitySnapshotBatching,
+		ConnectorCapabilitySmsOptimized,
+	}
+}
+
 const (
 	// ConnectorStatusHealthy is a ConnectorStatus enum value
 	ConnectorStatusHealthy = "HEALTHY"
@@ -8578,6 +8667,14 @@ const (
 	// ConnectorStatusUnhealthy is a ConnectorStatus enum value
 	ConnectorStatusUnhealthy = "UNHEALTHY"
 )
+
+// ConnectorStatus_Values returns all elements of the ConnectorStatus enum
+func ConnectorStatus_Values() []string {
+	return []string{
+		ConnectorStatusHealthy,
+		ConnectorStatusUnhealthy,
+	}
+}
 
 const (
 	// LicenseTypeAws is a LicenseType enum value
@@ -8587,6 +8684,14 @@ const (
 	LicenseTypeByol = "BYOL"
 )
 
+// LicenseType_Values returns all elements of the LicenseType enum
+func LicenseType_Values() []string {
+	return []string{
+		LicenseTypeAws,
+		LicenseTypeByol,
+	}
+}
+
 const (
 	// OutputFormatJson is a OutputFormat enum value
 	OutputFormatJson = "JSON"
@@ -8594,6 +8699,14 @@ const (
 	// OutputFormatYaml is a OutputFormat enum value
 	OutputFormatYaml = "YAML"
 )
+
+// OutputFormat_Values returns all elements of the OutputFormat enum
+func OutputFormat_Values() []string {
+	return []string{
+		OutputFormatJson,
+		OutputFormatYaml,
+	}
+}
 
 const (
 	// ReplicationJobStatePending is a ReplicationJobState enum value
@@ -8621,6 +8734,20 @@ const (
 	ReplicationJobStateFailing = "FAILING"
 )
 
+// ReplicationJobState_Values returns all elements of the ReplicationJobState enum
+func ReplicationJobState_Values() []string {
+	return []string{
+		ReplicationJobStatePending,
+		ReplicationJobStateActive,
+		ReplicationJobStateFailed,
+		ReplicationJobStateDeleting,
+		ReplicationJobStateDeleted,
+		ReplicationJobStateCompleted,
+		ReplicationJobStatePausedOnFailure,
+		ReplicationJobStateFailing,
+	}
+}
+
 const (
 	// ReplicationRunStatePending is a ReplicationRunState enum value
 	ReplicationRunStatePending = "PENDING"
@@ -8644,6 +8771,19 @@ const (
 	ReplicationRunStateDeleted = "DELETED"
 )
 
+// ReplicationRunState_Values returns all elements of the ReplicationRunState enum
+func ReplicationRunState_Values() []string {
+	return []string{
+		ReplicationRunStatePending,
+		ReplicationRunStateMissed,
+		ReplicationRunStateActive,
+		ReplicationRunStateFailed,
+		ReplicationRunStateCompleted,
+		ReplicationRunStateDeleting,
+		ReplicationRunStateDeleted,
+	}
+}
+
 const (
 	// ReplicationRunTypeOnDemand is a ReplicationRunType enum value
 	ReplicationRunTypeOnDemand = "ON_DEMAND"
@@ -8652,6 +8792,14 @@ const (
 	ReplicationRunTypeAutomatic = "AUTOMATIC"
 )
 
+// ReplicationRunType_Values returns all elements of the ReplicationRunType enum
+func ReplicationRunType_Values() []string {
+	return []string{
+		ReplicationRunTypeOnDemand,
+		ReplicationRunTypeAutomatic,
+	}
+}
+
 const (
 	// ScriptTypeShellScript is a ScriptType enum value
 	ScriptTypeShellScript = "SHELL_SCRIPT"
@@ -8659,6 +8807,14 @@ const (
 	// ScriptTypePowershellScript is a ScriptType enum value
 	ScriptTypePowershellScript = "POWERSHELL_SCRIPT"
 )
+
+// ScriptType_Values returns all elements of the ScriptType enum
+func ScriptType_Values() []string {
+	return []string{
+		ScriptTypeShellScript,
+		ScriptTypePowershellScript,
+	}
+}
 
 const (
 	// ServerCatalogStatusNotImported is a ServerCatalogStatus enum value
@@ -8677,15 +8833,40 @@ const (
 	ServerCatalogStatusExpired = "EXPIRED"
 )
 
+// ServerCatalogStatus_Values returns all elements of the ServerCatalogStatus enum
+func ServerCatalogStatus_Values() []string {
+	return []string{
+		ServerCatalogStatusNotImported,
+		ServerCatalogStatusImporting,
+		ServerCatalogStatusAvailable,
+		ServerCatalogStatusDeleted,
+		ServerCatalogStatusExpired,
+	}
+}
+
 const (
 	// ServerTypeVirtualMachine is a ServerType enum value
 	ServerTypeVirtualMachine = "VIRTUAL_MACHINE"
 )
 
+// ServerType_Values returns all elements of the ServerType enum
+func ServerType_Values() []string {
+	return []string{
+		ServerTypeVirtualMachine,
+	}
+}
+
 const (
 	// ServerValidationStrategyUserdata is a ServerValidationStrategy enum value
 	ServerValidationStrategyUserdata = "USERDATA"
 )
+
+// ServerValidationStrategy_Values returns all elements of the ServerValidationStrategy enum
+func ServerValidationStrategy_Values() []string {
+	return []string{
+		ServerValidationStrategyUserdata,
+	}
+}
 
 const (
 	// ValidationStatusReadyForValidation is a ValidationStatus enum value
@@ -8704,6 +8885,17 @@ const (
 	ValidationStatusFailed = "FAILED"
 )
 
+// ValidationStatus_Values returns all elements of the ValidationStatus enum
+func ValidationStatus_Values() []string {
+	return []string{
+		ValidationStatusReadyForValidation,
+		ValidationStatusPending,
+		ValidationStatusInProgress,
+		ValidationStatusSucceeded,
+		ValidationStatusFailed,
+	}
+}
+
 const (
 	// VmManagerTypeVsphere is a VmManagerType enum value
 	VmManagerTypeVsphere = "VSPHERE"
@@ -8714,3 +8906,12 @@ const (
 	// VmManagerTypeHypervManager is a VmManagerType enum value
 	VmManagerTypeHypervManager = "HYPERV-MANAGER"
 )
+
+// VmManagerType_Values returns all elements of the VmManagerType enum
+func VmManagerType_Values() []string {
+	return []string{
+		VmManagerTypeVsphere,
+		VmManagerTypeScvmm,
+		VmManagerTypeHypervManager,
+	}
+}

--- a/service/snowball/api.go
+++ b/service/snowball/api.go
@@ -5604,6 +5604,19 @@ const (
 	CapacityNoPreference = "NoPreference"
 )
 
+// Capacity_Values returns all elements of the Capacity enum
+func Capacity_Values() []string {
+	return []string{
+		CapacityT50,
+		CapacityT80,
+		CapacityT100,
+		CapacityT42,
+		CapacityT98,
+		CapacityT8,
+		CapacityNoPreference,
+	}
+}
+
 const (
 	// ClusterStateAwaitingQuorum is a ClusterState enum value
 	ClusterStateAwaitingQuorum = "AwaitingQuorum"
@@ -5620,6 +5633,17 @@ const (
 	// ClusterStateCancelled is a ClusterState enum value
 	ClusterStateCancelled = "Cancelled"
 )
+
+// ClusterState_Values returns all elements of the ClusterState enum
+func ClusterState_Values() []string {
+	return []string{
+		ClusterStateAwaitingQuorum,
+		ClusterStatePending,
+		ClusterStateInUse,
+		ClusterStateComplete,
+		ClusterStateCancelled,
+	}
+}
 
 const (
 	// JobStateNew is a JobState enum value
@@ -5662,6 +5686,25 @@ const (
 	JobStatePending = "Pending"
 )
 
+// JobState_Values returns all elements of the JobState enum
+func JobState_Values() []string {
+	return []string{
+		JobStateNew,
+		JobStatePreparingAppliance,
+		JobStatePreparingShipment,
+		JobStateInTransitToCustomer,
+		JobStateWithCustomer,
+		JobStateInTransitToAws,
+		JobStateWithAwssortingFacility,
+		JobStateWithAws,
+		JobStateInProgress,
+		JobStateComplete,
+		JobStateCancelled,
+		JobStateListing,
+		JobStatePending,
+	}
+}
+
 const (
 	// JobTypeImport is a JobType enum value
 	JobTypeImport = "IMPORT"
@@ -5672,6 +5715,15 @@ const (
 	// JobTypeLocalUse is a JobType enum value
 	JobTypeLocalUse = "LOCAL_USE"
 )
+
+// JobType_Values returns all elements of the JobType enum
+func JobType_Values() []string {
+	return []string{
+		JobTypeImport,
+		JobTypeExport,
+		JobTypeLocalUse,
+	}
+}
 
 const (
 	// ShippingOptionSecondDay is a ShippingOption enum value
@@ -5686,6 +5738,16 @@ const (
 	// ShippingOptionStandard is a ShippingOption enum value
 	ShippingOptionStandard = "STANDARD"
 )
+
+// ShippingOption_Values returns all elements of the ShippingOption enum
+func ShippingOption_Values() []string {
+	return []string{
+		ShippingOptionSecondDay,
+		ShippingOptionNextDay,
+		ShippingOptionExpress,
+		ShippingOptionStandard,
+	}
+}
 
 const (
 	// TypeStandard is a Type enum value
@@ -5706,3 +5768,15 @@ const (
 	// TypeSnc1Hdd is a Type enum value
 	TypeSnc1Hdd = "SNC1_HDD"
 )
+
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypeStandard,
+		TypeEdge,
+		TypeEdgeC,
+		TypeEdgeCg,
+		TypeEdgeS,
+		TypeSnc1Hdd,
+	}
+}

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -5176,10 +5176,31 @@ const (
 	MessageSystemAttributeNameAwstraceHeader = "AWSTraceHeader"
 )
 
+// MessageSystemAttributeName_Values returns all elements of the MessageSystemAttributeName enum
+func MessageSystemAttributeName_Values() []string {
+	return []string{
+		MessageSystemAttributeNameSenderId,
+		MessageSystemAttributeNameSentTimestamp,
+		MessageSystemAttributeNameApproximateReceiveCount,
+		MessageSystemAttributeNameApproximateFirstReceiveTimestamp,
+		MessageSystemAttributeNameSequenceNumber,
+		MessageSystemAttributeNameMessageDeduplicationId,
+		MessageSystemAttributeNameMessageGroupId,
+		MessageSystemAttributeNameAwstraceHeader,
+	}
+}
+
 const (
 	// MessageSystemAttributeNameForSendsAwstraceHeader is a MessageSystemAttributeNameForSends enum value
 	MessageSystemAttributeNameForSendsAwstraceHeader = "AWSTraceHeader"
 )
+
+// MessageSystemAttributeNameForSends_Values returns all elements of the MessageSystemAttributeNameForSends enum
+func MessageSystemAttributeNameForSends_Values() []string {
+	return []string{
+		MessageSystemAttributeNameForSendsAwstraceHeader,
+	}
+}
 
 const (
 	// QueueAttributeNameAll is a QueueAttributeName enum value
@@ -5236,3 +5257,27 @@ const (
 	// QueueAttributeNameKmsDataKeyReusePeriodSeconds is a QueueAttributeName enum value
 	QueueAttributeNameKmsDataKeyReusePeriodSeconds = "KmsDataKeyReusePeriodSeconds"
 )
+
+// QueueAttributeName_Values returns all elements of the QueueAttributeName enum
+func QueueAttributeName_Values() []string {
+	return []string{
+		QueueAttributeNameAll,
+		QueueAttributeNamePolicy,
+		QueueAttributeNameVisibilityTimeout,
+		QueueAttributeNameMaximumMessageSize,
+		QueueAttributeNameMessageRetentionPeriod,
+		QueueAttributeNameApproximateNumberOfMessages,
+		QueueAttributeNameApproximateNumberOfMessagesNotVisible,
+		QueueAttributeNameCreatedTimestamp,
+		QueueAttributeNameLastModifiedTimestamp,
+		QueueAttributeNameQueueArn,
+		QueueAttributeNameApproximateNumberOfMessagesDelayed,
+		QueueAttributeNameDelaySeconds,
+		QueueAttributeNameReceiveMessageWaitTimeSeconds,
+		QueueAttributeNameRedrivePolicy,
+		QueueAttributeNameFifoQueue,
+		QueueAttributeNameContentBasedDeduplication,
+		QueueAttributeNameKmsMasterKeyId,
+		QueueAttributeNameKmsDataKeyReusePeriodSeconds,
+	}
+}

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -47253,6 +47253,17 @@ const (
 	AssociationComplianceSeverityUnspecified = "UNSPECIFIED"
 )
 
+// AssociationComplianceSeverity_Values returns all elements of the AssociationComplianceSeverity enum
+func AssociationComplianceSeverity_Values() []string {
+	return []string{
+		AssociationComplianceSeverityCritical,
+		AssociationComplianceSeverityHigh,
+		AssociationComplianceSeverityMedium,
+		AssociationComplianceSeverityLow,
+		AssociationComplianceSeverityUnspecified,
+	}
+}
+
 const (
 	// AssociationExecutionFilterKeyExecutionId is a AssociationExecutionFilterKey enum value
 	AssociationExecutionFilterKeyExecutionId = "ExecutionId"
@@ -47264,6 +47275,15 @@ const (
 	AssociationExecutionFilterKeyCreatedTime = "CreatedTime"
 )
 
+// AssociationExecutionFilterKey_Values returns all elements of the AssociationExecutionFilterKey enum
+func AssociationExecutionFilterKey_Values() []string {
+	return []string{
+		AssociationExecutionFilterKeyExecutionId,
+		AssociationExecutionFilterKeyStatus,
+		AssociationExecutionFilterKeyCreatedTime,
+	}
+}
+
 const (
 	// AssociationExecutionTargetsFilterKeyStatus is a AssociationExecutionTargetsFilterKey enum value
 	AssociationExecutionTargetsFilterKeyStatus = "Status"
@@ -47274,6 +47294,15 @@ const (
 	// AssociationExecutionTargetsFilterKeyResourceType is a AssociationExecutionTargetsFilterKey enum value
 	AssociationExecutionTargetsFilterKeyResourceType = "ResourceType"
 )
+
+// AssociationExecutionTargetsFilterKey_Values returns all elements of the AssociationExecutionTargetsFilterKey enum
+func AssociationExecutionTargetsFilterKey_Values() []string {
+	return []string{
+		AssociationExecutionTargetsFilterKeyStatus,
+		AssociationExecutionTargetsFilterKeyResourceId,
+		AssociationExecutionTargetsFilterKeyResourceType,
+	}
+}
 
 const (
 	// AssociationFilterKeyInstanceId is a AssociationFilterKey enum value
@@ -47301,6 +47330,20 @@ const (
 	AssociationFilterKeyResourceGroupName = "ResourceGroupName"
 )
 
+// AssociationFilterKey_Values returns all elements of the AssociationFilterKey enum
+func AssociationFilterKey_Values() []string {
+	return []string{
+		AssociationFilterKeyInstanceId,
+		AssociationFilterKeyName,
+		AssociationFilterKeyAssociationId,
+		AssociationFilterKeyAssociationStatusName,
+		AssociationFilterKeyLastExecutedBefore,
+		AssociationFilterKeyLastExecutedAfter,
+		AssociationFilterKeyAssociationName,
+		AssociationFilterKeyResourceGroupName,
+	}
+}
+
 const (
 	// AssociationFilterOperatorTypeEqual is a AssociationFilterOperatorType enum value
 	AssociationFilterOperatorTypeEqual = "EQUAL"
@@ -47311,6 +47354,15 @@ const (
 	// AssociationFilterOperatorTypeGreaterThan is a AssociationFilterOperatorType enum value
 	AssociationFilterOperatorTypeGreaterThan = "GREATER_THAN"
 )
+
+// AssociationFilterOperatorType_Values returns all elements of the AssociationFilterOperatorType enum
+func AssociationFilterOperatorType_Values() []string {
+	return []string{
+		AssociationFilterOperatorTypeEqual,
+		AssociationFilterOperatorTypeLessThan,
+		AssociationFilterOperatorTypeGreaterThan,
+	}
+}
 
 const (
 	// AssociationStatusNamePending is a AssociationStatusName enum value
@@ -47323,6 +47375,15 @@ const (
 	AssociationStatusNameFailed = "Failed"
 )
 
+// AssociationStatusName_Values returns all elements of the AssociationStatusName enum
+func AssociationStatusName_Values() []string {
+	return []string{
+		AssociationStatusNamePending,
+		AssociationStatusNameSuccess,
+		AssociationStatusNameFailed,
+	}
+}
+
 const (
 	// AssociationSyncComplianceAuto is a AssociationSyncCompliance enum value
 	AssociationSyncComplianceAuto = "AUTO"
@@ -47331,10 +47392,25 @@ const (
 	AssociationSyncComplianceManual = "MANUAL"
 )
 
+// AssociationSyncCompliance_Values returns all elements of the AssociationSyncCompliance enum
+func AssociationSyncCompliance_Values() []string {
+	return []string{
+		AssociationSyncComplianceAuto,
+		AssociationSyncComplianceManual,
+	}
+}
+
 const (
 	// AttachmentHashTypeSha256 is a AttachmentHashType enum value
 	AttachmentHashTypeSha256 = "Sha256"
 )
+
+// AttachmentHashType_Values returns all elements of the AttachmentHashType enum
+func AttachmentHashType_Values() []string {
+	return []string{
+		AttachmentHashTypeSha256,
+	}
+}
 
 const (
 	// AttachmentsSourceKeySourceUrl is a AttachmentsSourceKey enum value
@@ -47346,6 +47422,15 @@ const (
 	// AttachmentsSourceKeyAttachmentReference is a AttachmentsSourceKey enum value
 	AttachmentsSourceKeyAttachmentReference = "AttachmentReference"
 )
+
+// AttachmentsSourceKey_Values returns all elements of the AttachmentsSourceKey enum
+func AttachmentsSourceKey_Values() []string {
+	return []string{
+		AttachmentsSourceKeySourceUrl,
+		AttachmentsSourceKeyS3fileUrl,
+		AttachmentsSourceKeyAttachmentReference,
+	}
+}
 
 const (
 	// AutomationExecutionFilterKeyDocumentNamePrefix is a AutomationExecutionFilterKey enum value
@@ -47376,6 +47461,21 @@ const (
 	AutomationExecutionFilterKeyTagKey = "TagKey"
 )
 
+// AutomationExecutionFilterKey_Values returns all elements of the AutomationExecutionFilterKey enum
+func AutomationExecutionFilterKey_Values() []string {
+	return []string{
+		AutomationExecutionFilterKeyDocumentNamePrefix,
+		AutomationExecutionFilterKeyExecutionStatus,
+		AutomationExecutionFilterKeyExecutionId,
+		AutomationExecutionFilterKeyParentExecutionId,
+		AutomationExecutionFilterKeyCurrentAction,
+		AutomationExecutionFilterKeyStartTimeBefore,
+		AutomationExecutionFilterKeyStartTimeAfter,
+		AutomationExecutionFilterKeyAutomationType,
+		AutomationExecutionFilterKeyTagKey,
+	}
+}
+
 const (
 	// AutomationExecutionStatusPending is a AutomationExecutionStatus enum value
 	AutomationExecutionStatusPending = "Pending"
@@ -47402,6 +47502,20 @@ const (
 	AutomationExecutionStatusFailed = "Failed"
 )
 
+// AutomationExecutionStatus_Values returns all elements of the AutomationExecutionStatus enum
+func AutomationExecutionStatus_Values() []string {
+	return []string{
+		AutomationExecutionStatusPending,
+		AutomationExecutionStatusInProgress,
+		AutomationExecutionStatusWaiting,
+		AutomationExecutionStatusSuccess,
+		AutomationExecutionStatusTimedOut,
+		AutomationExecutionStatusCancelling,
+		AutomationExecutionStatusCancelled,
+		AutomationExecutionStatusFailed,
+	}
+}
+
 const (
 	// AutomationTypeCrossAccount is a AutomationType enum value
 	AutomationTypeCrossAccount = "CrossAccount"
@@ -47410,6 +47524,14 @@ const (
 	AutomationTypeLocal = "Local"
 )
 
+// AutomationType_Values returns all elements of the AutomationType enum
+func AutomationType_Values() []string {
+	return []string{
+		AutomationTypeCrossAccount,
+		AutomationTypeLocal,
+	}
+}
+
 const (
 	// CalendarStateOpen is a CalendarState enum value
 	CalendarStateOpen = "OPEN"
@@ -47417,6 +47539,14 @@ const (
 	// CalendarStateClosed is a CalendarState enum value
 	CalendarStateClosed = "CLOSED"
 )
+
+// CalendarState_Values returns all elements of the CalendarState enum
+func CalendarState_Values() []string {
+	return []string{
+		CalendarStateOpen,
+		CalendarStateClosed,
+	}
+}
 
 const (
 	// CommandFilterKeyInvokedAfter is a CommandFilterKey enum value
@@ -47434,6 +47564,17 @@ const (
 	// CommandFilterKeyDocumentName is a CommandFilterKey enum value
 	CommandFilterKeyDocumentName = "DocumentName"
 )
+
+// CommandFilterKey_Values returns all elements of the CommandFilterKey enum
+func CommandFilterKey_Values() []string {
+	return []string{
+		CommandFilterKeyInvokedAfter,
+		CommandFilterKeyInvokedBefore,
+		CommandFilterKeyStatus,
+		CommandFilterKeyExecutionStage,
+		CommandFilterKeyDocumentName,
+	}
+}
 
 const (
 	// CommandInvocationStatusPending is a CommandInvocationStatus enum value
@@ -47461,6 +47602,20 @@ const (
 	CommandInvocationStatusCancelling = "Cancelling"
 )
 
+// CommandInvocationStatus_Values returns all elements of the CommandInvocationStatus enum
+func CommandInvocationStatus_Values() []string {
+	return []string{
+		CommandInvocationStatusPending,
+		CommandInvocationStatusInProgress,
+		CommandInvocationStatusDelayed,
+		CommandInvocationStatusSuccess,
+		CommandInvocationStatusCancelled,
+		CommandInvocationStatusTimedOut,
+		CommandInvocationStatusFailed,
+		CommandInvocationStatusCancelling,
+	}
+}
+
 const (
 	// CommandPluginStatusPending is a CommandPluginStatus enum value
 	CommandPluginStatusPending = "Pending"
@@ -47480,6 +47635,18 @@ const (
 	// CommandPluginStatusFailed is a CommandPluginStatus enum value
 	CommandPluginStatusFailed = "Failed"
 )
+
+// CommandPluginStatus_Values returns all elements of the CommandPluginStatus enum
+func CommandPluginStatus_Values() []string {
+	return []string{
+		CommandPluginStatusPending,
+		CommandPluginStatusInProgress,
+		CommandPluginStatusSuccess,
+		CommandPluginStatusTimedOut,
+		CommandPluginStatusCancelled,
+		CommandPluginStatusFailed,
+	}
+}
 
 const (
 	// CommandStatusPending is a CommandStatus enum value
@@ -47504,6 +47671,19 @@ const (
 	CommandStatusCancelling = "Cancelling"
 )
 
+// CommandStatus_Values returns all elements of the CommandStatus enum
+func CommandStatus_Values() []string {
+	return []string{
+		CommandStatusPending,
+		CommandStatusInProgress,
+		CommandStatusSuccess,
+		CommandStatusCancelled,
+		CommandStatusFailed,
+		CommandStatusTimedOut,
+		CommandStatusCancelling,
+	}
+}
+
 const (
 	// ComplianceQueryOperatorTypeEqual is a ComplianceQueryOperatorType enum value
 	ComplianceQueryOperatorTypeEqual = "EQUAL"
@@ -47520,6 +47700,17 @@ const (
 	// ComplianceQueryOperatorTypeGreaterThan is a ComplianceQueryOperatorType enum value
 	ComplianceQueryOperatorTypeGreaterThan = "GREATER_THAN"
 )
+
+// ComplianceQueryOperatorType_Values returns all elements of the ComplianceQueryOperatorType enum
+func ComplianceQueryOperatorType_Values() []string {
+	return []string{
+		ComplianceQueryOperatorTypeEqual,
+		ComplianceQueryOperatorTypeNotEqual,
+		ComplianceQueryOperatorTypeBeginWith,
+		ComplianceQueryOperatorTypeLessThan,
+		ComplianceQueryOperatorTypeGreaterThan,
+	}
+}
 
 const (
 	// ComplianceSeverityCritical is a ComplianceSeverity enum value
@@ -47541,6 +47732,18 @@ const (
 	ComplianceSeverityUnspecified = "UNSPECIFIED"
 )
 
+// ComplianceSeverity_Values returns all elements of the ComplianceSeverity enum
+func ComplianceSeverity_Values() []string {
+	return []string{
+		ComplianceSeverityCritical,
+		ComplianceSeverityHigh,
+		ComplianceSeverityMedium,
+		ComplianceSeverityLow,
+		ComplianceSeverityInformational,
+		ComplianceSeverityUnspecified,
+	}
+}
+
 const (
 	// ComplianceStatusCompliant is a ComplianceStatus enum value
 	ComplianceStatusCompliant = "COMPLIANT"
@@ -47548,6 +47751,14 @@ const (
 	// ComplianceStatusNonCompliant is a ComplianceStatus enum value
 	ComplianceStatusNonCompliant = "NON_COMPLIANT"
 )
+
+// ComplianceStatus_Values returns all elements of the ComplianceStatus enum
+func ComplianceStatus_Values() []string {
+	return []string{
+		ComplianceStatusCompliant,
+		ComplianceStatusNonCompliant,
+	}
+}
 
 const (
 	// ComplianceUploadTypeComplete is a ComplianceUploadType enum value
@@ -47557,6 +47768,14 @@ const (
 	ComplianceUploadTypePartial = "PARTIAL"
 )
 
+// ComplianceUploadType_Values returns all elements of the ComplianceUploadType enum
+func ComplianceUploadType_Values() []string {
+	return []string{
+		ComplianceUploadTypeComplete,
+		ComplianceUploadTypePartial,
+	}
+}
+
 const (
 	// ConnectionStatusConnected is a ConnectionStatus enum value
 	ConnectionStatusConnected = "Connected"
@@ -47564,6 +47783,14 @@ const (
 	// ConnectionStatusNotConnected is a ConnectionStatus enum value
 	ConnectionStatusNotConnected = "NotConnected"
 )
+
+// ConnectionStatus_Values returns all elements of the ConnectionStatus enum
+func ConnectionStatus_Values() []string {
+	return []string{
+		ConnectionStatusConnected,
+		ConnectionStatusNotConnected,
+	}
+}
 
 const (
 	// DescribeActivationsFilterKeysActivationIds is a DescribeActivationsFilterKeys enum value
@@ -47575,6 +47802,15 @@ const (
 	// DescribeActivationsFilterKeysIamRole is a DescribeActivationsFilterKeys enum value
 	DescribeActivationsFilterKeysIamRole = "IamRole"
 )
+
+// DescribeActivationsFilterKeys_Values returns all elements of the DescribeActivationsFilterKeys enum
+func DescribeActivationsFilterKeys_Values() []string {
+	return []string{
+		DescribeActivationsFilterKeysActivationIds,
+		DescribeActivationsFilterKeysDefaultInstanceName,
+		DescribeActivationsFilterKeysIamRole,
+	}
+}
 
 const (
 	// DocumentFilterKeyName is a DocumentFilterKey enum value
@@ -47590,6 +47826,16 @@ const (
 	DocumentFilterKeyDocumentType = "DocumentType"
 )
 
+// DocumentFilterKey_Values returns all elements of the DocumentFilterKey enum
+func DocumentFilterKey_Values() []string {
+	return []string{
+		DocumentFilterKeyName,
+		DocumentFilterKeyOwner,
+		DocumentFilterKeyPlatformTypes,
+		DocumentFilterKeyDocumentType,
+	}
+}
+
 const (
 	// DocumentFormatYaml is a DocumentFormat enum value
 	DocumentFormatYaml = "YAML"
@@ -47601,6 +47847,15 @@ const (
 	DocumentFormatText = "TEXT"
 )
 
+// DocumentFormat_Values returns all elements of the DocumentFormat enum
+func DocumentFormat_Values() []string {
+	return []string{
+		DocumentFormatYaml,
+		DocumentFormatJson,
+		DocumentFormatText,
+	}
+}
+
 const (
 	// DocumentHashTypeSha256 is a DocumentHashType enum value
 	DocumentHashTypeSha256 = "Sha256"
@@ -47608,6 +47863,14 @@ const (
 	// DocumentHashTypeSha1 is a DocumentHashType enum value
 	DocumentHashTypeSha1 = "Sha1"
 )
+
+// DocumentHashType_Values returns all elements of the DocumentHashType enum
+func DocumentHashType_Values() []string {
+	return []string{
+		DocumentHashTypeSha256,
+		DocumentHashTypeSha1,
+	}
+}
 
 const (
 	// DocumentParameterTypeString is a DocumentParameterType enum value
@@ -47617,10 +47880,25 @@ const (
 	DocumentParameterTypeStringList = "StringList"
 )
 
+// DocumentParameterType_Values returns all elements of the DocumentParameterType enum
+func DocumentParameterType_Values() []string {
+	return []string{
+		DocumentParameterTypeString,
+		DocumentParameterTypeStringList,
+	}
+}
+
 const (
 	// DocumentPermissionTypeShare is a DocumentPermissionType enum value
 	DocumentPermissionTypeShare = "Share"
 )
+
+// DocumentPermissionType_Values returns all elements of the DocumentPermissionType enum
+func DocumentPermissionType_Values() []string {
+	return []string{
+		DocumentPermissionTypeShare,
+	}
+}
 
 // The status of a document.
 const (
@@ -47639,6 +47917,17 @@ const (
 	// DocumentStatusFailed is a DocumentStatus enum value
 	DocumentStatusFailed = "Failed"
 )
+
+// DocumentStatus_Values returns all elements of the DocumentStatus enum
+func DocumentStatus_Values() []string {
+	return []string{
+		DocumentStatusCreating,
+		DocumentStatusActive,
+		DocumentStatusUpdating,
+		DocumentStatusDeleting,
+		DocumentStatusFailed,
+	}
+}
 
 const (
 	// DocumentTypeCommand is a DocumentType enum value
@@ -47669,6 +47958,21 @@ const (
 	DocumentTypeChangeCalendar = "ChangeCalendar"
 )
 
+// DocumentType_Values returns all elements of the DocumentType enum
+func DocumentType_Values() []string {
+	return []string{
+		DocumentTypeCommand,
+		DocumentTypePolicy,
+		DocumentTypeAutomation,
+		DocumentTypeSession,
+		DocumentTypePackage,
+		DocumentTypeApplicationConfiguration,
+		DocumentTypeApplicationConfigurationSchema,
+		DocumentTypeDeploymentStrategy,
+		DocumentTypeChangeCalendar,
+	}
+}
+
 const (
 	// ExecutionModeAuto is a ExecutionMode enum value
 	ExecutionModeAuto = "Auto"
@@ -47676,6 +47980,14 @@ const (
 	// ExecutionModeInteractive is a ExecutionMode enum value
 	ExecutionModeInteractive = "Interactive"
 )
+
+// ExecutionMode_Values returns all elements of the ExecutionMode enum
+func ExecutionMode_Values() []string {
+	return []string{
+		ExecutionModeAuto,
+		ExecutionModeInteractive,
+	}
+}
 
 const (
 	// FaultClient is a Fault enum value
@@ -47687,6 +47999,15 @@ const (
 	// FaultUnknown is a Fault enum value
 	FaultUnknown = "Unknown"
 )
+
+// Fault_Values returns all elements of the Fault enum
+func Fault_Values() []string {
+	return []string{
+		FaultClient,
+		FaultServer,
+		FaultUnknown,
+	}
+}
 
 const (
 	// InstanceInformationFilterKeyInstanceIds is a InstanceInformationFilterKey enum value
@@ -47714,6 +48035,20 @@ const (
 	InstanceInformationFilterKeyAssociationStatus = "AssociationStatus"
 )
 
+// InstanceInformationFilterKey_Values returns all elements of the InstanceInformationFilterKey enum
+func InstanceInformationFilterKey_Values() []string {
+	return []string{
+		InstanceInformationFilterKeyInstanceIds,
+		InstanceInformationFilterKeyAgentVersion,
+		InstanceInformationFilterKeyPingStatus,
+		InstanceInformationFilterKeyPlatformTypes,
+		InstanceInformationFilterKeyActivationIds,
+		InstanceInformationFilterKeyIamRole,
+		InstanceInformationFilterKeyResourceType,
+		InstanceInformationFilterKeyAssociationStatus,
+	}
+}
+
 const (
 	// InstancePatchStateOperatorTypeEqual is a InstancePatchStateOperatorType enum value
 	InstancePatchStateOperatorTypeEqual = "Equal"
@@ -47728,6 +48063,16 @@ const (
 	InstancePatchStateOperatorTypeGreaterThan = "GreaterThan"
 )
 
+// InstancePatchStateOperatorType_Values returns all elements of the InstancePatchStateOperatorType enum
+func InstancePatchStateOperatorType_Values() []string {
+	return []string{
+		InstancePatchStateOperatorTypeEqual,
+		InstancePatchStateOperatorTypeNotEqual,
+		InstancePatchStateOperatorTypeLessThan,
+		InstancePatchStateOperatorTypeGreaterThan,
+	}
+}
+
 const (
 	// InventoryAttributeDataTypeString is a InventoryAttributeDataType enum value
 	InventoryAttributeDataTypeString = "string"
@@ -47736,6 +48081,14 @@ const (
 	InventoryAttributeDataTypeNumber = "number"
 )
 
+// InventoryAttributeDataType_Values returns all elements of the InventoryAttributeDataType enum
+func InventoryAttributeDataType_Values() []string {
+	return []string{
+		InventoryAttributeDataTypeString,
+		InventoryAttributeDataTypeNumber,
+	}
+}
+
 const (
 	// InventoryDeletionStatusInProgress is a InventoryDeletionStatus enum value
 	InventoryDeletionStatusInProgress = "InProgress"
@@ -47743,6 +48096,14 @@ const (
 	// InventoryDeletionStatusComplete is a InventoryDeletionStatus enum value
 	InventoryDeletionStatusComplete = "Complete"
 )
+
+// InventoryDeletionStatus_Values returns all elements of the InventoryDeletionStatus enum
+func InventoryDeletionStatus_Values() []string {
+	return []string{
+		InventoryDeletionStatusInProgress,
+		InventoryDeletionStatusComplete,
+	}
+}
 
 const (
 	// InventoryQueryOperatorTypeEqual is a InventoryQueryOperatorType enum value
@@ -47764,6 +48125,18 @@ const (
 	InventoryQueryOperatorTypeExists = "Exists"
 )
 
+// InventoryQueryOperatorType_Values returns all elements of the InventoryQueryOperatorType enum
+func InventoryQueryOperatorType_Values() []string {
+	return []string{
+		InventoryQueryOperatorTypeEqual,
+		InventoryQueryOperatorTypeNotEqual,
+		InventoryQueryOperatorTypeBeginWith,
+		InventoryQueryOperatorTypeLessThan,
+		InventoryQueryOperatorTypeGreaterThan,
+		InventoryQueryOperatorTypeExists,
+	}
+}
+
 const (
 	// InventorySchemaDeleteOptionDisableSchema is a InventorySchemaDeleteOption enum value
 	InventorySchemaDeleteOptionDisableSchema = "DisableSchema"
@@ -47771,6 +48144,14 @@ const (
 	// InventorySchemaDeleteOptionDeleteSchema is a InventorySchemaDeleteOption enum value
 	InventorySchemaDeleteOptionDeleteSchema = "DeleteSchema"
 )
+
+// InventorySchemaDeleteOption_Values returns all elements of the InventorySchemaDeleteOption enum
+func InventorySchemaDeleteOption_Values() []string {
+	return []string{
+		InventorySchemaDeleteOptionDisableSchema,
+		InventorySchemaDeleteOptionDeleteSchema,
+	}
+}
 
 const (
 	// LastResourceDataSyncStatusSuccessful is a LastResourceDataSyncStatus enum value
@@ -47782,6 +48163,15 @@ const (
 	// LastResourceDataSyncStatusInProgress is a LastResourceDataSyncStatus enum value
 	LastResourceDataSyncStatusInProgress = "InProgress"
 )
+
+// LastResourceDataSyncStatus_Values returns all elements of the LastResourceDataSyncStatus enum
+func LastResourceDataSyncStatus_Values() []string {
+	return []string{
+		LastResourceDataSyncStatusSuccessful,
+		LastResourceDataSyncStatusFailed,
+		LastResourceDataSyncStatusInProgress,
+	}
+}
 
 const (
 	// MaintenanceWindowExecutionStatusPending is a MaintenanceWindowExecutionStatus enum value
@@ -47809,6 +48199,20 @@ const (
 	MaintenanceWindowExecutionStatusSkippedOverlapping = "SKIPPED_OVERLAPPING"
 )
 
+// MaintenanceWindowExecutionStatus_Values returns all elements of the MaintenanceWindowExecutionStatus enum
+func MaintenanceWindowExecutionStatus_Values() []string {
+	return []string{
+		MaintenanceWindowExecutionStatusPending,
+		MaintenanceWindowExecutionStatusInProgress,
+		MaintenanceWindowExecutionStatusSuccess,
+		MaintenanceWindowExecutionStatusFailed,
+		MaintenanceWindowExecutionStatusTimedOut,
+		MaintenanceWindowExecutionStatusCancelling,
+		MaintenanceWindowExecutionStatusCancelled,
+		MaintenanceWindowExecutionStatusSkippedOverlapping,
+	}
+}
+
 const (
 	// MaintenanceWindowResourceTypeInstance is a MaintenanceWindowResourceType enum value
 	MaintenanceWindowResourceTypeInstance = "INSTANCE"
@@ -47816,6 +48220,14 @@ const (
 	// MaintenanceWindowResourceTypeResourceGroup is a MaintenanceWindowResourceType enum value
 	MaintenanceWindowResourceTypeResourceGroup = "RESOURCE_GROUP"
 )
+
+// MaintenanceWindowResourceType_Values returns all elements of the MaintenanceWindowResourceType enum
+func MaintenanceWindowResourceType_Values() []string {
+	return []string{
+		MaintenanceWindowResourceTypeInstance,
+		MaintenanceWindowResourceTypeResourceGroup,
+	}
+}
 
 const (
 	// MaintenanceWindowTaskTypeRunCommand is a MaintenanceWindowTaskType enum value
@@ -47830,6 +48242,16 @@ const (
 	// MaintenanceWindowTaskTypeLambda is a MaintenanceWindowTaskType enum value
 	MaintenanceWindowTaskTypeLambda = "LAMBDA"
 )
+
+// MaintenanceWindowTaskType_Values returns all elements of the MaintenanceWindowTaskType enum
+func MaintenanceWindowTaskType_Values() []string {
+	return []string{
+		MaintenanceWindowTaskTypeRunCommand,
+		MaintenanceWindowTaskTypeAutomation,
+		MaintenanceWindowTaskTypeStepFunctions,
+		MaintenanceWindowTaskTypeLambda,
+	}
+}
 
 const (
 	// NotificationEventAll is a NotificationEvent enum value
@@ -47851,6 +48273,18 @@ const (
 	NotificationEventFailed = "Failed"
 )
 
+// NotificationEvent_Values returns all elements of the NotificationEvent enum
+func NotificationEvent_Values() []string {
+	return []string{
+		NotificationEventAll,
+		NotificationEventInProgress,
+		NotificationEventSuccess,
+		NotificationEventTimedOut,
+		NotificationEventCancelled,
+		NotificationEventFailed,
+	}
+}
+
 const (
 	// NotificationTypeCommand is a NotificationType enum value
 	NotificationTypeCommand = "Command"
@@ -47858,6 +48292,14 @@ const (
 	// NotificationTypeInvocation is a NotificationType enum value
 	NotificationTypeInvocation = "Invocation"
 )
+
+// NotificationType_Values returns all elements of the NotificationType enum
+func NotificationType_Values() []string {
+	return []string{
+		NotificationTypeCommand,
+		NotificationTypeInvocation,
+	}
+}
 
 const (
 	// OperatingSystemWindows is a OperatingSystem enum value
@@ -47888,6 +48330,21 @@ const (
 	OperatingSystemDebian = "DEBIAN"
 )
 
+// OperatingSystem_Values returns all elements of the OperatingSystem enum
+func OperatingSystem_Values() []string {
+	return []string{
+		OperatingSystemWindows,
+		OperatingSystemAmazonLinux,
+		OperatingSystemAmazonLinux2,
+		OperatingSystemUbuntu,
+		OperatingSystemRedhatEnterpriseLinux,
+		OperatingSystemSuse,
+		OperatingSystemCentos,
+		OperatingSystemOracleLinux,
+		OperatingSystemDebian,
+	}
+}
+
 const (
 	// OpsFilterOperatorTypeEqual is a OpsFilterOperatorType enum value
 	OpsFilterOperatorTypeEqual = "Equal"
@@ -47908,6 +48365,18 @@ const (
 	OpsFilterOperatorTypeExists = "Exists"
 )
 
+// OpsFilterOperatorType_Values returns all elements of the OpsFilterOperatorType enum
+func OpsFilterOperatorType_Values() []string {
+	return []string{
+		OpsFilterOperatorTypeEqual,
+		OpsFilterOperatorTypeNotEqual,
+		OpsFilterOperatorTypeBeginWith,
+		OpsFilterOperatorTypeLessThan,
+		OpsFilterOperatorTypeGreaterThan,
+		OpsFilterOperatorTypeExists,
+	}
+}
+
 const (
 	// OpsItemDataTypeSearchableString is a OpsItemDataType enum value
 	OpsItemDataTypeSearchableString = "SearchableString"
@@ -47915,6 +48384,14 @@ const (
 	// OpsItemDataTypeString is a OpsItemDataType enum value
 	OpsItemDataTypeString = "String"
 )
+
+// OpsItemDataType_Values returns all elements of the OpsItemDataType enum
+func OpsItemDataType_Values() []string {
+	return []string{
+		OpsItemDataTypeSearchableString,
+		OpsItemDataTypeString,
+	}
+}
 
 const (
 	// OpsItemFilterKeyStatus is a OpsItemFilterKey enum value
@@ -47963,6 +48440,27 @@ const (
 	OpsItemFilterKeySeverity = "Severity"
 )
 
+// OpsItemFilterKey_Values returns all elements of the OpsItemFilterKey enum
+func OpsItemFilterKey_Values() []string {
+	return []string{
+		OpsItemFilterKeyStatus,
+		OpsItemFilterKeyCreatedBy,
+		OpsItemFilterKeySource,
+		OpsItemFilterKeyPriority,
+		OpsItemFilterKeyTitle,
+		OpsItemFilterKeyOpsItemId,
+		OpsItemFilterKeyCreatedTime,
+		OpsItemFilterKeyLastModifiedTime,
+		OpsItemFilterKeyOperationalData,
+		OpsItemFilterKeyOperationalDataKey,
+		OpsItemFilterKeyOperationalDataValue,
+		OpsItemFilterKeyResourceId,
+		OpsItemFilterKeyAutomationId,
+		OpsItemFilterKeyCategory,
+		OpsItemFilterKeySeverity,
+	}
+}
+
 const (
 	// OpsItemFilterOperatorEqual is a OpsItemFilterOperator enum value
 	OpsItemFilterOperatorEqual = "Equal"
@@ -47977,6 +48475,16 @@ const (
 	OpsItemFilterOperatorLessThan = "LessThan"
 )
 
+// OpsItemFilterOperator_Values returns all elements of the OpsItemFilterOperator enum
+func OpsItemFilterOperator_Values() []string {
+	return []string{
+		OpsItemFilterOperatorEqual,
+		OpsItemFilterOperatorContains,
+		OpsItemFilterOperatorGreaterThan,
+		OpsItemFilterOperatorLessThan,
+	}
+}
+
 const (
 	// OpsItemStatusOpen is a OpsItemStatus enum value
 	OpsItemStatusOpen = "Open"
@@ -47987,6 +48495,15 @@ const (
 	// OpsItemStatusResolved is a OpsItemStatus enum value
 	OpsItemStatusResolved = "Resolved"
 )
+
+// OpsItemStatus_Values returns all elements of the OpsItemStatus enum
+func OpsItemStatus_Values() []string {
+	return []string{
+		OpsItemStatusOpen,
+		OpsItemStatusInProgress,
+		OpsItemStatusResolved,
+	}
+}
 
 const (
 	// ParameterTierStandard is a ParameterTier enum value
@@ -47999,6 +48516,15 @@ const (
 	ParameterTierIntelligentTiering = "Intelligent-Tiering"
 )
 
+// ParameterTier_Values returns all elements of the ParameterTier enum
+func ParameterTier_Values() []string {
+	return []string{
+		ParameterTierStandard,
+		ParameterTierAdvanced,
+		ParameterTierIntelligentTiering,
+	}
+}
+
 const (
 	// ParameterTypeString is a ParameterType enum value
 	ParameterTypeString = "String"
@@ -48009,6 +48535,15 @@ const (
 	// ParameterTypeSecureString is a ParameterType enum value
 	ParameterTypeSecureString = "SecureString"
 )
+
+// ParameterType_Values returns all elements of the ParameterType enum
+func ParameterType_Values() []string {
+	return []string{
+		ParameterTypeString,
+		ParameterTypeStringList,
+		ParameterTypeSecureString,
+	}
+}
 
 const (
 	// ParametersFilterKeyName is a ParametersFilterKey enum value
@@ -48021,6 +48556,15 @@ const (
 	ParametersFilterKeyKeyId = "KeyId"
 )
 
+// ParametersFilterKey_Values returns all elements of the ParametersFilterKey enum
+func ParametersFilterKey_Values() []string {
+	return []string{
+		ParametersFilterKeyName,
+		ParametersFilterKeyType,
+		ParametersFilterKeyKeyId,
+	}
+}
+
 const (
 	// PatchActionAllowAsDependency is a PatchAction enum value
 	PatchActionAllowAsDependency = "ALLOW_AS_DEPENDENCY"
@@ -48028,6 +48572,14 @@ const (
 	// PatchActionBlock is a PatchAction enum value
 	PatchActionBlock = "BLOCK"
 )
+
+// PatchAction_Values returns all elements of the PatchAction enum
+func PatchAction_Values() []string {
+	return []string{
+		PatchActionAllowAsDependency,
+		PatchActionBlock,
+	}
+}
 
 const (
 	// PatchComplianceDataStateInstalled is a PatchComplianceDataState enum value
@@ -48052,6 +48604,19 @@ const (
 	PatchComplianceDataStateFailed = "FAILED"
 )
 
+// PatchComplianceDataState_Values returns all elements of the PatchComplianceDataState enum
+func PatchComplianceDataState_Values() []string {
+	return []string{
+		PatchComplianceDataStateInstalled,
+		PatchComplianceDataStateInstalledOther,
+		PatchComplianceDataStateInstalledPendingReboot,
+		PatchComplianceDataStateInstalledRejected,
+		PatchComplianceDataStateMissing,
+		PatchComplianceDataStateNotApplicable,
+		PatchComplianceDataStateFailed,
+	}
+}
+
 const (
 	// PatchComplianceLevelCritical is a PatchComplianceLevel enum value
 	PatchComplianceLevelCritical = "CRITICAL"
@@ -48072,6 +48637,18 @@ const (
 	PatchComplianceLevelUnspecified = "UNSPECIFIED"
 )
 
+// PatchComplianceLevel_Values returns all elements of the PatchComplianceLevel enum
+func PatchComplianceLevel_Values() []string {
+	return []string{
+		PatchComplianceLevelCritical,
+		PatchComplianceLevelHigh,
+		PatchComplianceLevelMedium,
+		PatchComplianceLevelLow,
+		PatchComplianceLevelInformational,
+		PatchComplianceLevelUnspecified,
+	}
+}
+
 const (
 	// PatchDeploymentStatusApproved is a PatchDeploymentStatus enum value
 	PatchDeploymentStatusApproved = "APPROVED"
@@ -48085,6 +48662,16 @@ const (
 	// PatchDeploymentStatusExplicitRejected is a PatchDeploymentStatus enum value
 	PatchDeploymentStatusExplicitRejected = "EXPLICIT_REJECTED"
 )
+
+// PatchDeploymentStatus_Values returns all elements of the PatchDeploymentStatus enum
+func PatchDeploymentStatus_Values() []string {
+	return []string{
+		PatchDeploymentStatusApproved,
+		PatchDeploymentStatusPendingApproval,
+		PatchDeploymentStatusExplicitApproved,
+		PatchDeploymentStatusExplicitRejected,
+	}
+}
 
 const (
 	// PatchFilterKeyPatchSet is a PatchFilterKey enum value
@@ -48115,6 +48702,21 @@ const (
 	PatchFilterKeySeverity = "SEVERITY"
 )
 
+// PatchFilterKey_Values returns all elements of the PatchFilterKey enum
+func PatchFilterKey_Values() []string {
+	return []string{
+		PatchFilterKeyPatchSet,
+		PatchFilterKeyProduct,
+		PatchFilterKeyProductFamily,
+		PatchFilterKeyClassification,
+		PatchFilterKeyMsrcSeverity,
+		PatchFilterKeyPatchId,
+		PatchFilterKeySection,
+		PatchFilterKeyPriority,
+		PatchFilterKeySeverity,
+	}
+}
+
 const (
 	// PatchOperationTypeScan is a PatchOperationType enum value
 	PatchOperationTypeScan = "Scan"
@@ -48122,6 +48724,14 @@ const (
 	// PatchOperationTypeInstall is a PatchOperationType enum value
 	PatchOperationTypeInstall = "Install"
 )
+
+// PatchOperationType_Values returns all elements of the PatchOperationType enum
+func PatchOperationType_Values() []string {
+	return []string{
+		PatchOperationTypeScan,
+		PatchOperationTypeInstall,
+	}
+}
 
 const (
 	// PatchPropertyProduct is a PatchProperty enum value
@@ -48143,6 +48753,18 @@ const (
 	PatchPropertySeverity = "SEVERITY"
 )
 
+// PatchProperty_Values returns all elements of the PatchProperty enum
+func PatchProperty_Values() []string {
+	return []string{
+		PatchPropertyProduct,
+		PatchPropertyProductFamily,
+		PatchPropertyClassification,
+		PatchPropertyMsrcSeverity,
+		PatchPropertyPriority,
+		PatchPropertySeverity,
+	}
+}
+
 const (
 	// PatchSetOs is a PatchSet enum value
 	PatchSetOs = "OS"
@@ -48150,6 +48772,14 @@ const (
 	// PatchSetApplication is a PatchSet enum value
 	PatchSetApplication = "APPLICATION"
 )
+
+// PatchSet_Values returns all elements of the PatchSet enum
+func PatchSet_Values() []string {
+	return []string{
+		PatchSetOs,
+		PatchSetApplication,
+	}
+}
 
 const (
 	// PingStatusOnline is a PingStatus enum value
@@ -48162,6 +48792,15 @@ const (
 	PingStatusInactive = "Inactive"
 )
 
+// PingStatus_Values returns all elements of the PingStatus enum
+func PingStatus_Values() []string {
+	return []string{
+		PingStatusOnline,
+		PingStatusConnectionLost,
+		PingStatusInactive,
+	}
+}
+
 const (
 	// PlatformTypeWindows is a PlatformType enum value
 	PlatformTypeWindows = "Windows"
@@ -48169,6 +48808,14 @@ const (
 	// PlatformTypeLinux is a PlatformType enum value
 	PlatformTypeLinux = "Linux"
 )
+
+// PlatformType_Values returns all elements of the PlatformType enum
+func PlatformType_Values() []string {
+	return []string{
+		PlatformTypeWindows,
+		PlatformTypeLinux,
+	}
+}
 
 const (
 	// RebootOptionRebootIfNeeded is a RebootOption enum value
@@ -48178,10 +48825,25 @@ const (
 	RebootOptionNoReboot = "NoReboot"
 )
 
+// RebootOption_Values returns all elements of the RebootOption enum
+func RebootOption_Values() []string {
+	return []string{
+		RebootOptionRebootIfNeeded,
+		RebootOptionNoReboot,
+	}
+}
+
 const (
 	// ResourceDataSyncS3FormatJsonSerDe is a ResourceDataSyncS3Format enum value
 	ResourceDataSyncS3FormatJsonSerDe = "JsonSerDe"
 )
+
+// ResourceDataSyncS3Format_Values returns all elements of the ResourceDataSyncS3Format enum
+func ResourceDataSyncS3Format_Values() []string {
+	return []string{
+		ResourceDataSyncS3FormatJsonSerDe,
+	}
+}
 
 const (
 	// ResourceTypeManagedInstance is a ResourceType enum value
@@ -48193,6 +48855,15 @@ const (
 	// ResourceTypeEc2instance is a ResourceType enum value
 	ResourceTypeEc2instance = "EC2Instance"
 )
+
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeManagedInstance,
+		ResourceTypeDocument,
+		ResourceTypeEc2instance,
+	}
+}
 
 const (
 	// ResourceTypeForTaggingDocument is a ResourceTypeForTagging enum value
@@ -48214,6 +48885,18 @@ const (
 	ResourceTypeForTaggingOpsItem = "OpsItem"
 )
 
+// ResourceTypeForTagging_Values returns all elements of the ResourceTypeForTagging enum
+func ResourceTypeForTagging_Values() []string {
+	return []string{
+		ResourceTypeForTaggingDocument,
+		ResourceTypeForTaggingManagedInstance,
+		ResourceTypeForTaggingMaintenanceWindow,
+		ResourceTypeForTaggingParameter,
+		ResourceTypeForTaggingPatchBaseline,
+		ResourceTypeForTaggingOpsItem,
+	}
+}
+
 const (
 	// SessionFilterKeyInvokedAfter is a SessionFilterKey enum value
 	SessionFilterKeyInvokedAfter = "InvokedAfter"
@@ -48231,6 +48914,17 @@ const (
 	SessionFilterKeyStatus = "Status"
 )
 
+// SessionFilterKey_Values returns all elements of the SessionFilterKey enum
+func SessionFilterKey_Values() []string {
+	return []string{
+		SessionFilterKeyInvokedAfter,
+		SessionFilterKeyInvokedBefore,
+		SessionFilterKeyTarget,
+		SessionFilterKeyOwner,
+		SessionFilterKeyStatus,
+	}
+}
+
 const (
 	// SessionStateActive is a SessionState enum value
 	SessionStateActive = "Active"
@@ -48238,6 +48932,14 @@ const (
 	// SessionStateHistory is a SessionState enum value
 	SessionStateHistory = "History"
 )
+
+// SessionState_Values returns all elements of the SessionState enum
+func SessionState_Values() []string {
+	return []string{
+		SessionStateActive,
+		SessionStateHistory,
+	}
+}
 
 const (
 	// SessionStatusConnected is a SessionStatus enum value
@@ -48259,6 +48961,18 @@ const (
 	SessionStatusFailed = "Failed"
 )
 
+// SessionStatus_Values returns all elements of the SessionStatus enum
+func SessionStatus_Values() []string {
+	return []string{
+		SessionStatusConnected,
+		SessionStatusConnecting,
+		SessionStatusDisconnected,
+		SessionStatusTerminated,
+		SessionStatusTerminating,
+		SessionStatusFailed,
+	}
+}
+
 const (
 	// SignalTypeApprove is a SignalType enum value
 	SignalTypeApprove = "Approve"
@@ -48275,6 +48989,17 @@ const (
 	// SignalTypeResume is a SignalType enum value
 	SignalTypeResume = "Resume"
 )
+
+// SignalType_Values returns all elements of the SignalType enum
+func SignalType_Values() []string {
+	return []string{
+		SignalTypeApprove,
+		SignalTypeReject,
+		SignalTypeStartStep,
+		SignalTypeStopStep,
+		SignalTypeResume,
+	}
+}
 
 const (
 	// StepExecutionFilterKeyStartTimeBefore is a StepExecutionFilterKey enum value
@@ -48296,6 +49021,18 @@ const (
 	StepExecutionFilterKeyAction = "Action"
 )
 
+// StepExecutionFilterKey_Values returns all elements of the StepExecutionFilterKey enum
+func StepExecutionFilterKey_Values() []string {
+	return []string{
+		StepExecutionFilterKeyStartTimeBefore,
+		StepExecutionFilterKeyStartTimeAfter,
+		StepExecutionFilterKeyStepExecutionStatus,
+		StepExecutionFilterKeyStepExecutionId,
+		StepExecutionFilterKeyStepName,
+		StepExecutionFilterKeyAction,
+	}
+}
+
 const (
 	// StopTypeComplete is a StopType enum value
 	StopTypeComplete = "Complete"
@@ -48303,3 +49040,11 @@ const (
 	// StopTypeCancel is a StopType enum value
 	StopTypeCancel = "Cancel"
 )
+
+// StopType_Values returns all elements of the StopType enum
+func StopType_Values() []string {
+	return []string{
+		StopTypeComplete,
+		StopTypeCancel,
+	}
+}

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -18999,6 +18999,19 @@ const (
 	ActiveDirectoryStatusUnknownError = "UNKNOWN_ERROR"
 )
 
+// ActiveDirectoryStatus_Values returns all elements of the ActiveDirectoryStatus enum
+func ActiveDirectoryStatus_Values() []string {
+	return []string{
+		ActiveDirectoryStatusAccessDenied,
+		ActiveDirectoryStatusDetached,
+		ActiveDirectoryStatusJoined,
+		ActiveDirectoryStatusJoining,
+		ActiveDirectoryStatusNetworkError,
+		ActiveDirectoryStatusTimeout,
+		ActiveDirectoryStatusUnknownError,
+	}
+}
+
 const (
 	// AvailabilityMonitorTestStatusComplete is a AvailabilityMonitorTestStatus enum value
 	AvailabilityMonitorTestStatusComplete = "COMPLETE"
@@ -19010,6 +19023,15 @@ const (
 	AvailabilityMonitorTestStatusPending = "PENDING"
 )
 
+// AvailabilityMonitorTestStatus_Values returns all elements of the AvailabilityMonitorTestStatus enum
+func AvailabilityMonitorTestStatus_Values() []string {
+	return []string{
+		AvailabilityMonitorTestStatusComplete,
+		AvailabilityMonitorTestStatusFailed,
+		AvailabilityMonitorTestStatusPending,
+	}
+}
+
 const (
 	// CaseSensitivityClientSpecified is a CaseSensitivity enum value
 	CaseSensitivityClientSpecified = "ClientSpecified"
@@ -19017,6 +19039,14 @@ const (
 	// CaseSensitivityCaseSensitive is a CaseSensitivity enum value
 	CaseSensitivityCaseSensitive = "CaseSensitive"
 )
+
+// CaseSensitivity_Values returns all elements of the CaseSensitivity enum
+func CaseSensitivity_Values() []string {
+	return []string{
+		CaseSensitivityClientSpecified,
+		CaseSensitivityCaseSensitive,
+	}
+}
 
 const (
 	// ErrorCodeActivationKeyExpired is a ErrorCode enum value
@@ -19206,6 +19236,74 @@ const (
 	ErrorCodeVolumeNotReady = "VolumeNotReady"
 )
 
+// ErrorCode_Values returns all elements of the ErrorCode enum
+func ErrorCode_Values() []string {
+	return []string{
+		ErrorCodeActivationKeyExpired,
+		ErrorCodeActivationKeyInvalid,
+		ErrorCodeActivationKeyNotFound,
+		ErrorCodeGatewayInternalError,
+		ErrorCodeGatewayNotConnected,
+		ErrorCodeGatewayNotFound,
+		ErrorCodeGatewayProxyNetworkConnectionBusy,
+		ErrorCodeAuthenticationFailure,
+		ErrorCodeBandwidthThrottleScheduleNotFound,
+		ErrorCodeBlocked,
+		ErrorCodeCannotExportSnapshot,
+		ErrorCodeChapCredentialNotFound,
+		ErrorCodeDiskAlreadyAllocated,
+		ErrorCodeDiskDoesNotExist,
+		ErrorCodeDiskSizeGreaterThanVolumeMaxSize,
+		ErrorCodeDiskSizeLessThanVolumeSize,
+		ErrorCodeDiskSizeNotGigAligned,
+		ErrorCodeDuplicateCertificateInfo,
+		ErrorCodeDuplicateSchedule,
+		ErrorCodeEndpointNotFound,
+		ErrorCodeIamnotSupported,
+		ErrorCodeInitiatorInvalid,
+		ErrorCodeInitiatorNotFound,
+		ErrorCodeInternalError,
+		ErrorCodeInvalidGateway,
+		ErrorCodeInvalidEndpoint,
+		ErrorCodeInvalidParameters,
+		ErrorCodeInvalidSchedule,
+		ErrorCodeLocalStorageLimitExceeded,
+		ErrorCodeLunAlreadyAllocated,
+		ErrorCodeLunInvalid,
+		ErrorCodeJoinDomainInProgress,
+		ErrorCodeMaximumContentLengthExceeded,
+		ErrorCodeMaximumTapeCartridgeCountExceeded,
+		ErrorCodeMaximumVolumeCountExceeded,
+		ErrorCodeNetworkConfigurationChanged,
+		ErrorCodeNoDisksAvailable,
+		ErrorCodeNotImplemented,
+		ErrorCodeNotSupported,
+		ErrorCodeOperationAborted,
+		ErrorCodeOutdatedGateway,
+		ErrorCodeParametersNotImplemented,
+		ErrorCodeRegionInvalid,
+		ErrorCodeRequestTimeout,
+		ErrorCodeServiceUnavailable,
+		ErrorCodeSnapshotDeleted,
+		ErrorCodeSnapshotIdInvalid,
+		ErrorCodeSnapshotInProgress,
+		ErrorCodeSnapshotNotFound,
+		ErrorCodeSnapshotScheduleNotFound,
+		ErrorCodeStagingAreaFull,
+		ErrorCodeStorageFailure,
+		ErrorCodeTapeCartridgeNotFound,
+		ErrorCodeTargetAlreadyExists,
+		ErrorCodeTargetInvalid,
+		ErrorCodeTargetNotFound,
+		ErrorCodeUnauthorizedOperation,
+		ErrorCodeVolumeAlreadyExists,
+		ErrorCodeVolumeIdInvalid,
+		ErrorCodeVolumeInUse,
+		ErrorCodeVolumeNotFound,
+		ErrorCodeVolumeNotReady,
+	}
+}
+
 // The type of the file share.
 const (
 	// FileShareTypeNfs is a FileShareType enum value
@@ -19214,6 +19312,14 @@ const (
 	// FileShareTypeSmb is a FileShareType enum value
 	FileShareTypeSmb = "SMB"
 )
+
+// FileShareType_Values returns all elements of the FileShareType enum
+func FileShareType_Values() []string {
+	return []string{
+		FileShareTypeNfs,
+		FileShareTypeSmb,
+	}
+}
 
 const (
 	// HostEnvironmentVmware is a HostEnvironment enum value
@@ -19231,6 +19337,17 @@ const (
 	// HostEnvironmentOther is a HostEnvironment enum value
 	HostEnvironmentOther = "OTHER"
 )
+
+// HostEnvironment_Values returns all elements of the HostEnvironment enum
+func HostEnvironment_Values() []string {
+	return []string{
+		HostEnvironmentVmware,
+		HostEnvironmentHyperV,
+		HostEnvironmentEc2,
+		HostEnvironmentKvm,
+		HostEnvironmentOther,
+	}
+}
 
 // A value that sets the access control list (ACL) permission for objects in
 // the S3 bucket that a file gateway puts objects into. The default value is
@@ -19258,6 +19375,19 @@ const (
 	ObjectACLAwsExecRead = "aws-exec-read"
 )
 
+// ObjectACL_Values returns all elements of the ObjectACL enum
+func ObjectACL_Values() []string {
+	return []string{
+		ObjectACLPrivate,
+		ObjectACLPublicRead,
+		ObjectACLPublicReadWrite,
+		ObjectACLAuthenticatedRead,
+		ObjectACLBucketOwnerRead,
+		ObjectACLBucketOwnerFullControl,
+		ObjectACLAwsExecRead,
+	}
+}
+
 const (
 	// SMBSecurityStrategyClientSpecified is a SMBSecurityStrategy enum value
 	SMBSecurityStrategyClientSpecified = "ClientSpecified"
@@ -19268,3 +19398,12 @@ const (
 	// SMBSecurityStrategyMandatoryEncryption is a SMBSecurityStrategy enum value
 	SMBSecurityStrategyMandatoryEncryption = "MandatoryEncryption"
 )
+
+// SMBSecurityStrategy_Values returns all elements of the SMBSecurityStrategy enum
+func SMBSecurityStrategy_Values() []string {
+	return []string{
+		SMBSecurityStrategyClientSpecified,
+		SMBSecurityStrategyMandatorySigning,
+		SMBSecurityStrategyMandatoryEncryption,
+	}
+}

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -16607,6 +16607,16 @@ const (
 	ActivityTaskTimeoutTypeHeartbeat = "HEARTBEAT"
 )
 
+// ActivityTaskTimeoutType_Values returns all elements of the ActivityTaskTimeoutType enum
+func ActivityTaskTimeoutType_Values() []string {
+	return []string{
+		ActivityTaskTimeoutTypeStartToClose,
+		ActivityTaskTimeoutTypeScheduleToStart,
+		ActivityTaskTimeoutTypeScheduleToClose,
+		ActivityTaskTimeoutTypeHeartbeat,
+	}
+}
+
 const (
 	// CancelTimerFailedCauseTimerIdUnknown is a CancelTimerFailedCause enum value
 	CancelTimerFailedCauseTimerIdUnknown = "TIMER_ID_UNKNOWN"
@@ -16615,6 +16625,14 @@ const (
 	CancelTimerFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
 
+// CancelTimerFailedCause_Values returns all elements of the CancelTimerFailedCause enum
+func CancelTimerFailedCause_Values() []string {
+	return []string{
+		CancelTimerFailedCauseTimerIdUnknown,
+		CancelTimerFailedCauseOperationNotPermitted,
+	}
+}
+
 const (
 	// CancelWorkflowExecutionFailedCauseUnhandledDecision is a CancelWorkflowExecutionFailedCause enum value
 	CancelWorkflowExecutionFailedCauseUnhandledDecision = "UNHANDLED_DECISION"
@@ -16622,6 +16640,14 @@ const (
 	// CancelWorkflowExecutionFailedCauseOperationNotPermitted is a CancelWorkflowExecutionFailedCause enum value
 	CancelWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
+
+// CancelWorkflowExecutionFailedCause_Values returns all elements of the CancelWorkflowExecutionFailedCause enum
+func CancelWorkflowExecutionFailedCause_Values() []string {
+	return []string{
+		CancelWorkflowExecutionFailedCauseUnhandledDecision,
+		CancelWorkflowExecutionFailedCauseOperationNotPermitted,
+	}
+}
 
 const (
 	// ChildPolicyTerminate is a ChildPolicy enum value
@@ -16633,6 +16659,15 @@ const (
 	// ChildPolicyAbandon is a ChildPolicy enum value
 	ChildPolicyAbandon = "ABANDON"
 )
+
+// ChildPolicy_Values returns all elements of the ChildPolicy enum
+func ChildPolicy_Values() []string {
+	return []string{
+		ChildPolicyTerminate,
+		ChildPolicyRequestCancel,
+		ChildPolicyAbandon,
+	}
+}
 
 const (
 	// CloseStatusCompleted is a CloseStatus enum value
@@ -16654,6 +16689,18 @@ const (
 	CloseStatusTimedOut = "TIMED_OUT"
 )
 
+// CloseStatus_Values returns all elements of the CloseStatus enum
+func CloseStatus_Values() []string {
+	return []string{
+		CloseStatusCompleted,
+		CloseStatusFailed,
+		CloseStatusCanceled,
+		CloseStatusTerminated,
+		CloseStatusContinuedAsNew,
+		CloseStatusTimedOut,
+	}
+}
+
 const (
 	// CompleteWorkflowExecutionFailedCauseUnhandledDecision is a CompleteWorkflowExecutionFailedCause enum value
 	CompleteWorkflowExecutionFailedCauseUnhandledDecision = "UNHANDLED_DECISION"
@@ -16661,6 +16708,14 @@ const (
 	// CompleteWorkflowExecutionFailedCauseOperationNotPermitted is a CompleteWorkflowExecutionFailedCause enum value
 	CompleteWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
+
+// CompleteWorkflowExecutionFailedCause_Values returns all elements of the CompleteWorkflowExecutionFailedCause enum
+func CompleteWorkflowExecutionFailedCause_Values() []string {
+	return []string{
+		CompleteWorkflowExecutionFailedCauseUnhandledDecision,
+		CompleteWorkflowExecutionFailedCauseOperationNotPermitted,
+	}
+}
 
 const (
 	// ContinueAsNewWorkflowExecutionFailedCauseUnhandledDecision is a ContinueAsNewWorkflowExecutionFailedCause enum value
@@ -16691,10 +16746,32 @@ const (
 	ContinueAsNewWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
 
+// ContinueAsNewWorkflowExecutionFailedCause_Values returns all elements of the ContinueAsNewWorkflowExecutionFailedCause enum
+func ContinueAsNewWorkflowExecutionFailedCause_Values() []string {
+	return []string{
+		ContinueAsNewWorkflowExecutionFailedCauseUnhandledDecision,
+		ContinueAsNewWorkflowExecutionFailedCauseWorkflowTypeDeprecated,
+		ContinueAsNewWorkflowExecutionFailedCauseWorkflowTypeDoesNotExist,
+		ContinueAsNewWorkflowExecutionFailedCauseDefaultExecutionStartToCloseTimeoutUndefined,
+		ContinueAsNewWorkflowExecutionFailedCauseDefaultTaskStartToCloseTimeoutUndefined,
+		ContinueAsNewWorkflowExecutionFailedCauseDefaultTaskListUndefined,
+		ContinueAsNewWorkflowExecutionFailedCauseDefaultChildPolicyUndefined,
+		ContinueAsNewWorkflowExecutionFailedCauseContinueAsNewWorkflowExecutionRateExceeded,
+		ContinueAsNewWorkflowExecutionFailedCauseOperationNotPermitted,
+	}
+}
+
 const (
 	// DecisionTaskTimeoutTypeStartToClose is a DecisionTaskTimeoutType enum value
 	DecisionTaskTimeoutTypeStartToClose = "START_TO_CLOSE"
 )
+
+// DecisionTaskTimeoutType_Values returns all elements of the DecisionTaskTimeoutType enum
+func DecisionTaskTimeoutType_Values() []string {
+	return []string{
+		DecisionTaskTimeoutTypeStartToClose,
+	}
+}
 
 const (
 	// DecisionTypeScheduleActivityTask is a DecisionType enum value
@@ -16736,6 +16813,25 @@ const (
 	// DecisionTypeScheduleLambdaFunction is a DecisionType enum value
 	DecisionTypeScheduleLambdaFunction = "ScheduleLambdaFunction"
 )
+
+// DecisionType_Values returns all elements of the DecisionType enum
+func DecisionType_Values() []string {
+	return []string{
+		DecisionTypeScheduleActivityTask,
+		DecisionTypeRequestCancelActivityTask,
+		DecisionTypeCompleteWorkflowExecution,
+		DecisionTypeFailWorkflowExecution,
+		DecisionTypeCancelWorkflowExecution,
+		DecisionTypeContinueAsNewWorkflowExecution,
+		DecisionTypeRecordMarker,
+		DecisionTypeStartTimer,
+		DecisionTypeCancelTimer,
+		DecisionTypeSignalExternalWorkflowExecution,
+		DecisionTypeRequestCancelExternalWorkflowExecution,
+		DecisionTypeStartChildWorkflowExecution,
+		DecisionTypeScheduleLambdaFunction,
+	}
+}
 
 const (
 	// EventTypeWorkflowExecutionStarted is a EventType enum value
@@ -16901,6 +16997,66 @@ const (
 	EventTypeStartLambdaFunctionFailed = "StartLambdaFunctionFailed"
 )
 
+// EventType_Values returns all elements of the EventType enum
+func EventType_Values() []string {
+	return []string{
+		EventTypeWorkflowExecutionStarted,
+		EventTypeWorkflowExecutionCancelRequested,
+		EventTypeWorkflowExecutionCompleted,
+		EventTypeCompleteWorkflowExecutionFailed,
+		EventTypeWorkflowExecutionFailed,
+		EventTypeFailWorkflowExecutionFailed,
+		EventTypeWorkflowExecutionTimedOut,
+		EventTypeWorkflowExecutionCanceled,
+		EventTypeCancelWorkflowExecutionFailed,
+		EventTypeWorkflowExecutionContinuedAsNew,
+		EventTypeContinueAsNewWorkflowExecutionFailed,
+		EventTypeWorkflowExecutionTerminated,
+		EventTypeDecisionTaskScheduled,
+		EventTypeDecisionTaskStarted,
+		EventTypeDecisionTaskCompleted,
+		EventTypeDecisionTaskTimedOut,
+		EventTypeActivityTaskScheduled,
+		EventTypeScheduleActivityTaskFailed,
+		EventTypeActivityTaskStarted,
+		EventTypeActivityTaskCompleted,
+		EventTypeActivityTaskFailed,
+		EventTypeActivityTaskTimedOut,
+		EventTypeActivityTaskCanceled,
+		EventTypeActivityTaskCancelRequested,
+		EventTypeRequestCancelActivityTaskFailed,
+		EventTypeWorkflowExecutionSignaled,
+		EventTypeMarkerRecorded,
+		EventTypeRecordMarkerFailed,
+		EventTypeTimerStarted,
+		EventTypeStartTimerFailed,
+		EventTypeTimerFired,
+		EventTypeTimerCanceled,
+		EventTypeCancelTimerFailed,
+		EventTypeStartChildWorkflowExecutionInitiated,
+		EventTypeStartChildWorkflowExecutionFailed,
+		EventTypeChildWorkflowExecutionStarted,
+		EventTypeChildWorkflowExecutionCompleted,
+		EventTypeChildWorkflowExecutionFailed,
+		EventTypeChildWorkflowExecutionTimedOut,
+		EventTypeChildWorkflowExecutionCanceled,
+		EventTypeChildWorkflowExecutionTerminated,
+		EventTypeSignalExternalWorkflowExecutionInitiated,
+		EventTypeSignalExternalWorkflowExecutionFailed,
+		EventTypeExternalWorkflowExecutionSignaled,
+		EventTypeRequestCancelExternalWorkflowExecutionInitiated,
+		EventTypeRequestCancelExternalWorkflowExecutionFailed,
+		EventTypeExternalWorkflowExecutionCancelRequested,
+		EventTypeLambdaFunctionScheduled,
+		EventTypeLambdaFunctionStarted,
+		EventTypeLambdaFunctionCompleted,
+		EventTypeLambdaFunctionFailed,
+		EventTypeLambdaFunctionTimedOut,
+		EventTypeScheduleLambdaFunctionFailed,
+		EventTypeStartLambdaFunctionFailed,
+	}
+}
+
 const (
 	// ExecutionStatusOpen is a ExecutionStatus enum value
 	ExecutionStatusOpen = "OPEN"
@@ -16908,6 +17064,14 @@ const (
 	// ExecutionStatusClosed is a ExecutionStatus enum value
 	ExecutionStatusClosed = "CLOSED"
 )
+
+// ExecutionStatus_Values returns all elements of the ExecutionStatus enum
+func ExecutionStatus_Values() []string {
+	return []string{
+		ExecutionStatusOpen,
+		ExecutionStatusClosed,
+	}
+}
 
 const (
 	// FailWorkflowExecutionFailedCauseUnhandledDecision is a FailWorkflowExecutionFailedCause enum value
@@ -16917,15 +17081,37 @@ const (
 	FailWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
 
+// FailWorkflowExecutionFailedCause_Values returns all elements of the FailWorkflowExecutionFailedCause enum
+func FailWorkflowExecutionFailedCause_Values() []string {
+	return []string{
+		FailWorkflowExecutionFailedCauseUnhandledDecision,
+		FailWorkflowExecutionFailedCauseOperationNotPermitted,
+	}
+}
+
 const (
 	// LambdaFunctionTimeoutTypeStartToClose is a LambdaFunctionTimeoutType enum value
 	LambdaFunctionTimeoutTypeStartToClose = "START_TO_CLOSE"
 )
 
+// LambdaFunctionTimeoutType_Values returns all elements of the LambdaFunctionTimeoutType enum
+func LambdaFunctionTimeoutType_Values() []string {
+	return []string{
+		LambdaFunctionTimeoutTypeStartToClose,
+	}
+}
+
 const (
 	// RecordMarkerFailedCauseOperationNotPermitted is a RecordMarkerFailedCause enum value
 	RecordMarkerFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
+
+// RecordMarkerFailedCause_Values returns all elements of the RecordMarkerFailedCause enum
+func RecordMarkerFailedCause_Values() []string {
+	return []string{
+		RecordMarkerFailedCauseOperationNotPermitted,
+	}
+}
 
 const (
 	// RegistrationStatusRegistered is a RegistrationStatus enum value
@@ -16935,6 +17121,14 @@ const (
 	RegistrationStatusDeprecated = "DEPRECATED"
 )
 
+// RegistrationStatus_Values returns all elements of the RegistrationStatus enum
+func RegistrationStatus_Values() []string {
+	return []string{
+		RegistrationStatusRegistered,
+		RegistrationStatusDeprecated,
+	}
+}
+
 const (
 	// RequestCancelActivityTaskFailedCauseActivityIdUnknown is a RequestCancelActivityTaskFailedCause enum value
 	RequestCancelActivityTaskFailedCauseActivityIdUnknown = "ACTIVITY_ID_UNKNOWN"
@@ -16942,6 +17136,14 @@ const (
 	// RequestCancelActivityTaskFailedCauseOperationNotPermitted is a RequestCancelActivityTaskFailedCause enum value
 	RequestCancelActivityTaskFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
+
+// RequestCancelActivityTaskFailedCause_Values returns all elements of the RequestCancelActivityTaskFailedCause enum
+func RequestCancelActivityTaskFailedCause_Values() []string {
+	return []string{
+		RequestCancelActivityTaskFailedCauseActivityIdUnknown,
+		RequestCancelActivityTaskFailedCauseOperationNotPermitted,
+	}
+}
 
 const (
 	// RequestCancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution is a RequestCancelExternalWorkflowExecutionFailedCause enum value
@@ -16953,6 +17155,15 @@ const (
 	// RequestCancelExternalWorkflowExecutionFailedCauseOperationNotPermitted is a RequestCancelExternalWorkflowExecutionFailedCause enum value
 	RequestCancelExternalWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
+
+// RequestCancelExternalWorkflowExecutionFailedCause_Values returns all elements of the RequestCancelExternalWorkflowExecutionFailedCause enum
+func RequestCancelExternalWorkflowExecutionFailedCause_Values() []string {
+	return []string{
+		RequestCancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution,
+		RequestCancelExternalWorkflowExecutionFailedCauseRequestCancelExternalWorkflowExecutionRateExceeded,
+		RequestCancelExternalWorkflowExecutionFailedCauseOperationNotPermitted,
+	}
+}
 
 const (
 	// ScheduleActivityTaskFailedCauseActivityTypeDeprecated is a ScheduleActivityTaskFailedCause enum value
@@ -16989,6 +17200,23 @@ const (
 	ScheduleActivityTaskFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
 
+// ScheduleActivityTaskFailedCause_Values returns all elements of the ScheduleActivityTaskFailedCause enum
+func ScheduleActivityTaskFailedCause_Values() []string {
+	return []string{
+		ScheduleActivityTaskFailedCauseActivityTypeDeprecated,
+		ScheduleActivityTaskFailedCauseActivityTypeDoesNotExist,
+		ScheduleActivityTaskFailedCauseActivityIdAlreadyInUse,
+		ScheduleActivityTaskFailedCauseOpenActivitiesLimitExceeded,
+		ScheduleActivityTaskFailedCauseActivityCreationRateExceeded,
+		ScheduleActivityTaskFailedCauseDefaultScheduleToCloseTimeoutUndefined,
+		ScheduleActivityTaskFailedCauseDefaultTaskListUndefined,
+		ScheduleActivityTaskFailedCauseDefaultScheduleToStartTimeoutUndefined,
+		ScheduleActivityTaskFailedCauseDefaultStartToCloseTimeoutUndefined,
+		ScheduleActivityTaskFailedCauseDefaultHeartbeatTimeoutUndefined,
+		ScheduleActivityTaskFailedCauseOperationNotPermitted,
+	}
+}
+
 const (
 	// ScheduleLambdaFunctionFailedCauseIdAlreadyInUse is a ScheduleLambdaFunctionFailedCause enum value
 	ScheduleLambdaFunctionFailedCauseIdAlreadyInUse = "ID_ALREADY_IN_USE"
@@ -17003,6 +17231,16 @@ const (
 	ScheduleLambdaFunctionFailedCauseLambdaServiceNotAvailableInRegion = "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION"
 )
 
+// ScheduleLambdaFunctionFailedCause_Values returns all elements of the ScheduleLambdaFunctionFailedCause enum
+func ScheduleLambdaFunctionFailedCause_Values() []string {
+	return []string{
+		ScheduleLambdaFunctionFailedCauseIdAlreadyInUse,
+		ScheduleLambdaFunctionFailedCauseOpenLambdaFunctionsLimitExceeded,
+		ScheduleLambdaFunctionFailedCauseLambdaFunctionCreationRateExceeded,
+		ScheduleLambdaFunctionFailedCauseLambdaServiceNotAvailableInRegion,
+	}
+}
+
 const (
 	// SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution is a SignalExternalWorkflowExecutionFailedCause enum value
 	SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution = "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
@@ -17013,6 +17251,15 @@ const (
 	// SignalExternalWorkflowExecutionFailedCauseOperationNotPermitted is a SignalExternalWorkflowExecutionFailedCause enum value
 	SignalExternalWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
+
+// SignalExternalWorkflowExecutionFailedCause_Values returns all elements of the SignalExternalWorkflowExecutionFailedCause enum
+func SignalExternalWorkflowExecutionFailedCause_Values() []string {
+	return []string{
+		SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution,
+		SignalExternalWorkflowExecutionFailedCauseSignalExternalWorkflowExecutionRateExceeded,
+		SignalExternalWorkflowExecutionFailedCauseOperationNotPermitted,
+	}
+}
 
 const (
 	// StartChildWorkflowExecutionFailedCauseWorkflowTypeDoesNotExist is a StartChildWorkflowExecutionFailedCause enum value
@@ -17049,10 +17296,34 @@ const (
 	StartChildWorkflowExecutionFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
 
+// StartChildWorkflowExecutionFailedCause_Values returns all elements of the StartChildWorkflowExecutionFailedCause enum
+func StartChildWorkflowExecutionFailedCause_Values() []string {
+	return []string{
+		StartChildWorkflowExecutionFailedCauseWorkflowTypeDoesNotExist,
+		StartChildWorkflowExecutionFailedCauseWorkflowTypeDeprecated,
+		StartChildWorkflowExecutionFailedCauseOpenChildrenLimitExceeded,
+		StartChildWorkflowExecutionFailedCauseOpenWorkflowsLimitExceeded,
+		StartChildWorkflowExecutionFailedCauseChildCreationRateExceeded,
+		StartChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning,
+		StartChildWorkflowExecutionFailedCauseDefaultExecutionStartToCloseTimeoutUndefined,
+		StartChildWorkflowExecutionFailedCauseDefaultTaskListUndefined,
+		StartChildWorkflowExecutionFailedCauseDefaultTaskStartToCloseTimeoutUndefined,
+		StartChildWorkflowExecutionFailedCauseDefaultChildPolicyUndefined,
+		StartChildWorkflowExecutionFailedCauseOperationNotPermitted,
+	}
+}
+
 const (
 	// StartLambdaFunctionFailedCauseAssumeRoleFailed is a StartLambdaFunctionFailedCause enum value
 	StartLambdaFunctionFailedCauseAssumeRoleFailed = "ASSUME_ROLE_FAILED"
 )
+
+// StartLambdaFunctionFailedCause_Values returns all elements of the StartLambdaFunctionFailedCause enum
+func StartLambdaFunctionFailedCause_Values() []string {
+	return []string{
+		StartLambdaFunctionFailedCauseAssumeRoleFailed,
+	}
+}
 
 const (
 	// StartTimerFailedCauseTimerIdAlreadyInUse is a StartTimerFailedCause enum value
@@ -17068,10 +17339,27 @@ const (
 	StartTimerFailedCauseOperationNotPermitted = "OPERATION_NOT_PERMITTED"
 )
 
+// StartTimerFailedCause_Values returns all elements of the StartTimerFailedCause enum
+func StartTimerFailedCause_Values() []string {
+	return []string{
+		StartTimerFailedCauseTimerIdAlreadyInUse,
+		StartTimerFailedCauseOpenTimersLimitExceeded,
+		StartTimerFailedCauseTimerCreationRateExceeded,
+		StartTimerFailedCauseOperationNotPermitted,
+	}
+}
+
 const (
 	// WorkflowExecutionCancelRequestedCauseChildPolicyApplied is a WorkflowExecutionCancelRequestedCause enum value
 	WorkflowExecutionCancelRequestedCauseChildPolicyApplied = "CHILD_POLICY_APPLIED"
 )
+
+// WorkflowExecutionCancelRequestedCause_Values returns all elements of the WorkflowExecutionCancelRequestedCause enum
+func WorkflowExecutionCancelRequestedCause_Values() []string {
+	return []string{
+		WorkflowExecutionCancelRequestedCauseChildPolicyApplied,
+	}
+}
 
 const (
 	// WorkflowExecutionTerminatedCauseChildPolicyApplied is a WorkflowExecutionTerminatedCause enum value
@@ -17084,7 +17372,23 @@ const (
 	WorkflowExecutionTerminatedCauseOperatorInitiated = "OPERATOR_INITIATED"
 )
 
+// WorkflowExecutionTerminatedCause_Values returns all elements of the WorkflowExecutionTerminatedCause enum
+func WorkflowExecutionTerminatedCause_Values() []string {
+	return []string{
+		WorkflowExecutionTerminatedCauseChildPolicyApplied,
+		WorkflowExecutionTerminatedCauseEventLimitExceeded,
+		WorkflowExecutionTerminatedCauseOperatorInitiated,
+	}
+}
+
 const (
 	// WorkflowExecutionTimeoutTypeStartToClose is a WorkflowExecutionTimeoutType enum value
 	WorkflowExecutionTimeoutTypeStartToClose = "START_TO_CLOSE"
 )
+
+// WorkflowExecutionTimeoutType_Values returns all elements of the WorkflowExecutionTimeoutType enum
+func WorkflowExecutionTimeoutType_Values() []string {
+	return []string{
+		WorkflowExecutionTimeoutTypeStartToClose,
+	}
+}

--- a/service/synthetics/api.go
+++ b/service/synthetics/api.go
@@ -3774,6 +3774,15 @@ const (
 	CanaryRunStateFailed = "FAILED"
 )
 
+// CanaryRunState_Values returns all elements of the CanaryRunState enum
+func CanaryRunState_Values() []string {
+	return []string{
+		CanaryRunStateRunning,
+		CanaryRunStatePassed,
+		CanaryRunStateFailed,
+	}
+}
+
 const (
 	// CanaryRunStateReasonCodeCanaryFailure is a CanaryRunStateReasonCode enum value
 	CanaryRunStateReasonCodeCanaryFailure = "CANARY_FAILURE"
@@ -3781,6 +3790,14 @@ const (
 	// CanaryRunStateReasonCodeExecutionFailure is a CanaryRunStateReasonCode enum value
 	CanaryRunStateReasonCodeExecutionFailure = "EXECUTION_FAILURE"
 )
+
+// CanaryRunStateReasonCode_Values returns all elements of the CanaryRunStateReasonCode enum
+func CanaryRunStateReasonCode_Values() []string {
+	return []string{
+		CanaryRunStateReasonCodeCanaryFailure,
+		CanaryRunStateReasonCodeExecutionFailure,
+	}
+}
 
 const (
 	// CanaryStateCreating is a CanaryState enum value
@@ -3811,7 +3828,29 @@ const (
 	CanaryStateDeleting = "DELETING"
 )
 
+// CanaryState_Values returns all elements of the CanaryState enum
+func CanaryState_Values() []string {
+	return []string{
+		CanaryStateCreating,
+		CanaryStateReady,
+		CanaryStateStarting,
+		CanaryStateRunning,
+		CanaryStateUpdating,
+		CanaryStateStopping,
+		CanaryStateStopped,
+		CanaryStateError,
+		CanaryStateDeleting,
+	}
+}
+
 const (
 	// CanaryStateReasonCodeInvalidPermissions is a CanaryStateReasonCode enum value
 	CanaryStateReasonCodeInvalidPermissions = "INVALID_PERMISSIONS"
 )
+
+// CanaryStateReasonCode_Values returns all elements of the CanaryStateReasonCode enum
+func CanaryStateReasonCode_Values() []string {
+	return []string{
+		CanaryStateReasonCodeInvalidPermissions,
+	}
+}

--- a/service/textract/api.go
+++ b/service/textract/api.go
@@ -3217,6 +3217,19 @@ const (
 	BlockTypeSelectionElement = "SELECTION_ELEMENT"
 )
 
+// BlockType_Values returns all elements of the BlockType enum
+func BlockType_Values() []string {
+	return []string{
+		BlockTypeKeyValueSet,
+		BlockTypePage,
+		BlockTypeLine,
+		BlockTypeWord,
+		BlockTypeTable,
+		BlockTypeCell,
+		BlockTypeSelectionElement,
+	}
+}
+
 const (
 	// ContentClassifierFreeOfPersonallyIdentifiableInformation is a ContentClassifier enum value
 	ContentClassifierFreeOfPersonallyIdentifiableInformation = "FreeOfPersonallyIdentifiableInformation"
@@ -3224,6 +3237,14 @@ const (
 	// ContentClassifierFreeOfAdultContent is a ContentClassifier enum value
 	ContentClassifierFreeOfAdultContent = "FreeOfAdultContent"
 )
+
+// ContentClassifier_Values returns all elements of the ContentClassifier enum
+func ContentClassifier_Values() []string {
+	return []string{
+		ContentClassifierFreeOfPersonallyIdentifiableInformation,
+		ContentClassifierFreeOfAdultContent,
+	}
+}
 
 const (
 	// EntityTypeKey is a EntityType enum value
@@ -3233,6 +3254,14 @@ const (
 	EntityTypeValue = "VALUE"
 )
 
+// EntityType_Values returns all elements of the EntityType enum
+func EntityType_Values() []string {
+	return []string{
+		EntityTypeKey,
+		EntityTypeValue,
+	}
+}
+
 const (
 	// FeatureTypeTables is a FeatureType enum value
 	FeatureTypeTables = "TABLES"
@@ -3240,6 +3269,14 @@ const (
 	// FeatureTypeForms is a FeatureType enum value
 	FeatureTypeForms = "FORMS"
 )
+
+// FeatureType_Values returns all elements of the FeatureType enum
+func FeatureType_Values() []string {
+	return []string{
+		FeatureTypeTables,
+		FeatureTypeForms,
+	}
+}
 
 const (
 	// JobStatusInProgress is a JobStatus enum value
@@ -3255,6 +3292,16 @@ const (
 	JobStatusPartialSuccess = "PARTIAL_SUCCESS"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusInProgress,
+		JobStatusSucceeded,
+		JobStatusFailed,
+		JobStatusPartialSuccess,
+	}
+}
+
 const (
 	// RelationshipTypeValue is a RelationshipType enum value
 	RelationshipTypeValue = "VALUE"
@@ -3263,6 +3310,14 @@ const (
 	RelationshipTypeChild = "CHILD"
 )
 
+// RelationshipType_Values returns all elements of the RelationshipType enum
+func RelationshipType_Values() []string {
+	return []string{
+		RelationshipTypeValue,
+		RelationshipTypeChild,
+	}
+}
+
 const (
 	// SelectionStatusSelected is a SelectionStatus enum value
 	SelectionStatusSelected = "SELECTED"
@@ -3270,3 +3325,11 @@ const (
 	// SelectionStatusNotSelected is a SelectionStatus enum value
 	SelectionStatusNotSelected = "NOT_SELECTED"
 )
+
+// SelectionStatus_Values returns all elements of the SelectionStatus enum
+func SelectionStatus_Values() []string {
+	return []string{
+		SelectionStatusSelected,
+		SelectionStatusNotSelected,
+	}
+}

--- a/service/transcribeservice/api.go
+++ b/service/transcribeservice/api.go
@@ -7584,10 +7584,25 @@ const (
 	BaseModelNameWideBand = "WideBand"
 )
 
+// BaseModelName_Values returns all elements of the BaseModelName enum
+func BaseModelName_Values() []string {
+	return []string{
+		BaseModelNameNarrowBand,
+		BaseModelNameWideBand,
+	}
+}
+
 const (
 	// CLMLanguageCodeEnUs is a CLMLanguageCode enum value
 	CLMLanguageCodeEnUs = "en-US"
 )
+
+// CLMLanguageCode_Values returns all elements of the CLMLanguageCode enum
+func CLMLanguageCode_Values() []string {
+	return []string{
+		CLMLanguageCodeEnUs,
+	}
+}
 
 const (
 	// LanguageCodeAfZa is a LanguageCode enum value
@@ -7699,6 +7714,48 @@ const (
 	LanguageCodeZhCn = "zh-CN"
 )
 
+// LanguageCode_Values returns all elements of the LanguageCode enum
+func LanguageCode_Values() []string {
+	return []string{
+		LanguageCodeAfZa,
+		LanguageCodeArAe,
+		LanguageCodeArSa,
+		LanguageCodeCyGb,
+		LanguageCodeDaDk,
+		LanguageCodeDeCh,
+		LanguageCodeDeDe,
+		LanguageCodeEnAb,
+		LanguageCodeEnAu,
+		LanguageCodeEnGb,
+		LanguageCodeEnIe,
+		LanguageCodeEnIn,
+		LanguageCodeEnUs,
+		LanguageCodeEnWl,
+		LanguageCodeEsEs,
+		LanguageCodeEsUs,
+		LanguageCodeFaIr,
+		LanguageCodeFrCa,
+		LanguageCodeFrFr,
+		LanguageCodeGaIe,
+		LanguageCodeGdGb,
+		LanguageCodeHeIl,
+		LanguageCodeHiIn,
+		LanguageCodeIdId,
+		LanguageCodeItIt,
+		LanguageCodeJaJp,
+		LanguageCodeKoKr,
+		LanguageCodeMsMy,
+		LanguageCodeNlNl,
+		LanguageCodePtBr,
+		LanguageCodePtPt,
+		LanguageCodeRuRu,
+		LanguageCodeTaIn,
+		LanguageCodeTeIn,
+		LanguageCodeTrTr,
+		LanguageCodeZhCn,
+	}
+}
+
 const (
 	// MediaFormatMp3 is a MediaFormat enum value
 	MediaFormatMp3 = "mp3"
@@ -7713,6 +7770,16 @@ const (
 	MediaFormatFlac = "flac"
 )
 
+// MediaFormat_Values returns all elements of the MediaFormat enum
+func MediaFormat_Values() []string {
+	return []string{
+		MediaFormatMp3,
+		MediaFormatMp4,
+		MediaFormatWav,
+		MediaFormatFlac,
+	}
+}
+
 const (
 	// ModelStatusInProgress is a ModelStatus enum value
 	ModelStatusInProgress = "IN_PROGRESS"
@@ -7724,6 +7791,15 @@ const (
 	ModelStatusCompleted = "COMPLETED"
 )
 
+// ModelStatus_Values returns all elements of the ModelStatus enum
+func ModelStatus_Values() []string {
+	return []string{
+		ModelStatusInProgress,
+		ModelStatusFailed,
+		ModelStatusCompleted,
+	}
+}
+
 const (
 	// OutputLocationTypeCustomerBucket is a OutputLocationType enum value
 	OutputLocationTypeCustomerBucket = "CUSTOMER_BUCKET"
@@ -7731,6 +7807,14 @@ const (
 	// OutputLocationTypeServiceBucket is a OutputLocationType enum value
 	OutputLocationTypeServiceBucket = "SERVICE_BUCKET"
 )
+
+// OutputLocationType_Values returns all elements of the OutputLocationType enum
+func OutputLocationType_Values() []string {
+	return []string{
+		OutputLocationTypeCustomerBucket,
+		OutputLocationTypeServiceBucket,
+	}
+}
 
 const (
 	// RedactionOutputRedacted is a RedactionOutput enum value
@@ -7740,15 +7824,37 @@ const (
 	RedactionOutputRedactedAndUnredacted = "redacted_and_unredacted"
 )
 
+// RedactionOutput_Values returns all elements of the RedactionOutput enum
+func RedactionOutput_Values() []string {
+	return []string{
+		RedactionOutputRedacted,
+		RedactionOutputRedactedAndUnredacted,
+	}
+}
+
 const (
 	// RedactionTypePii is a RedactionType enum value
 	RedactionTypePii = "PII"
 )
 
+// RedactionType_Values returns all elements of the RedactionType enum
+func RedactionType_Values() []string {
+	return []string{
+		RedactionTypePii,
+	}
+}
+
 const (
 	// SpecialtyPrimarycare is a Specialty enum value
 	SpecialtyPrimarycare = "PRIMARYCARE"
 )
+
+// Specialty_Values returns all elements of the Specialty enum
+func Specialty_Values() []string {
+	return []string{
+		SpecialtyPrimarycare,
+	}
+}
 
 const (
 	// TranscriptionJobStatusQueued is a TranscriptionJobStatus enum value
@@ -7764,6 +7870,16 @@ const (
 	TranscriptionJobStatusCompleted = "COMPLETED"
 )
 
+// TranscriptionJobStatus_Values returns all elements of the TranscriptionJobStatus enum
+func TranscriptionJobStatus_Values() []string {
+	return []string{
+		TranscriptionJobStatusQueued,
+		TranscriptionJobStatusInProgress,
+		TranscriptionJobStatusFailed,
+		TranscriptionJobStatusCompleted,
+	}
+}
+
 const (
 	// TypeConversation is a Type enum value
 	TypeConversation = "CONVERSATION"
@@ -7772,6 +7888,14 @@ const (
 	TypeDictation = "DICTATION"
 )
 
+// Type_Values returns all elements of the Type enum
+func Type_Values() []string {
+	return []string{
+		TypeConversation,
+		TypeDictation,
+	}
+}
+
 const (
 	// VocabularyFilterMethodRemove is a VocabularyFilterMethod enum value
 	VocabularyFilterMethodRemove = "remove"
@@ -7779,6 +7903,14 @@ const (
 	// VocabularyFilterMethodMask is a VocabularyFilterMethod enum value
 	VocabularyFilterMethodMask = "mask"
 )
+
+// VocabularyFilterMethod_Values returns all elements of the VocabularyFilterMethod enum
+func VocabularyFilterMethod_Values() []string {
+	return []string{
+		VocabularyFilterMethodRemove,
+		VocabularyFilterMethodMask,
+	}
+}
 
 const (
 	// VocabularyStatePending is a VocabularyState enum value
@@ -7790,3 +7922,12 @@ const (
 	// VocabularyStateFailed is a VocabularyState enum value
 	VocabularyStateFailed = "FAILED"
 )
+
+// VocabularyState_Values returns all elements of the VocabularyState enum
+func VocabularyState_Values() []string {
+	return []string{
+		VocabularyStatePending,
+		VocabularyStateReady,
+		VocabularyStateFailed,
+	}
+}

--- a/service/transcribestreamingservice/api.go
+++ b/service/transcribestreamingservice/api.go
@@ -1535,6 +1535,14 @@ const (
 	ItemTypePunctuation = "punctuation"
 )
 
+// ItemType_Values returns all elements of the ItemType enum
+func ItemType_Values() []string {
+	return []string{
+		ItemTypePronunciation,
+		ItemTypePunctuation,
+	}
+}
+
 const (
 	// LanguageCodeEnUs is a LanguageCode enum value
 	LanguageCodeEnUs = "en-US"
@@ -1555,10 +1563,29 @@ const (
 	LanguageCodeEnAu = "en-AU"
 )
 
+// LanguageCode_Values returns all elements of the LanguageCode enum
+func LanguageCode_Values() []string {
+	return []string{
+		LanguageCodeEnUs,
+		LanguageCodeEnGb,
+		LanguageCodeEsUs,
+		LanguageCodeFrCa,
+		LanguageCodeFrFr,
+		LanguageCodeEnAu,
+	}
+}
+
 const (
 	// MediaEncodingPcm is a MediaEncoding enum value
 	MediaEncodingPcm = "pcm"
 )
+
+// MediaEncoding_Values returns all elements of the MediaEncoding enum
+func MediaEncoding_Values() []string {
+	return []string{
+		MediaEncodingPcm,
+	}
+}
 
 const (
 	// VocabularyFilterMethodRemove is a VocabularyFilterMethod enum value
@@ -1570,3 +1597,12 @@ const (
 	// VocabularyFilterMethodTag is a VocabularyFilterMethod enum value
 	VocabularyFilterMethodTag = "tag"
 )
+
+// VocabularyFilterMethod_Values returns all elements of the VocabularyFilterMethod enum
+func VocabularyFilterMethod_Values() []string {
+	return []string{
+		VocabularyFilterMethodRemove,
+		VocabularyFilterMethodMask,
+		VocabularyFilterMethodTag,
+	}
+}

--- a/service/transfer/api.go
+++ b/service/transfer/api.go
@@ -5415,6 +5415,15 @@ const (
 	EndpointTypeVpcEndpoint = "VPC_ENDPOINT"
 )
 
+// EndpointType_Values returns all elements of the EndpointType enum
+func EndpointType_Values() []string {
+	return []string{
+		EndpointTypePublic,
+		EndpointTypeVpc,
+		EndpointTypeVpcEndpoint,
+	}
+}
+
 const (
 	// HomeDirectoryTypePath is a HomeDirectoryType enum value
 	HomeDirectoryTypePath = "PATH"
@@ -5422,6 +5431,14 @@ const (
 	// HomeDirectoryTypeLogical is a HomeDirectoryType enum value
 	HomeDirectoryTypeLogical = "LOGICAL"
 )
+
+// HomeDirectoryType_Values returns all elements of the HomeDirectoryType enum
+func HomeDirectoryType_Values() []string {
+	return []string{
+		HomeDirectoryTypePath,
+		HomeDirectoryTypeLogical,
+	}
+}
 
 // Returns information related to the type of user authentication that is in
 // use for a file transfer protocol-enabled server's users. For SERVICE_MANAGED
@@ -5437,6 +5454,14 @@ const (
 	IdentityProviderTypeApiGateway = "API_GATEWAY"
 )
 
+// IdentityProviderType_Values returns all elements of the IdentityProviderType enum
+func IdentityProviderType_Values() []string {
+	return []string{
+		IdentityProviderTypeServiceManaged,
+		IdentityProviderTypeApiGateway,
+	}
+}
+
 const (
 	// ProtocolSftp is a Protocol enum value
 	ProtocolSftp = "SFTP"
@@ -5447,6 +5472,15 @@ const (
 	// ProtocolFtps is a Protocol enum value
 	ProtocolFtps = "FTPS"
 )
+
+// Protocol_Values returns all elements of the Protocol enum
+func Protocol_Values() []string {
+	return []string{
+		ProtocolSftp,
+		ProtocolFtp,
+		ProtocolFtps,
+	}
+}
 
 // Describes the condition of a file transfer protocol-enabled server with respect
 // to its ability to perform file operations. There are six possible states:
@@ -5477,3 +5511,15 @@ const (
 	// StateStopFailed is a State enum value
 	StateStopFailed = "STOP_FAILED"
 )
+
+// State_Values returns all elements of the State enum
+func State_Values() []string {
+	return []string{
+		StateOffline,
+		StateOnline,
+		StateStarting,
+		StateStopping,
+		StateStartFailed,
+		StateStopFailed,
+	}
+}

--- a/service/translate/api.go
+++ b/service/translate/api.go
@@ -3255,6 +3255,13 @@ const (
 	EncryptionKeyTypeKms = "KMS"
 )
 
+// EncryptionKeyType_Values returns all elements of the EncryptionKeyType enum
+func EncryptionKeyType_Values() []string {
+	return []string{
+		EncryptionKeyTypeKms,
+	}
+}
+
 const (
 	// JobStatusSubmitted is a JobStatus enum value
 	JobStatusSubmitted = "SUBMITTED"
@@ -3278,10 +3285,30 @@ const (
 	JobStatusStopped = "STOPPED"
 )
 
+// JobStatus_Values returns all elements of the JobStatus enum
+func JobStatus_Values() []string {
+	return []string{
+		JobStatusSubmitted,
+		JobStatusInProgress,
+		JobStatusCompleted,
+		JobStatusCompletedWithError,
+		JobStatusFailed,
+		JobStatusStopRequested,
+		JobStatusStopped,
+	}
+}
+
 const (
 	// MergeStrategyOverwrite is a MergeStrategy enum value
 	MergeStrategyOverwrite = "OVERWRITE"
 )
+
+// MergeStrategy_Values returns all elements of the MergeStrategy enum
+func MergeStrategy_Values() []string {
+	return []string{
+		MergeStrategyOverwrite,
+	}
+}
 
 const (
 	// TerminologyDataFormatCsv is a TerminologyDataFormat enum value
@@ -3290,3 +3317,11 @@ const (
 	// TerminologyDataFormatTmx is a TerminologyDataFormat enum value
 	TerminologyDataFormatTmx = "TMX"
 )
+
+// TerminologyDataFormat_Values returns all elements of the TerminologyDataFormat enum
+func TerminologyDataFormat_Values() []string {
+	return []string{
+		TerminologyDataFormatCsv,
+		TerminologyDataFormatTmx,
+	}
+}

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -23047,6 +23047,14 @@ const (
 	ChangeActionDelete = "DELETE"
 )
 
+// ChangeAction_Values returns all elements of the ChangeAction enum
+func ChangeAction_Values() []string {
+	return []string{
+		ChangeActionInsert,
+		ChangeActionDelete,
+	}
+}
+
 const (
 	// ChangeTokenStatusProvisioned is a ChangeTokenStatus enum value
 	ChangeTokenStatusProvisioned = "PROVISIONED"
@@ -23057,6 +23065,15 @@ const (
 	// ChangeTokenStatusInsync is a ChangeTokenStatus enum value
 	ChangeTokenStatusInsync = "INSYNC"
 )
+
+// ChangeTokenStatus_Values returns all elements of the ChangeTokenStatus enum
+func ChangeTokenStatus_Values() []string {
+	return []string{
+		ChangeTokenStatusProvisioned,
+		ChangeTokenStatusPending,
+		ChangeTokenStatusInsync,
+	}
+}
 
 const (
 	// ComparisonOperatorEq is a ComparisonOperator enum value
@@ -23078,10 +23095,29 @@ const (
 	ComparisonOperatorGt = "GT"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorEq,
+		ComparisonOperatorNe,
+		ComparisonOperatorLe,
+		ComparisonOperatorLt,
+		ComparisonOperatorGe,
+		ComparisonOperatorGt,
+	}
+}
+
 const (
 	// GeoMatchConstraintTypeCountry is a GeoMatchConstraintType enum value
 	GeoMatchConstraintTypeCountry = "Country"
 )
+
+// GeoMatchConstraintType_Values returns all elements of the GeoMatchConstraintType enum
+func GeoMatchConstraintType_Values() []string {
+	return []string{
+		GeoMatchConstraintTypeCountry,
+	}
+}
 
 const (
 	// GeoMatchConstraintValueAf is a GeoMatchConstraintValue enum value
@@ -23832,6 +23868,261 @@ const (
 	GeoMatchConstraintValueZw = "ZW"
 )
 
+// GeoMatchConstraintValue_Values returns all elements of the GeoMatchConstraintValue enum
+func GeoMatchConstraintValue_Values() []string {
+	return []string{
+		GeoMatchConstraintValueAf,
+		GeoMatchConstraintValueAx,
+		GeoMatchConstraintValueAl,
+		GeoMatchConstraintValueDz,
+		GeoMatchConstraintValueAs,
+		GeoMatchConstraintValueAd,
+		GeoMatchConstraintValueAo,
+		GeoMatchConstraintValueAi,
+		GeoMatchConstraintValueAq,
+		GeoMatchConstraintValueAg,
+		GeoMatchConstraintValueAr,
+		GeoMatchConstraintValueAm,
+		GeoMatchConstraintValueAw,
+		GeoMatchConstraintValueAu,
+		GeoMatchConstraintValueAt,
+		GeoMatchConstraintValueAz,
+		GeoMatchConstraintValueBs,
+		GeoMatchConstraintValueBh,
+		GeoMatchConstraintValueBd,
+		GeoMatchConstraintValueBb,
+		GeoMatchConstraintValueBy,
+		GeoMatchConstraintValueBe,
+		GeoMatchConstraintValueBz,
+		GeoMatchConstraintValueBj,
+		GeoMatchConstraintValueBm,
+		GeoMatchConstraintValueBt,
+		GeoMatchConstraintValueBo,
+		GeoMatchConstraintValueBq,
+		GeoMatchConstraintValueBa,
+		GeoMatchConstraintValueBw,
+		GeoMatchConstraintValueBv,
+		GeoMatchConstraintValueBr,
+		GeoMatchConstraintValueIo,
+		GeoMatchConstraintValueBn,
+		GeoMatchConstraintValueBg,
+		GeoMatchConstraintValueBf,
+		GeoMatchConstraintValueBi,
+		GeoMatchConstraintValueKh,
+		GeoMatchConstraintValueCm,
+		GeoMatchConstraintValueCa,
+		GeoMatchConstraintValueCv,
+		GeoMatchConstraintValueKy,
+		GeoMatchConstraintValueCf,
+		GeoMatchConstraintValueTd,
+		GeoMatchConstraintValueCl,
+		GeoMatchConstraintValueCn,
+		GeoMatchConstraintValueCx,
+		GeoMatchConstraintValueCc,
+		GeoMatchConstraintValueCo,
+		GeoMatchConstraintValueKm,
+		GeoMatchConstraintValueCg,
+		GeoMatchConstraintValueCd,
+		GeoMatchConstraintValueCk,
+		GeoMatchConstraintValueCr,
+		GeoMatchConstraintValueCi,
+		GeoMatchConstraintValueHr,
+		GeoMatchConstraintValueCu,
+		GeoMatchConstraintValueCw,
+		GeoMatchConstraintValueCy,
+		GeoMatchConstraintValueCz,
+		GeoMatchConstraintValueDk,
+		GeoMatchConstraintValueDj,
+		GeoMatchConstraintValueDm,
+		GeoMatchConstraintValueDo,
+		GeoMatchConstraintValueEc,
+		GeoMatchConstraintValueEg,
+		GeoMatchConstraintValueSv,
+		GeoMatchConstraintValueGq,
+		GeoMatchConstraintValueEr,
+		GeoMatchConstraintValueEe,
+		GeoMatchConstraintValueEt,
+		GeoMatchConstraintValueFk,
+		GeoMatchConstraintValueFo,
+		GeoMatchConstraintValueFj,
+		GeoMatchConstraintValueFi,
+		GeoMatchConstraintValueFr,
+		GeoMatchConstraintValueGf,
+		GeoMatchConstraintValuePf,
+		GeoMatchConstraintValueTf,
+		GeoMatchConstraintValueGa,
+		GeoMatchConstraintValueGm,
+		GeoMatchConstraintValueGe,
+		GeoMatchConstraintValueDe,
+		GeoMatchConstraintValueGh,
+		GeoMatchConstraintValueGi,
+		GeoMatchConstraintValueGr,
+		GeoMatchConstraintValueGl,
+		GeoMatchConstraintValueGd,
+		GeoMatchConstraintValueGp,
+		GeoMatchConstraintValueGu,
+		GeoMatchConstraintValueGt,
+		GeoMatchConstraintValueGg,
+		GeoMatchConstraintValueGn,
+		GeoMatchConstraintValueGw,
+		GeoMatchConstraintValueGy,
+		GeoMatchConstraintValueHt,
+		GeoMatchConstraintValueHm,
+		GeoMatchConstraintValueVa,
+		GeoMatchConstraintValueHn,
+		GeoMatchConstraintValueHk,
+		GeoMatchConstraintValueHu,
+		GeoMatchConstraintValueIs,
+		GeoMatchConstraintValueIn,
+		GeoMatchConstraintValueId,
+		GeoMatchConstraintValueIr,
+		GeoMatchConstraintValueIq,
+		GeoMatchConstraintValueIe,
+		GeoMatchConstraintValueIm,
+		GeoMatchConstraintValueIl,
+		GeoMatchConstraintValueIt,
+		GeoMatchConstraintValueJm,
+		GeoMatchConstraintValueJp,
+		GeoMatchConstraintValueJe,
+		GeoMatchConstraintValueJo,
+		GeoMatchConstraintValueKz,
+		GeoMatchConstraintValueKe,
+		GeoMatchConstraintValueKi,
+		GeoMatchConstraintValueKp,
+		GeoMatchConstraintValueKr,
+		GeoMatchConstraintValueKw,
+		GeoMatchConstraintValueKg,
+		GeoMatchConstraintValueLa,
+		GeoMatchConstraintValueLv,
+		GeoMatchConstraintValueLb,
+		GeoMatchConstraintValueLs,
+		GeoMatchConstraintValueLr,
+		GeoMatchConstraintValueLy,
+		GeoMatchConstraintValueLi,
+		GeoMatchConstraintValueLt,
+		GeoMatchConstraintValueLu,
+		GeoMatchConstraintValueMo,
+		GeoMatchConstraintValueMk,
+		GeoMatchConstraintValueMg,
+		GeoMatchConstraintValueMw,
+		GeoMatchConstraintValueMy,
+		GeoMatchConstraintValueMv,
+		GeoMatchConstraintValueMl,
+		GeoMatchConstraintValueMt,
+		GeoMatchConstraintValueMh,
+		GeoMatchConstraintValueMq,
+		GeoMatchConstraintValueMr,
+		GeoMatchConstraintValueMu,
+		GeoMatchConstraintValueYt,
+		GeoMatchConstraintValueMx,
+		GeoMatchConstraintValueFm,
+		GeoMatchConstraintValueMd,
+		GeoMatchConstraintValueMc,
+		GeoMatchConstraintValueMn,
+		GeoMatchConstraintValueMe,
+		GeoMatchConstraintValueMs,
+		GeoMatchConstraintValueMa,
+		GeoMatchConstraintValueMz,
+		GeoMatchConstraintValueMm,
+		GeoMatchConstraintValueNa,
+		GeoMatchConstraintValueNr,
+		GeoMatchConstraintValueNp,
+		GeoMatchConstraintValueNl,
+		GeoMatchConstraintValueNc,
+		GeoMatchConstraintValueNz,
+		GeoMatchConstraintValueNi,
+		GeoMatchConstraintValueNe,
+		GeoMatchConstraintValueNg,
+		GeoMatchConstraintValueNu,
+		GeoMatchConstraintValueNf,
+		GeoMatchConstraintValueMp,
+		GeoMatchConstraintValueNo,
+		GeoMatchConstraintValueOm,
+		GeoMatchConstraintValuePk,
+		GeoMatchConstraintValuePw,
+		GeoMatchConstraintValuePs,
+		GeoMatchConstraintValuePa,
+		GeoMatchConstraintValuePg,
+		GeoMatchConstraintValuePy,
+		GeoMatchConstraintValuePe,
+		GeoMatchConstraintValuePh,
+		GeoMatchConstraintValuePn,
+		GeoMatchConstraintValuePl,
+		GeoMatchConstraintValuePt,
+		GeoMatchConstraintValuePr,
+		GeoMatchConstraintValueQa,
+		GeoMatchConstraintValueRe,
+		GeoMatchConstraintValueRo,
+		GeoMatchConstraintValueRu,
+		GeoMatchConstraintValueRw,
+		GeoMatchConstraintValueBl,
+		GeoMatchConstraintValueSh,
+		GeoMatchConstraintValueKn,
+		GeoMatchConstraintValueLc,
+		GeoMatchConstraintValueMf,
+		GeoMatchConstraintValuePm,
+		GeoMatchConstraintValueVc,
+		GeoMatchConstraintValueWs,
+		GeoMatchConstraintValueSm,
+		GeoMatchConstraintValueSt,
+		GeoMatchConstraintValueSa,
+		GeoMatchConstraintValueSn,
+		GeoMatchConstraintValueRs,
+		GeoMatchConstraintValueSc,
+		GeoMatchConstraintValueSl,
+		GeoMatchConstraintValueSg,
+		GeoMatchConstraintValueSx,
+		GeoMatchConstraintValueSk,
+		GeoMatchConstraintValueSi,
+		GeoMatchConstraintValueSb,
+		GeoMatchConstraintValueSo,
+		GeoMatchConstraintValueZa,
+		GeoMatchConstraintValueGs,
+		GeoMatchConstraintValueSs,
+		GeoMatchConstraintValueEs,
+		GeoMatchConstraintValueLk,
+		GeoMatchConstraintValueSd,
+		GeoMatchConstraintValueSr,
+		GeoMatchConstraintValueSj,
+		GeoMatchConstraintValueSz,
+		GeoMatchConstraintValueSe,
+		GeoMatchConstraintValueCh,
+		GeoMatchConstraintValueSy,
+		GeoMatchConstraintValueTw,
+		GeoMatchConstraintValueTj,
+		GeoMatchConstraintValueTz,
+		GeoMatchConstraintValueTh,
+		GeoMatchConstraintValueTl,
+		GeoMatchConstraintValueTg,
+		GeoMatchConstraintValueTk,
+		GeoMatchConstraintValueTo,
+		GeoMatchConstraintValueTt,
+		GeoMatchConstraintValueTn,
+		GeoMatchConstraintValueTr,
+		GeoMatchConstraintValueTm,
+		GeoMatchConstraintValueTc,
+		GeoMatchConstraintValueTv,
+		GeoMatchConstraintValueUg,
+		GeoMatchConstraintValueUa,
+		GeoMatchConstraintValueAe,
+		GeoMatchConstraintValueGb,
+		GeoMatchConstraintValueUs,
+		GeoMatchConstraintValueUm,
+		GeoMatchConstraintValueUy,
+		GeoMatchConstraintValueUz,
+		GeoMatchConstraintValueVu,
+		GeoMatchConstraintValueVe,
+		GeoMatchConstraintValueVn,
+		GeoMatchConstraintValueVg,
+		GeoMatchConstraintValueVi,
+		GeoMatchConstraintValueWf,
+		GeoMatchConstraintValueEh,
+		GeoMatchConstraintValueYe,
+		GeoMatchConstraintValueZm,
+		GeoMatchConstraintValueZw,
+	}
+}
+
 const (
 	// IPSetDescriptorTypeIpv4 is a IPSetDescriptorType enum value
 	IPSetDescriptorTypeIpv4 = "IPV4"
@@ -23839,6 +24130,14 @@ const (
 	// IPSetDescriptorTypeIpv6 is a IPSetDescriptorType enum value
 	IPSetDescriptorTypeIpv6 = "IPV6"
 )
+
+// IPSetDescriptorType_Values returns all elements of the IPSetDescriptorType enum
+func IPSetDescriptorType_Values() []string {
+	return []string{
+		IPSetDescriptorTypeIpv4,
+		IPSetDescriptorTypeIpv6,
+	}
+}
 
 const (
 	// MatchFieldTypeUri is a MatchFieldType enum value
@@ -23863,6 +24162,19 @@ const (
 	MatchFieldTypeAllQueryArgs = "ALL_QUERY_ARGS"
 )
 
+// MatchFieldType_Values returns all elements of the MatchFieldType enum
+func MatchFieldType_Values() []string {
+	return []string{
+		MatchFieldTypeUri,
+		MatchFieldTypeQueryString,
+		MatchFieldTypeHeader,
+		MatchFieldTypeMethod,
+		MatchFieldTypeBody,
+		MatchFieldTypeSingleQueryArg,
+		MatchFieldTypeAllQueryArgs,
+	}
+}
+
 const (
 	// MigrationErrorTypeEntityNotSupported is a MigrationErrorType enum value
 	MigrationErrorTypeEntityNotSupported = "ENTITY_NOT_SUPPORTED"
@@ -23885,6 +24197,19 @@ const (
 	// MigrationErrorTypeS3InternalError is a MigrationErrorType enum value
 	MigrationErrorTypeS3InternalError = "S3_INTERNAL_ERROR"
 )
+
+// MigrationErrorType_Values returns all elements of the MigrationErrorType enum
+func MigrationErrorType_Values() []string {
+	return []string{
+		MigrationErrorTypeEntityNotSupported,
+		MigrationErrorTypeEntityNotFound,
+		MigrationErrorTypeS3BucketNoPermission,
+		MigrationErrorTypeS3BucketNotAccessible,
+		MigrationErrorTypeS3BucketNotFound,
+		MigrationErrorTypeS3BucketInvalidRegion,
+		MigrationErrorTypeS3InternalError,
+	}
+}
 
 const (
 	// ParameterExceptionFieldChangeAction is a ParameterExceptionField enum value
@@ -23942,6 +24267,30 @@ const (
 	ParameterExceptionFieldTagKeys = "TAG_KEYS"
 )
 
+// ParameterExceptionField_Values returns all elements of the ParameterExceptionField enum
+func ParameterExceptionField_Values() []string {
+	return []string{
+		ParameterExceptionFieldChangeAction,
+		ParameterExceptionFieldWafAction,
+		ParameterExceptionFieldWafOverrideAction,
+		ParameterExceptionFieldPredicateType,
+		ParameterExceptionFieldIpsetType,
+		ParameterExceptionFieldByteMatchFieldType,
+		ParameterExceptionFieldSqlInjectionMatchFieldType,
+		ParameterExceptionFieldByteMatchTextTransformation,
+		ParameterExceptionFieldByteMatchPositionalConstraint,
+		ParameterExceptionFieldSizeConstraintComparisonOperator,
+		ParameterExceptionFieldGeoMatchLocationType,
+		ParameterExceptionFieldGeoMatchLocationValue,
+		ParameterExceptionFieldRateKey,
+		ParameterExceptionFieldRuleType,
+		ParameterExceptionFieldNextMarker,
+		ParameterExceptionFieldResourceArn,
+		ParameterExceptionFieldTags,
+		ParameterExceptionFieldTagKeys,
+	}
+}
+
 const (
 	// ParameterExceptionReasonInvalidOption is a ParameterExceptionReason enum value
 	ParameterExceptionReasonInvalidOption = "INVALID_OPTION"
@@ -23955,6 +24304,16 @@ const (
 	// ParameterExceptionReasonInvalidTagKey is a ParameterExceptionReason enum value
 	ParameterExceptionReasonInvalidTagKey = "INVALID_TAG_KEY"
 )
+
+// ParameterExceptionReason_Values returns all elements of the ParameterExceptionReason enum
+func ParameterExceptionReason_Values() []string {
+	return []string{
+		ParameterExceptionReasonInvalidOption,
+		ParameterExceptionReasonIllegalCombination,
+		ParameterExceptionReasonIllegalArgument,
+		ParameterExceptionReasonInvalidTagKey,
+	}
+}
 
 const (
 	// PositionalConstraintExactly is a PositionalConstraint enum value
@@ -23972,6 +24331,17 @@ const (
 	// PositionalConstraintContainsWord is a PositionalConstraint enum value
 	PositionalConstraintContainsWord = "CONTAINS_WORD"
 )
+
+// PositionalConstraint_Values returns all elements of the PositionalConstraint enum
+func PositionalConstraint_Values() []string {
+	return []string{
+		PositionalConstraintExactly,
+		PositionalConstraintStartsWith,
+		PositionalConstraintEndsWith,
+		PositionalConstraintContains,
+		PositionalConstraintContainsWord,
+	}
+}
 
 const (
 	// PredicateTypeIpmatch is a PredicateType enum value
@@ -23996,10 +24366,30 @@ const (
 	PredicateTypeRegexMatch = "RegexMatch"
 )
 
+// PredicateType_Values returns all elements of the PredicateType enum
+func PredicateType_Values() []string {
+	return []string{
+		PredicateTypeIpmatch,
+		PredicateTypeByteMatch,
+		PredicateTypeSqlInjectionMatch,
+		PredicateTypeGeoMatch,
+		PredicateTypeSizeConstraint,
+		PredicateTypeXssMatch,
+		PredicateTypeRegexMatch,
+	}
+}
+
 const (
 	// RateKeyIp is a RateKey enum value
 	RateKeyIp = "IP"
 )
+
+// RateKey_Values returns all elements of the RateKey enum
+func RateKey_Values() []string {
+	return []string{
+		RateKeyIp,
+	}
+}
 
 const (
 	// TextTransformationNone is a TextTransformation enum value
@@ -24021,6 +24411,18 @@ const (
 	TextTransformationUrlDecode = "URL_DECODE"
 )
 
+// TextTransformation_Values returns all elements of the TextTransformation enum
+func TextTransformation_Values() []string {
+	return []string{
+		TextTransformationNone,
+		TextTransformationCompressWhiteSpace,
+		TextTransformationHtmlEntityDecode,
+		TextTransformationLowercase,
+		TextTransformationCmdLine,
+		TextTransformationUrlDecode,
+	}
+}
+
 const (
 	// WafActionTypeBlock is a WafActionType enum value
 	WafActionTypeBlock = "BLOCK"
@@ -24032,6 +24434,15 @@ const (
 	WafActionTypeCount = "COUNT"
 )
 
+// WafActionType_Values returns all elements of the WafActionType enum
+func WafActionType_Values() []string {
+	return []string{
+		WafActionTypeBlock,
+		WafActionTypeAllow,
+		WafActionTypeCount,
+	}
+}
+
 const (
 	// WafOverrideActionTypeNone is a WafOverrideActionType enum value
 	WafOverrideActionTypeNone = "NONE"
@@ -24039,6 +24450,14 @@ const (
 	// WafOverrideActionTypeCount is a WafOverrideActionType enum value
 	WafOverrideActionTypeCount = "COUNT"
 )
+
+// WafOverrideActionType_Values returns all elements of the WafOverrideActionType enum
+func WafOverrideActionType_Values() []string {
+	return []string{
+		WafOverrideActionTypeNone,
+		WafOverrideActionTypeCount,
+	}
+}
 
 const (
 	// WafRuleTypeRegular is a WafRuleType enum value
@@ -24050,3 +24469,12 @@ const (
 	// WafRuleTypeGroup is a WafRuleType enum value
 	WafRuleTypeGroup = "GROUP"
 )
+
+// WafRuleType_Values returns all elements of the WafRuleType enum
+func WafRuleType_Values() []string {
+	return []string{
+		WafRuleTypeRegular,
+		WafRuleTypeRateBased,
+		WafRuleTypeGroup,
+	}
+}

--- a/service/wafregional/api.go
+++ b/service/wafregional/api.go
@@ -12338,6 +12338,14 @@ const (
 	ChangeActionDelete = "DELETE"
 )
 
+// ChangeAction_Values returns all elements of the ChangeAction enum
+func ChangeAction_Values() []string {
+	return []string{
+		ChangeActionInsert,
+		ChangeActionDelete,
+	}
+}
+
 const (
 	// ChangeTokenStatusProvisioned is a ChangeTokenStatus enum value
 	ChangeTokenStatusProvisioned = "PROVISIONED"
@@ -12348,6 +12356,15 @@ const (
 	// ChangeTokenStatusInsync is a ChangeTokenStatus enum value
 	ChangeTokenStatusInsync = "INSYNC"
 )
+
+// ChangeTokenStatus_Values returns all elements of the ChangeTokenStatus enum
+func ChangeTokenStatus_Values() []string {
+	return []string{
+		ChangeTokenStatusProvisioned,
+		ChangeTokenStatusPending,
+		ChangeTokenStatusInsync,
+	}
+}
 
 const (
 	// ComparisonOperatorEq is a ComparisonOperator enum value
@@ -12369,10 +12386,29 @@ const (
 	ComparisonOperatorGt = "GT"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorEq,
+		ComparisonOperatorNe,
+		ComparisonOperatorLe,
+		ComparisonOperatorLt,
+		ComparisonOperatorGe,
+		ComparisonOperatorGt,
+	}
+}
+
 const (
 	// GeoMatchConstraintTypeCountry is a GeoMatchConstraintType enum value
 	GeoMatchConstraintTypeCountry = "Country"
 )
+
+// GeoMatchConstraintType_Values returns all elements of the GeoMatchConstraintType enum
+func GeoMatchConstraintType_Values() []string {
+	return []string{
+		GeoMatchConstraintTypeCountry,
+	}
+}
 
 const (
 	// GeoMatchConstraintValueAf is a GeoMatchConstraintValue enum value
@@ -13123,6 +13159,261 @@ const (
 	GeoMatchConstraintValueZw = "ZW"
 )
 
+// GeoMatchConstraintValue_Values returns all elements of the GeoMatchConstraintValue enum
+func GeoMatchConstraintValue_Values() []string {
+	return []string{
+		GeoMatchConstraintValueAf,
+		GeoMatchConstraintValueAx,
+		GeoMatchConstraintValueAl,
+		GeoMatchConstraintValueDz,
+		GeoMatchConstraintValueAs,
+		GeoMatchConstraintValueAd,
+		GeoMatchConstraintValueAo,
+		GeoMatchConstraintValueAi,
+		GeoMatchConstraintValueAq,
+		GeoMatchConstraintValueAg,
+		GeoMatchConstraintValueAr,
+		GeoMatchConstraintValueAm,
+		GeoMatchConstraintValueAw,
+		GeoMatchConstraintValueAu,
+		GeoMatchConstraintValueAt,
+		GeoMatchConstraintValueAz,
+		GeoMatchConstraintValueBs,
+		GeoMatchConstraintValueBh,
+		GeoMatchConstraintValueBd,
+		GeoMatchConstraintValueBb,
+		GeoMatchConstraintValueBy,
+		GeoMatchConstraintValueBe,
+		GeoMatchConstraintValueBz,
+		GeoMatchConstraintValueBj,
+		GeoMatchConstraintValueBm,
+		GeoMatchConstraintValueBt,
+		GeoMatchConstraintValueBo,
+		GeoMatchConstraintValueBq,
+		GeoMatchConstraintValueBa,
+		GeoMatchConstraintValueBw,
+		GeoMatchConstraintValueBv,
+		GeoMatchConstraintValueBr,
+		GeoMatchConstraintValueIo,
+		GeoMatchConstraintValueBn,
+		GeoMatchConstraintValueBg,
+		GeoMatchConstraintValueBf,
+		GeoMatchConstraintValueBi,
+		GeoMatchConstraintValueKh,
+		GeoMatchConstraintValueCm,
+		GeoMatchConstraintValueCa,
+		GeoMatchConstraintValueCv,
+		GeoMatchConstraintValueKy,
+		GeoMatchConstraintValueCf,
+		GeoMatchConstraintValueTd,
+		GeoMatchConstraintValueCl,
+		GeoMatchConstraintValueCn,
+		GeoMatchConstraintValueCx,
+		GeoMatchConstraintValueCc,
+		GeoMatchConstraintValueCo,
+		GeoMatchConstraintValueKm,
+		GeoMatchConstraintValueCg,
+		GeoMatchConstraintValueCd,
+		GeoMatchConstraintValueCk,
+		GeoMatchConstraintValueCr,
+		GeoMatchConstraintValueCi,
+		GeoMatchConstraintValueHr,
+		GeoMatchConstraintValueCu,
+		GeoMatchConstraintValueCw,
+		GeoMatchConstraintValueCy,
+		GeoMatchConstraintValueCz,
+		GeoMatchConstraintValueDk,
+		GeoMatchConstraintValueDj,
+		GeoMatchConstraintValueDm,
+		GeoMatchConstraintValueDo,
+		GeoMatchConstraintValueEc,
+		GeoMatchConstraintValueEg,
+		GeoMatchConstraintValueSv,
+		GeoMatchConstraintValueGq,
+		GeoMatchConstraintValueEr,
+		GeoMatchConstraintValueEe,
+		GeoMatchConstraintValueEt,
+		GeoMatchConstraintValueFk,
+		GeoMatchConstraintValueFo,
+		GeoMatchConstraintValueFj,
+		GeoMatchConstraintValueFi,
+		GeoMatchConstraintValueFr,
+		GeoMatchConstraintValueGf,
+		GeoMatchConstraintValuePf,
+		GeoMatchConstraintValueTf,
+		GeoMatchConstraintValueGa,
+		GeoMatchConstraintValueGm,
+		GeoMatchConstraintValueGe,
+		GeoMatchConstraintValueDe,
+		GeoMatchConstraintValueGh,
+		GeoMatchConstraintValueGi,
+		GeoMatchConstraintValueGr,
+		GeoMatchConstraintValueGl,
+		GeoMatchConstraintValueGd,
+		GeoMatchConstraintValueGp,
+		GeoMatchConstraintValueGu,
+		GeoMatchConstraintValueGt,
+		GeoMatchConstraintValueGg,
+		GeoMatchConstraintValueGn,
+		GeoMatchConstraintValueGw,
+		GeoMatchConstraintValueGy,
+		GeoMatchConstraintValueHt,
+		GeoMatchConstraintValueHm,
+		GeoMatchConstraintValueVa,
+		GeoMatchConstraintValueHn,
+		GeoMatchConstraintValueHk,
+		GeoMatchConstraintValueHu,
+		GeoMatchConstraintValueIs,
+		GeoMatchConstraintValueIn,
+		GeoMatchConstraintValueId,
+		GeoMatchConstraintValueIr,
+		GeoMatchConstraintValueIq,
+		GeoMatchConstraintValueIe,
+		GeoMatchConstraintValueIm,
+		GeoMatchConstraintValueIl,
+		GeoMatchConstraintValueIt,
+		GeoMatchConstraintValueJm,
+		GeoMatchConstraintValueJp,
+		GeoMatchConstraintValueJe,
+		GeoMatchConstraintValueJo,
+		GeoMatchConstraintValueKz,
+		GeoMatchConstraintValueKe,
+		GeoMatchConstraintValueKi,
+		GeoMatchConstraintValueKp,
+		GeoMatchConstraintValueKr,
+		GeoMatchConstraintValueKw,
+		GeoMatchConstraintValueKg,
+		GeoMatchConstraintValueLa,
+		GeoMatchConstraintValueLv,
+		GeoMatchConstraintValueLb,
+		GeoMatchConstraintValueLs,
+		GeoMatchConstraintValueLr,
+		GeoMatchConstraintValueLy,
+		GeoMatchConstraintValueLi,
+		GeoMatchConstraintValueLt,
+		GeoMatchConstraintValueLu,
+		GeoMatchConstraintValueMo,
+		GeoMatchConstraintValueMk,
+		GeoMatchConstraintValueMg,
+		GeoMatchConstraintValueMw,
+		GeoMatchConstraintValueMy,
+		GeoMatchConstraintValueMv,
+		GeoMatchConstraintValueMl,
+		GeoMatchConstraintValueMt,
+		GeoMatchConstraintValueMh,
+		GeoMatchConstraintValueMq,
+		GeoMatchConstraintValueMr,
+		GeoMatchConstraintValueMu,
+		GeoMatchConstraintValueYt,
+		GeoMatchConstraintValueMx,
+		GeoMatchConstraintValueFm,
+		GeoMatchConstraintValueMd,
+		GeoMatchConstraintValueMc,
+		GeoMatchConstraintValueMn,
+		GeoMatchConstraintValueMe,
+		GeoMatchConstraintValueMs,
+		GeoMatchConstraintValueMa,
+		GeoMatchConstraintValueMz,
+		GeoMatchConstraintValueMm,
+		GeoMatchConstraintValueNa,
+		GeoMatchConstraintValueNr,
+		GeoMatchConstraintValueNp,
+		GeoMatchConstraintValueNl,
+		GeoMatchConstraintValueNc,
+		GeoMatchConstraintValueNz,
+		GeoMatchConstraintValueNi,
+		GeoMatchConstraintValueNe,
+		GeoMatchConstraintValueNg,
+		GeoMatchConstraintValueNu,
+		GeoMatchConstraintValueNf,
+		GeoMatchConstraintValueMp,
+		GeoMatchConstraintValueNo,
+		GeoMatchConstraintValueOm,
+		GeoMatchConstraintValuePk,
+		GeoMatchConstraintValuePw,
+		GeoMatchConstraintValuePs,
+		GeoMatchConstraintValuePa,
+		GeoMatchConstraintValuePg,
+		GeoMatchConstraintValuePy,
+		GeoMatchConstraintValuePe,
+		GeoMatchConstraintValuePh,
+		GeoMatchConstraintValuePn,
+		GeoMatchConstraintValuePl,
+		GeoMatchConstraintValuePt,
+		GeoMatchConstraintValuePr,
+		GeoMatchConstraintValueQa,
+		GeoMatchConstraintValueRe,
+		GeoMatchConstraintValueRo,
+		GeoMatchConstraintValueRu,
+		GeoMatchConstraintValueRw,
+		GeoMatchConstraintValueBl,
+		GeoMatchConstraintValueSh,
+		GeoMatchConstraintValueKn,
+		GeoMatchConstraintValueLc,
+		GeoMatchConstraintValueMf,
+		GeoMatchConstraintValuePm,
+		GeoMatchConstraintValueVc,
+		GeoMatchConstraintValueWs,
+		GeoMatchConstraintValueSm,
+		GeoMatchConstraintValueSt,
+		GeoMatchConstraintValueSa,
+		GeoMatchConstraintValueSn,
+		GeoMatchConstraintValueRs,
+		GeoMatchConstraintValueSc,
+		GeoMatchConstraintValueSl,
+		GeoMatchConstraintValueSg,
+		GeoMatchConstraintValueSx,
+		GeoMatchConstraintValueSk,
+		GeoMatchConstraintValueSi,
+		GeoMatchConstraintValueSb,
+		GeoMatchConstraintValueSo,
+		GeoMatchConstraintValueZa,
+		GeoMatchConstraintValueGs,
+		GeoMatchConstraintValueSs,
+		GeoMatchConstraintValueEs,
+		GeoMatchConstraintValueLk,
+		GeoMatchConstraintValueSd,
+		GeoMatchConstraintValueSr,
+		GeoMatchConstraintValueSj,
+		GeoMatchConstraintValueSz,
+		GeoMatchConstraintValueSe,
+		GeoMatchConstraintValueCh,
+		GeoMatchConstraintValueSy,
+		GeoMatchConstraintValueTw,
+		GeoMatchConstraintValueTj,
+		GeoMatchConstraintValueTz,
+		GeoMatchConstraintValueTh,
+		GeoMatchConstraintValueTl,
+		GeoMatchConstraintValueTg,
+		GeoMatchConstraintValueTk,
+		GeoMatchConstraintValueTo,
+		GeoMatchConstraintValueTt,
+		GeoMatchConstraintValueTn,
+		GeoMatchConstraintValueTr,
+		GeoMatchConstraintValueTm,
+		GeoMatchConstraintValueTc,
+		GeoMatchConstraintValueTv,
+		GeoMatchConstraintValueUg,
+		GeoMatchConstraintValueUa,
+		GeoMatchConstraintValueAe,
+		GeoMatchConstraintValueGb,
+		GeoMatchConstraintValueUs,
+		GeoMatchConstraintValueUm,
+		GeoMatchConstraintValueUy,
+		GeoMatchConstraintValueUz,
+		GeoMatchConstraintValueVu,
+		GeoMatchConstraintValueVe,
+		GeoMatchConstraintValueVn,
+		GeoMatchConstraintValueVg,
+		GeoMatchConstraintValueVi,
+		GeoMatchConstraintValueWf,
+		GeoMatchConstraintValueEh,
+		GeoMatchConstraintValueYe,
+		GeoMatchConstraintValueZm,
+		GeoMatchConstraintValueZw,
+	}
+}
+
 const (
 	// IPSetDescriptorTypeIpv4 is a IPSetDescriptorType enum value
 	IPSetDescriptorTypeIpv4 = "IPV4"
@@ -13130,6 +13421,14 @@ const (
 	// IPSetDescriptorTypeIpv6 is a IPSetDescriptorType enum value
 	IPSetDescriptorTypeIpv6 = "IPV6"
 )
+
+// IPSetDescriptorType_Values returns all elements of the IPSetDescriptorType enum
+func IPSetDescriptorType_Values() []string {
+	return []string{
+		IPSetDescriptorTypeIpv4,
+		IPSetDescriptorTypeIpv6,
+	}
+}
 
 const (
 	// MatchFieldTypeUri is a MatchFieldType enum value
@@ -13154,6 +13453,19 @@ const (
 	MatchFieldTypeAllQueryArgs = "ALL_QUERY_ARGS"
 )
 
+// MatchFieldType_Values returns all elements of the MatchFieldType enum
+func MatchFieldType_Values() []string {
+	return []string{
+		MatchFieldTypeUri,
+		MatchFieldTypeQueryString,
+		MatchFieldTypeHeader,
+		MatchFieldTypeMethod,
+		MatchFieldTypeBody,
+		MatchFieldTypeSingleQueryArg,
+		MatchFieldTypeAllQueryArgs,
+	}
+}
+
 const (
 	// MigrationErrorTypeEntityNotSupported is a MigrationErrorType enum value
 	MigrationErrorTypeEntityNotSupported = "ENTITY_NOT_SUPPORTED"
@@ -13176,6 +13488,19 @@ const (
 	// MigrationErrorTypeS3InternalError is a MigrationErrorType enum value
 	MigrationErrorTypeS3InternalError = "S3_INTERNAL_ERROR"
 )
+
+// MigrationErrorType_Values returns all elements of the MigrationErrorType enum
+func MigrationErrorType_Values() []string {
+	return []string{
+		MigrationErrorTypeEntityNotSupported,
+		MigrationErrorTypeEntityNotFound,
+		MigrationErrorTypeS3BucketNoPermission,
+		MigrationErrorTypeS3BucketNotAccessible,
+		MigrationErrorTypeS3BucketNotFound,
+		MigrationErrorTypeS3BucketInvalidRegion,
+		MigrationErrorTypeS3InternalError,
+	}
+}
 
 const (
 	// ParameterExceptionFieldChangeAction is a ParameterExceptionField enum value
@@ -13233,6 +13558,30 @@ const (
 	ParameterExceptionFieldTagKeys = "TAG_KEYS"
 )
 
+// ParameterExceptionField_Values returns all elements of the ParameterExceptionField enum
+func ParameterExceptionField_Values() []string {
+	return []string{
+		ParameterExceptionFieldChangeAction,
+		ParameterExceptionFieldWafAction,
+		ParameterExceptionFieldWafOverrideAction,
+		ParameterExceptionFieldPredicateType,
+		ParameterExceptionFieldIpsetType,
+		ParameterExceptionFieldByteMatchFieldType,
+		ParameterExceptionFieldSqlInjectionMatchFieldType,
+		ParameterExceptionFieldByteMatchTextTransformation,
+		ParameterExceptionFieldByteMatchPositionalConstraint,
+		ParameterExceptionFieldSizeConstraintComparisonOperator,
+		ParameterExceptionFieldGeoMatchLocationType,
+		ParameterExceptionFieldGeoMatchLocationValue,
+		ParameterExceptionFieldRateKey,
+		ParameterExceptionFieldRuleType,
+		ParameterExceptionFieldNextMarker,
+		ParameterExceptionFieldResourceArn,
+		ParameterExceptionFieldTags,
+		ParameterExceptionFieldTagKeys,
+	}
+}
+
 const (
 	// ParameterExceptionReasonInvalidOption is a ParameterExceptionReason enum value
 	ParameterExceptionReasonInvalidOption = "INVALID_OPTION"
@@ -13246,6 +13595,16 @@ const (
 	// ParameterExceptionReasonInvalidTagKey is a ParameterExceptionReason enum value
 	ParameterExceptionReasonInvalidTagKey = "INVALID_TAG_KEY"
 )
+
+// ParameterExceptionReason_Values returns all elements of the ParameterExceptionReason enum
+func ParameterExceptionReason_Values() []string {
+	return []string{
+		ParameterExceptionReasonInvalidOption,
+		ParameterExceptionReasonIllegalCombination,
+		ParameterExceptionReasonIllegalArgument,
+		ParameterExceptionReasonInvalidTagKey,
+	}
+}
 
 const (
 	// PositionalConstraintExactly is a PositionalConstraint enum value
@@ -13263,6 +13622,17 @@ const (
 	// PositionalConstraintContainsWord is a PositionalConstraint enum value
 	PositionalConstraintContainsWord = "CONTAINS_WORD"
 )
+
+// PositionalConstraint_Values returns all elements of the PositionalConstraint enum
+func PositionalConstraint_Values() []string {
+	return []string{
+		PositionalConstraintExactly,
+		PositionalConstraintStartsWith,
+		PositionalConstraintEndsWith,
+		PositionalConstraintContains,
+		PositionalConstraintContainsWord,
+	}
+}
 
 const (
 	// PredicateTypeIpmatch is a PredicateType enum value
@@ -13287,10 +13657,30 @@ const (
 	PredicateTypeRegexMatch = "RegexMatch"
 )
 
+// PredicateType_Values returns all elements of the PredicateType enum
+func PredicateType_Values() []string {
+	return []string{
+		PredicateTypeIpmatch,
+		PredicateTypeByteMatch,
+		PredicateTypeSqlInjectionMatch,
+		PredicateTypeGeoMatch,
+		PredicateTypeSizeConstraint,
+		PredicateTypeXssMatch,
+		PredicateTypeRegexMatch,
+	}
+}
+
 const (
 	// RateKeyIp is a RateKey enum value
 	RateKeyIp = "IP"
 )
+
+// RateKey_Values returns all elements of the RateKey enum
+func RateKey_Values() []string {
+	return []string{
+		RateKeyIp,
+	}
+}
 
 const (
 	// ResourceTypeApplicationLoadBalancer is a ResourceType enum value
@@ -13299,6 +13689,14 @@ const (
 	// ResourceTypeApiGateway is a ResourceType enum value
 	ResourceTypeApiGateway = "API_GATEWAY"
 )
+
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeApplicationLoadBalancer,
+		ResourceTypeApiGateway,
+	}
+}
 
 const (
 	// TextTransformationNone is a TextTransformation enum value
@@ -13320,6 +13718,18 @@ const (
 	TextTransformationUrlDecode = "URL_DECODE"
 )
 
+// TextTransformation_Values returns all elements of the TextTransformation enum
+func TextTransformation_Values() []string {
+	return []string{
+		TextTransformationNone,
+		TextTransformationCompressWhiteSpace,
+		TextTransformationHtmlEntityDecode,
+		TextTransformationLowercase,
+		TextTransformationCmdLine,
+		TextTransformationUrlDecode,
+	}
+}
+
 const (
 	// WafActionTypeBlock is a WafActionType enum value
 	WafActionTypeBlock = "BLOCK"
@@ -13331,6 +13741,15 @@ const (
 	WafActionTypeCount = "COUNT"
 )
 
+// WafActionType_Values returns all elements of the WafActionType enum
+func WafActionType_Values() []string {
+	return []string{
+		WafActionTypeBlock,
+		WafActionTypeAllow,
+		WafActionTypeCount,
+	}
+}
+
 const (
 	// WafOverrideActionTypeNone is a WafOverrideActionType enum value
 	WafOverrideActionTypeNone = "NONE"
@@ -13338,6 +13757,14 @@ const (
 	// WafOverrideActionTypeCount is a WafOverrideActionType enum value
 	WafOverrideActionTypeCount = "COUNT"
 )
+
+// WafOverrideActionType_Values returns all elements of the WafOverrideActionType enum
+func WafOverrideActionType_Values() []string {
+	return []string{
+		WafOverrideActionTypeNone,
+		WafOverrideActionTypeCount,
+	}
+}
 
 const (
 	// WafRuleTypeRegular is a WafRuleType enum value
@@ -13349,3 +13776,12 @@ const (
 	// WafRuleTypeGroup is a WafRuleType enum value
 	WafRuleTypeGroup = "GROUP"
 )
+
+// WafRuleType_Values returns all elements of the WafRuleType enum
+func WafRuleType_Values() []string {
+	return []string{
+		WafRuleTypeRegular,
+		WafRuleTypeRateBased,
+		WafRuleTypeGroup,
+	}
+}

--- a/service/wafv2/api.go
+++ b/service/wafv2/api.go
@@ -14615,6 +14615,18 @@ const (
 	ComparisonOperatorGt = "GT"
 )
 
+// ComparisonOperator_Values returns all elements of the ComparisonOperator enum
+func ComparisonOperator_Values() []string {
+	return []string{
+		ComparisonOperatorEq,
+		ComparisonOperatorNe,
+		ComparisonOperatorLe,
+		ComparisonOperatorLt,
+		ComparisonOperatorGe,
+		ComparisonOperatorGt,
+	}
+}
+
 const (
 	// CountryCodeAf is a CountryCode enum value
 	CountryCodeAf = "AF"
@@ -15364,6 +15376,261 @@ const (
 	CountryCodeZw = "ZW"
 )
 
+// CountryCode_Values returns all elements of the CountryCode enum
+func CountryCode_Values() []string {
+	return []string{
+		CountryCodeAf,
+		CountryCodeAx,
+		CountryCodeAl,
+		CountryCodeDz,
+		CountryCodeAs,
+		CountryCodeAd,
+		CountryCodeAo,
+		CountryCodeAi,
+		CountryCodeAq,
+		CountryCodeAg,
+		CountryCodeAr,
+		CountryCodeAm,
+		CountryCodeAw,
+		CountryCodeAu,
+		CountryCodeAt,
+		CountryCodeAz,
+		CountryCodeBs,
+		CountryCodeBh,
+		CountryCodeBd,
+		CountryCodeBb,
+		CountryCodeBy,
+		CountryCodeBe,
+		CountryCodeBz,
+		CountryCodeBj,
+		CountryCodeBm,
+		CountryCodeBt,
+		CountryCodeBo,
+		CountryCodeBq,
+		CountryCodeBa,
+		CountryCodeBw,
+		CountryCodeBv,
+		CountryCodeBr,
+		CountryCodeIo,
+		CountryCodeBn,
+		CountryCodeBg,
+		CountryCodeBf,
+		CountryCodeBi,
+		CountryCodeKh,
+		CountryCodeCm,
+		CountryCodeCa,
+		CountryCodeCv,
+		CountryCodeKy,
+		CountryCodeCf,
+		CountryCodeTd,
+		CountryCodeCl,
+		CountryCodeCn,
+		CountryCodeCx,
+		CountryCodeCc,
+		CountryCodeCo,
+		CountryCodeKm,
+		CountryCodeCg,
+		CountryCodeCd,
+		CountryCodeCk,
+		CountryCodeCr,
+		CountryCodeCi,
+		CountryCodeHr,
+		CountryCodeCu,
+		CountryCodeCw,
+		CountryCodeCy,
+		CountryCodeCz,
+		CountryCodeDk,
+		CountryCodeDj,
+		CountryCodeDm,
+		CountryCodeDo,
+		CountryCodeEc,
+		CountryCodeEg,
+		CountryCodeSv,
+		CountryCodeGq,
+		CountryCodeEr,
+		CountryCodeEe,
+		CountryCodeEt,
+		CountryCodeFk,
+		CountryCodeFo,
+		CountryCodeFj,
+		CountryCodeFi,
+		CountryCodeFr,
+		CountryCodeGf,
+		CountryCodePf,
+		CountryCodeTf,
+		CountryCodeGa,
+		CountryCodeGm,
+		CountryCodeGe,
+		CountryCodeDe,
+		CountryCodeGh,
+		CountryCodeGi,
+		CountryCodeGr,
+		CountryCodeGl,
+		CountryCodeGd,
+		CountryCodeGp,
+		CountryCodeGu,
+		CountryCodeGt,
+		CountryCodeGg,
+		CountryCodeGn,
+		CountryCodeGw,
+		CountryCodeGy,
+		CountryCodeHt,
+		CountryCodeHm,
+		CountryCodeVa,
+		CountryCodeHn,
+		CountryCodeHk,
+		CountryCodeHu,
+		CountryCodeIs,
+		CountryCodeIn,
+		CountryCodeId,
+		CountryCodeIr,
+		CountryCodeIq,
+		CountryCodeIe,
+		CountryCodeIm,
+		CountryCodeIl,
+		CountryCodeIt,
+		CountryCodeJm,
+		CountryCodeJp,
+		CountryCodeJe,
+		CountryCodeJo,
+		CountryCodeKz,
+		CountryCodeKe,
+		CountryCodeKi,
+		CountryCodeKp,
+		CountryCodeKr,
+		CountryCodeKw,
+		CountryCodeKg,
+		CountryCodeLa,
+		CountryCodeLv,
+		CountryCodeLb,
+		CountryCodeLs,
+		CountryCodeLr,
+		CountryCodeLy,
+		CountryCodeLi,
+		CountryCodeLt,
+		CountryCodeLu,
+		CountryCodeMo,
+		CountryCodeMk,
+		CountryCodeMg,
+		CountryCodeMw,
+		CountryCodeMy,
+		CountryCodeMv,
+		CountryCodeMl,
+		CountryCodeMt,
+		CountryCodeMh,
+		CountryCodeMq,
+		CountryCodeMr,
+		CountryCodeMu,
+		CountryCodeYt,
+		CountryCodeMx,
+		CountryCodeFm,
+		CountryCodeMd,
+		CountryCodeMc,
+		CountryCodeMn,
+		CountryCodeMe,
+		CountryCodeMs,
+		CountryCodeMa,
+		CountryCodeMz,
+		CountryCodeMm,
+		CountryCodeNa,
+		CountryCodeNr,
+		CountryCodeNp,
+		CountryCodeNl,
+		CountryCodeNc,
+		CountryCodeNz,
+		CountryCodeNi,
+		CountryCodeNe,
+		CountryCodeNg,
+		CountryCodeNu,
+		CountryCodeNf,
+		CountryCodeMp,
+		CountryCodeNo,
+		CountryCodeOm,
+		CountryCodePk,
+		CountryCodePw,
+		CountryCodePs,
+		CountryCodePa,
+		CountryCodePg,
+		CountryCodePy,
+		CountryCodePe,
+		CountryCodePh,
+		CountryCodePn,
+		CountryCodePl,
+		CountryCodePt,
+		CountryCodePr,
+		CountryCodeQa,
+		CountryCodeRe,
+		CountryCodeRo,
+		CountryCodeRu,
+		CountryCodeRw,
+		CountryCodeBl,
+		CountryCodeSh,
+		CountryCodeKn,
+		CountryCodeLc,
+		CountryCodeMf,
+		CountryCodePm,
+		CountryCodeVc,
+		CountryCodeWs,
+		CountryCodeSm,
+		CountryCodeSt,
+		CountryCodeSa,
+		CountryCodeSn,
+		CountryCodeRs,
+		CountryCodeSc,
+		CountryCodeSl,
+		CountryCodeSg,
+		CountryCodeSx,
+		CountryCodeSk,
+		CountryCodeSi,
+		CountryCodeSb,
+		CountryCodeSo,
+		CountryCodeZa,
+		CountryCodeGs,
+		CountryCodeSs,
+		CountryCodeEs,
+		CountryCodeLk,
+		CountryCodeSd,
+		CountryCodeSr,
+		CountryCodeSj,
+		CountryCodeSz,
+		CountryCodeSe,
+		CountryCodeCh,
+		CountryCodeSy,
+		CountryCodeTw,
+		CountryCodeTj,
+		CountryCodeTz,
+		CountryCodeTh,
+		CountryCodeTl,
+		CountryCodeTg,
+		CountryCodeTk,
+		CountryCodeTo,
+		CountryCodeTt,
+		CountryCodeTn,
+		CountryCodeTr,
+		CountryCodeTm,
+		CountryCodeTc,
+		CountryCodeTv,
+		CountryCodeUg,
+		CountryCodeUa,
+		CountryCodeAe,
+		CountryCodeGb,
+		CountryCodeUs,
+		CountryCodeUm,
+		CountryCodeUy,
+		CountryCodeUz,
+		CountryCodeVu,
+		CountryCodeVe,
+		CountryCodeVn,
+		CountryCodeVg,
+		CountryCodeVi,
+		CountryCodeWf,
+		CountryCodeEh,
+		CountryCodeYe,
+		CountryCodeZm,
+		CountryCodeZw,
+	}
+}
+
 const (
 	// FallbackBehaviorMatch is a FallbackBehavior enum value
 	FallbackBehaviorMatch = "MATCH"
@@ -15371,6 +15638,14 @@ const (
 	// FallbackBehaviorNoMatch is a FallbackBehavior enum value
 	FallbackBehaviorNoMatch = "NO_MATCH"
 )
+
+// FallbackBehavior_Values returns all elements of the FallbackBehavior enum
+func FallbackBehavior_Values() []string {
+	return []string{
+		FallbackBehaviorMatch,
+		FallbackBehaviorNoMatch,
+	}
+}
 
 const (
 	// ForwardedIPPositionFirst is a ForwardedIPPosition enum value
@@ -15383,6 +15658,15 @@ const (
 	ForwardedIPPositionAny = "ANY"
 )
 
+// ForwardedIPPosition_Values returns all elements of the ForwardedIPPosition enum
+func ForwardedIPPosition_Values() []string {
+	return []string{
+		ForwardedIPPositionFirst,
+		ForwardedIPPositionLast,
+		ForwardedIPPositionAny,
+	}
+}
+
 const (
 	// IPAddressVersionIpv4 is a IPAddressVersion enum value
 	IPAddressVersionIpv4 = "IPV4"
@@ -15390,6 +15674,14 @@ const (
 	// IPAddressVersionIpv6 is a IPAddressVersion enum value
 	IPAddressVersionIpv6 = "IPV6"
 )
+
+// IPAddressVersion_Values returns all elements of the IPAddressVersion enum
+func IPAddressVersion_Values() []string {
+	return []string{
+		IPAddressVersionIpv4,
+		IPAddressVersionIpv6,
+	}
+}
 
 const (
 	// ParameterExceptionFieldWebAcl is a ParameterExceptionField enum value
@@ -15522,6 +15814,55 @@ const (
 	ParameterExceptionFieldHeaderName = "HEADER_NAME"
 )
 
+// ParameterExceptionField_Values returns all elements of the ParameterExceptionField enum
+func ParameterExceptionField_Values() []string {
+	return []string{
+		ParameterExceptionFieldWebAcl,
+		ParameterExceptionFieldRuleGroup,
+		ParameterExceptionFieldRegexPatternSet,
+		ParameterExceptionFieldIpSet,
+		ParameterExceptionFieldManagedRuleSet,
+		ParameterExceptionFieldRule,
+		ParameterExceptionFieldExcludedRule,
+		ParameterExceptionFieldStatement,
+		ParameterExceptionFieldByteMatchStatement,
+		ParameterExceptionFieldSqliMatchStatement,
+		ParameterExceptionFieldXssMatchStatement,
+		ParameterExceptionFieldSizeConstraintStatement,
+		ParameterExceptionFieldGeoMatchStatement,
+		ParameterExceptionFieldRateBasedStatement,
+		ParameterExceptionFieldRuleGroupReferenceStatement,
+		ParameterExceptionFieldRegexPatternReferenceStatement,
+		ParameterExceptionFieldIpSetReferenceStatement,
+		ParameterExceptionFieldManagedRuleSetStatement,
+		ParameterExceptionFieldAndStatement,
+		ParameterExceptionFieldOrStatement,
+		ParameterExceptionFieldNotStatement,
+		ParameterExceptionFieldIpAddress,
+		ParameterExceptionFieldIpAddressVersion,
+		ParameterExceptionFieldFieldToMatch,
+		ParameterExceptionFieldTextTransformation,
+		ParameterExceptionFieldSingleQueryArgument,
+		ParameterExceptionFieldSingleHeader,
+		ParameterExceptionFieldDefaultAction,
+		ParameterExceptionFieldRuleAction,
+		ParameterExceptionFieldEntityLimit,
+		ParameterExceptionFieldOverrideAction,
+		ParameterExceptionFieldScopeValue,
+		ParameterExceptionFieldResourceArn,
+		ParameterExceptionFieldResourceType,
+		ParameterExceptionFieldTags,
+		ParameterExceptionFieldTagKeys,
+		ParameterExceptionFieldMetricName,
+		ParameterExceptionFieldFirewallManagerStatement,
+		ParameterExceptionFieldFallbackBehavior,
+		ParameterExceptionFieldPosition,
+		ParameterExceptionFieldForwardedIpConfig,
+		ParameterExceptionFieldIpSetForwardedIpConfig,
+		ParameterExceptionFieldHeaderName,
+	}
+}
+
 const (
 	// PositionalConstraintExactly is a PositionalConstraint enum value
 	PositionalConstraintExactly = "EXACTLY"
@@ -15539,6 +15880,17 @@ const (
 	PositionalConstraintContainsWord = "CONTAINS_WORD"
 )
 
+// PositionalConstraint_Values returns all elements of the PositionalConstraint enum
+func PositionalConstraint_Values() []string {
+	return []string{
+		PositionalConstraintExactly,
+		PositionalConstraintStartsWith,
+		PositionalConstraintEndsWith,
+		PositionalConstraintContains,
+		PositionalConstraintContainsWord,
+	}
+}
+
 const (
 	// RateBasedStatementAggregateKeyTypeIp is a RateBasedStatementAggregateKeyType enum value
 	RateBasedStatementAggregateKeyTypeIp = "IP"
@@ -15546,6 +15898,14 @@ const (
 	// RateBasedStatementAggregateKeyTypeForwardedIp is a RateBasedStatementAggregateKeyType enum value
 	RateBasedStatementAggregateKeyTypeForwardedIp = "FORWARDED_IP"
 )
+
+// RateBasedStatementAggregateKeyType_Values returns all elements of the RateBasedStatementAggregateKeyType enum
+func RateBasedStatementAggregateKeyType_Values() []string {
+	return []string{
+		RateBasedStatementAggregateKeyTypeIp,
+		RateBasedStatementAggregateKeyTypeForwardedIp,
+	}
+}
 
 const (
 	// ResourceTypeApplicationLoadBalancer is a ResourceType enum value
@@ -15555,6 +15915,14 @@ const (
 	ResourceTypeApiGateway = "API_GATEWAY"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeApplicationLoadBalancer,
+		ResourceTypeApiGateway,
+	}
+}
+
 const (
 	// ScopeCloudfront is a Scope enum value
 	ScopeCloudfront = "CLOUDFRONT"
@@ -15562,6 +15930,14 @@ const (
 	// ScopeRegional is a Scope enum value
 	ScopeRegional = "REGIONAL"
 )
+
+// Scope_Values returns all elements of the Scope enum
+func Scope_Values() []string {
+	return []string{
+		ScopeCloudfront,
+		ScopeRegional,
+	}
+}
 
 const (
 	// TextTransformationTypeNone is a TextTransformationType enum value
@@ -15582,3 +15958,15 @@ const (
 	// TextTransformationTypeUrlDecode is a TextTransformationType enum value
 	TextTransformationTypeUrlDecode = "URL_DECODE"
 )
+
+// TextTransformationType_Values returns all elements of the TextTransformationType enum
+func TextTransformationType_Values() []string {
+	return []string{
+		TextTransformationTypeNone,
+		TextTransformationTypeCompressWhiteSpace,
+		TextTransformationTypeHtmlEntityDecode,
+		TextTransformationTypeLowercase,
+		TextTransformationTypeCmdLine,
+		TextTransformationTypeUrlDecode,
+	}
+}

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -11536,6 +11536,45 @@ const (
 	ActivityTypeFolderMoved = "FOLDER_MOVED"
 )
 
+// ActivityType_Values returns all elements of the ActivityType enum
+func ActivityType_Values() []string {
+	return []string{
+		ActivityTypeDocumentCheckedIn,
+		ActivityTypeDocumentCheckedOut,
+		ActivityTypeDocumentRenamed,
+		ActivityTypeDocumentVersionUploaded,
+		ActivityTypeDocumentVersionDeleted,
+		ActivityTypeDocumentVersionViewed,
+		ActivityTypeDocumentVersionDownloaded,
+		ActivityTypeDocumentRecycled,
+		ActivityTypeDocumentRestored,
+		ActivityTypeDocumentReverted,
+		ActivityTypeDocumentShared,
+		ActivityTypeDocumentUnshared,
+		ActivityTypeDocumentSharePermissionChanged,
+		ActivityTypeDocumentShareableLinkCreated,
+		ActivityTypeDocumentShareableLinkRemoved,
+		ActivityTypeDocumentShareableLinkPermissionChanged,
+		ActivityTypeDocumentMoved,
+		ActivityTypeDocumentCommentAdded,
+		ActivityTypeDocumentCommentDeleted,
+		ActivityTypeDocumentAnnotationAdded,
+		ActivityTypeDocumentAnnotationDeleted,
+		ActivityTypeFolderCreated,
+		ActivityTypeFolderDeleted,
+		ActivityTypeFolderRenamed,
+		ActivityTypeFolderRecycled,
+		ActivityTypeFolderRestored,
+		ActivityTypeFolderShared,
+		ActivityTypeFolderUnshared,
+		ActivityTypeFolderSharePermissionChanged,
+		ActivityTypeFolderShareableLinkCreated,
+		ActivityTypeFolderShareableLinkRemoved,
+		ActivityTypeFolderShareableLinkPermissionChanged,
+		ActivityTypeFolderMoved,
+	}
+}
+
 const (
 	// BooleanEnumTypeTrue is a BooleanEnumType enum value
 	BooleanEnumTypeTrue = "TRUE"
@@ -11543,6 +11582,14 @@ const (
 	// BooleanEnumTypeFalse is a BooleanEnumType enum value
 	BooleanEnumTypeFalse = "FALSE"
 )
+
+// BooleanEnumType_Values returns all elements of the BooleanEnumType enum
+func BooleanEnumType_Values() []string {
+	return []string{
+		BooleanEnumTypeTrue,
+		BooleanEnumTypeFalse,
+	}
+}
 
 const (
 	// CommentStatusTypeDraft is a CommentStatusType enum value
@@ -11555,6 +11602,15 @@ const (
 	CommentStatusTypeDeleted = "DELETED"
 )
 
+// CommentStatusType_Values returns all elements of the CommentStatusType enum
+func CommentStatusType_Values() []string {
+	return []string{
+		CommentStatusTypeDraft,
+		CommentStatusTypePublished,
+		CommentStatusTypeDeleted,
+	}
+}
+
 const (
 	// CommentVisibilityTypePublic is a CommentVisibilityType enum value
 	CommentVisibilityTypePublic = "PUBLIC"
@@ -11562,6 +11618,14 @@ const (
 	// CommentVisibilityTypePrivate is a CommentVisibilityType enum value
 	CommentVisibilityTypePrivate = "PRIVATE"
 )
+
+// CommentVisibilityType_Values returns all elements of the CommentVisibilityType enum
+func CommentVisibilityType_Values() []string {
+	return []string{
+		CommentVisibilityTypePublic,
+		CommentVisibilityTypePrivate,
+	}
+}
 
 const (
 	// DocumentSourceTypeOriginal is a DocumentSourceType enum value
@@ -11571,6 +11635,14 @@ const (
 	DocumentSourceTypeWithComments = "WITH_COMMENTS"
 )
 
+// DocumentSourceType_Values returns all elements of the DocumentSourceType enum
+func DocumentSourceType_Values() []string {
+	return []string{
+		DocumentSourceTypeOriginal,
+		DocumentSourceTypeWithComments,
+	}
+}
+
 const (
 	// DocumentStatusTypeInitialized is a DocumentStatusType enum value
 	DocumentStatusTypeInitialized = "INITIALIZED"
@@ -11578,6 +11650,14 @@ const (
 	// DocumentStatusTypeActive is a DocumentStatusType enum value
 	DocumentStatusTypeActive = "ACTIVE"
 )
+
+// DocumentStatusType_Values returns all elements of the DocumentStatusType enum
+func DocumentStatusType_Values() []string {
+	return []string{
+		DocumentStatusTypeInitialized,
+		DocumentStatusTypeActive,
+	}
+}
 
 const (
 	// DocumentThumbnailTypeSmall is a DocumentThumbnailType enum value
@@ -11590,10 +11670,26 @@ const (
 	DocumentThumbnailTypeLarge = "LARGE"
 )
 
+// DocumentThumbnailType_Values returns all elements of the DocumentThumbnailType enum
+func DocumentThumbnailType_Values() []string {
+	return []string{
+		DocumentThumbnailTypeSmall,
+		DocumentThumbnailTypeSmallHq,
+		DocumentThumbnailTypeLarge,
+	}
+}
+
 const (
 	// DocumentVersionStatusActive is a DocumentVersionStatus enum value
 	DocumentVersionStatusActive = "ACTIVE"
 )
+
+// DocumentVersionStatus_Values returns all elements of the DocumentVersionStatus enum
+func DocumentVersionStatus_Values() []string {
+	return []string{
+		DocumentVersionStatusActive,
+	}
+}
 
 const (
 	// FolderContentTypeAll is a FolderContentType enum value
@@ -11605,6 +11701,15 @@ const (
 	// FolderContentTypeFolder is a FolderContentType enum value
 	FolderContentTypeFolder = "FOLDER"
 )
+
+// FolderContentType_Values returns all elements of the FolderContentType enum
+func FolderContentType_Values() []string {
+	return []string{
+		FolderContentTypeAll,
+		FolderContentTypeDocument,
+		FolderContentTypeFolder,
+	}
+}
 
 const (
 	// LocaleTypeEn is a LocaleType enum value
@@ -11641,6 +11746,23 @@ const (
 	LocaleTypeDefault = "default"
 )
 
+// LocaleType_Values returns all elements of the LocaleType enum
+func LocaleType_Values() []string {
+	return []string{
+		LocaleTypeEn,
+		LocaleTypeFr,
+		LocaleTypeKo,
+		LocaleTypeDe,
+		LocaleTypeEs,
+		LocaleTypeJa,
+		LocaleTypeRu,
+		LocaleTypeZhCn,
+		LocaleTypeZhTw,
+		LocaleTypePtBr,
+		LocaleTypeDefault,
+	}
+}
+
 const (
 	// OrderTypeAscending is a OrderType enum value
 	OrderTypeAscending = "ASCENDING"
@@ -11648,6 +11770,14 @@ const (
 	// OrderTypeDescending is a OrderType enum value
 	OrderTypeDescending = "DESCENDING"
 )
+
+// OrderType_Values returns all elements of the OrderType enum
+func OrderType_Values() []string {
+	return []string{
+		OrderTypeAscending,
+		OrderTypeDescending,
+	}
+}
 
 const (
 	// PrincipalTypeUser is a PrincipalType enum value
@@ -11666,10 +11796,28 @@ const (
 	PrincipalTypeOrganization = "ORGANIZATION"
 )
 
+// PrincipalType_Values returns all elements of the PrincipalType enum
+func PrincipalType_Values() []string {
+	return []string{
+		PrincipalTypeUser,
+		PrincipalTypeGroup,
+		PrincipalTypeInvite,
+		PrincipalTypeAnonymous,
+		PrincipalTypeOrganization,
+	}
+}
+
 const (
 	// ResourceCollectionTypeSharedWithMe is a ResourceCollectionType enum value
 	ResourceCollectionTypeSharedWithMe = "SHARED_WITH_ME"
 )
+
+// ResourceCollectionType_Values returns all elements of the ResourceCollectionType enum
+func ResourceCollectionType_Values() []string {
+	return []string{
+		ResourceCollectionTypeSharedWithMe,
+	}
+}
 
 const (
 	// ResourceSortTypeDate is a ResourceSortType enum value
@@ -11678,6 +11826,14 @@ const (
 	// ResourceSortTypeName is a ResourceSortType enum value
 	ResourceSortTypeName = "NAME"
 )
+
+// ResourceSortType_Values returns all elements of the ResourceSortType enum
+func ResourceSortType_Values() []string {
+	return []string{
+		ResourceSortTypeDate,
+		ResourceSortTypeName,
+	}
+}
 
 const (
 	// ResourceStateTypeActive is a ResourceStateType enum value
@@ -11693,6 +11849,16 @@ const (
 	ResourceStateTypeRecycled = "RECYCLED"
 )
 
+// ResourceStateType_Values returns all elements of the ResourceStateType enum
+func ResourceStateType_Values() []string {
+	return []string{
+		ResourceStateTypeActive,
+		ResourceStateTypeRestoring,
+		ResourceStateTypeRecycling,
+		ResourceStateTypeRecycled,
+	}
+}
+
 const (
 	// ResourceTypeFolder is a ResourceType enum value
 	ResourceTypeFolder = "FOLDER"
@@ -11701,6 +11867,14 @@ const (
 	ResourceTypeDocument = "DOCUMENT"
 )
 
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeFolder,
+		ResourceTypeDocument,
+	}
+}
+
 const (
 	// RolePermissionTypeDirect is a RolePermissionType enum value
 	RolePermissionTypeDirect = "DIRECT"
@@ -11708,6 +11882,14 @@ const (
 	// RolePermissionTypeInherited is a RolePermissionType enum value
 	RolePermissionTypeInherited = "INHERITED"
 )
+
+// RolePermissionType_Values returns all elements of the RolePermissionType enum
+func RolePermissionType_Values() []string {
+	return []string{
+		RolePermissionTypeDirect,
+		RolePermissionTypeInherited,
+	}
+}
 
 const (
 	// RoleTypeViewer is a RoleType enum value
@@ -11723,6 +11905,16 @@ const (
 	RoleTypeCoowner = "COOWNER"
 )
 
+// RoleType_Values returns all elements of the RoleType enum
+func RoleType_Values() []string {
+	return []string{
+		RoleTypeViewer,
+		RoleTypeContributor,
+		RoleTypeOwner,
+		RoleTypeCoowner,
+	}
+}
+
 const (
 	// ShareStatusTypeSuccess is a ShareStatusType enum value
 	ShareStatusTypeSuccess = "SUCCESS"
@@ -11730,6 +11922,14 @@ const (
 	// ShareStatusTypeFailure is a ShareStatusType enum value
 	ShareStatusTypeFailure = "FAILURE"
 )
+
+// ShareStatusType_Values returns all elements of the ShareStatusType enum
+func ShareStatusType_Values() []string {
+	return []string{
+		ShareStatusTypeSuccess,
+		ShareStatusTypeFailure,
+	}
+}
 
 const (
 	// StorageTypeUnlimited is a StorageType enum value
@@ -11739,15 +11939,37 @@ const (
 	StorageTypeQuota = "QUOTA"
 )
 
+// StorageType_Values returns all elements of the StorageType enum
+func StorageType_Values() []string {
+	return []string{
+		StorageTypeUnlimited,
+		StorageTypeQuota,
+	}
+}
+
 const (
 	// SubscriptionProtocolTypeHttps is a SubscriptionProtocolType enum value
 	SubscriptionProtocolTypeHttps = "HTTPS"
 )
 
+// SubscriptionProtocolType_Values returns all elements of the SubscriptionProtocolType enum
+func SubscriptionProtocolType_Values() []string {
+	return []string{
+		SubscriptionProtocolTypeHttps,
+	}
+}
+
 const (
 	// SubscriptionTypeAll is a SubscriptionType enum value
 	SubscriptionTypeAll = "ALL"
 )
+
+// SubscriptionType_Values returns all elements of the SubscriptionType enum
+func SubscriptionType_Values() []string {
+	return []string{
+		SubscriptionTypeAll,
+	}
+}
 
 const (
 	// UserFilterTypeAll is a UserFilterType enum value
@@ -11756,6 +11978,14 @@ const (
 	// UserFilterTypeActivePending is a UserFilterType enum value
 	UserFilterTypeActivePending = "ACTIVE_PENDING"
 )
+
+// UserFilterType_Values returns all elements of the UserFilterType enum
+func UserFilterType_Values() []string {
+	return []string{
+		UserFilterTypeAll,
+		UserFilterTypeActivePending,
+	}
+}
 
 const (
 	// UserSortTypeUserName is a UserSortType enum value
@@ -11774,6 +12004,17 @@ const (
 	UserSortTypeStorageUsed = "STORAGE_USED"
 )
 
+// UserSortType_Values returns all elements of the UserSortType enum
+func UserSortType_Values() []string {
+	return []string{
+		UserSortTypeUserName,
+		UserSortTypeFullName,
+		UserSortTypeStorageLimit,
+		UserSortTypeUserStatus,
+		UserSortTypeStorageUsed,
+	}
+}
+
 const (
 	// UserStatusTypeActive is a UserStatusType enum value
 	UserStatusTypeActive = "ACTIVE"
@@ -11784,6 +12025,15 @@ const (
 	// UserStatusTypePending is a UserStatusType enum value
 	UserStatusTypePending = "PENDING"
 )
+
+// UserStatusType_Values returns all elements of the UserStatusType enum
+func UserStatusType_Values() []string {
+	return []string{
+		UserStatusTypeActive,
+		UserStatusTypeInactive,
+		UserStatusTypePending,
+	}
+}
 
 const (
 	// UserTypeUser is a UserType enum value
@@ -11801,3 +12051,14 @@ const (
 	// UserTypeWorkspacesuser is a UserType enum value
 	UserTypeWorkspacesuser = "WORKSPACESUSER"
 )
+
+// UserType_Values returns all elements of the UserType enum
+func UserType_Values() []string {
+	return []string{
+		UserTypeUser,
+		UserTypeAdmin,
+		UserTypePoweruser,
+		UserTypeMinimaluser,
+		UserTypeWorkspacesuser,
+	}
+}

--- a/service/worklink/api.go
+++ b/service/worklink/api.go
@@ -6724,6 +6724,13 @@ const (
 	AuthorizationProviderTypeSaml = "SAML"
 )
 
+// AuthorizationProviderType_Values returns all elements of the AuthorizationProviderType enum
+func AuthorizationProviderType_Values() []string {
+	return []string{
+		AuthorizationProviderTypeSaml,
+	}
+}
+
 const (
 	// DeviceStatusActive is a DeviceStatus enum value
 	DeviceStatusActive = "ACTIVE"
@@ -6731,6 +6738,14 @@ const (
 	// DeviceStatusSignedOut is a DeviceStatus enum value
 	DeviceStatusSignedOut = "SIGNED_OUT"
 )
+
+// DeviceStatus_Values returns all elements of the DeviceStatus enum
+func DeviceStatus_Values() []string {
+	return []string{
+		DeviceStatusActive,
+		DeviceStatusSignedOut,
+	}
+}
 
 const (
 	// DomainStatusPendingValidation is a DomainStatus enum value
@@ -6758,6 +6773,20 @@ const (
 	DomainStatusFailedToDisassociate = "FAILED_TO_DISASSOCIATE"
 )
 
+// DomainStatus_Values returns all elements of the DomainStatus enum
+func DomainStatus_Values() []string {
+	return []string{
+		DomainStatusPendingValidation,
+		DomainStatusAssociating,
+		DomainStatusActive,
+		DomainStatusInactive,
+		DomainStatusDisassociating,
+		DomainStatusDisassociated,
+		DomainStatusFailedToAssociate,
+		DomainStatusFailedToDisassociate,
+	}
+}
+
 const (
 	// FleetStatusCreating is a FleetStatus enum value
 	FleetStatusCreating = "CREATING"
@@ -6778,7 +6807,26 @@ const (
 	FleetStatusFailedToDelete = "FAILED_TO_DELETE"
 )
 
+// FleetStatus_Values returns all elements of the FleetStatus enum
+func FleetStatus_Values() []string {
+	return []string{
+		FleetStatusCreating,
+		FleetStatusActive,
+		FleetStatusDeleting,
+		FleetStatusDeleted,
+		FleetStatusFailedToCreate,
+		FleetStatusFailedToDelete,
+	}
+}
+
 const (
 	// IdentityProviderTypeSaml is a IdentityProviderType enum value
 	IdentityProviderTypeSaml = "SAML"
 )
+
+// IdentityProviderType_Values returns all elements of the IdentityProviderType enum
+func IdentityProviderType_Values() []string {
+	return []string{
+		IdentityProviderTypeSaml,
+	}
+}

--- a/service/workmail/api.go
+++ b/service/workmail/api.go
@@ -10462,6 +10462,14 @@ const (
 	AccessControlRuleEffectDeny = "DENY"
 )
 
+// AccessControlRuleEffect_Values returns all elements of the AccessControlRuleEffect enum
+func AccessControlRuleEffect_Values() []string {
+	return []string{
+		AccessControlRuleEffectAllow,
+		AccessControlRuleEffectDeny,
+	}
+}
+
 const (
 	// EntityStateEnabled is a EntityState enum value
 	EntityStateEnabled = "ENABLED"
@@ -10472,6 +10480,15 @@ const (
 	// EntityStateDeleted is a EntityState enum value
 	EntityStateDeleted = "DELETED"
 )
+
+// EntityState_Values returns all elements of the EntityState enum
+func EntityState_Values() []string {
+	return []string{
+		EntityStateEnabled,
+		EntityStateDisabled,
+		EntityStateDeleted,
+	}
+}
 
 const (
 	// FolderNameInbox is a FolderName enum value
@@ -10490,6 +10507,17 @@ const (
 	FolderNameJunkEmail = "JUNK_EMAIL"
 )
 
+// FolderName_Values returns all elements of the FolderName enum
+func FolderName_Values() []string {
+	return []string{
+		FolderNameInbox,
+		FolderNameDeletedItems,
+		FolderNameSentItems,
+		FolderNameDrafts,
+		FolderNameJunkEmail,
+	}
+}
+
 const (
 	// MemberTypeGroup is a MemberType enum value
 	MemberTypeGroup = "GROUP"
@@ -10497,6 +10525,14 @@ const (
 	// MemberTypeUser is a MemberType enum value
 	MemberTypeUser = "USER"
 )
+
+// MemberType_Values returns all elements of the MemberType enum
+func MemberType_Values() []string {
+	return []string{
+		MemberTypeGroup,
+		MemberTypeUser,
+	}
+}
 
 const (
 	// PermissionTypeFullAccess is a PermissionType enum value
@@ -10509,6 +10545,15 @@ const (
 	PermissionTypeSendOnBehalf = "SEND_ON_BEHALF"
 )
 
+// PermissionType_Values returns all elements of the PermissionType enum
+func PermissionType_Values() []string {
+	return []string{
+		PermissionTypeFullAccess,
+		PermissionTypeSendAs,
+		PermissionTypeSendOnBehalf,
+	}
+}
+
 const (
 	// ResourceTypeRoom is a ResourceType enum value
 	ResourceTypeRoom = "ROOM"
@@ -10516,6 +10561,14 @@ const (
 	// ResourceTypeEquipment is a ResourceType enum value
 	ResourceTypeEquipment = "EQUIPMENT"
 )
+
+// ResourceType_Values returns all elements of the ResourceType enum
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeRoom,
+		ResourceTypeEquipment,
+	}
+}
 
 const (
 	// RetentionActionNone is a RetentionAction enum value
@@ -10528,6 +10581,15 @@ const (
 	RetentionActionPermanentlyDelete = "PERMANENTLY_DELETE"
 )
 
+// RetentionAction_Values returns all elements of the RetentionAction enum
+func RetentionAction_Values() []string {
+	return []string{
+		RetentionActionNone,
+		RetentionActionDelete,
+		RetentionActionPermanentlyDelete,
+	}
+}
+
 const (
 	// UserRoleUser is a UserRole enum value
 	UserRoleUser = "USER"
@@ -10538,3 +10600,12 @@ const (
 	// UserRoleSystemUser is a UserRole enum value
 	UserRoleSystemUser = "SYSTEM_USER"
 )
+
+// UserRole_Values returns all elements of the UserRole enum
+func UserRole_Values() []string {
+	return []string{
+		UserRoleUser,
+		UserRoleResource,
+		UserRoleSystemUser,
+	}
+}

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -9955,6 +9955,14 @@ const (
 	AccessPropertyValueDeny = "DENY"
 )
 
+// AccessPropertyValue_Values returns all elements of the AccessPropertyValue enum
+func AccessPropertyValue_Values() []string {
+	return []string{
+		AccessPropertyValueAllow,
+		AccessPropertyValueDeny,
+	}
+}
+
 const (
 	// ComputeValue is a Compute enum value
 	ComputeValue = "VALUE"
@@ -9978,6 +9986,19 @@ const (
 	ComputeGraphicspro = "GRAPHICSPRO"
 )
 
+// Compute_Values returns all elements of the Compute enum
+func Compute_Values() []string {
+	return []string{
+		ComputeValue,
+		ComputeStandard,
+		ComputePerformance,
+		ComputePower,
+		ComputeGraphics,
+		ComputePowerpro,
+		ComputeGraphicspro,
+	}
+}
+
 const (
 	// ConnectionStateConnected is a ConnectionState enum value
 	ConnectionStateConnected = "CONNECTED"
@@ -9988,6 +10009,15 @@ const (
 	// ConnectionStateUnknown is a ConnectionState enum value
 	ConnectionStateUnknown = "UNKNOWN"
 )
+
+// ConnectionState_Values returns all elements of the ConnectionState enum
+func ConnectionState_Values() []string {
+	return []string{
+		ConnectionStateConnected,
+		ConnectionStateDisconnected,
+		ConnectionStateUnknown,
+	}
+}
 
 const (
 	// DedicatedTenancyModificationStateEnumPending is a DedicatedTenancyModificationStateEnum enum value
@@ -10000,10 +10030,26 @@ const (
 	DedicatedTenancyModificationStateEnumFailed = "FAILED"
 )
 
+// DedicatedTenancyModificationStateEnum_Values returns all elements of the DedicatedTenancyModificationStateEnum enum
+func DedicatedTenancyModificationStateEnum_Values() []string {
+	return []string{
+		DedicatedTenancyModificationStateEnumPending,
+		DedicatedTenancyModificationStateEnumCompleted,
+		DedicatedTenancyModificationStateEnumFailed,
+	}
+}
+
 const (
 	// DedicatedTenancySupportEnumEnabled is a DedicatedTenancySupportEnum enum value
 	DedicatedTenancySupportEnumEnabled = "ENABLED"
 )
+
+// DedicatedTenancySupportEnum_Values returns all elements of the DedicatedTenancySupportEnum enum
+func DedicatedTenancySupportEnum_Values() []string {
+	return []string{
+		DedicatedTenancySupportEnumEnabled,
+	}
+}
 
 const (
 	// DedicatedTenancySupportResultEnumEnabled is a DedicatedTenancySupportResultEnum enum value
@@ -10013,6 +10059,14 @@ const (
 	DedicatedTenancySupportResultEnumDisabled = "DISABLED"
 )
 
+// DedicatedTenancySupportResultEnum_Values returns all elements of the DedicatedTenancySupportResultEnum enum
+func DedicatedTenancySupportResultEnum_Values() []string {
+	return []string{
+		DedicatedTenancySupportResultEnumEnabled,
+		DedicatedTenancySupportResultEnumDisabled,
+	}
+}
+
 const (
 	// ImageTypeOwned is a ImageType enum value
 	ImageTypeOwned = "OWNED"
@@ -10020,6 +10074,14 @@ const (
 	// ImageTypeShared is a ImageType enum value
 	ImageTypeShared = "SHARED"
 )
+
+// ImageType_Values returns all elements of the ImageType enum
+func ImageType_Values() []string {
+	return []string{
+		ImageTypeOwned,
+		ImageTypeShared,
+	}
+}
 
 const (
 	// ModificationResourceEnumRootVolume is a ModificationResourceEnum enum value
@@ -10032,6 +10094,15 @@ const (
 	ModificationResourceEnumComputeType = "COMPUTE_TYPE"
 )
 
+// ModificationResourceEnum_Values returns all elements of the ModificationResourceEnum enum
+func ModificationResourceEnum_Values() []string {
+	return []string{
+		ModificationResourceEnumRootVolume,
+		ModificationResourceEnumUserVolume,
+		ModificationResourceEnumComputeType,
+	}
+}
+
 const (
 	// ModificationStateEnumUpdateInitiated is a ModificationStateEnum enum value
 	ModificationStateEnumUpdateInitiated = "UPDATE_INITIATED"
@@ -10039,6 +10110,14 @@ const (
 	// ModificationStateEnumUpdateInProgress is a ModificationStateEnum enum value
 	ModificationStateEnumUpdateInProgress = "UPDATE_IN_PROGRESS"
 )
+
+// ModificationStateEnum_Values returns all elements of the ModificationStateEnum enum
+func ModificationStateEnum_Values() []string {
+	return []string{
+		ModificationStateEnumUpdateInitiated,
+		ModificationStateEnumUpdateInProgress,
+	}
+}
 
 const (
 	// OperatingSystemTypeWindows is a OperatingSystemType enum value
@@ -10048,6 +10127,14 @@ const (
 	OperatingSystemTypeLinux = "LINUX"
 )
 
+// OperatingSystemType_Values returns all elements of the OperatingSystemType enum
+func OperatingSystemType_Values() []string {
+	return []string{
+		OperatingSystemTypeWindows,
+		OperatingSystemTypeLinux,
+	}
+}
+
 const (
 	// ReconnectEnumEnabled is a ReconnectEnum enum value
 	ReconnectEnumEnabled = "ENABLED"
@@ -10055,6 +10142,14 @@ const (
 	// ReconnectEnumDisabled is a ReconnectEnum enum value
 	ReconnectEnumDisabled = "DISABLED"
 )
+
+// ReconnectEnum_Values returns all elements of the ReconnectEnum enum
+func ReconnectEnum_Values() []string {
+	return []string{
+		ReconnectEnumEnabled,
+		ReconnectEnumDisabled,
+	}
+}
 
 const (
 	// RunningModeAutoStop is a RunningMode enum value
@@ -10064,6 +10159,14 @@ const (
 	RunningModeAlwaysOn = "ALWAYS_ON"
 )
 
+// RunningMode_Values returns all elements of the RunningMode enum
+func RunningMode_Values() []string {
+	return []string{
+		RunningModeAutoStop,
+		RunningModeAlwaysOn,
+	}
+}
+
 const (
 	// TargetWorkspaceStateAvailable is a TargetWorkspaceState enum value
 	TargetWorkspaceStateAvailable = "AVAILABLE"
@@ -10072,6 +10175,14 @@ const (
 	TargetWorkspaceStateAdminMaintenance = "ADMIN_MAINTENANCE"
 )
 
+// TargetWorkspaceState_Values returns all elements of the TargetWorkspaceState enum
+func TargetWorkspaceState_Values() []string {
+	return []string{
+		TargetWorkspaceStateAvailable,
+		TargetWorkspaceStateAdminMaintenance,
+	}
+}
+
 const (
 	// TenancyDedicated is a Tenancy enum value
 	TenancyDedicated = "DEDICATED"
@@ -10079,6 +10190,14 @@ const (
 	// TenancyShared is a Tenancy enum value
 	TenancyShared = "SHARED"
 )
+
+// Tenancy_Values returns all elements of the Tenancy enum
+func Tenancy_Values() []string {
+	return []string{
+		TenancyDedicated,
+		TenancyShared,
+	}
+}
 
 const (
 	// WorkspaceDirectoryStateRegistering is a WorkspaceDirectoryState enum value
@@ -10097,6 +10216,17 @@ const (
 	WorkspaceDirectoryStateError = "ERROR"
 )
 
+// WorkspaceDirectoryState_Values returns all elements of the WorkspaceDirectoryState enum
+func WorkspaceDirectoryState_Values() []string {
+	return []string{
+		WorkspaceDirectoryStateRegistering,
+		WorkspaceDirectoryStateRegistered,
+		WorkspaceDirectoryStateDeregistering,
+		WorkspaceDirectoryStateDeregistered,
+		WorkspaceDirectoryStateError,
+	}
+}
+
 const (
 	// WorkspaceDirectoryTypeSimpleAd is a WorkspaceDirectoryType enum value
 	WorkspaceDirectoryTypeSimpleAd = "SIMPLE_AD"
@@ -10104,6 +10234,14 @@ const (
 	// WorkspaceDirectoryTypeAdConnector is a WorkspaceDirectoryType enum value
 	WorkspaceDirectoryTypeAdConnector = "AD_CONNECTOR"
 )
+
+// WorkspaceDirectoryType_Values returns all elements of the WorkspaceDirectoryType enum
+func WorkspaceDirectoryType_Values() []string {
+	return []string{
+		WorkspaceDirectoryTypeSimpleAd,
+		WorkspaceDirectoryTypeAdConnector,
+	}
+}
 
 const (
 	// WorkspaceImageIngestionProcessByolRegular is a WorkspaceImageIngestionProcess enum value
@@ -10116,6 +10254,15 @@ const (
 	WorkspaceImageIngestionProcessByolGraphicspro = "BYOL_GRAPHICSPRO"
 )
 
+// WorkspaceImageIngestionProcess_Values returns all elements of the WorkspaceImageIngestionProcess enum
+func WorkspaceImageIngestionProcess_Values() []string {
+	return []string{
+		WorkspaceImageIngestionProcessByolRegular,
+		WorkspaceImageIngestionProcessByolGraphics,
+		WorkspaceImageIngestionProcessByolGraphicspro,
+	}
+}
+
 const (
 	// WorkspaceImageRequiredTenancyDefault is a WorkspaceImageRequiredTenancy enum value
 	WorkspaceImageRequiredTenancyDefault = "DEFAULT"
@@ -10123,6 +10270,14 @@ const (
 	// WorkspaceImageRequiredTenancyDedicated is a WorkspaceImageRequiredTenancy enum value
 	WorkspaceImageRequiredTenancyDedicated = "DEDICATED"
 )
+
+// WorkspaceImageRequiredTenancy_Values returns all elements of the WorkspaceImageRequiredTenancy enum
+func WorkspaceImageRequiredTenancy_Values() []string {
+	return []string{
+		WorkspaceImageRequiredTenancyDefault,
+		WorkspaceImageRequiredTenancyDedicated,
+	}
+}
 
 const (
 	// WorkspaceImageStateAvailable is a WorkspaceImageState enum value
@@ -10134,6 +10289,15 @@ const (
 	// WorkspaceImageStateError is a WorkspaceImageState enum value
 	WorkspaceImageStateError = "ERROR"
 )
+
+// WorkspaceImageState_Values returns all elements of the WorkspaceImageState enum
+func WorkspaceImageState_Values() []string {
+	return []string{
+		WorkspaceImageStateAvailable,
+		WorkspaceImageStatePending,
+		WorkspaceImageStateError,
+	}
+}
 
 const (
 	// WorkspaceStatePending is a WorkspaceState enum value
@@ -10187,3 +10351,26 @@ const (
 	// WorkspaceStateError is a WorkspaceState enum value
 	WorkspaceStateError = "ERROR"
 )
+
+// WorkspaceState_Values returns all elements of the WorkspaceState enum
+func WorkspaceState_Values() []string {
+	return []string{
+		WorkspaceStatePending,
+		WorkspaceStateAvailable,
+		WorkspaceStateImpaired,
+		WorkspaceStateUnhealthy,
+		WorkspaceStateRebooting,
+		WorkspaceStateStarting,
+		WorkspaceStateRebuilding,
+		WorkspaceStateRestoring,
+		WorkspaceStateMaintenance,
+		WorkspaceStateAdminMaintenance,
+		WorkspaceStateTerminating,
+		WorkspaceStateTerminated,
+		WorkspaceStateSuspended,
+		WorkspaceStateUpdating,
+		WorkspaceStateStopping,
+		WorkspaceStateStopped,
+		WorkspaceStateError,
+	}
+}

--- a/service/xray/api.go
+++ b/service/xray/api.go
@@ -6603,6 +6603,14 @@ const (
 	EncryptionStatusActive = "ACTIVE"
 )
 
+// EncryptionStatus_Values returns all elements of the EncryptionStatus enum
+func EncryptionStatus_Values() []string {
+	return []string{
+		EncryptionStatusUpdating,
+		EncryptionStatusActive,
+	}
+}
+
 const (
 	// EncryptionTypeNone is a EncryptionType enum value
 	EncryptionTypeNone = "NONE"
@@ -6610,6 +6618,14 @@ const (
 	// EncryptionTypeKms is a EncryptionType enum value
 	EncryptionTypeKms = "KMS"
 )
+
+// EncryptionType_Values returns all elements of the EncryptionType enum
+func EncryptionType_Values() []string {
+	return []string{
+		EncryptionTypeNone,
+		EncryptionTypeKms,
+	}
+}
 
 const (
 	// SamplingStrategyNamePartialScan is a SamplingStrategyName enum value
@@ -6619,6 +6635,14 @@ const (
 	SamplingStrategyNameFixedRate = "FixedRate"
 )
 
+// SamplingStrategyName_Values returns all elements of the SamplingStrategyName enum
+func SamplingStrategyName_Values() []string {
+	return []string{
+		SamplingStrategyNamePartialScan,
+		SamplingStrategyNameFixedRate,
+	}
+}
+
 const (
 	// TimeRangeTypeTraceId is a TimeRangeType enum value
 	TimeRangeTypeTraceId = "TraceId"
@@ -6626,3 +6650,11 @@ const (
 	// TimeRangeTypeEvent is a TimeRangeType enum value
 	TimeRangeTypeEvent = "Event"
 )
+
+// TimeRangeType_Values returns all elements of the TimeRangeType enum
+func TimeRangeType_Values() []string {
+	return []string{
+		TimeRangeTypeTraceId,
+		TimeRangeTypeEvent,
+	}
+}


### PR DESCRIPTION
Closes #3441

Allows consumers to easily retrieve all values of an enumeration shape.

Maintainer note: Happy to change this to the non-idiomatic `_Values()` naming if desired. 
