### PR TITLE
codegen: Fix eventstream require params and test generation

### DIFF
--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -855,7 +855,7 @@ func resolveShapeValidations(s *Shape, ancestry ...*Shape) {
 		ref := s.MemberRefs[name]
 		// Since this is a grab bag we will just continue since
 		// we can't validate because we don't know the valued shape.
-		if ref.JSONValue {
+		if ref.JSONValue || (s.UsedAsInput && ref.Shape.IsEventStream) {
 			continue
 		}
 

--- a/private/model/api/eventstream_tmpl_writertests.go
+++ b/private/model/api/eventstream_tmpl_writertests.go
@@ -201,6 +201,13 @@ var eventStreamWriterTestTmpl = template.Must(
 			{{- end }}
 		}
 
+		var marshalers request.HandlerList
+		marshalers.PushBackNamed({{ $.API.ProtocolPackage }}.BuildHandler)
+		payloadMarshaler := protocol.HandlerPayloadMarshal{
+			Marshalers: marshalers,
+		}
+		_ = payloadMarshaler
+
 		eventMsgs := []eventstream.Message{
 			{{- range $idx, $event := $.InputStream.Events }}
 				{{- template "set event message" Map "idx" $idx "parentShape" $event.Shape "eventName" $event.Name }}

--- a/service/transcribestreamingservice/eventstream_test.go
+++ b/service/transcribestreamingservice/eventstream_test.go
@@ -768,6 +768,13 @@ func mockStartStreamTranscriptionWriteEvents() (
 		},
 	}
 
+	var marshalers request.HandlerList
+	marshalers.PushBackNamed(restjson.BuildHandler)
+	payloadMarshaler := protocol.HandlerPayloadMarshal{
+		Marshalers: marshalers,
+	}
+	_ = payloadMarshaler
+
 	eventMsgs := []eventstream.Message{
 		{
 			Headers: eventstream.Headers{


### PR DESCRIPTION
Fixes the code generation for eventstream APIs to correctly not generated required parameter validation, and fix test WriteEvents code generation.