### PR TITLE
service/ec2: Fix max retries with client customizations

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,5 @@
 ### SDK Bugs
 * `codegen`: Export event stream constructor for easier mocking ([#3473](https://github.com/aws/aws-sdk-go/pull/3473))
   * Fixes [#3412](https://github.com/aws/aws-sdk-go/issues/3412) by exporting the operation's EventStream type's constructor function so it can be used to fully initialize fully when mocking out behavior for API operations with event streams.
+* `service/ec2`: Fix max retries with client customizations ([#3465](https://github.com/aws/aws-sdk-go/pull/3465))
+  * Fixes [#3374](https://github.com/aws/aws-sdk-go/issues/3374) by correcting the EC2 API client's customization for ModifyNetworkInterfaceAttribute and AssignPrivateIpAddresses operations to use the aws.Config.MaxRetries value if set. Previously the API client's customizations would ignore MaxRetries specified in the SDK's aws.Config.MaxRetries field.

--- a/service/ec2/customizations.go
+++ b/service/ec2/customizations.go
@@ -26,8 +26,12 @@ func init() {
 
 		// only set the retryer on request if config doesn't have a retryer
 		if r.Config.Retryer == nil && (r.Operation.Name == opModifyNetworkInterfaceAttribute || r.Operation.Name == opAssignPrivateIpAddresses) {
+			maxRetries := client.DefaultRetryerMaxNumRetries
+			if m := r.Config.MaxRetries; m != nil && *m != aws.UseServiceDefaultRetries {
+				maxRetries = *m
+			}
 			r.Retryer = client.DefaultRetryer{
-				NumMaxRetries:    client.DefaultRetryerMaxNumRetries,
+				NumMaxRetries:    maxRetries,
 				MinRetryDelay:    customRetryerMinRetryDelay,
 				MinThrottleDelay: customRetryerMinRetryDelay,
 				MaxRetryDelay:    customRetryerMaxRetryDelay,

--- a/service/ec2/customizations_test.go
+++ b/service/ec2/customizations_test.go
@@ -1,12 +1,17 @@
 package ec2_test
 
 import (
+	"bytes"
+	"context"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	sdkclient "github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
@@ -44,5 +49,57 @@ func TestCopySnapshotPresignedURL(t *testing.T) {
 	r := regexp.MustCompile(`^https://ec2\.us-west-1\.amazonaws\.com/.+&DestinationRegion=us-west-2`)
 	if !r.MatchString(u) {
 		t.Errorf("expect %v to match, got %v", r.String(), u)
+	}
+}
+
+func TestNoCustomRetryerWithMaxRetries(t *testing.T) {
+	cases := map[string]struct {
+		Config           aws.Config
+		ExpectMaxRetries int
+	}{
+		"With custom retrier": {
+			Config: aws.Config{
+				Retryer: sdkclient.DefaultRetryer{
+					NumMaxRetries: 10,
+				},
+			},
+			ExpectMaxRetries: 10,
+		},
+		"with max retries": {
+			Config: aws.Config{
+				MaxRetries: aws.Int(10),
+			},
+			ExpectMaxRetries: 10,
+		},
+		"no options set": {
+			ExpectMaxRetries: sdkclient.DefaultRetryerMaxNumRetries,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := ec2.New(unit.Session, &aws.Config{
+				DisableParamValidation: aws.Bool(true),
+			}, c.Config.Copy())
+			client.ModifyNetworkInterfaceAttributeWithContext(context.Background(), nil, checkRetryerMaxRetries(t, c.ExpectMaxRetries))
+			client.AssignPrivateIpAddressesWithContext(context.Background(), nil, checkRetryerMaxRetries(t, c.ExpectMaxRetries))
+		})
+	}
+
+}
+
+func checkRetryerMaxRetries(t *testing.T, maxRetries int) func(*request.Request) {
+	return func(r *request.Request) {
+		r.Handlers.Send.Clear()
+		r.Handlers.Send.PushBack(func(rr *request.Request) {
+			if e, a := maxRetries, rr.Retryer.MaxRetries(); e != a {
+				t.Errorf("%s, expect %v max retries, got %v", rr.Operation.Name, e, a)
+			}
+			rr.HTTPResponse = &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{},
+				Body:       ioutil.NopCloser(&bytes.Buffer{}),
+			}
+		})
 	}
 }

--- a/service/ec2/customizations_test.go
+++ b/service/ec2/customizations_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package ec2_test
 
 import (


### PR DESCRIPTION
Fixes #3374 by correcting the EC2 API client's customization for ModifyNetworkInterfaceAttribute and AssignPrivateIpAddresses operations to use the aws.Config.MaxRetries value if set. Previously the API client's customizations would ignore MaxRetries specified in the SDK's aws.Config.MaxRetries field.