### PR TITLE
codegen: Export event stream constructor for easier mocking

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `codegen`: Export event stream constructor for easier mocking ([#3473](https://github.com/aws/aws-sdk-go/pull/3473))
+  * Fixes [#3412](https://github.com/aws/aws-sdk-go/issues/3412) by exporting the operation's EventStream type's constructor function so it can be used to fully initialize fully when mocking out behavior for API operations with event streams.

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -61,7 +61,7 @@ func (c *RESTJSONService) EmptyStreamRequest(input *EmptyStreamInput) (req *requ
 	output = &EmptyStreamOutput{}
 	req = c.newRequest(op, input, output)
 
-	es := newEmptyStreamEventStream()
+	es := NewEmptyStreamEventStream()
 	output.eventStream = es
 
 	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
@@ -104,6 +104,10 @@ func (c *RESTJSONService) EmptyStreamWithContext(ctx aws.Context, input *EmptySt
 var _ awserr.Error
 
 // EmptyStreamEventStream provides the event stream handling for the EmptyStream.
+//
+// For testing and mocking the event stream this type should be initialized via
+// the NewEmptyStreamEventStream constructor function. Using the functional options
+// to pass in nested mock behavior.
 type EmptyStreamEventStream struct {
 
 	// Reader is the EventStream reader for the EmptyEventStream
@@ -121,11 +125,26 @@ type EmptyStreamEventStream struct {
 	err       *eventstreamapi.OnceError
 }
 
-func newEmptyStreamEventStream() *EmptyStreamEventStream {
-	return &EmptyStreamEventStream{
+// NewEmptyStreamEventStream initializes an EmptyStreamEventStream.
+// This function should only be used for testing and mocking the EmptyStreamEventStream
+// stream within your application.
+//
+// The Reader member must be set before reading events from the stream.
+//
+//   es := NewEmptyStreamEventStream(func(o *EmptyStreamEventStream{
+//       es.Reader = myMockStreamReader
+//   })
+func NewEmptyStreamEventStream(opts ...func(*EmptyStreamEventStream)) *EmptyStreamEventStream {
+	es := &EmptyStreamEventStream{
 		done: make(chan struct{}),
 		err:  eventstreamapi.NewOnceError(),
 	}
+
+	for _, fn := range opts {
+		fn(es)
+	}
+
+	return es
 }
 
 func (es *EmptyStreamEventStream) runOnStreamPartClose(r *request.Request) {
@@ -269,7 +288,7 @@ func (c *RESTJSONService) GetEventStreamRequest(input *GetEventStreamInput) (req
 	output = &GetEventStreamOutput{}
 	req = c.newRequest(op, input, output)
 
-	es := newGetEventStreamEventStream()
+	es := NewGetEventStreamEventStream()
 	output.eventStream = es
 
 	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
@@ -312,6 +331,10 @@ func (c *RESTJSONService) GetEventStreamWithContext(ctx aws.Context, input *GetE
 var _ awserr.Error
 
 // GetEventStreamEventStream provides the event stream handling for the GetEventStream.
+//
+// For testing and mocking the event stream this type should be initialized via
+// the NewGetEventStreamEventStream constructor function. Using the functional options
+// to pass in nested mock behavior.
 type GetEventStreamEventStream struct {
 
 	// Reader is the EventStream reader for the EventStream
@@ -329,11 +352,26 @@ type GetEventStreamEventStream struct {
 	err       *eventstreamapi.OnceError
 }
 
-func newGetEventStreamEventStream() *GetEventStreamEventStream {
-	return &GetEventStreamEventStream{
+// NewGetEventStreamEventStream initializes an GetEventStreamEventStream.
+// This function should only be used for testing and mocking the GetEventStreamEventStream
+// stream within your application.
+//
+// The Reader member must be set before reading events from the stream.
+//
+//   es := NewGetEventStreamEventStream(func(o *GetEventStreamEventStream{
+//       es.Reader = myMockStreamReader
+//   })
+func NewGetEventStreamEventStream(opts ...func(*GetEventStreamEventStream)) *GetEventStreamEventStream {
+	es := &GetEventStreamEventStream{
 		done: make(chan struct{}),
 		err:  eventstreamapi.NewOnceError(),
 	}
+
+	for _, fn := range opts {
+		fn(es)
+	}
+
+	return es
 }
 
 func (es *GetEventStreamEventStream) runOnStreamPartClose(r *request.Request) {

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -61,7 +61,7 @@ func (c *RESTXMLService) EmptyStreamRequest(input *EmptyStreamInput) (req *reque
 	output = &EmptyStreamOutput{}
 	req = c.newRequest(op, input, output)
 
-	es := newEmptyStreamEventStream()
+	es := NewEmptyStreamEventStream()
 	output.eventStream = es
 
 	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
@@ -104,6 +104,10 @@ func (c *RESTXMLService) EmptyStreamWithContext(ctx aws.Context, input *EmptyStr
 var _ awserr.Error
 
 // EmptyStreamEventStream provides the event stream handling for the EmptyStream.
+//
+// For testing and mocking the event stream this type should be initialized via
+// the NewEmptyStreamEventStream constructor function. Using the functional options
+// to pass in nested mock behavior.
 type EmptyStreamEventStream struct {
 
 	// Reader is the EventStream reader for the EmptyEventStream
@@ -121,11 +125,26 @@ type EmptyStreamEventStream struct {
 	err       *eventstreamapi.OnceError
 }
 
-func newEmptyStreamEventStream() *EmptyStreamEventStream {
-	return &EmptyStreamEventStream{
+// NewEmptyStreamEventStream initializes an EmptyStreamEventStream.
+// This function should only be used for testing and mocking the EmptyStreamEventStream
+// stream within your application.
+//
+// The Reader member must be set before reading events from the stream.
+//
+//   es := NewEmptyStreamEventStream(func(o *EmptyStreamEventStream{
+//       es.Reader = myMockStreamReader
+//   })
+func NewEmptyStreamEventStream(opts ...func(*EmptyStreamEventStream)) *EmptyStreamEventStream {
+	es := &EmptyStreamEventStream{
 		done: make(chan struct{}),
 		err:  eventstreamapi.NewOnceError(),
 	}
+
+	for _, fn := range opts {
+		fn(es)
+	}
+
+	return es
 }
 
 func (es *EmptyStreamEventStream) runOnStreamPartClose(r *request.Request) {
@@ -269,7 +288,7 @@ func (c *RESTXMLService) GetEventStreamRequest(input *GetEventStreamInput) (req 
 	output = &GetEventStreamOutput{}
 	req = c.newRequest(op, input, output)
 
-	es := newGetEventStreamEventStream()
+	es := NewGetEventStreamEventStream()
 	output.eventStream = es
 
 	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
@@ -312,6 +331,10 @@ func (c *RESTXMLService) GetEventStreamWithContext(ctx aws.Context, input *GetEv
 var _ awserr.Error
 
 // GetEventStreamEventStream provides the event stream handling for the GetEventStream.
+//
+// For testing and mocking the event stream this type should be initialized via
+// the NewGetEventStreamEventStream constructor function. Using the functional options
+// to pass in nested mock behavior.
 type GetEventStreamEventStream struct {
 
 	// Reader is the EventStream reader for the EventStream
@@ -329,11 +352,26 @@ type GetEventStreamEventStream struct {
 	err       *eventstreamapi.OnceError
 }
 
-func newGetEventStreamEventStream() *GetEventStreamEventStream {
-	return &GetEventStreamEventStream{
+// NewGetEventStreamEventStream initializes an GetEventStreamEventStream.
+// This function should only be used for testing and mocking the GetEventStreamEventStream
+// stream within your application.
+//
+// The Reader member must be set before reading events from the stream.
+//
+//   es := NewGetEventStreamEventStream(func(o *GetEventStreamEventStream{
+//       es.Reader = myMockStreamReader
+//   })
+func NewGetEventStreamEventStream(opts ...func(*GetEventStreamEventStream)) *GetEventStreamEventStream {
+	es := &GetEventStreamEventStream{
 		done: make(chan struct{}),
 		err:  eventstreamapi.NewOnceError(),
 	}
+
+	for _, fn := range opts {
+		fn(es)
+	}
+
+	return es
 }
 
 func (es *GetEventStreamEventStream) runOnStreamPartClose(r *request.Request) {

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -61,7 +61,7 @@ func (c *RPCService) EmptyStreamRequest(input *EmptyStreamInput) (req *request.R
 	output = &EmptyStreamOutput{}
 	req = c.newRequest(op, input, output)
 
-	es := newEmptyStreamEventStream()
+	es := NewEmptyStreamEventStream()
 	output.eventStream = es
 
 	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
@@ -106,6 +106,10 @@ func (c *RPCService) EmptyStreamWithContext(ctx aws.Context, input *EmptyStreamI
 var _ awserr.Error
 
 // EmptyStreamEventStream provides the event stream handling for the EmptyStream.
+//
+// For testing and mocking the event stream this type should be initialized via
+// the NewEmptyStreamEventStream constructor function. Using the functional options
+// to pass in nested mock behavior.
 type EmptyStreamEventStream struct {
 
 	// Reader is the EventStream reader for the EmptyEventStream
@@ -124,11 +128,26 @@ type EmptyStreamEventStream struct {
 	err       *eventstreamapi.OnceError
 }
 
-func newEmptyStreamEventStream() *EmptyStreamEventStream {
-	return &EmptyStreamEventStream{
+// NewEmptyStreamEventStream initializes an EmptyStreamEventStream.
+// This function should only be used for testing and mocking the EmptyStreamEventStream
+// stream within your application.
+//
+// The Reader member must be set before reading events from the stream.
+//
+//   es := NewEmptyStreamEventStream(func(o *EmptyStreamEventStream{
+//       es.Reader = myMockStreamReader
+//   })
+func NewEmptyStreamEventStream(opts ...func(*EmptyStreamEventStream)) *EmptyStreamEventStream {
+	es := &EmptyStreamEventStream{
 		done: make(chan struct{}),
 		err:  eventstreamapi.NewOnceError(),
 	}
+
+	for _, fn := range opts {
+		fn(es)
+	}
+
+	return es
 }
 
 func (es *EmptyStreamEventStream) runOnStreamPartClose(r *request.Request) {
@@ -312,7 +331,7 @@ func (c *RPCService) GetEventStreamRequest(input *GetEventStreamInput) (req *req
 	output = &GetEventStreamOutput{}
 	req = c.newRequest(op, input, output)
 
-	es := newGetEventStreamEventStream()
+	es := NewGetEventStreamEventStream()
 	output.eventStream = es
 
 	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
@@ -357,6 +376,10 @@ func (c *RPCService) GetEventStreamWithContext(ctx aws.Context, input *GetEventS
 var _ awserr.Error
 
 // GetEventStreamEventStream provides the event stream handling for the GetEventStream.
+//
+// For testing and mocking the event stream this type should be initialized via
+// the NewGetEventStreamEventStream constructor function. Using the functional options
+// to pass in nested mock behavior.
 type GetEventStreamEventStream struct {
 
 	// Reader is the EventStream reader for the EventStream
@@ -375,11 +398,26 @@ type GetEventStreamEventStream struct {
 	err       *eventstreamapi.OnceError
 }
 
-func newGetEventStreamEventStream() *GetEventStreamEventStream {
-	return &GetEventStreamEventStream{
+// NewGetEventStreamEventStream initializes an GetEventStreamEventStream.
+// This function should only be used for testing and mocking the GetEventStreamEventStream
+// stream within your application.
+//
+// The Reader member must be set before reading events from the stream.
+//
+//   es := NewGetEventStreamEventStream(func(o *GetEventStreamEventStream{
+//       es.Reader = myMockStreamReader
+//   })
+func NewGetEventStreamEventStream(opts ...func(*GetEventStreamEventStream)) *GetEventStreamEventStream {
+	es := &GetEventStreamEventStream{
 		done: make(chan struct{}),
 		err:  eventstreamapi.NewOnceError(),
 	}
+
+	for _, fn := range opts {
+		fn(es)
+	}
+
+	return es
 }
 
 func (es *GetEventStreamEventStream) runOnStreamPartClose(r *request.Request) {

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -222,7 +222,7 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}Request(` +
 				)
 			{{- end }}
 
-			es := new{{ $esapi.Name }}()
+			es := New{{ $esapi.Name }}()
 			{{- if $esapi.Legacy }}
 				req.Handlers.Unmarshal.PushBack(es.setStreamCloser)
 			{{- end }}

--- a/service/transcribestreamingservice/api.go
+++ b/service/transcribestreamingservice/api.go
@@ -65,7 +65,7 @@ func (c *TranscribeStreamingService) StartStreamTranscriptionRequest(input *Star
 		protocol.RequireHTTPMinProtocol{Major: 2}.Handler,
 	)
 
-	es := newStartStreamTranscriptionEventStream()
+	es := NewStartStreamTranscriptionEventStream()
 	output.eventStream = es
 
 	req.Handlers.Sign.PushFront(es.setupInputPipe)
@@ -154,6 +154,10 @@ func (c *TranscribeStreamingService) StartStreamTranscriptionWithContext(ctx aws
 var _ awserr.Error
 
 // StartStreamTranscriptionEventStream provides the event stream handling for the StartStreamTranscription.
+//
+// For testing and mocking the event stream this type should be initialized via
+// the NewStartStreamTranscriptionEventStream constructor function. Using the functional options
+// to pass in nested mock behavior.
 type StartStreamTranscriptionEventStream struct {
 
 	// Writer is the EventStream writer for the AudioStream
@@ -181,11 +185,29 @@ type StartStreamTranscriptionEventStream struct {
 	err       *eventstreamapi.OnceError
 }
 
-func newStartStreamTranscriptionEventStream() *StartStreamTranscriptionEventStream {
-	return &StartStreamTranscriptionEventStream{
+// NewStartStreamTranscriptionEventStream initializes an StartStreamTranscriptionEventStream.
+// This function should only be used for testing and mocking the StartStreamTranscriptionEventStream
+// stream within your application.
+//
+// The Writer member must be set before writing events to the stream.
+//
+// The Reader member must be set before reading events from the stream.
+//
+//   es := NewStartStreamTranscriptionEventStream(func(o *StartStreamTranscriptionEventStream{
+//       es.Writer = myMockStreamWriter
+//       es.Reader = myMockStreamReader
+//   })
+func NewStartStreamTranscriptionEventStream(opts ...func(*StartStreamTranscriptionEventStream)) *StartStreamTranscriptionEventStream {
+	es := &StartStreamTranscriptionEventStream{
 		done: make(chan struct{}),
 		err:  eventstreamapi.NewOnceError(),
 	}
+
+	for _, fn := range opts {
+		fn(es)
+	}
+
+	return es
 }
 
 func (es *StartStreamTranscriptionEventStream) runOnStreamPartClose(r *request.Request) {


### PR DESCRIPTION
Fixes #3412 by exporting the operation's EventStream type's constructor function so it can be used to fully initialize fully when mocking out behavior for API operations with event streams.