### PR TITLE
aws/request: Allows "use of closed network connection" errors to be retryable

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 ### SDK Enhancements
 * `codegen`: Add XXX_Values functions for getting slice of API enums by type.
   * Fixes [#3441](https://github.com/aws/aws-sdk-go/issues/3441) by adding a new XXX_Values function for each API enum type that returns a slice of enum values, e.g `DomainStatus_Values`.
+* `aws/request`: Update default retry to retry "use of closed network connection" errors ([#3476](https://github.com/aws/aws-sdk-go/pull/3476))
+  * Fixes [#3406](https://github.com/aws/aws-sdk-go/issues/3406)
 
 ### SDK Bugs
 * `private/protocol/json/jsonutil`: Fixes a bug that truncated millisecond precision time in API response to seconds. ([#3474](https://github.com/aws/aws-sdk-go/pull/3474))

--- a/aws/request/connection_reset_error.go
+++ b/aws/request/connection_reset_error.go
@@ -9,7 +9,8 @@ func isErrConnectionReset(err error) bool {
 		return false
 	}
 
-	if strings.Contains(err.Error(), "connection reset") ||
+	if strings.Contains(err.Error(), "use of closed network connection") ||
+		strings.Contains(err.Error(), "connection reset") ||
 		strings.Contains(err.Error(), "broken pipe") {
 		return true
 	}

--- a/aws/request/connection_reset_error_test.go
+++ b/aws/request/connection_reset_error_test.go
@@ -56,6 +56,10 @@ func TestSerializationErrConnectionReset_accept(t *testing.T) {
 			Err:            errConnectionResetStub,
 			ExpectAttempts: 6,
 		},
+		"use of closed network connection": {
+			Err:            errUseOfClosedConnectionStub,
+			ExpectAttempts: 6,
+		},
 	}
 
 	for name, c := range cases {

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -64,6 +64,9 @@ var (
 
 	// Generic connection reset error
 	errConnectionResetStub = errors.New("connection reset")
+
+	// use of closed network connection error
+	errUseOfClosedConnectionStub = errors.New("use of closed network connection")
 )
 
 type testData struct {


### PR DESCRIPTION
Allows "use of closed network connection" errors to be retryable by the SDK.

Fixes #3406