### PR TITLE
Update SDK CI and sandbox tests for Go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ go:
     - 1.12.x
     - 1.13.x
     - 1.14.x
+    - 1.15.x
     - tip
 
 matrix:
@@ -36,6 +37,8 @@ matrix:
         - os: windows
           go: 1.14.x
         - os: windows
+          go: 1.15.x
+        - os: windows
           go: tip
 
 before_install:
@@ -43,7 +46,8 @@ before_install:
 
 script:
   - if [ -z $(go env GOMOD) ]; then
-      if [ "$TRAVIS_GO_VERSION" == "1.12.x" ] ||
+      if [ "$TRAVIS_GO_VERSION" == "1.13.x" ] ||
+          [ "$TRAVIS_GO_VERSION" == "1.12.x" ] ||
           [ "$TRAVIS_GO_VERSION" == "1.11.x" ] ||
           [ "$TRAVIS_GO_VERSION" == "1.10.x" ]; then
         make get-deps-x-tests;
@@ -51,8 +55,8 @@ script:
       make get-deps;
     fi;
     if [ "$TRAVIS_GO_VERSION" == "tip" ] ||
-        [ "$TRAVIS_GO_VERSION" == "1.14.x" ] ||
-        [ "$TRAVIS_GO_VERSION" == "1.13.x" ]; then
+        [ "$TRAVIS_GO_VERSION" == "1.15.x" ] ||
+        [ "$TRAVIS_GO_VERSION" == "1.14.x" ]; then
 
       if [ "$TRAVIS_OS_NAME" = "windows" ]; then
         make unit-no-verify;

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ cleanup-integ-buckets:
 ###################
 # Sandbox Testing #
 ###################
-sandbox-tests: sandbox-test-go1.5 sandbox-test-go1.6 sandbox-test-go1.7 sandbox-test-go1.8 sandbox-test-go1.9 sandbox-test-go1.10 sandbox-test-go1.11 sandbox-test-go1.12 sandbox-test-gotip
+sandbox-tests: sandbox-test-go1.5 sandbox-test-go1.6 sandbox-test-go1.7 sandbox-test-go1.8 sandbox-test-go1.9 sandbox-test-go1.10 sandbox-test-go1.11 sandbox-test-go1.12 sandbox-test-go1.13 sandbox-test-go1.14 sandbox-test-go1.15 sandbox-test-gotip
 
 sandbox-build-go1.5:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.5 -t "aws-sdk-go-1.5" .
@@ -172,6 +172,20 @@ sandbox-go1.13: sandbox-build-go1.13
 	docker run -i -t aws-sdk-go-1.13 bash
 sandbox-test-go1.13: sandbox-build-go1.13
 	docker run -t aws-sdk-go-1.13
+
+sandbox-build-go1.14:
+	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.14 -t "aws-sdk-go-1.14" .
+sandbox-go1.14: sandbox-build-go1.14
+	docker run -i -t aws-sdk-go-1.14 bash
+sandbox-test-go1.14: sandbox-build-go1.14
+	docker run -t aws-sdk-go-1.14
+
+sandbox-build-go1.15:
+	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.15 -t "aws-sdk-go-1.15" .
+sandbox-go1.15: sandbox-build-go1.15
+	docker run -i -t aws-sdk-go-1.15 bash
+sandbox-test-go1.15: sandbox-build-go1.15
+	docker run -t aws-sdk-go-1.15
 
 sandbox-build-gotip:
 	@echo "Run make update-aws-golang-tip, if this test fails because missing aws-golang:tip container"

--- a/awstesting/sandbox/Dockerfile.test.go1.14
+++ b/awstesting/sandbox/Dockerfile.test.go1.14
@@ -1,0 +1,12 @@
+FROM golang:1.14
+
+ENV GOPROXY=direct
+
+ADD . /go/src/github.com/aws/aws-sdk-go
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		vim \
+	&& rm -rf /var/list/apt/lists/*
+
+WORKDIR /go/src/github.com/aws/aws-sdk-go
+CMD ["make", "get-deps-verify", "unit"]

--- a/awstesting/sandbox/Dockerfile.test.go1.15
+++ b/awstesting/sandbox/Dockerfile.test.go1.15
@@ -1,0 +1,12 @@
+FROM golang:1.15
+
+ENV GOPROXY=direct
+
+ADD . /go/src/github.com/aws/aws-sdk-go
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		vim \
+	&& rm -rf /var/list/apt/lists/*
+
+WORKDIR /go/src/github.com/aws/aws-sdk-go
+CMD ["make", "get-deps-verify", "unit"]


### PR DESCRIPTION
Adds Go 1.15 to CI tests, and creates sandbox test environments for missing go versions.