### PR TITLE
add ContextLogger for enhanced logging capabilities

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws`: aws.Logger has been deprecated in favor of aws.ContextLogger. This allows passing the request context to the logger so that values can be pulled out of it. ([#3485](https://github.com/aws/aws-sdk-go/pull/3485))
 
 ### SDK Bugs

--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"fmt"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client/metadata"
@@ -59,8 +59,7 @@ func New(cfg aws.Config, info metadata.ClientInfo, handlers request.Handlers, op
 	case ok:
 		svc.Retryer = retryer
 	case cfg.Retryer != nil && cfg.Logger != nil:
-		s := fmt.Sprintf("WARNING: %T does not implement request.Retryer; using DefaultRetryer instead", cfg.Retryer)
-		cfg.Logger.Log(s)
+		awslog.Warnf(aws.BackgroundContext(), &cfg, "%T does not implement request.Retryer; using DefaultRetryer instead", cfg.Retryer)
 		fallthrough
 	default:
 		maxRetries := aws.IntValue(cfg.MaxRetries)

--- a/aws/config.go
+++ b/aws/config.go
@@ -84,7 +84,12 @@ type Config struct {
 
 	// The logger writer interface to write logging messages to. Defaults to
 	// standard out.
+	// This field is ignored if ContextLogger is non-nil.
+	// Deprecated: Use ContextLogger instead.
 	Logger Logger
+
+	// The logger interface to write logging messages with.
+	ContextLogger ContextLogger
 
 	// The maximum number of times that a request will be retried for failures.
 	// Defaults to -1, which defers the max retry setting to the service
@@ -362,8 +367,16 @@ func (c *Config) WithLogLevel(level LogLevelType) *Config {
 
 // WithLogger sets a config Logger value returning a Config pointer for
 // chaining.
+// Deprecated: Use WithContextLogger instead.
 func (c *Config) WithLogger(logger Logger) *Config {
 	c.Logger = logger
+	return c
+}
+
+// WithContextLogger sets a config ContextLogger value returning a Config pointer for
+// chaining.
+func (c *Config) WithContextLogger(logger ContextLogger) *Config {
+	c.ContextLogger = logger
 	return c
 }
 
@@ -498,6 +511,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.Logger != nil {
 		dst.Logger = other.Logger
+	}
+
+	if other.ContextLogger != nil {
+		dst.ContextLogger = other.ContextLogger
 	}
 
 	if other.MaxRetries != nil {

--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 	"github.com/aws/aws-sdk-go/internal/shareddefaults"
 )
 
@@ -172,9 +173,7 @@ func localHTTPCredProvider(cfg aws.Config, handlers request.Handlers, u string) 
 	}
 
 	if len(errMsg) > 0 {
-		if cfg.Logger != nil {
-			cfg.Logger.Log("Ignoring, HTTP credential provider", errMsg, err)
-		}
+		awslog.Error(aws.BackgroundContext(), &cfg, "Ignoring, HTTP credential provider", errMsg, err)
 		return credentials.ErrorProvider{
 			Err:          awserr.New("CredentialsEndpointError", errMsg, err),
 			ProviderName: endpointcreds.ProviderName,

--- a/aws/request/handlers.go
+++ b/aws/request/handlers.go
@@ -3,6 +3,8 @@ package request
 import (
 	"fmt"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/internal/awslog"
 )
 
 // A Handlers provides a collection of request handlers for various
@@ -281,7 +283,7 @@ func HandlerListLogItem(item HandlerListRunItem) bool {
 	if item.Request.Config.Logger == nil {
 		return true
 	}
-	item.Request.Config.Logger.Log("DEBUG: RequestHandler",
+	awslog.Debug(item.Request.Context(), &item.Request.Config, "RequestHandler",
 		item.Index, item.Handler.Name, item.Request.Error)
 
 	return true

--- a/aws/request/handlers_test.go
+++ b/aws/request/handlers_test.go
@@ -158,7 +158,7 @@ func TestLoggedHandlers(t *testing.T) {
 	loggedHandlers := []string{}
 	l.AfterEachFn = request.HandlerListLogItem
 	cfg := aws.Config{Logger: aws.LoggerFunc(func(args ...interface{}) {
-		loggedHandlers = append(loggedHandlers, args[2].(string))
+		loggedHandlers = append(loggedHandlers, args[3].(string))
 	})}
 
 	named1 := request.NamedHandler{Name: "name1", Fn: func(r *request.Request) {}}

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client/metadata"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 	"github.com/aws/aws-sdk-go/internal/sdkio"
 )
 
@@ -381,8 +382,8 @@ func debugLogReqError(r *Request, stage, retryStr string, err error) {
 		return
 	}
 
-	r.Config.Logger.Log(fmt.Sprintf("DEBUG: %s %s/%s failed, %s, error %v",
-		stage, r.ClientInfo.ServiceName, r.Operation.Name, retryStr, err))
+	awslog.Debugf(r.Context(), &r.Config, "%s %s/%s failed, %s, error %v",
+		stage, r.ClientInfo.ServiceName, r.Operation.Name, retryStr, err)
 }
 
 // Build will build the request's object so it can be signed and sent
@@ -547,8 +548,8 @@ func (r *Request) Send() error {
 
 func (r *Request) prepareRetry() error {
 	if r.Config.LogLevel.Matches(aws.LogDebugWithRequestRetries) {
-		r.Config.Logger.Log(fmt.Sprintf("DEBUG: Retrying Request %s/%s, attempt %d",
-			r.ClientInfo.ServiceName, r.Operation.Name, r.RetryCount))
+		awslog.Debugf(r.Context(), &r.Config, "Retrying Request %s/%s, attempt %d",
+			r.ClientInfo.ServiceName, r.Operation.Name, r.RetryCount)
 	}
 
 	// The previous http.Request will have a reference to the r.Body

--- a/aws/request/request_pagination.go
+++ b/aws/request/request_pagination.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 )
 
 // A Pagination provides paginating of SDK API operations which are paginatable.
@@ -188,12 +189,12 @@ func (r *Request) nextPageTokens() []interface{} {
 }
 
 // Ensure a deprecated item is only logged once instead of each time its used.
-func logDeprecatedf(logger aws.Logger, flag *int32, msg string) {
-	if logger == nil {
+func logDeprecated(r *Request, flag *int32, msg string) {
+	if r.Config.Logger == nil && r.Config.ContextLogger == nil {
 		return
 	}
 	if atomic.CompareAndSwapInt32(flag, 0, 1) {
-		logger.Log(msg)
+		awslog.Warn(r.Context(), &r.Config, msg)
 	}
 }
 
@@ -207,7 +208,7 @@ var (
 //
 // Deprecated Use Pagination type for configurable pagination of API operations
 func (r *Request) HasNextPage() bool {
-	logDeprecatedf(r.Config.Logger, &logDeprecatedHasNextPage,
+	logDeprecated(r, &logDeprecatedHasNextPage,
 		"Request.HasNextPage deprecated. Use Pagination type for configurable pagination of API operations")
 
 	return len(r.nextPageTokens()) > 0
@@ -218,7 +219,7 @@ func (r *Request) HasNextPage() bool {
 //
 // Deprecated Use Pagination type for configurable pagination of API operations
 func (r *Request) NextPage() *Request {
-	logDeprecatedf(r.Config.Logger, &logDeprecatedNextPage,
+	logDeprecated(r, &logDeprecatedNextPage,
 		"Request.NextPage deprecated. Use Pagination type for configurable pagination of API operations")
 
 	tokens := r.nextPageTokens()
@@ -250,7 +251,7 @@ func (r *Request) NextPage() *Request {
 //
 // Deprecated Use Pagination type for configurable pagination of API operations
 func (r *Request) EachPage(fn func(data interface{}, isLastPage bool) (shouldContinue bool)) error {
-	logDeprecatedf(r.Config.Logger, &logDeprecatedEachPage,
+	logDeprecated(r, &logDeprecatedEachPage,
 		"Request.EachPage deprecated. Use Pagination type for configurable pagination of API operations")
 
 	for page := r; page != nil; page = page.NextPage() {

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 )
 
 // Retryer provides the interface drive the SDK's request retry behavior. The
@@ -38,9 +39,7 @@ type Retryer interface {
 // value for chaining. The value must not be nil.
 func WithRetryer(cfg *aws.Config, retryer Retryer) *aws.Config {
 	if retryer == nil {
-		if cfg.Logger != nil {
-			cfg.Logger.Log("ERROR: Request.WithRetryer called with nil retryer. Replacing with retry disabled Retryer.")
-		}
+		awslog.Error(aws.BackgroundContext(), cfg, "Request.WithRetryer called with nil retryer. Replacing with retry disabled Retryer.")
 		retryer = noOpRetryer{}
 	}
 	cfg.Retryer = retryer

--- a/internal/awslog/log.go
+++ b/internal/awslog/log.go
@@ -1,0 +1,124 @@
+package awslog
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+// Error logs an error via the Config's ContextLogger or Logger.
+func Error(ctx aws.Context, c *aws.Config, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Error(ctx, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(prefixLevel("ERROR:", v)...)
+	} else {
+		// no-op
+	}
+}
+
+// Errorf logs an error via the Config's ContextLogger or Logger.
+func Errorf(ctx aws.Context, c *aws.Config, format string, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Errorf(ctx, format, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(fmt.Sprintf("ERROR: "+format, v...))
+	} else {
+		// no-op
+	}
+}
+
+// Warn logs a warning via the Config's ContextLogger or Logger.
+func Warn(ctx aws.Context, c *aws.Config, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Warn(ctx, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(prefixLevel("WARNING:", v)...)
+	} else {
+		// no-op
+	}
+}
+
+// Warnf logs a warning via the Config's ContextLogger or Logger.
+func Warnf(ctx aws.Context, c *aws.Config, format string, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Warnf(ctx, format, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(fmt.Sprintf("WARNING: "+format, v...))
+	} else {
+		// no-op
+	}
+}
+
+// Info logs an information message via the Config's ContextLogger or Logger.
+func Info(ctx aws.Context, c *aws.Config, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Info(ctx, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(prefixLevel("INFO:", v)...)
+	} else {
+		// no-op
+	}
+}
+
+// Infof logs an information message via the Config's ContextLogger or Logger.
+func Infof(ctx aws.Context, c *aws.Config, format string, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Infof(ctx, format, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(fmt.Sprintf("INFO: "+format, v...))
+	} else {
+		// no-op
+	}
+}
+
+// DebugError logs a debug error via the Config's ContextLogger or Logger.
+func DebugError(ctx aws.Context, c *aws.Config, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Error(ctx, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(prefixLevel("DEBUG ERROR:", v)...)
+	} else {
+		// no-op
+	}
+}
+
+// DebugErrorf logs a debug error via the Config's ContextLogger or Logger.
+func DebugErrorf(ctx aws.Context, c *aws.Config, format string, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Errorf(ctx, format, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(fmt.Sprintf("DEBUG ERROR: "+format, v...))
+	} else {
+		// no-op
+	}
+}
+
+// Debug logs a debug message via the Config's ContextLogger or Logger.
+func Debug(ctx aws.Context, c *aws.Config, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Debug(ctx, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(prefixLevel("DEBUG:", v)...)
+	} else {
+		// no-op
+	}
+}
+
+// Debugf logs a debug message via the Config's ContextLogger or Logger.
+func Debugf(ctx aws.Context, c *aws.Config, format string, v ...interface{}) {
+	if c.ContextLogger != nil {
+		c.ContextLogger.Debugf(ctx, format, v...)
+	} else if c.Logger != nil {
+		c.Logger.Log(fmt.Sprintf("DEBUG: "+format, v...))
+	} else {
+		// no-op
+	}
+}
+
+func prefixLevel(level string, v []interface{}) []interface{} {
+	cpy := make([]interface{}, len(v)+1)
+	cpy[0] = level
+	copy(cpy[1:], v)
+	return cpy
+}

--- a/private/checksum/content_md5.go
+++ b/private/checksum/content_md5.go
@@ -3,11 +3,11 @@ package checksum
 import (
 	"crypto/md5"
 	"encoding/base64"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 )
 
 const contentMD5Header = "Content-Md5"
@@ -32,11 +32,9 @@ func AddBodyContentMD5Handler(r *request.Request) {
 
 	// if body is not seekable, return
 	if !aws.IsReaderSeekable(r.Body) {
-		if r.Config.Logger != nil {
-			r.Config.Logger.Log(fmt.Sprintf(
-				"Unable to compute Content-MD5 for unseekable body, S3.%s",
-				r.Operation.Name))
-		}
+		awslog.Errorf(r.Context(), &r.Config,
+			"Unable to compute Content-MD5 for unseekable body, S3.%s",
+			r.Operation.Name)
 		return
 	}
 

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -189,8 +189,13 @@ func (es *EmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
 
 func (es *EmptyStreamEventStream) runOutputStream(r *request.Request) {
 	var opts []func(*eventstream.Decoder)
-	if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
-		opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+	if r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		if r.Config.ContextLogger != nil {
+			opts = append(opts, eventstream.DecodeWithContextLogger(r.Config.ContextLogger))
+		}
+		if r.Config.Logger != nil {
+			opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+		}
 	}
 
 	unmarshalerForEvent := unmarshalerForEmptyEventStreamEvent{
@@ -423,8 +428,13 @@ func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 
 func (es *GetEventStreamEventStream) runOutputStream(r *request.Request) {
 	var opts []func(*eventstream.Decoder)
-	if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
-		opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+	if r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		if r.Config.ContextLogger != nil {
+			opts = append(opts, eventstream.DecodeWithContextLogger(r.Config.ContextLogger))
+		}
+		if r.Config.Logger != nil {
+			opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+		}
 	}
 
 	unmarshalerForEvent := unmarshalerForEventStreamEvent{

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -189,8 +189,13 @@ func (es *EmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
 
 func (es *EmptyStreamEventStream) runOutputStream(r *request.Request) {
 	var opts []func(*eventstream.Decoder)
-	if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
-		opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+	if r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		if r.Config.ContextLogger != nil {
+			opts = append(opts, eventstream.DecodeWithContextLogger(r.Config.ContextLogger))
+		}
+		if r.Config.Logger != nil {
+			opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+		}
 	}
 
 	unmarshalerForEvent := unmarshalerForEmptyEventStreamEvent{
@@ -423,8 +428,13 @@ func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 
 func (es *GetEventStreamEventStream) runOutputStream(r *request.Request) {
 	var opts []func(*eventstream.Decoder)
-	if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
-		opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+	if r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		if r.Config.ContextLogger != nil {
+			opts = append(opts, eventstream.DecodeWithContextLogger(r.Config.ContextLogger))
+		}
+		if r.Config.Logger != nil {
+			opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+		}
 	}
 
 	unmarshalerForEvent := unmarshalerForEventStreamEvent{

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -204,8 +204,13 @@ func (es *EmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
 
 func (es *EmptyStreamEventStream) runOutputStream(r *request.Request) {
 	var opts []func(*eventstream.Decoder)
-	if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
-		opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+	if r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		if r.Config.ContextLogger != nil {
+			opts = append(opts, eventstream.DecodeWithContextLogger(r.Config.ContextLogger))
+		}
+		if r.Config.Logger != nil {
+			opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+		}
 	}
 
 	unmarshalerForEvent := unmarshalerForEmptyEventStreamEvent{
@@ -481,8 +486,13 @@ func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 
 func (es *GetEventStreamEventStream) runOutputStream(r *request.Request) {
 	var opts []func(*eventstream.Decoder)
-	if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
-		opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+	if r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		if r.Config.ContextLogger != nil {
+			opts = append(opts, eventstream.DecodeWithContextLogger(r.Config.ContextLogger))
+		}
+		if r.Config.Logger != nil {
+			opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+		}
 	}
 
 	unmarshalerForEvent := unmarshalerForEventStreamEvent{

--- a/private/model/api/eventstream_tmpl.go
+++ b/private/model/api/eventstream_tmpl.go
@@ -227,7 +227,10 @@ func (es *{{ $esapi.Name }}) waitStreamPartClose() {
 
 	func (es *{{ $esapi.Name }}) runInputStream(r *request.Request) {
 		var opts []func(*eventstream.Encoder)
-		if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		if r.Config.ContextLogger != nil {
+			opts = append(opts, eventstream.EncodeWithContextLogger(r.Config.ContextLogger))
+		}
+		if r.Config.Logger != nil {
 			opts = append(opts, eventstream.EncodeWithLogger(r.Config.Logger))
 		}
 		var encoder eventstreamapi.Encoder = eventstream.NewEncoder(es.inputWriter, opts...)
@@ -304,8 +307,13 @@ func (es *{{ $esapi.Name }}) waitStreamPartClose() {
 
 	func (es *{{ $esapi.Name }}) runOutputStream(r *request.Request) {
 		var opts []func(*eventstream.Decoder)
-		if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
-			opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+		if r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+			if r.Config.ContextLogger != nil {
+				opts = append(opts, eventstream.DecodeWithContextLogger(r.Config.ContextLogger))
+			}
+			if r.Config.Logger != nil {
+				opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+			}
 		}
 
 		unmarshalerForEvent := {{ $outputStream.StreamUnmarshalerForEventName }}{

--- a/private/model/api/waiters.go
+++ b/private/model/api/waiters.go
@@ -146,6 +146,7 @@ func (c *{{ .Operation.API.StructName }}) WaitUntil{{ .Name }}WithContext(` +
 			{{ end }}
 		},
 		Logger: c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy {{ .Operation.InputRef.GoType }}
 			if input != nil  {

--- a/private/signer/v2/request_context_go1.5.go
+++ b/private/signer/v2/request_context_go1.5.go
@@ -1,0 +1,13 @@
+// +build !go1.7
+
+package v2
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func requestContext(r *http.Request) aws.Context {
+	return aws.BackgroundContext()
+}

--- a/private/signer/v2/request_context_go1.7.go
+++ b/private/signer/v2/request_context_go1.7.go
@@ -1,0 +1,13 @@
+// +build go1.7
+
+package v2
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func requestContext(r *http.Request) aws.Context {
+	return r.Context()
+}

--- a/service/acm/waiters.go
+++ b/service/acm/waiters.go
@@ -52,7 +52,8 @@ func (c *ACM) WaitUntilCertificateValidatedWithContext(ctx aws.Context, input *D
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeCertificateInput
 			if input != nil {

--- a/service/acmpca/waiters.go
+++ b/service/acmpca/waiters.go
@@ -42,7 +42,8 @@ func (c *ACMPCA) WaitUntilAuditReportCreatedWithContext(ctx aws.Context, input *
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeCertificateAuthorityAuditReportInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *ACMPCA) WaitUntilCertificateAuthorityCSRCreatedWithContext(ctx aws.Cont
 				Expected: "RequestInProgressException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetCertificateAuthorityCsrInput
 			if input != nil {
@@ -144,7 +146,8 @@ func (c *ACMPCA) WaitUntilCertificateIssuedWithContext(ctx aws.Context, input *G
 				Expected: "RequestInProgressException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetCertificateInput
 			if input != nil {

--- a/service/applicationdiscoveryservice/api.go
+++ b/service/applicationdiscoveryservice/api.go
@@ -991,9 +991,15 @@ const opDescribeExportConfigurations = "DescribeExportConfigurations"
 //
 // Deprecated: DescribeExportConfigurations has been deprecated
 func (c *ApplicationDiscoveryService) DescribeExportConfigurationsRequest(input *DescribeExportConfigurationsInput) (req *request.Request, output *DescribeExportConfigurationsOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DescribeExportConfigurations, has been deprecated")
+	msg := "This operation, DescribeExportConfigurations, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDescribeExportConfigurations,
 		HTTPMethod: "POST",
@@ -1547,9 +1553,15 @@ const opExportConfigurations = "ExportConfigurations"
 //
 // Deprecated: ExportConfigurations has been deprecated
 func (c *ApplicationDiscoveryService) ExportConfigurationsRequest(input *ExportConfigurationsInput) (req *request.Request, output *ExportConfigurationsOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, ExportConfigurations, has been deprecated")
+	msg := "This operation, ExportConfigurations, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opExportConfigurations,
 		HTTPMethod: "POST",

--- a/service/appstream/waiters.go
+++ b/service/appstream/waiters.go
@@ -47,7 +47,8 @@ func (c *AppStream) WaitUntilFleetStartedWithContext(ctx aws.Context, input *Des
 				Expected: "INACTIVE",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeFleetsInput
 			if input != nil {
@@ -103,7 +104,8 @@ func (c *AppStream) WaitUntilFleetStoppedWithContext(ctx aws.Context, input *Des
 				Expected: "ACTIVE",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeFleetsInput
 			if input != nil {

--- a/service/autoscaling/waiters.go
+++ b/service/autoscaling/waiters.go
@@ -42,7 +42,8 @@ func (c *AutoScaling) WaitUntilGroupExistsWithContext(ctx aws.Context, input *De
 				Expected: false,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAutoScalingGroupsInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *AutoScaling) WaitUntilGroupInServiceWithContext(ctx aws.Context, input 
 				Expected: true,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAutoScalingGroupsInput
 			if input != nil {
@@ -144,7 +146,8 @@ func (c *AutoScaling) WaitUntilGroupNotExistsWithContext(ctx aws.Context, input 
 				Expected: true,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAutoScalingGroupsInput
 			if input != nil {

--- a/service/cloudformation/waiters.go
+++ b/service/cloudformation/waiters.go
@@ -47,7 +47,8 @@ func (c *CloudFormation) WaitUntilChangeSetCreateCompleteWithContext(ctx aws.Con
 				Expected: "ValidationError",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeChangeSetInput
 			if input != nil {
@@ -123,7 +124,8 @@ func (c *CloudFormation) WaitUntilStackCreateCompleteWithContext(ctx aws.Context
 				Expected: "ValidationError",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeStacksInput
 			if input != nil {
@@ -204,7 +206,8 @@ func (c *CloudFormation) WaitUntilStackDeleteCompleteWithContext(ctx aws.Context
 				Expected: "UPDATE_ROLLBACK_COMPLETE",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeStacksInput
 			if input != nil {
@@ -255,7 +258,8 @@ func (c *CloudFormation) WaitUntilStackExistsWithContext(ctx aws.Context, input 
 				Expected: "ValidationError",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeStacksInput
 			if input != nil {
@@ -331,7 +335,8 @@ func (c *CloudFormation) WaitUntilStackImportCompleteWithContext(ctx aws.Context
 				Expected: "ValidationError",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeStacksInput
 			if input != nil {
@@ -397,7 +402,8 @@ func (c *CloudFormation) WaitUntilStackRollbackCompleteWithContext(ctx aws.Conte
 				Expected: "ValidationError",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeStacksInput
 			if input != nil {
@@ -463,7 +469,8 @@ func (c *CloudFormation) WaitUntilStackUpdateCompleteWithContext(ctx aws.Context
 				Expected: "ValidationError",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeStacksInput
 			if input != nil {
@@ -514,7 +521,8 @@ func (c *CloudFormation) WaitUntilTypeRegistrationCompleteWithContext(ctx aws.Co
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeTypeRegistrationInput
 			if input != nil {

--- a/service/cloudfront/waiters.go
+++ b/service/cloudfront/waiters.go
@@ -37,7 +37,8 @@ func (c *CloudFront) WaitUntilDistributionDeployedWithContext(ctx aws.Context, i
 				Expected: "Deployed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetDistributionInput
 			if input != nil {
@@ -83,7 +84,8 @@ func (c *CloudFront) WaitUntilInvalidationCompletedWithContext(ctx aws.Context, 
 				Expected: "Completed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetInvalidationInput
 			if input != nil {
@@ -129,7 +131,8 @@ func (c *CloudFront) WaitUntilStreamingDistributionDeployedWithContext(ctx aws.C
 				Expected: "Deployed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetStreamingDistributionInput
 			if input != nil {

--- a/service/cloudwatch/waiters.go
+++ b/service/cloudwatch/waiters.go
@@ -37,7 +37,8 @@ func (c *CloudWatch) WaitUntilAlarmExistsWithContext(ctx aws.Context, input *Des
 				Expected: true,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAlarmsInput
 			if input != nil {
@@ -83,7 +84,8 @@ func (c *CloudWatch) WaitUntilCompositeAlarmExistsWithContext(ctx aws.Context, i
 				Expected: true,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAlarmsInput
 			if input != nil {

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -422,9 +422,15 @@ const opBatchGetDeploymentInstances = "BatchGetDeploymentInstances"
 //
 // Deprecated: This operation is deprecated, use BatchGetDeploymentTargets instead.
 func (c *CodeDeploy) BatchGetDeploymentInstancesRequest(input *BatchGetDeploymentInstancesInput) (req *request.Request, output *BatchGetDeploymentInstancesOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, BatchGetDeploymentInstances, has been deprecated")
+	msg := "This operation, BatchGetDeploymentInstances, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opBatchGetDeploymentInstances,
 		HTTPMethod: "POST",
@@ -2473,9 +2479,15 @@ const opGetDeploymentInstance = "GetDeploymentInstance"
 //
 // Deprecated: This operation is deprecated, use GetDeploymentTarget instead.
 func (c *CodeDeploy) GetDeploymentInstanceRequest(input *GetDeploymentInstanceInput) (req *request.Request, output *GetDeploymentInstanceOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, GetDeploymentInstance, has been deprecated")
+	msg := "This operation, GetDeploymentInstance, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opGetDeploymentInstance,
 		HTTPMethod: "POST",
@@ -3351,9 +3363,15 @@ const opListDeploymentInstances = "ListDeploymentInstances"
 //
 // Deprecated: This operation is deprecated, use ListDeploymentTargets instead.
 func (c *CodeDeploy) ListDeploymentInstancesRequest(input *ListDeploymentInstancesInput) (req *request.Request, output *ListDeploymentInstancesOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, ListDeploymentInstances, has been deprecated")
+	msg := "This operation, ListDeploymentInstances, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opListDeploymentInstances,
 		HTTPMethod: "POST",
@@ -4484,9 +4502,15 @@ const opSkipWaitTimeForInstanceTermination = "SkipWaitTimeForInstanceTermination
 //
 // Deprecated: This operation is deprecated, use ContinueDeployment with DeploymentWaitType instead.
 func (c *CodeDeploy) SkipWaitTimeForInstanceTerminationRequest(input *SkipWaitTimeForInstanceTerminationInput) (req *request.Request, output *SkipWaitTimeForInstanceTerminationOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, SkipWaitTimeForInstanceTermination, has been deprecated")
+	msg := "This operation, SkipWaitTimeForInstanceTermination, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opSkipWaitTimeForInstanceTermination,
 		HTTPMethod: "POST",

--- a/service/codedeploy/waiters.go
+++ b/service/codedeploy/waiters.go
@@ -47,7 +47,8 @@ func (c *CodeDeploy) WaitUntilDeploymentSuccessfulWithContext(ctx aws.Context, i
 				Expected: "Stopped",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetDeploymentInput
 			if input != nil {

--- a/service/comprehendmedical/api.go
+++ b/service/comprehendmedical/api.go
@@ -413,9 +413,15 @@ const opDetectEntities = "DetectEntities"
 //
 // Deprecated: This operation is deprecated, use DetectEntitiesV2 instead.
 func (c *ComprehendMedical) DetectEntitiesRequest(input *DetectEntitiesInput) (req *request.Request, output *DetectEntitiesOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DetectEntities, has been deprecated")
+	msg := "This operation, DetectEntities, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDetectEntities,
 		HTTPMethod: "POST",

--- a/service/databasemigrationservice/waiters.go
+++ b/service/databasemigrationservice/waiters.go
@@ -47,7 +47,8 @@ func (c *DatabaseMigrationService) WaitUntilEndpointDeletedWithContext(ctx aws.C
 				Expected: "creating",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeEndpointsInput
 			if input != nil {
@@ -113,7 +114,8 @@ func (c *DatabaseMigrationService) WaitUntilReplicationInstanceAvailableWithCont
 				Expected: "inaccessible-encryption-credentials",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeReplicationInstancesInput
 			if input != nil {
@@ -164,7 +166,8 @@ func (c *DatabaseMigrationService) WaitUntilReplicationInstanceDeletedWithContex
 				Expected: "ResourceNotFoundFault",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeReplicationInstancesInput
 			if input != nil {
@@ -235,7 +238,8 @@ func (c *DatabaseMigrationService) WaitUntilReplicationTaskDeletedWithContext(ct
 				Expected: "ResourceNotFoundFault",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeReplicationTasksInput
 			if input != nil {
@@ -321,7 +325,8 @@ func (c *DatabaseMigrationService) WaitUntilReplicationTaskReadyWithContext(ctx 
 				Expected: "deleting",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeReplicationTasksInput
 			if input != nil {
@@ -407,7 +412,8 @@ func (c *DatabaseMigrationService) WaitUntilReplicationTaskRunningWithContext(ct
 				Expected: "deleting",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeReplicationTasksInput
 			if input != nil {
@@ -493,7 +499,8 @@ func (c *DatabaseMigrationService) WaitUntilReplicationTaskStoppedWithContext(ct
 				Expected: "deleting",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeReplicationTasksInput
 			if input != nil {
@@ -544,7 +551,8 @@ func (c *DatabaseMigrationService) WaitUntilTestConnectionSucceedsWithContext(ct
 				Expected: "failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeConnectionsInput
 			if input != nil {

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -125,9 +125,15 @@ const opAllocateConnectionOnInterconnect = "AllocateConnectionOnInterconnect"
 //
 // Deprecated: AllocateConnectionOnInterconnect has been deprecated
 func (c *DirectConnect) AllocateConnectionOnInterconnectRequest(input *AllocateConnectionOnInterconnectInput) (req *request.Request, output *Connection) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, AllocateConnectionOnInterconnect, has been deprecated")
+	msg := "This operation, AllocateConnectionOnInterconnect, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opAllocateConnectionOnInterconnect,
 		HTTPMethod: "POST",
@@ -2885,9 +2891,15 @@ const opDescribeConnectionLoa = "DescribeConnectionLoa"
 //
 // Deprecated: DescribeConnectionLoa has been deprecated
 func (c *DirectConnect) DescribeConnectionLoaRequest(input *DescribeConnectionLoaInput) (req *request.Request, output *DescribeConnectionLoaOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DescribeConnectionLoa, has been deprecated")
+	msg := "This operation, DescribeConnectionLoa, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDescribeConnectionLoa,
 		HTTPMethod: "POST",
@@ -3066,9 +3078,15 @@ const opDescribeConnectionsOnInterconnect = "DescribeConnectionsOnInterconnect"
 //
 // Deprecated: DescribeConnectionsOnInterconnect has been deprecated
 func (c *DirectConnect) DescribeConnectionsOnInterconnectRequest(input *DescribeConnectionsOnInterconnectInput) (req *request.Request, output *Connections) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DescribeConnectionsOnInterconnect, has been deprecated")
+	msg := "This operation, DescribeConnectionsOnInterconnect, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDescribeConnectionsOnInterconnect,
 		HTTPMethod: "POST",
@@ -3589,9 +3607,15 @@ const opDescribeInterconnectLoa = "DescribeInterconnectLoa"
 //
 // Deprecated: DescribeInterconnectLoa has been deprecated
 func (c *DirectConnect) DescribeInterconnectLoaRequest(input *DescribeInterconnectLoaInput) (req *request.Request, output *DescribeInterconnectLoaOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DescribeInterconnectLoa, has been deprecated")
+	msg := "This operation, DescribeInterconnectLoa, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDescribeInterconnectLoa,
 		HTTPMethod: "POST",

--- a/service/docdb/waiters.go
+++ b/service/docdb/waiters.go
@@ -62,7 +62,8 @@ func (c *DocDB) WaitUntilDBInstanceAvailableWithContext(ctx aws.Context, input *
 				Expected: "incompatible-parameters",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBInstancesInput
 			if input != nil {
@@ -133,7 +134,8 @@ func (c *DocDB) WaitUntilDBInstanceDeletedWithContext(ctx aws.Context, input *De
 				Expected: "resetting-master-credentials",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBInstancesInput
 			if input != nil {

--- a/service/dynamodb/waiters.go
+++ b/service/dynamodb/waiters.go
@@ -42,7 +42,8 @@ func (c *DynamoDB) WaitUntilTableExistsWithContext(ctx aws.Context, input *Descr
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeTableInput
 			if input != nil {
@@ -88,7 +89,8 @@ func (c *DynamoDB) WaitUntilTableNotExistsWithContext(ctx aws.Context, input *De
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeTableInput
 			if input != nil {

--- a/service/ec2/waiters.go
+++ b/service/ec2/waiters.go
@@ -42,7 +42,8 @@ func (c *EC2) WaitUntilBundleTaskCompleteWithContext(ctx aws.Context, input *Des
 				Expected: "failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeBundleTasksInput
 			if input != nil {
@@ -88,7 +89,8 @@ func (c *EC2) WaitUntilConversionTaskCancelledWithContext(ctx aws.Context, input
 				Expected: "cancelled",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeConversionTasksInput
 			if input != nil {
@@ -144,7 +146,8 @@ func (c *EC2) WaitUntilConversionTaskCompletedWithContext(ctx aws.Context, input
 				Expected: "cancelling",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeConversionTasksInput
 			if input != nil {
@@ -190,7 +193,8 @@ func (c *EC2) WaitUntilConversionTaskDeletedWithContext(ctx aws.Context, input *
 				Expected: "deleted",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeConversionTasksInput
 			if input != nil {
@@ -246,7 +250,8 @@ func (c *EC2) WaitUntilCustomerGatewayAvailableWithContext(ctx aws.Context, inpu
 				Expected: "deleting",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeCustomerGatewaysInput
 			if input != nil {
@@ -292,7 +297,8 @@ func (c *EC2) WaitUntilExportTaskCancelledWithContext(ctx aws.Context, input *De
 				Expected: "cancelled",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeExportTasksInput
 			if input != nil {
@@ -338,7 +344,8 @@ func (c *EC2) WaitUntilExportTaskCompletedWithContext(ctx aws.Context, input *De
 				Expected: "completed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeExportTasksInput
 			if input != nil {
@@ -389,7 +396,8 @@ func (c *EC2) WaitUntilImageAvailableWithContext(ctx aws.Context, input *Describ
 				Expected: "failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeImagesInput
 			if input != nil {
@@ -440,7 +448,8 @@ func (c *EC2) WaitUntilImageExistsWithContext(ctx aws.Context, input *DescribeIm
 				Expected: "InvalidAMIID.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeImagesInput
 			if input != nil {
@@ -491,7 +500,8 @@ func (c *EC2) WaitUntilInstanceExistsWithContext(ctx aws.Context, input *Describ
 				Expected: "InvalidInstanceID.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstancesInput
 			if input != nil {
@@ -557,7 +567,8 @@ func (c *EC2) WaitUntilInstanceRunningWithContext(ctx aws.Context, input *Descri
 				Expected: "InvalidInstanceID.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstancesInput
 			if input != nil {
@@ -608,7 +619,8 @@ func (c *EC2) WaitUntilInstanceStatusOkWithContext(ctx aws.Context, input *Descr
 				Expected: "InvalidInstanceID.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstanceStatusInput
 			if input != nil {
@@ -664,7 +676,8 @@ func (c *EC2) WaitUntilInstanceStoppedWithContext(ctx aws.Context, input *Descri
 				Expected: "terminated",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstancesInput
 			if input != nil {
@@ -720,7 +733,8 @@ func (c *EC2) WaitUntilInstanceTerminatedWithContext(ctx aws.Context, input *Des
 				Expected: "stopping",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstancesInput
 			if input != nil {
@@ -771,7 +785,8 @@ func (c *EC2) WaitUntilKeyPairExistsWithContext(ctx aws.Context, input *Describe
 				Expected: "InvalidKeyPair.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeKeyPairsInput
 			if input != nil {
@@ -837,7 +852,8 @@ func (c *EC2) WaitUntilNatGatewayAvailableWithContext(ctx aws.Context, input *De
 				Expected: "NatGatewayNotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeNatGatewaysInput
 			if input != nil {
@@ -888,7 +904,8 @@ func (c *EC2) WaitUntilNetworkInterfaceAvailableWithContext(ctx aws.Context, inp
 				Expected: "InvalidNetworkInterfaceID.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeNetworkInterfacesInput
 			if input != nil {
@@ -934,7 +951,8 @@ func (c *EC2) WaitUntilPasswordDataAvailableWithContext(ctx aws.Context, input *
 				Expected: true,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetPasswordDataInput
 			if input != nil {
@@ -985,7 +1003,8 @@ func (c *EC2) WaitUntilSecurityGroupExistsWithContext(ctx aws.Context, input *De
 				Expected: "InvalidGroupNotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeSecurityGroupsInput
 			if input != nil {
@@ -1031,7 +1050,8 @@ func (c *EC2) WaitUntilSnapshotCompletedWithContext(ctx aws.Context, input *Desc
 				Expected: "completed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeSnapshotsInput
 			if input != nil {
@@ -1107,7 +1127,8 @@ func (c *EC2) WaitUntilSpotInstanceRequestFulfilledWithContext(ctx aws.Context, 
 				Expected: "InvalidSpotInstanceRequestID.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeSpotInstanceRequestsInput
 			if input != nil {
@@ -1153,7 +1174,8 @@ func (c *EC2) WaitUntilSubnetAvailableWithContext(ctx aws.Context, input *Descri
 				Expected: "available",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeSubnetsInput
 			if input != nil {
@@ -1199,7 +1221,8 @@ func (c *EC2) WaitUntilSystemStatusOkWithContext(ctx aws.Context, input *Describ
 				Expected: "ok",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstanceStatusInput
 			if input != nil {
@@ -1250,7 +1273,8 @@ func (c *EC2) WaitUntilVolumeAvailableWithContext(ctx aws.Context, input *Descri
 				Expected: "deleted",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVolumesInput
 			if input != nil {
@@ -1301,7 +1325,8 @@ func (c *EC2) WaitUntilVolumeDeletedWithContext(ctx aws.Context, input *Describe
 				Expected: "InvalidVolume.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVolumesInput
 			if input != nil {
@@ -1352,7 +1377,8 @@ func (c *EC2) WaitUntilVolumeInUseWithContext(ctx aws.Context, input *DescribeVo
 				Expected: "deleted",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVolumesInput
 			if input != nil {
@@ -1398,7 +1424,8 @@ func (c *EC2) WaitUntilVpcAvailableWithContext(ctx aws.Context, input *DescribeV
 				Expected: "available",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVpcsInput
 			if input != nil {
@@ -1449,7 +1476,8 @@ func (c *EC2) WaitUntilVpcExistsWithContext(ctx aws.Context, input *DescribeVpcs
 				Expected: "InvalidVpcID.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVpcsInput
 			if input != nil {
@@ -1500,7 +1528,8 @@ func (c *EC2) WaitUntilVpcPeeringConnectionDeletedWithContext(ctx aws.Context, i
 				Expected: "InvalidVpcPeeringConnectionID.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVpcPeeringConnectionsInput
 			if input != nil {
@@ -1551,7 +1580,8 @@ func (c *EC2) WaitUntilVpcPeeringConnectionExistsWithContext(ctx aws.Context, in
 				Expected: "InvalidVpcPeeringConnectionID.NotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVpcPeeringConnectionsInput
 			if input != nil {
@@ -1607,7 +1637,8 @@ func (c *EC2) WaitUntilVpnConnectionAvailableWithContext(ctx aws.Context, input 
 				Expected: "deleted",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVpnConnectionsInput
 			if input != nil {
@@ -1658,7 +1689,8 @@ func (c *EC2) WaitUntilVpnConnectionDeletedWithContext(ctx aws.Context, input *D
 				Expected: "pending",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVpnConnectionsInput
 			if input != nil {

--- a/service/ecr/waiters.go
+++ b/service/ecr/waiters.go
@@ -42,7 +42,8 @@ func (c *ECR) WaitUntilImageScanCompleteWithContext(ctx aws.Context, input *Desc
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeImageScanFindingsInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *ECR) WaitUntilLifecyclePolicyPreviewCompleteWithContext(ctx aws.Context
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetLifecyclePolicyPreviewInput
 			if input != nil {

--- a/service/ecs/waiters.go
+++ b/service/ecs/waiters.go
@@ -42,7 +42,8 @@ func (c *ECS) WaitUntilServicesInactiveWithContext(ctx aws.Context, input *Descr
 				Expected: "INACTIVE",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeServicesInput
 			if input != nil {
@@ -103,7 +104,8 @@ func (c *ECS) WaitUntilServicesStableWithContext(ctx aws.Context, input *Describ
 				Expected: true,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeServicesInput
 			if input != nil {
@@ -159,7 +161,8 @@ func (c *ECS) WaitUntilTasksRunningWithContext(ctx aws.Context, input *DescribeT
 				Expected: "RUNNING",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeTasksInput
 			if input != nil {
@@ -205,7 +208,8 @@ func (c *ECS) WaitUntilTasksStoppedWithContext(ctx aws.Context, input *DescribeT
 				Expected: "STOPPED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeTasksInput
 			if input != nil {

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -509,9 +509,15 @@ const opCreateTags = "CreateTags"
 //
 // Deprecated: Use TagResource.
 func (c *EFS) CreateTagsRequest(input *CreateTagsInput) (req *request.Request, output *CreateTagsOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, CreateTags, has been deprecated")
+	msg := "This operation, CreateTags, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opCreateTags,
 		HTTPMethod: "POST",
@@ -1021,9 +1027,15 @@ const opDeleteTags = "DeleteTags"
 //
 // Deprecated: Use UntagResource.
 func (c *EFS) DeleteTagsRequest(input *DeleteTagsInput) (req *request.Request, output *DeleteTagsOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DeleteTags, has been deprecated")
+	msg := "This operation, DeleteTags, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDeleteTags,
 		HTTPMethod: "POST",
@@ -1928,9 +1940,15 @@ const opDescribeTags = "DescribeTags"
 //
 // Deprecated: Use ListTagsForResource.
 func (c *EFS) DescribeTagsRequest(input *DescribeTagsInput) (req *request.Request, output *DescribeTagsOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DescribeTags, has been deprecated")
+	msg := "This operation, DescribeTags, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDescribeTags,
 		HTTPMethod: "GET",

--- a/service/eks/waiters.go
+++ b/service/eks/waiters.go
@@ -47,7 +47,8 @@ func (c *EKS) WaitUntilClusterActiveWithContext(ctx aws.Context, input *Describe
 				Expected: "ACTIVE",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeClusterInput
 			if input != nil {
@@ -103,7 +104,8 @@ func (c *EKS) WaitUntilClusterDeletedWithContext(ctx aws.Context, input *Describ
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeClusterInput
 			if input != nil {
@@ -154,7 +156,8 @@ func (c *EKS) WaitUntilNodegroupActiveWithContext(ctx aws.Context, input *Descri
 				Expected: "ACTIVE",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeNodegroupInput
 			if input != nil {
@@ -205,7 +208,8 @@ func (c *EKS) WaitUntilNodegroupDeletedWithContext(ctx aws.Context, input *Descr
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeNodegroupInput
 			if input != nil {

--- a/service/elasticache/waiters.go
+++ b/service/elasticache/waiters.go
@@ -57,7 +57,8 @@ func (c *ElastiCache) WaitUntilCacheClusterAvailableWithContext(ctx aws.Context,
 				Expected: "restore-failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeCacheClustersInput
 			if input != nil {
@@ -138,7 +139,8 @@ func (c *ElastiCache) WaitUntilCacheClusterDeletedWithContext(ctx aws.Context, i
 				Expected: "snapshotting",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeCacheClustersInput
 			if input != nil {
@@ -189,7 +191,8 @@ func (c *ElastiCache) WaitUntilReplicationGroupAvailableWithContext(ctx aws.Cont
 				Expected: "deleted",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeReplicationGroupsInput
 			if input != nil {
@@ -245,7 +248,8 @@ func (c *ElastiCache) WaitUntilReplicationGroupDeletedWithContext(ctx aws.Contex
 				Expected: "ReplicationGroupNotFoundFault",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeReplicationGroupsInput
 			if input != nil {

--- a/service/elasticbeanstalk/waiters.go
+++ b/service/elasticbeanstalk/waiters.go
@@ -42,7 +42,8 @@ func (c *ElasticBeanstalk) WaitUntilEnvironmentExistsWithContext(ctx aws.Context
 				Expected: "Launching",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeEnvironmentsInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *ElasticBeanstalk) WaitUntilEnvironmentTerminatedWithContext(ctx aws.Con
 				Expected: "Terminating",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeEnvironmentsInput
 			if input != nil {
@@ -144,7 +146,8 @@ func (c *ElasticBeanstalk) WaitUntilEnvironmentUpdatedWithContext(ctx aws.Contex
 				Expected: "Updating",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeEnvironmentsInput
 			if input != nil {

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -1487,9 +1487,15 @@ const opTestRole = "TestRole"
 //
 // Deprecated: TestRole has been deprecated
 func (c *ElasticTranscoder) TestRoleRequest(input *TestRoleInput) (req *request.Request, output *TestRoleOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, TestRole, has been deprecated")
+	msg := "This operation, TestRole, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opTestRole,
 		HTTPMethod: "POST",

--- a/service/elastictranscoder/waiters.go
+++ b/service/elastictranscoder/waiters.go
@@ -47,7 +47,8 @@ func (c *ElasticTranscoder) WaitUntilJobCompleteWithContext(ctx aws.Context, inp
 				Expected: "Error",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *ReadJobInput
 			if input != nil {

--- a/service/elb/waiters.go
+++ b/service/elb/waiters.go
@@ -37,7 +37,8 @@ func (c *ELB) WaitUntilAnyInstanceInServiceWithContext(ctx aws.Context, input *D
 				Expected: "InService",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstanceHealthInput
 			if input != nil {
@@ -88,7 +89,8 @@ func (c *ELB) WaitUntilInstanceDeregisteredWithContext(ctx aws.Context, input *D
 				Expected: "InvalidInstance",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstanceHealthInput
 			if input != nil {
@@ -139,7 +141,8 @@ func (c *ELB) WaitUntilInstanceInServiceWithContext(ctx aws.Context, input *Desc
 				Expected: "InvalidInstance",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstanceHealthInput
 			if input != nil {

--- a/service/elbv2/waiters.go
+++ b/service/elbv2/waiters.go
@@ -47,7 +47,8 @@ func (c *ELBV2) WaitUntilLoadBalancerAvailableWithContext(ctx aws.Context, input
 				Expected: "LoadBalancerNotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeLoadBalancersInput
 			if input != nil {
@@ -98,7 +99,8 @@ func (c *ELBV2) WaitUntilLoadBalancerExistsWithContext(ctx aws.Context, input *D
 				Expected: "LoadBalancerNotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeLoadBalancersInput
 			if input != nil {
@@ -149,7 +151,8 @@ func (c *ELBV2) WaitUntilLoadBalancersDeletedWithContext(ctx aws.Context, input 
 				Expected: "LoadBalancerNotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeLoadBalancersInput
 			if input != nil {
@@ -200,7 +203,8 @@ func (c *ELBV2) WaitUntilTargetDeregisteredWithContext(ctx aws.Context, input *D
 				Expected: "unused",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeTargetHealthInput
 			if input != nil {
@@ -251,7 +255,8 @@ func (c *ELBV2) WaitUntilTargetInServiceWithContext(ctx aws.Context, input *Desc
 				Expected: "InvalidInstance",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeTargetHealthInput
 			if input != nil {

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -730,9 +730,15 @@ const opDescribeJobFlows = "DescribeJobFlows"
 //
 // Deprecated: DescribeJobFlows has been deprecated
 func (c *EMR) DescribeJobFlowsRequest(input *DescribeJobFlowsInput) (req *request.Request, output *DescribeJobFlowsOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DescribeJobFlows, has been deprecated")
+	msg := "This operation, DescribeJobFlows, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDescribeJobFlows,
 		HTTPMethod: "POST",

--- a/service/emr/waiters.go
+++ b/service/emr/waiters.go
@@ -57,7 +57,8 @@ func (c *EMR) WaitUntilClusterRunningWithContext(ctx aws.Context, input *Describ
 				Expected: "TERMINATED_WITH_ERRORS",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeClusterInput
 			if input != nil {
@@ -108,7 +109,8 @@ func (c *EMR) WaitUntilClusterTerminatedWithContext(ctx aws.Context, input *Desc
 				Expected: "TERMINATED_WITH_ERRORS",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeClusterInput
 			if input != nil {
@@ -164,7 +166,8 @@ func (c *EMR) WaitUntilStepCompleteWithContext(ctx aws.Context, input *DescribeS
 				Expected: "CANCELLED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeStepInput
 			if input != nil {

--- a/service/glacier/waiters.go
+++ b/service/glacier/waiters.go
@@ -42,7 +42,8 @@ func (c *Glacier) WaitUntilVaultExistsWithContext(ctx aws.Context, input *Descri
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVaultInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *Glacier) WaitUntilVaultNotExistsWithContext(ctx aws.Context, input *Des
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeVaultInput
 			if input != nil {

--- a/service/iam/waiters.go
+++ b/service/iam/waiters.go
@@ -42,7 +42,8 @@ func (c *IAM) WaitUntilInstanceProfileExistsWithContext(ctx aws.Context, input *
 				Expected: 404,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetInstanceProfileInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *IAM) WaitUntilPolicyExistsWithContext(ctx aws.Context, input *GetPolicy
 				Expected: "NoSuchEntity",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetPolicyInput
 			if input != nil {
@@ -144,7 +146,8 @@ func (c *IAM) WaitUntilRoleExistsWithContext(ctx aws.Context, input *GetRoleInpu
 				Expected: "NoSuchEntity",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetRoleInput
 			if input != nil {
@@ -195,7 +198,8 @@ func (c *IAM) WaitUntilUserExistsWithContext(ctx aws.Context, input *GetUserInpu
 				Expected: "NoSuchEntity",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetUserInput
 			if input != nil {

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -503,9 +503,15 @@ const opAttachPrincipalPolicy = "AttachPrincipalPolicy"
 //
 // Deprecated: AttachPrincipalPolicy has been deprecated
 func (c *IoT) AttachPrincipalPolicyRequest(input *AttachPrincipalPolicyInput) (req *request.Request, output *AttachPrincipalPolicyOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, AttachPrincipalPolicy, has been deprecated")
+	msg := "This operation, AttachPrincipalPolicy, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opAttachPrincipalPolicy,
 		HTTPMethod: "PUT",
@@ -9007,9 +9013,15 @@ const opDetachPrincipalPolicy = "DetachPrincipalPolicy"
 //
 // Deprecated: DetachPrincipalPolicy has been deprecated
 func (c *IoT) DetachPrincipalPolicyRequest(input *DetachPrincipalPolicyInput) (req *request.Request, output *DetachPrincipalPolicyOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DetachPrincipalPolicy, has been deprecated")
+	msg := "This operation, DetachPrincipalPolicy, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDetachPrincipalPolicy,
 		HTTPMethod: "DELETE",
@@ -13924,9 +13936,15 @@ const opListPolicyPrincipals = "ListPolicyPrincipals"
 //
 // Deprecated: ListPolicyPrincipals has been deprecated
 func (c *IoT) ListPolicyPrincipalsRequest(input *ListPolicyPrincipalsInput) (req *request.Request, output *ListPolicyPrincipalsOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, ListPolicyPrincipals, has been deprecated")
+	msg := "This operation, ListPolicyPrincipals, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opListPolicyPrincipals,
 		HTTPMethod: "GET",
@@ -14179,9 +14197,15 @@ const opListPrincipalPolicies = "ListPrincipalPolicies"
 //
 // Deprecated: ListPrincipalPolicies has been deprecated
 func (c *IoT) ListPrincipalPoliciesRequest(input *ListPrincipalPoliciesInput) (req *request.Request, output *ListPrincipalPoliciesOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, ListPrincipalPolicies, has been deprecated")
+	msg := "This operation, ListPrincipalPolicies, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opListPrincipalPolicies,
 		HTTPMethod: "GET",

--- a/service/iotsitewise/waiters.go
+++ b/service/iotsitewise/waiters.go
@@ -42,7 +42,8 @@ func (c *IoTSiteWise) WaitUntilAssetActiveWithContext(ctx aws.Context, input *De
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAssetInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *IoTSiteWise) WaitUntilAssetModelActiveWithContext(ctx aws.Context, inpu
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAssetModelInput
 			if input != nil {
@@ -139,7 +141,8 @@ func (c *IoTSiteWise) WaitUntilAssetModelNotExistsWithContext(ctx aws.Context, i
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAssetModelInput
 			if input != nil {
@@ -185,7 +188,8 @@ func (c *IoTSiteWise) WaitUntilAssetNotExistsWithContext(ctx aws.Context, input 
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAssetInput
 			if input != nil {
@@ -231,7 +235,8 @@ func (c *IoTSiteWise) WaitUntilPortalActiveWithContext(ctx aws.Context, input *D
 				Expected: "ACTIVE",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribePortalInput
 			if input != nil {
@@ -277,7 +282,8 @@ func (c *IoTSiteWise) WaitUntilPortalNotExistsWithContext(ctx aws.Context, input
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribePortalInput
 			if input != nil {

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -3382,8 +3382,13 @@ func (es *SubscribeToShardEventStream) Events() <-chan SubscribeToShardEventStre
 
 func (es *SubscribeToShardEventStream) runOutputStream(r *request.Request) {
 	var opts []func(*eventstream.Decoder)
-	if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
-		opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+	if r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		if r.Config.ContextLogger != nil {
+			opts = append(opts, eventstream.DecodeWithContextLogger(r.Config.ContextLogger))
+		}
+		if r.Config.Logger != nil {
+			opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+		}
 	}
 
 	unmarshalerForEvent := unmarshalerForSubscribeToShardEventStreamEvent{

--- a/service/kinesis/waiters.go
+++ b/service/kinesis/waiters.go
@@ -37,7 +37,8 @@ func (c *Kinesis) WaitUntilStreamExistsWithContext(ctx aws.Context, input *Descr
 				Expected: "ACTIVE",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeStreamInput
 			if input != nil {
@@ -83,7 +84,8 @@ func (c *Kinesis) WaitUntilStreamNotExistsWithContext(ctx aws.Context, input *De
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeStreamInput
 			if input != nil {

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -2531,9 +2531,15 @@ const opInvokeAsync = "InvokeAsync"
 //
 // Deprecated: InvokeAsync has been deprecated
 func (c *Lambda) InvokeAsyncRequest(input *InvokeAsyncInput) (req *request.Request, output *InvokeAsyncOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, InvokeAsync, has been deprecated")
+	msg := "This operation, InvokeAsync, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opInvokeAsync,
 		HTTPMethod: "POST",

--- a/service/lambda/waiters.go
+++ b/service/lambda/waiters.go
@@ -47,7 +47,8 @@ func (c *Lambda) WaitUntilFunctionActiveWithContext(ctx aws.Context, input *GetF
 				Expected: "Pending",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetFunctionConfigurationInput
 			if input != nil {
@@ -98,7 +99,8 @@ func (c *Lambda) WaitUntilFunctionExistsWithContext(ctx aws.Context, input *GetF
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetFunctionInput
 			if input != nil {
@@ -154,7 +156,8 @@ func (c *Lambda) WaitUntilFunctionUpdatedWithContext(ctx aws.Context, input *Get
 				Expected: "InProgress",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetFunctionConfigurationInput
 			if input != nil {

--- a/service/machinelearning/waiters.go
+++ b/service/machinelearning/waiters.go
@@ -42,7 +42,8 @@ func (c *MachineLearning) WaitUntilBatchPredictionAvailableWithContext(ctx aws.C
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeBatchPredictionsInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *MachineLearning) WaitUntilDataSourceAvailableWithContext(ctx aws.Contex
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDataSourcesInput
 			if input != nil {
@@ -144,7 +146,8 @@ func (c *MachineLearning) WaitUntilEvaluationAvailableWithContext(ctx aws.Contex
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeEvaluationsInput
 			if input != nil {
@@ -195,7 +198,8 @@ func (c *MachineLearning) WaitUntilMLModelAvailableWithContext(ctx aws.Context, 
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeMLModelsInput
 			if input != nil {

--- a/service/medialive/waiters.go
+++ b/service/medialive/waiters.go
@@ -52,7 +52,8 @@ func (c *MediaLive) WaitUntilChannelCreatedWithContext(ctx aws.Context, input *D
 				Expected: "CREATE_FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeChannelInput
 			if input != nil {
@@ -108,7 +109,8 @@ func (c *MediaLive) WaitUntilChannelDeletedWithContext(ctx aws.Context, input *D
 				Expected: 500,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeChannelInput
 			if input != nil {
@@ -164,7 +166,8 @@ func (c *MediaLive) WaitUntilChannelRunningWithContext(ctx aws.Context, input *D
 				Expected: 500,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeChannelInput
 			if input != nil {
@@ -220,7 +223,8 @@ func (c *MediaLive) WaitUntilChannelStoppedWithContext(ctx aws.Context, input *D
 				Expected: 500,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeChannelInput
 			if input != nil {
@@ -276,7 +280,8 @@ func (c *MediaLive) WaitUntilInputAttachedWithContext(ctx aws.Context, input *De
 				Expected: 500,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInputInput
 			if input != nil {
@@ -332,7 +337,8 @@ func (c *MediaLive) WaitUntilInputDeletedWithContext(ctx aws.Context, input *Des
 				Expected: 500,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInputInput
 			if input != nil {
@@ -393,7 +399,8 @@ func (c *MediaLive) WaitUntilInputDetachedWithContext(ctx aws.Context, input *De
 				Expected: 500,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInputInput
 			if input != nil {
@@ -454,7 +461,8 @@ func (c *MediaLive) WaitUntilMultiplexCreatedWithContext(ctx aws.Context, input 
 				Expected: "CREATE_FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeMultiplexInput
 			if input != nil {
@@ -510,7 +518,8 @@ func (c *MediaLive) WaitUntilMultiplexDeletedWithContext(ctx aws.Context, input 
 				Expected: 500,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeMultiplexInput
 			if input != nil {
@@ -566,7 +575,8 @@ func (c *MediaLive) WaitUntilMultiplexRunningWithContext(ctx aws.Context, input 
 				Expected: 500,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeMultiplexInput
 			if input != nil {
@@ -622,7 +632,8 @@ func (c *MediaLive) WaitUntilMultiplexStoppedWithContext(ctx aws.Context, input 
 				Expected: 500,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeMultiplexInput
 			if input != nil {

--- a/service/mediapackage/api.go
+++ b/service/mediapackage/api.go
@@ -1257,9 +1257,15 @@ const opRotateChannelCredentials = "RotateChannelCredentials"
 //
 // Deprecated: This API is deprecated. Please use RotateIngestEndpointCredentials instead
 func (c *MediaPackage) RotateChannelCredentialsRequest(input *RotateChannelCredentialsInput) (req *request.Request, output *RotateChannelCredentialsOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, RotateChannelCredentials, has been deprecated")
+	msg := "This operation, RotateChannelCredentials, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opRotateChannelCredentials,
 		HTTPMethod: "PUT",

--- a/service/neptune/waiters.go
+++ b/service/neptune/waiters.go
@@ -62,7 +62,8 @@ func (c *Neptune) WaitUntilDBInstanceAvailableWithContext(ctx aws.Context, input
 				Expected: "incompatible-parameters",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBInstancesInput
 			if input != nil {
@@ -133,7 +134,8 @@ func (c *Neptune) WaitUntilDBInstanceDeletedWithContext(ctx aws.Context, input *
 				Expected: "resetting-master-credentials",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBInstancesInput
 			if input != nil {

--- a/service/opsworks/waiters.go
+++ b/service/opsworks/waiters.go
@@ -42,7 +42,8 @@ func (c *OpsWorks) WaitUntilAppExistsWithContext(ctx aws.Context, input *Describ
 				Expected: 400,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeAppsInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *OpsWorks) WaitUntilDeploymentSuccessfulWithContext(ctx aws.Context, inp
 				Expected: "failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDeploymentsInput
 			if input != nil {
@@ -179,7 +181,8 @@ func (c *OpsWorks) WaitUntilInstanceOnlineWithContext(ctx aws.Context, input *De
 				Expected: "stop_failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstancesInput
 			if input != nil {
@@ -260,7 +263,8 @@ func (c *OpsWorks) WaitUntilInstanceRegisteredWithContext(ctx aws.Context, input
 				Expected: "stop_failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstancesInput
 			if input != nil {
@@ -346,7 +350,8 @@ func (c *OpsWorks) WaitUntilInstanceStoppedWithContext(ctx aws.Context, input *D
 				Expected: "stop_failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstancesInput
 			if input != nil {
@@ -437,7 +442,8 @@ func (c *OpsWorks) WaitUntilInstanceTerminatedWithContext(ctx aws.Context, input
 				Expected: "start_failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeInstancesInput
 			if input != nil {

--- a/service/opsworkscm/waiters.go
+++ b/service/opsworkscm/waiters.go
@@ -42,7 +42,8 @@ func (c *OpsWorksCM) WaitUntilNodeAssociatedWithContext(ctx aws.Context, input *
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeNodeAssociationStatusInput
 			if input != nil {

--- a/service/rds/waiters.go
+++ b/service/rds/waiters.go
@@ -62,7 +62,8 @@ func (c *RDS) WaitUntilDBClusterSnapshotAvailableWithContext(ctx aws.Context, in
 				Expected: "incompatible-parameters",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBClusterSnapshotsInput
 			if input != nil {
@@ -133,7 +134,8 @@ func (c *RDS) WaitUntilDBClusterSnapshotDeletedWithContext(ctx aws.Context, inpu
 				Expected: "resetting-master-credentials",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBClusterSnapshotsInput
 			if input != nil {
@@ -204,7 +206,8 @@ func (c *RDS) WaitUntilDBInstanceAvailableWithContext(ctx aws.Context, input *De
 				Expected: "incompatible-parameters",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBInstancesInput
 			if input != nil {
@@ -275,7 +278,8 @@ func (c *RDS) WaitUntilDBInstanceDeletedWithContext(ctx aws.Context, input *Desc
 				Expected: "resetting-master-credentials",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBInstancesInput
 			if input != nil {
@@ -346,7 +350,8 @@ func (c *RDS) WaitUntilDBSnapshotAvailableWithContext(ctx aws.Context, input *De
 				Expected: "incompatible-parameters",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBSnapshotsInput
 			if input != nil {
@@ -417,7 +422,8 @@ func (c *RDS) WaitUntilDBSnapshotDeletedWithContext(ctx aws.Context, input *Desc
 				Expected: "resetting-master-credentials",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeDBSnapshotsInput
 			if input != nil {

--- a/service/rdsdataservice/api.go
+++ b/service/rdsdataservice/api.go
@@ -332,9 +332,15 @@ const opExecuteSql = "ExecuteSql"
 //
 // Deprecated: The ExecuteSql API is deprecated, please use the ExecuteStatement API.
 func (c *RDSDataService) ExecuteSqlRequest(input *ExecuteSqlInput) (req *request.Request, output *ExecuteSqlOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, ExecuteSql, has been deprecated")
+	msg := "This operation, ExecuteSql, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opExecuteSql,
 		HTTPMethod: "POST",

--- a/service/redshift/waiters.go
+++ b/service/redshift/waiters.go
@@ -47,7 +47,8 @@ func (c *Redshift) WaitUntilClusterAvailableWithContext(ctx aws.Context, input *
 				Expected: "ClusterNotFound",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeClustersInput
 			if input != nil {
@@ -103,7 +104,8 @@ func (c *Redshift) WaitUntilClusterDeletedWithContext(ctx aws.Context, input *De
 				Expected: "modifying",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeClustersInput
 			if input != nil {
@@ -154,7 +156,8 @@ func (c *Redshift) WaitUntilClusterRestoredWithContext(ctx aws.Context, input *D
 				Expected: "deleting",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeClustersInput
 			if input != nil {
@@ -210,7 +213,8 @@ func (c *Redshift) WaitUntilSnapshotAvailableWithContext(ctx aws.Context, input 
 				Expected: "deleted",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeClusterSnapshotsInput
 			if input != nil {

--- a/service/rekognition/waiters.go
+++ b/service/rekognition/waiters.go
@@ -42,7 +42,8 @@ func (c *Rekognition) WaitUntilProjectVersionRunningWithContext(ctx aws.Context,
 				Expected: "FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeProjectVersionsInput
 			if input != nil {
@@ -93,7 +94,8 @@ func (c *Rekognition) WaitUntilProjectVersionTrainingCompletedWithContext(ctx aw
 				Expected: "TRAINING_FAILED",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeProjectVersionsInput
 			if input != nil {

--- a/service/route53/waiters.go
+++ b/service/route53/waiters.go
@@ -37,7 +37,8 @@ func (c *Route53) WaitUntilResourceRecordSetsChangedWithContext(ctx aws.Context,
 				Expected: "INSYNC",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetChangeInput
 			if input != nil {

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -2830,9 +2830,15 @@ const opGetBucketLifecycle = "GetBucketLifecycle"
 //
 // Deprecated: GetBucketLifecycle has been deprecated
 func (c *S3) GetBucketLifecycleRequest(input *GetBucketLifecycleInput) (req *request.Request, output *GetBucketLifecycleOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, GetBucketLifecycle, has been deprecated")
+	msg := "This operation, GetBucketLifecycle, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opGetBucketLifecycle,
 		HTTPMethod: "GET",
@@ -3303,9 +3309,15 @@ const opGetBucketNotification = "GetBucketNotification"
 //
 // Deprecated: GetBucketNotification has been deprecated
 func (c *S3) GetBucketNotificationRequest(input *GetBucketNotificationConfigurationRequest) (req *request.Request, output *NotificationConfigurationDeprecated) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, GetBucketNotification, has been deprecated")
+	msg := "This operation, GetBucketNotification, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opGetBucketNotification,
 		HTTPMethod: "GET",
@@ -7033,9 +7045,15 @@ const opPutBucketLifecycle = "PutBucketLifecycle"
 //
 // Deprecated: PutBucketLifecycle has been deprecated
 func (c *S3) PutBucketLifecycleRequest(input *PutBucketLifecycleInput) (req *request.Request, output *PutBucketLifecycleOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, PutBucketLifecycle, has been deprecated")
+	msg := "This operation, PutBucketLifecycle, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opPutBucketLifecycle,
 		HTTPMethod: "PUT",
@@ -7537,9 +7555,15 @@ const opPutBucketNotification = "PutBucketNotification"
 //
 // Deprecated: PutBucketNotification has been deprecated
 func (c *S3) PutBucketNotificationRequest(input *PutBucketNotificationInput) (req *request.Request, output *PutBucketNotificationOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, PutBucketNotification, has been deprecated")
+	msg := "This operation, PutBucketNotification, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opPutBucketNotification,
 		HTTPMethod: "PUT",
@@ -9734,8 +9758,13 @@ func (es *SelectObjectContentEventStream) Events() <-chan SelectObjectContentEve
 
 func (es *SelectObjectContentEventStream) runOutputStream(r *request.Request) {
 	var opts []func(*eventstream.Decoder)
-	if r.Config.Logger != nil && r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
-		opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+	if r.Config.LogLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		if r.Config.ContextLogger != nil {
+			opts = append(opts, eventstream.DecodeWithContextLogger(r.Config.ContextLogger))
+		}
+		if r.Config.Logger != nil {
+			opts = append(opts, eventstream.DecodeWithLogger(r.Config.Logger))
+		}
 	}
 
 	unmarshalerForEvent := unmarshalerForSelectObjectContentEventStreamEvent{

--- a/service/s3/host_style_bucket.go
+++ b/service/s3/host_style_bucket.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 )
 
 // an operationBlacklist is a list of operation names that should a
@@ -39,9 +40,7 @@ func updateEndpointForS3Config(r *request.Request, bucketName string) {
 
 	if accelerate && accelerateOpBlacklist.Continue(r) {
 		if forceHostStyle {
-			if r.Config.Logger != nil {
-				r.Config.Logger.Log("ERROR: aws.Config.S3UseAccelerate is not compatible with aws.Config.S3ForcePathStyle, ignoring S3ForcePathStyle.")
-			}
+			awslog.Error(r.Context(), &r.Config, "aws.Config.S3UseAccelerate is not compatible with aws.Config.S3ForcePathStyle, ignoring S3ForcePathStyle.")
 		}
 		updateEndpointForAccelerate(r, bucketName)
 	} else if !forceHostStyle && r.Operation.Name != opGetBucketLocation {

--- a/service/s3/s3crypto/encryption_client_v2.go
+++ b/service/s3/s3crypto/encryption_client_v2.go
@@ -4,11 +4,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
-const customTypeWarningMessage = "WARNING: The S3 Encryption Client is configured to write encrypted objects using types not provided by AWS. Security and compatibility with these types can not be guaranteed."
+const customTypeWarningMessage = "The S3 Encryption Client is configured to write encrypted objects using types not provided by AWS. Security and compatibility with these types can not be guaranteed."
 
 // EncryptionClientV2 is an S3 crypto client. By default the SDK will use Authentication mode which
 // will use KMS for key wrapping and AES GCM for content encryption.
@@ -72,9 +73,7 @@ func NewEncryptionClientV2(prov client.ConfigProvider, contentCipherBuilder Cont
 
 	// Check if the passed in type is an fixture, if not log a warning message to the user
 	if fixture, ok := contentCipherBuilder.(awsFixture); !ok || !fixture.isAWSFixture() {
-		if s3client.Config.Logger != nil {
-			s3client.Config.Logger.Log(customTypeWarningMessage)
-		}
+		awslog.Warn(aws.BackgroundContext(), &s3client.Config, customTypeWarningMessage)
 	}
 
 	client = &EncryptionClientV2{

--- a/service/s3/s3crypto/encryption_client_v2_test.go
+++ b/service/s3/s3crypto/encryption_client_v2_test.go
@@ -29,7 +29,7 @@ func sessionWithLogCheck(message string) (*session.Session, *bool) {
 		if len(i) == 0 {
 			return
 		}
-		s, ok := i[0].(string)
+		s, ok := i[1].(string)
 		if !ok {
 			return
 		}

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
@@ -742,7 +743,7 @@ func (u *multiuploader) fail() {
 	}
 	_, err := u.cfg.S3.AbortMultipartUploadWithContext(u.ctx, params, u.cfg.RequestOptions...)
 	if err != nil {
-		logMessage(u.cfg.S3, aws.LogDebug, fmt.Sprintf("failed to abort multipart upload, %v", err))
+		logMessage(u.ctx, u.cfg.S3, aws.LogDebug, awslog.DebugErrorf, "failed to abort multipart upload, %v", err)
 	}
 }
 

--- a/service/s3/waiters.go
+++ b/service/s3/waiters.go
@@ -52,7 +52,8 @@ func (c *S3) WaitUntilBucketExistsWithContext(ctx aws.Context, input *HeadBucket
 				Expected: 404,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *HeadBucketInput
 			if input != nil {
@@ -98,7 +99,8 @@ func (c *S3) WaitUntilBucketNotExistsWithContext(ctx aws.Context, input *HeadBuc
 				Expected: 404,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *HeadBucketInput
 			if input != nil {
@@ -149,7 +151,8 @@ func (c *S3) WaitUntilObjectExistsWithContext(ctx aws.Context, input *HeadObject
 				Expected: 404,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *HeadObjectInput
 			if input != nil {
@@ -195,7 +198,8 @@ func (c *S3) WaitUntilObjectNotExistsWithContext(ctx aws.Context, input *HeadObj
 				Expected: 404,
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *HeadObjectInput
 			if input != nil {

--- a/service/sagemaker/waiters.go
+++ b/service/sagemaker/waiters.go
@@ -42,7 +42,8 @@ func (c *SageMaker) WaitUntilEndpointDeletedWithContext(ctx aws.Context, input *
 				Expected: "Failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeEndpointInput
 			if input != nil {
@@ -98,7 +99,8 @@ func (c *SageMaker) WaitUntilEndpointInServiceWithContext(ctx aws.Context, input
 				Expected: "ValidationException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeEndpointInput
 			if input != nil {
@@ -149,7 +151,8 @@ func (c *SageMaker) WaitUntilNotebookInstanceDeletedWithContext(ctx aws.Context,
 				Expected: "Failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeNotebookInstanceInput
 			if input != nil {
@@ -200,7 +203,8 @@ func (c *SageMaker) WaitUntilNotebookInstanceInServiceWithContext(ctx aws.Contex
 				Expected: "Failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeNotebookInstanceInput
 			if input != nil {
@@ -251,7 +255,8 @@ func (c *SageMaker) WaitUntilNotebookInstanceStoppedWithContext(ctx aws.Context,
 				Expected: "Failed",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeNotebookInstanceInput
 			if input != nil {
@@ -312,7 +317,8 @@ func (c *SageMaker) WaitUntilProcessingJobCompletedOrStoppedWithContext(ctx aws.
 				Expected: "ValidationException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeProcessingJobInput
 			if input != nil {
@@ -373,7 +379,8 @@ func (c *SageMaker) WaitUntilTrainingJobCompletedOrStoppedWithContext(ctx aws.Co
 				Expected: "ValidationException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeTrainingJobInput
 			if input != nil {
@@ -434,7 +441,8 @@ func (c *SageMaker) WaitUntilTransformJobCompletedOrStoppedWithContext(ctx aws.C
 				Expected: "ValidationException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeTransformJobInput
 			if input != nil {

--- a/service/schemas/waiters.go
+++ b/service/schemas/waiters.go
@@ -52,7 +52,8 @@ func (c *Schemas) WaitUntilCodeBindingExistsWithContext(ctx aws.Context, input *
 				Expected: "NotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeCodeBindingInput
 			if input != nil {

--- a/service/ses/waiters.go
+++ b/service/ses/waiters.go
@@ -37,7 +37,8 @@ func (c *SES) WaitUntilIdentityExistsWithContext(ctx aws.Context, input *GetIden
 				Expected: "Success",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetIdentityVerificationAttributesInput
 			if input != nil {

--- a/service/shield/api.go
+++ b/service/shield/api.go
@@ -792,9 +792,15 @@ const opDeleteSubscription = "DeleteSubscription"
 //
 // Deprecated: DeleteSubscription has been deprecated
 func (c *Shield) DeleteSubscriptionRequest(input *DeleteSubscriptionInput) (req *request.Request, output *DeleteSubscriptionOutput) {
-	if c.Client.Config.Logger != nil {
-		c.Client.Config.Logger.Log("This operation, DeleteSubscription, has been deprecated")
+	msg := "This operation, DeleteSubscription, has been deprecated"
+	if c.Client.Config.ContextLogger != nil {
+		c.Client.Config.ContextLogger.Warn(aws.BackgroundContext(), msg)
+	} else if c.Client.Config.Logger != nil {
+		c.Client.Config.Logger.Log(msg)
+	} else {
+		// no-op
 	}
+
 	op := &request.Operation{
 		Name:       opDeleteSubscription,
 		HTTPMethod: "POST",

--- a/service/signer/waiters.go
+++ b/service/signer/waiters.go
@@ -47,7 +47,8 @@ func (c *Signer) WaitUntilSuccessfulSigningJobWithContext(ctx aws.Context, input
 				Expected: "ResourceNotFoundException",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *DescribeSigningJobInput
 			if input != nil {

--- a/service/sqs/checksums.go
+++ b/service/sqs/checksums.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/awslog"
 )
 
 var (
@@ -74,12 +75,10 @@ func verifyReceiveMessage(r *request.Request) {
 			err := checksumsMatch(msg.Body, msg.MD5OfBody)
 			if err != nil {
 				if msg.MessageId == nil {
-					if r.Config.Logger != nil {
-						r.Config.Logger.Log(fmt.Sprintf(
-							"WARN: SQS.ReceiveMessage failed checksum request id: %s, message %d has no message ID.",
-							r.RequestID, i,
-						))
-					}
+					awslog.Warnf(r.Context(), &r.Config,
+						"SQS.ReceiveMessage failed checksum request id: %s, message %d has no message ID.",
+						r.RequestID, i,
+					)
 					continue
 				}
 

--- a/service/ssm/waiters.go
+++ b/service/ssm/waiters.go
@@ -72,7 +72,8 @@ func (c *SSM) WaitUntilCommandExecutedWithContext(ctx aws.Context, input *GetCom
 				Expected: "Cancelling",
 			},
 		},
-		Logger: c.Config.Logger,
+		Logger:        c.Config.Logger,
+		ContextLogger: c.Config.ContextLogger,
 		NewRequest: func(opts []request.Option) (*request.Request, error) {
 			var inCpy *GetCommandInvocationInput
 			if input != nil {


### PR DESCRIPTION
Deprecates `aws.Logger` in a favor of a new context-aware `aws.ContextLogger` interface. Fixes #3398.