### PR TITLE
Allow parsing of decimal precision iso8601 formats

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `private/protocol`: The SDK now supports the serialization of ISO8601 date-time formats with fractional seconds precision. ([#3489](https://github.com/aws/aws-sdk-go/pull/3489))
 
 ### SDK Bugs

--- a/private/protocol/timestamp.go
+++ b/private/protocol/timestamp.go
@@ -28,7 +28,7 @@ const (
 	ISO8601TimeFormat = "2006-01-02T15:04:05.999999999Z"
 
 	// This format is used for output time without seconds precision
-	ISO8601OutputTimeFormat = "2006-01-02T15:04:05Z"
+	ISO8601OutputTimeFormat = "2006-01-02T15:04:05.999999999Z"
 )
 
 // IsKnownTimestampFormat returns if the timestamp format name

--- a/private/protocol/timestamp_test.go
+++ b/private/protocol/timestamp_test.go
@@ -26,12 +26,17 @@ func TestFormatTime(t *testing.T) {
 		"ISO8601Test1": {
 			formatName:     ISO8601TimeFormatName,
 			expectedOutput: "2000-01-02T20:34:56Z",
-			input:          time.Date(2000, time.January, 2, 20, 34, 56, .123e9, time.UTC),
+			input:          time.Date(2000, time.January, 2, 20, 34, 56, 0, time.UTC),
 		},
 		"RFC822Test1": {
 			formatName:     RFC822TimeFormatName,
 			expectedOutput: "Sun, 02 Jan 2000 20:34:56 GMT",
 			input:          time.Date(2000, time.January, 2, 20, 34, 56, 0, time.UTC),
+		},
+		"ISO8601Test2": {
+			formatName:     ISO8601TimeFormatName,
+			expectedOutput: "2000-01-02T20:34:56.123Z",
+			input:          time.Date(2000, time.January, 2, 20, 34, 56, .123e9, time.UTC),
 		},
 	}
 


### PR DESCRIPTION
Allows the for parsing of decimal precision iso8601 time formats.