### PR TITLE
Reducing ancient issue threshold to 1 year

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category
-        ancient-issue-message: We have noticed this issue has not received attention in 3 years. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
+        ancient-issue-message: We have noticed this issue has not received attention in 1 year. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
         stale-issue-message: This issue has not received a response in 1 week. If you want to keep this issue open, please just leave a comment below and auto-close will be canceled.
 
         # These labels are required
@@ -31,7 +31,7 @@ jobs:
         # Issue timing
         days-before-stale: 7
         days-before-close: 4
-        days-before-ancient: 1095
+        days-before-ancient: 365
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is


### PR DESCRIPTION
Issues can be excluded from the stale-issue-cleanup workflow by applying the `no-autoclose` label.