### PR TITLE
example/aws/request/httptrace: Fix example with timeouts and retries

### DIFF
--- a/example/aws/request/httptrace/main.go
+++ b/example/aws/request/httptrace/main.go
@@ -55,7 +55,7 @@ func main() {
 	for scanner.Scan() {
 		trace, err := publishMessage(ctx, svc, topicARN, scanner.Text())
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to publish message, %v", err)
+			fmt.Fprintf(os.Stderr, "failed to publish message, %v\n", err)
 		}
 		log.Println(trace)
 
@@ -77,7 +77,7 @@ func publishMessage(ctx context.Context, svc *sns.SNS, topic, msg string) (*Requ
 		Message:  &msg,
 	}, trace.TraceRequest)
 	if err != nil {
-		return nil, err
+		return trace, err
 	}
 
 	return trace, nil


### PR DESCRIPTION
The tracing example incorrectly copied the HTTP trace between retry attempts, instead of replacing it. This update corrects this behavior so that each request attempt has its own HTTP trace. This also fixes potential output of negative values.

This fixes issues where latency obtaining an connection would incorrectly look like it had received response first byte, when that may not actually of been the case.