### PR TITLE
Limit iso8601 fractional second precision to milliseconds

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+*  `private/protocol`: Limit iso8601 fractional second precision to milliseconds ([#3507](https://github.com/aws/aws-sdk-go/pull/3507))
+  * Fixes [#3498](https://github.com/aws/aws-sdk-go/issues/3498)

--- a/private/protocol/timestamp.go
+++ b/private/protocol/timestamp.go
@@ -27,7 +27,7 @@ const (
 	// RFC3339 a subset of the ISO8601 timestamp format. e.g 2014-04-29T18:30:38Z
 	ISO8601TimeFormat = "2006-01-02T15:04:05.999999999Z"
 
-	// This format is used for output time with fractional second precision up milliseconds
+	// This format is used for output time with fractional second precision up to milliseconds
 	ISO8601OutputTimeFormat = "2006-01-02T15:04:05.999Z"
 )
 

--- a/private/protocol/timestamp.go
+++ b/private/protocol/timestamp.go
@@ -27,8 +27,8 @@ const (
 	// RFC3339 a subset of the ISO8601 timestamp format. e.g 2014-04-29T18:30:38Z
 	ISO8601TimeFormat = "2006-01-02T15:04:05.999999999Z"
 
-	// This format is used for output time without seconds precision
-	ISO8601OutputTimeFormat = "2006-01-02T15:04:05.999999999Z"
+	// This format is used for output time with fractional second precision up milliseconds
+	ISO8601OutputTimeFormat = "2006-01-02T15:04:05.999Z"
 )
 
 // IsKnownTimestampFormat returns if the timestamp format name

--- a/private/protocol/timestamp.go
+++ b/private/protocol/timestamp.go
@@ -28,7 +28,7 @@ const (
 	ISO8601TimeFormat = "2006-01-02T15:04:05.999999999Z"
 
 	// This format is used for output time with fractional second precision up to milliseconds
-	ISO8601OutputTimeFormat = "2006-01-02T15:04:05.999Z"
+	ISO8601OutputTimeFormat = "2006-01-02T15:04:05.999999999Z"
 )
 
 // IsKnownTimestampFormat returns if the timestamp format name
@@ -48,7 +48,7 @@ func IsKnownTimestampFormat(name string) bool {
 
 // FormatTime returns a string value of the time.
 func FormatTime(name string, t time.Time) string {
-	t = t.UTC()
+	t = t.UTC().Truncate(time.Millisecond)
 
 	switch name {
 	case RFC822TimeFormatName:

--- a/private/protocol/timestamp_test.go
+++ b/private/protocol/timestamp_test.go
@@ -38,6 +38,11 @@ func TestFormatTime(t *testing.T) {
 			expectedOutput: "2000-01-02T20:34:56.123Z",
 			input:          time.Date(2000, time.January, 2, 20, 34, 56, .123e9, time.UTC),
 		},
+		"ISO8601Test3": {
+			formatName:     ISO8601TimeFormatName,
+			expectedOutput: "2000-01-02T20:34:56.123Z",
+			input:          time.Date(2000, time.January, 2, 20, 34, 56, .123456e9, time.UTC),
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
Limits the iso8601 time format to milliseconds precision when serializing fractional seconds. This prevents issues seen with services like CloudWatch which don't support nanoseconds granular clock sources.

Fixes https://github.com/aws/aws-sdk-go/issues/3498