### PR TITLE
replace Deprecated function on session.New

### DIFF
--- a/example/service/ecr/createRepository/createRepository.go
+++ b/example/service/ecr/createRepository/createRepository.go
@@ -20,7 +20,7 @@ const DEFAULT_AWS_REGION = "us-east-1"
 func main() {
 
 	config := &aws.Config{Region: aws.String(getAwsRegion())}
-	svc := ecr.New(session.New(), config)
+	svc := ecr.New(session.Must(session.NewSession()), config)
 
 	repoName := getRepoNameArg()
 	if repoName == "" {

--- a/example/service/ecr/deleteRepository/deleteRepository.go
+++ b/example/service/ecr/deleteRepository/deleteRepository.go
@@ -20,7 +20,7 @@ const DEFAULT_AWS_REGION = "us-east-1"
 func main() {
 
 	config := &aws.Config{Region: aws.String(getAwsRegion())}
-	svc := ecr.New(session.New(), config)
+	svc := ecr.New(session.Must(session.NewSession()), config)
 
 	repoName := getRepoNameArg()
 	if repoName == "" {

--- a/example/service/rds/rdsutils/authentication/iam_authentication.go
+++ b/example/service/rds/rdsutils/authentication/iam_authentication.go
@@ -27,7 +27,7 @@ func main() {
 	dbUser := os.Args[2]
 	dbName := os.Args[3]
 	dbEndpoint := os.Args[4]
-	awsCreds := stscreds.NewCredentials(session.New(&aws.Config{Region: &awsRegion}), os.Args[5])
+	awsCreds := stscreds.NewCredentials(session.Must(NewSession(&aws.Config{Region: &awsRegion})), os.Args[5])
 	authToken, err := rdsutils.BuildAuthToken(dbEndpoint, awsRegion, dbUser, awsCreds)
 
 	// Create the MySQL DNS string for the DB connection

--- a/example/service/s3/concatObjects/concatObjects.go
+++ b/example/service/s3/concatObjects/concatObjects.go
@@ -57,7 +57,7 @@ func main() {
 	key1 := os.Args[2]
 	key2 := os.Args[3]
 	key3 := os.Args[4]
-	sess := session.New(&aws.Config{})
+	sess := session.Must(session.NewSession(&aws.Config{}))
 	svc := s3.New(sess)
 
 	c := client{svc, &bucket}

--- a/example/service/s3/sync/sync.go
+++ b/example/service/s3/sync/sync.go
@@ -102,9 +102,12 @@ func main() {
 	pathPtr := flag.String("path", "", "path of directory to be synced")
 	flag.Parse()
 
-	sess := session.New(&aws.Config{
+	sess, err := session.NewSession(&aws.Config{
 		Region: regionPtr,
 	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unexpected error occurred during creating session: %v", err)
+	}
 	uploader := s3manager.NewUploader(sess)
 
 	iter := NewSyncFolderIterator(*pathPtr, *bucketPtr)

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -740,7 +740,7 @@ var tplInterface = template.Must(template.New("interface").Parse(`
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := {{ .PackageName }}.New(sess)
 //
 //        myFunc(svc)

--- a/private/model/api/codegentest/service/awsendpointdiscoverytest/awsendpointdiscoverytestiface/interface.go
+++ b/private/model/api/codegentest/service/awsendpointdiscoverytest/awsendpointdiscoverytestiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := awsendpointdiscoverytest.New(sess)
 //
 //        myFunc(svc)

--- a/private/model/api/codegentest/service/restjsonservice/restjsonserviceiface/interface.go
+++ b/private/model/api/codegentest/service/restjsonservice/restjsonserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := restjsonservice.New(sess)
 //
 //        myFunc(svc)

--- a/private/model/api/codegentest/service/restxmlservice/restxmlserviceiface/interface.go
+++ b/private/model/api/codegentest/service/restxmlservice/restxmlserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := restxmlservice.New(sess)
 //
 //        myFunc(svc)

--- a/private/model/api/codegentest/service/rpcservice/rpcserviceiface/interface.go
+++ b/private/model/api/codegentest/service/rpcservice/rpcserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := rpcservice.New(sess)
 //
 //        myFunc(svc)

--- a/private/model/api/example.go
+++ b/private/model/api/example.go
@@ -58,7 +58,7 @@ var exampleTmpls = template.Must(template.New("example").Funcs(exampleFuncMap).P
 //
 {{ commentify (wrap .Description 80) }}
 func Example{{ .API.StructName }}_{{ .MethodName }}() {
-	svc := {{ .API.PackageName }}.New(session.New())
+	svc := {{ .API.PackageName }}.New(session.Must(session.NewSession()))
 	input := {{ generateExampleInput . }}
 
 	result, err := svc.{{ .OperationName }}(input)

--- a/private/model/api/example_test.go
+++ b/private/model/api/example_test.go
@@ -252,7 +252,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // Foo bar baz qux
 func ExampleFooService_Foo_shared00() {
-	svc := fooservice.New(session.New())
+	svc := fooservice.New(session.Must(session.NewSession()))
 	input := &fooservice.FooInput{
 		BarShape: aws.String("Hello world"),
 		ComplexField: &fooservice.ComplexShape{

--- a/service/accessanalyzer/accessanalyzeriface/interface.go
+++ b/service/accessanalyzer/accessanalyzeriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := accessanalyzer.New(sess)
 //
 //        myFunc(svc)

--- a/service/acm/acmiface/interface.go
+++ b/service/acm/acmiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := acm.New(sess)
 //
 //        myFunc(svc)

--- a/service/acmpca/acmpcaiface/interface.go
+++ b/service/acmpca/acmpcaiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := acmpca.New(sess)
 //
 //        myFunc(svc)

--- a/service/alexaforbusiness/alexaforbusinessiface/interface.go
+++ b/service/alexaforbusiness/alexaforbusinessiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := alexaforbusiness.New(sess)
 //
 //        myFunc(svc)

--- a/service/amplify/amplifyiface/interface.go
+++ b/service/amplify/amplifyiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := amplify.New(sess)
 //
 //        myFunc(svc)

--- a/service/apigateway/apigatewayiface/interface.go
+++ b/service/apigateway/apigatewayiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := apigateway.New(sess)
 //
 //        myFunc(svc)

--- a/service/apigatewaymanagementapi/apigatewaymanagementapiiface/interface.go
+++ b/service/apigatewaymanagementapi/apigatewaymanagementapiiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := apigatewaymanagementapi.New(sess)
 //
 //        myFunc(svc)

--- a/service/apigatewayv2/apigatewayv2iface/interface.go
+++ b/service/apigatewayv2/apigatewayv2iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := apigatewayv2.New(sess)
 //
 //        myFunc(svc)

--- a/service/appconfig/appconfigiface/interface.go
+++ b/service/appconfig/appconfigiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := appconfig.New(sess)
 //
 //        myFunc(svc)

--- a/service/appflow/appflowiface/interface.go
+++ b/service/appflow/appflowiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := appflow.New(sess)
 //
 //        myFunc(svc)

--- a/service/applicationautoscaling/applicationautoscalingiface/interface.go
+++ b/service/applicationautoscaling/applicationautoscalingiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := applicationautoscaling.New(sess)
 //
 //        myFunc(svc)

--- a/service/applicationautoscaling/examples_test.go
+++ b/service/applicationautoscaling/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // This example deletes a scaling policy for the Amazon ECS service called web-app,
 // which is running in the default cluster.
 func ExampleApplicationAutoScaling_DeleteScalingPolicy_shared00() {
-	svc := applicationautoscaling.New(session.New())
+	svc := applicationautoscaling.New(session.Must(session.NewSession()))
 	input := &applicationautoscaling.DeleteScalingPolicyInput{
 		PolicyName:        aws.String("web-app-cpu-lt-25"),
 		ResourceId:        aws.String("service/default/web-app"),
@@ -69,7 +69,7 @@ func ExampleApplicationAutoScaling_DeleteScalingPolicy_shared00() {
 // This example deregisters a scalable target for an Amazon ECS service called web-app
 // that is running in the default cluster.
 func ExampleApplicationAutoScaling_DeregisterScalableTarget_shared00() {
-	svc := applicationautoscaling.New(session.New())
+	svc := applicationautoscaling.New(session.Must(session.NewSession()))
 	input := &applicationautoscaling.DeregisterScalableTargetInput{
 		ResourceId:        aws.String("service/default/web-app"),
 		ScalableDimension: aws.String("ecs:service:DesiredCount"),
@@ -106,7 +106,7 @@ func ExampleApplicationAutoScaling_DeregisterScalableTarget_shared00() {
 //
 // This example describes the scalable targets for the ECS service namespace.
 func ExampleApplicationAutoScaling_DescribeScalableTargets_shared00() {
-	svc := applicationautoscaling.New(session.New())
+	svc := applicationautoscaling.New(session.Must(session.NewSession()))
 	input := &applicationautoscaling.DescribeScalableTargetsInput{
 		ServiceNamespace: aws.String("ecs"),
 	}
@@ -142,7 +142,7 @@ func ExampleApplicationAutoScaling_DescribeScalableTargets_shared00() {
 // This example describes the scaling activities for an Amazon ECS service called web-app
 // that is running in the default cluster.
 func ExampleApplicationAutoScaling_DescribeScalingActivities_shared00() {
-	svc := applicationautoscaling.New(session.New())
+	svc := applicationautoscaling.New(session.Must(session.NewSession()))
 	input := &applicationautoscaling.DescribeScalingActivitiesInput{
 		ResourceId:        aws.String("service/default/web-app"),
 		ScalableDimension: aws.String("ecs:service:DesiredCount"),
@@ -179,7 +179,7 @@ func ExampleApplicationAutoScaling_DescribeScalingActivities_shared00() {
 //
 // This example describes the scaling policies for the ECS service namespace.
 func ExampleApplicationAutoScaling_DescribeScalingPolicies_shared00() {
-	svc := applicationautoscaling.New(session.New())
+	svc := applicationautoscaling.New(session.Must(session.NewSession()))
 	input := &applicationautoscaling.DescribeScalingPoliciesInput{
 		ServiceNamespace: aws.String("ecs"),
 	}
@@ -219,7 +219,7 @@ func ExampleApplicationAutoScaling_DescribeScalingPolicies_shared00() {
 // The policy keeps the average CPU utilization of the service at 75 percent, with scale-out
 // and scale-in cooldown periods of 60 seconds.
 func ExampleApplicationAutoScaling_PutScalingPolicy_shared00() {
-	svc := applicationautoscaling.New(session.New())
+	svc := applicationautoscaling.New(session.Must(session.NewSession()))
 	input := &applicationautoscaling.PutScalingPolicyInput{
 		PolicyName:        aws.String("cpu75-target-tracking-scaling-policy"),
 		PolicyType:        aws.String("TargetTrackingScaling"),
@@ -272,7 +272,7 @@ func ExampleApplicationAutoScaling_PutScalingPolicy_shared00() {
 // that is running on the default cluster, with a minimum desired count of 1 task and
 // a maximum desired count of 10 tasks.
 func ExampleApplicationAutoScaling_RegisterScalableTarget_shared00() {
-	svc := applicationautoscaling.New(session.New())
+	svc := applicationautoscaling.New(session.Must(session.NewSession()))
 	input := &applicationautoscaling.RegisterScalableTargetInput{
 		MaxCapacity:       aws.Int64(10),
 		MinCapacity:       aws.Int64(1),

--- a/service/applicationdiscoveryservice/applicationdiscoveryserviceiface/interface.go
+++ b/service/applicationdiscoveryservice/applicationdiscoveryserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := applicationdiscoveryservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/applicationinsights/applicationinsightsiface/interface.go
+++ b/service/applicationinsights/applicationinsightsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := applicationinsights.New(sess)
 //
 //        myFunc(svc)

--- a/service/appmesh/appmeshiface/interface.go
+++ b/service/appmesh/appmeshiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := appmesh.New(sess)
 //
 //        myFunc(svc)

--- a/service/appstream/appstreamiface/interface.go
+++ b/service/appstream/appstreamiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := appstream.New(sess)
 //
 //        myFunc(svc)

--- a/service/appsync/appsynciface/interface.go
+++ b/service/appsync/appsynciface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := appsync.New(sess)
 //
 //        myFunc(svc)

--- a/service/athena/athenaiface/interface.go
+++ b/service/athena/athenaiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := athena.New(sess)
 //
 //        myFunc(svc)

--- a/service/augmentedairuntime/augmentedairuntimeiface/interface.go
+++ b/service/augmentedairuntime/augmentedairuntimeiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := augmentedairuntime.New(sess)
 //
 //        myFunc(svc)

--- a/service/autoscaling/autoscalingiface/interface.go
+++ b/service/autoscaling/autoscalingiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := autoscaling.New(sess)
 //
 //        myFunc(svc)

--- a/service/autoscaling/examples_test.go
+++ b/service/autoscaling/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This example attaches the specified instance to the specified Auto Scaling group.
 func ExampleAutoScaling_AttachInstances_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.AttachInstancesInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		InstanceIds: []*string{
@@ -63,7 +63,7 @@ func ExampleAutoScaling_AttachInstances_shared00() {
 //
 // This example attaches the specified target group to the specified Auto Scaling group.
 func ExampleAutoScaling_AttachLoadBalancerTargetGroups_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.AttachLoadBalancerTargetGroupsInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		TargetGroupARNs: []*string{
@@ -97,7 +97,7 @@ func ExampleAutoScaling_AttachLoadBalancerTargetGroups_shared00() {
 //
 // This example attaches the specified load balancer to the specified Auto Scaling group.
 func ExampleAutoScaling_AttachLoadBalancers_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.AttachLoadBalancersInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		LoadBalancerNames: []*string{
@@ -131,7 +131,7 @@ func ExampleAutoScaling_AttachLoadBalancers_shared00() {
 //
 // This example cancels an instance refresh operation in progress.
 func ExampleAutoScaling_CancelInstanceRefresh_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.CancelInstanceRefreshInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 	}
@@ -165,7 +165,7 @@ func ExampleAutoScaling_CancelInstanceRefresh_shared00() {
 // This example notifies Auto Scaling that the specified lifecycle action is complete
 // so that it can finish launching or terminating the instance.
 func ExampleAutoScaling_CompleteLifecycleAction_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.CompleteLifecycleActionInput{
 		AutoScalingGroupName:  aws.String("my-auto-scaling-group"),
 		LifecycleActionResult: aws.String("CONTINUE"),
@@ -197,7 +197,7 @@ func ExampleAutoScaling_CompleteLifecycleAction_shared00() {
 //
 // This example creates an Auto Scaling group.
 func ExampleAutoScaling_CreateAutoScalingGroup_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.CreateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		LaunchTemplate: &autoscaling.LaunchTemplateSpecification{
@@ -240,7 +240,7 @@ func ExampleAutoScaling_CreateAutoScalingGroup_shared00() {
 //
 // This example creates an Auto Scaling group and attaches the specified target group.
 func ExampleAutoScaling_CreateAutoScalingGroup_shared01() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.CreateAutoScalingGroupInput{
 		AutoScalingGroupName:    aws.String("my-auto-scaling-group"),
 		HealthCheckGracePeriod:  aws.Int64(120),
@@ -285,7 +285,7 @@ func ExampleAutoScaling_CreateAutoScalingGroup_shared01() {
 // This example creates an Auto Scaling group and attaches the specified Classic Load
 // Balancer.
 func ExampleAutoScaling_CreateAutoScalingGroup_shared02() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.CreateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		AvailabilityZones: []*string{
@@ -331,7 +331,7 @@ func ExampleAutoScaling_CreateAutoScalingGroup_shared02() {
 //
 // This example creates a launch configuration.
 func ExampleAutoScaling_CreateLaunchConfiguration_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.CreateLaunchConfigurationInput{
 		IamInstanceProfile:      aws.String("my-iam-role"),
 		ImageId:                 aws.String("ami-12345678"),
@@ -370,7 +370,7 @@ func ExampleAutoScaling_CreateLaunchConfiguration_shared00() {
 //
 // This example adds two tags to the specified Auto Scaling group.
 func ExampleAutoScaling_CreateOrUpdateTags_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.CreateOrUpdateTagsInput{
 		Tags: []*autoscaling.Tag{
 			{
@@ -420,7 +420,7 @@ func ExampleAutoScaling_CreateOrUpdateTags_shared00() {
 //
 // This example deletes the specified Auto Scaling group.
 func ExampleAutoScaling_DeleteAutoScalingGroup_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DeleteAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 	}
@@ -453,7 +453,7 @@ func ExampleAutoScaling_DeleteAutoScalingGroup_shared00() {
 //
 // This example deletes the specified Auto Scaling group and all its instances.
 func ExampleAutoScaling_DeleteAutoScalingGroup_shared01() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DeleteAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		ForceDelete:          aws.Bool(true),
@@ -487,7 +487,7 @@ func ExampleAutoScaling_DeleteAutoScalingGroup_shared01() {
 //
 // This example deletes the specified launch configuration.
 func ExampleAutoScaling_DeleteLaunchConfiguration_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DeleteLaunchConfigurationInput{
 		LaunchConfigurationName: aws.String("my-launch-config"),
 	}
@@ -518,7 +518,7 @@ func ExampleAutoScaling_DeleteLaunchConfiguration_shared00() {
 //
 // This example deletes the specified lifecycle hook.
 func ExampleAutoScaling_DeleteLifecycleHook_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DeleteLifecycleHookInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		LifecycleHookName:    aws.String("my-lifecycle-hook"),
@@ -548,7 +548,7 @@ func ExampleAutoScaling_DeleteLifecycleHook_shared00() {
 //
 // This example deletes the specified notification from the specified Auto Scaling group.
 func ExampleAutoScaling_DeleteNotificationConfiguration_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DeleteNotificationConfigurationInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		TopicARN:             aws.String("arn:aws:sns:us-west-2:123456789012:my-sns-topic"),
@@ -578,7 +578,7 @@ func ExampleAutoScaling_DeleteNotificationConfiguration_shared00() {
 //
 // This example deletes the specified Auto Scaling policy.
 func ExampleAutoScaling_DeletePolicy_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DeletePolicyInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		PolicyName:           aws.String("my-step-scale-out-policy"),
@@ -611,7 +611,7 @@ func ExampleAutoScaling_DeletePolicy_shared00() {
 // This example deletes the specified scheduled action from the specified Auto Scaling
 // group.
 func ExampleAutoScaling_DeleteScheduledAction_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DeleteScheduledActionInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		ScheduledActionName:  aws.String("my-scheduled-action"),
@@ -641,7 +641,7 @@ func ExampleAutoScaling_DeleteScheduledAction_shared00() {
 //
 // This example deletes the specified tag from the specified Auto Scaling group.
 func ExampleAutoScaling_DeleteTags_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DeleteTagsInput{
 		Tags: []*autoscaling.Tag{
 			{
@@ -679,7 +679,7 @@ func ExampleAutoScaling_DeleteTags_shared00() {
 //
 // This example describes the Auto Scaling limits for your AWS account.
 func ExampleAutoScaling_DescribeAccountLimits_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeAccountLimitsInput{}
 
 	result, err := svc.DescribeAccountLimits(input)
@@ -706,7 +706,7 @@ func ExampleAutoScaling_DescribeAccountLimits_shared00() {
 //
 // This example describes the available adjustment types.
 func ExampleAutoScaling_DescribeAdjustmentTypes_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeAdjustmentTypesInput{}
 
 	result, err := svc.DescribeAdjustmentTypes(input)
@@ -733,7 +733,7 @@ func ExampleAutoScaling_DescribeAdjustmentTypes_shared00() {
 //
 // This example describes the specified Auto Scaling group.
 func ExampleAutoScaling_DescribeAutoScalingGroups_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{
 			aws.String("my-auto-scaling-group"),
@@ -766,7 +766,7 @@ func ExampleAutoScaling_DescribeAutoScalingGroups_shared00() {
 //
 // This example describes the specified Auto Scaling instance.
 func ExampleAutoScaling_DescribeAutoScalingInstances_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeAutoScalingInstancesInput{
 		InstanceIds: []*string{
 			aws.String("i-4ba0837f"),
@@ -799,7 +799,7 @@ func ExampleAutoScaling_DescribeAutoScalingInstances_shared00() {
 //
 // This example describes the available notification types.
 func ExampleAutoScaling_DescribeAutoScalingNotificationTypes_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeAutoScalingNotificationTypesInput{}
 
 	result, err := svc.DescribeAutoScalingNotificationTypes(input)
@@ -826,7 +826,7 @@ func ExampleAutoScaling_DescribeAutoScalingNotificationTypes_shared00() {
 //
 // This example describes the instance refreshes for the specified Auto Scaling group.
 func ExampleAutoScaling_DescribeInstanceRefreshes_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeInstanceRefreshesInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 	}
@@ -857,7 +857,7 @@ func ExampleAutoScaling_DescribeInstanceRefreshes_shared00() {
 //
 // This example describes the specified launch configuration.
 func ExampleAutoScaling_DescribeLaunchConfigurations_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeLaunchConfigurationsInput{
 		LaunchConfigurationNames: []*string{
 			aws.String("my-launch-config"),
@@ -890,7 +890,7 @@ func ExampleAutoScaling_DescribeLaunchConfigurations_shared00() {
 //
 // This example describes the available lifecycle hook types.
 func ExampleAutoScaling_DescribeLifecycleHookTypes_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeLifecycleHookTypesInput{}
 
 	result, err := svc.DescribeLifecycleHookTypes(input)
@@ -917,7 +917,7 @@ func ExampleAutoScaling_DescribeLifecycleHookTypes_shared00() {
 //
 // This example describes the lifecycle hooks for the specified Auto Scaling group.
 func ExampleAutoScaling_DescribeLifecycleHooks_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeLifecycleHooksInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 	}
@@ -946,7 +946,7 @@ func ExampleAutoScaling_DescribeLifecycleHooks_shared00() {
 //
 // This example describes the target groups attached to the specified Auto Scaling group.
 func ExampleAutoScaling_DescribeLoadBalancerTargetGroups_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeLoadBalancerTargetGroupsInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 	}
@@ -976,7 +976,7 @@ func ExampleAutoScaling_DescribeLoadBalancerTargetGroups_shared00() {
 // This example describes the load balancers attached to the specified Auto Scaling
 // group.
 func ExampleAutoScaling_DescribeLoadBalancers_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeLoadBalancersInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 	}
@@ -1005,7 +1005,7 @@ func ExampleAutoScaling_DescribeLoadBalancers_shared00() {
 //
 // This example describes the available metric collection types.
 func ExampleAutoScaling_DescribeMetricCollectionTypes_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeMetricCollectionTypesInput{}
 
 	result, err := svc.DescribeMetricCollectionTypes(input)
@@ -1033,7 +1033,7 @@ func ExampleAutoScaling_DescribeMetricCollectionTypes_shared00() {
 // This example describes the notification configurations for the specified Auto Scaling
 // group.
 func ExampleAutoScaling_DescribeNotificationConfigurations_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeNotificationConfigurationsInput{
 		AutoScalingGroupNames: []*string{
 			aws.String("my-auto-scaling-group"),
@@ -1066,7 +1066,7 @@ func ExampleAutoScaling_DescribeNotificationConfigurations_shared00() {
 //
 // This example describes the policies for the specified Auto Scaling group.
 func ExampleAutoScaling_DescribePolicies_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribePoliciesInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 	}
@@ -1099,7 +1099,7 @@ func ExampleAutoScaling_DescribePolicies_shared00() {
 //
 // This example describes the scaling activities for the specified Auto Scaling group.
 func ExampleAutoScaling_DescribeScalingActivities_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeScalingActivitiesInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 	}
@@ -1130,7 +1130,7 @@ func ExampleAutoScaling_DescribeScalingActivities_shared00() {
 //
 // This example describes the Auto Scaling process types.
 func ExampleAutoScaling_DescribeScalingProcessTypes_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeScalingProcessTypesInput{}
 
 	result, err := svc.DescribeScalingProcessTypes(input)
@@ -1157,7 +1157,7 @@ func ExampleAutoScaling_DescribeScalingProcessTypes_shared00() {
 //
 // This example describes the scheduled actions for the specified Auto Scaling group.
 func ExampleAutoScaling_DescribeScheduledActions_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeScheduledActionsInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 	}
@@ -1188,7 +1188,7 @@ func ExampleAutoScaling_DescribeScheduledActions_shared00() {
 //
 // This example describes the tags for the specified Auto Scaling group.
 func ExampleAutoScaling_DescribeTags_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeTagsInput{
 		Filters: []*autoscaling.Filter{
 			{
@@ -1226,7 +1226,7 @@ func ExampleAutoScaling_DescribeTags_shared00() {
 //
 // This example describes the available termination policy types.
 func ExampleAutoScaling_DescribeTerminationPolicyTypes_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DescribeTerminationPolicyTypesInput{}
 
 	result, err := svc.DescribeTerminationPolicyTypes(input)
@@ -1253,7 +1253,7 @@ func ExampleAutoScaling_DescribeTerminationPolicyTypes_shared00() {
 //
 // This example detaches the specified instance from the specified Auto Scaling group.
 func ExampleAutoScaling_DetachInstances_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DetachInstancesInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		InstanceIds: []*string{
@@ -1287,7 +1287,7 @@ func ExampleAutoScaling_DetachInstances_shared00() {
 // This example detaches the specified target group from the specified Auto Scaling
 // group
 func ExampleAutoScaling_DetachLoadBalancerTargetGroups_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DetachLoadBalancerTargetGroupsInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		TargetGroupARNs: []*string{
@@ -1320,7 +1320,7 @@ func ExampleAutoScaling_DetachLoadBalancerTargetGroups_shared00() {
 // This example detaches the specified load balancer from the specified Auto Scaling
 // group.
 func ExampleAutoScaling_DetachLoadBalancers_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DetachLoadBalancersInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		LoadBalancerNames: []*string{
@@ -1353,7 +1353,7 @@ func ExampleAutoScaling_DetachLoadBalancers_shared00() {
 // This example disables collecting data for the GroupDesiredCapacity metric for the
 // specified Auto Scaling group.
 func ExampleAutoScaling_DisableMetricsCollection_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.DisableMetricsCollectionInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		Metrics: []*string{
@@ -1385,7 +1385,7 @@ func ExampleAutoScaling_DisableMetricsCollection_shared00() {
 //
 // This example enables data collection for the specified Auto Scaling group.
 func ExampleAutoScaling_EnableMetricsCollection_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.EnableMetricsCollectionInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		Granularity:          aws.String("1Minute"),
@@ -1415,7 +1415,7 @@ func ExampleAutoScaling_EnableMetricsCollection_shared00() {
 //
 // This example puts the specified instance into standby mode.
 func ExampleAutoScaling_EnterStandby_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.EnterStandbyInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		InstanceIds: []*string{
@@ -1448,7 +1448,7 @@ func ExampleAutoScaling_EnterStandby_shared00() {
 //
 // This example executes the specified policy.
 func ExampleAutoScaling_ExecutePolicy_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.ExecutePolicyInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		BreachThreshold:      aws.Float64(50.000000),
@@ -1482,7 +1482,7 @@ func ExampleAutoScaling_ExecutePolicy_shared00() {
 //
 // This example moves the specified instance out of standby mode.
 func ExampleAutoScaling_ExitStandby_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.ExitStandbyInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		InstanceIds: []*string{
@@ -1514,7 +1514,7 @@ func ExampleAutoScaling_ExitStandby_shared00() {
 //
 // This example creates a lifecycle hook.
 func ExampleAutoScaling_PutLifecycleHook_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.PutLifecycleHookInput{
 		AutoScalingGroupName:  aws.String("my-auto-scaling-group"),
 		LifecycleHookName:     aws.String("my-lifecycle-hook"),
@@ -1549,7 +1549,7 @@ func ExampleAutoScaling_PutLifecycleHook_shared00() {
 //
 // This example adds the specified notification to the specified Auto Scaling group.
 func ExampleAutoScaling_PutNotificationConfiguration_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.PutNotificationConfigurationInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		NotificationTypes: []*string{
@@ -1586,7 +1586,7 @@ func ExampleAutoScaling_PutNotificationConfiguration_shared00() {
 //
 // This example adds the specified policy to the specified Auto Scaling group.
 func ExampleAutoScaling_PutScalingPolicy_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.PutScalingPolicyInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		PolicyName:           aws.String("alb1000-target-tracking-scaling-policy"),
@@ -1628,7 +1628,7 @@ func ExampleAutoScaling_PutScalingPolicy_shared00() {
 //
 // This example adds the specified scheduled action to the specified Auto Scaling group.
 func ExampleAutoScaling_PutScheduledUpdateGroupAction_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.PutScheduledUpdateGroupActionInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		DesiredCapacity:      aws.Int64(4),
@@ -1668,7 +1668,7 @@ func ExampleAutoScaling_PutScheduledUpdateGroupAction_shared00() {
 // This example records a lifecycle action heartbeat to keep the instance in a pending
 // state.
 func ExampleAutoScaling_RecordLifecycleActionHeartbeat_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.RecordLifecycleActionHeartbeatInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		LifecycleActionToken: aws.String("bcd2f1b8-9a78-44d3-8a7a-4dd07d7cf635"),
@@ -1700,7 +1700,7 @@ func ExampleAutoScaling_RecordLifecycleActionHeartbeat_shared00() {
 // This example resumes the specified suspended scaling process for the specified Auto
 // Scaling group.
 func ExampleAutoScaling_ResumeProcesses_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.ScalingProcessQuery{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		ScalingProcesses: []*string{
@@ -1734,7 +1734,7 @@ func ExampleAutoScaling_ResumeProcesses_shared00() {
 //
 // This example sets the desired capacity for the specified Auto Scaling group.
 func ExampleAutoScaling_SetDesiredCapacity_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.SetDesiredCapacityInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		DesiredCapacity:      aws.Int64(2),
@@ -1767,7 +1767,7 @@ func ExampleAutoScaling_SetDesiredCapacity_shared00() {
 //
 // This example sets the health status of the specified instance to Unhealthy.
 func ExampleAutoScaling_SetInstanceHealth_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.SetInstanceHealthInput{
 		HealthStatus: aws.String("Unhealthy"),
 		InstanceId:   aws.String("i-93633f9b"),
@@ -1797,7 +1797,7 @@ func ExampleAutoScaling_SetInstanceHealth_shared00() {
 //
 // This example enables instance protection for the specified instance.
 func ExampleAutoScaling_SetInstanceProtection_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.SetInstanceProtectionInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		InstanceIds: []*string{
@@ -1832,7 +1832,7 @@ func ExampleAutoScaling_SetInstanceProtection_shared00() {
 //
 // This example disables instance protection for the specified instance.
 func ExampleAutoScaling_SetInstanceProtection_shared01() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.SetInstanceProtectionInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		InstanceIds: []*string{
@@ -1867,7 +1867,7 @@ func ExampleAutoScaling_SetInstanceProtection_shared01() {
 //
 // This example starts an instance refresh for the specified Auto Scaling group.
 func ExampleAutoScaling_StartInstanceRefresh_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.StartInstanceRefreshInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		Preferences: &autoscaling.RefreshPreferences{
@@ -1905,7 +1905,7 @@ func ExampleAutoScaling_StartInstanceRefresh_shared00() {
 // This example suspends the specified scaling process for the specified Auto Scaling
 // group.
 func ExampleAutoScaling_SuspendProcesses_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.ScalingProcessQuery{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		ScalingProcesses: []*string{
@@ -1941,7 +1941,7 @@ func ExampleAutoScaling_SuspendProcesses_shared00() {
 // without updating the size of the group. Auto Scaling launches a replacement instance
 // after the specified instance terminates.
 func ExampleAutoScaling_TerminateInstanceInAutoScalingGroup_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
 		InstanceId:                     aws.String("i-93633f9b"),
 		ShouldDecrementDesiredCapacity: aws.Bool(false),
@@ -1973,7 +1973,7 @@ func ExampleAutoScaling_TerminateInstanceInAutoScalingGroup_shared00() {
 //
 // This example updates the launch configuration of the specified Auto Scaling group.
 func ExampleAutoScaling_UpdateAutoScalingGroup_shared00() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName:    aws.String("my-auto-scaling-group"),
 		LaunchConfigurationName: aws.String("new-launch-config"),
@@ -2008,7 +2008,7 @@ func ExampleAutoScaling_UpdateAutoScalingGroup_shared00() {
 // This example updates the minimum size and maximum size of the specified Auto Scaling
 // group.
 func ExampleAutoScaling_UpdateAutoScalingGroup_shared01() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String("my-auto-scaling-group"),
 		MaxSize:              aws.Int64(3),
@@ -2043,7 +2043,7 @@ func ExampleAutoScaling_UpdateAutoScalingGroup_shared01() {
 //
 // This example enables instance protection for the specified Auto Scaling group.
 func ExampleAutoScaling_UpdateAutoScalingGroup_shared02() {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(session.Must(session.NewSession()))
 	input := &autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName:             aws.String("my-auto-scaling-group"),
 		NewInstancesProtectedFromScaleIn: aws.Bool(true),

--- a/service/autoscalingplans/autoscalingplansiface/interface.go
+++ b/service/autoscalingplans/autoscalingplansiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := autoscalingplans.New(sess)
 //
 //        myFunc(svc)

--- a/service/backup/backupiface/interface.go
+++ b/service/backup/backupiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := backup.New(sess)
 //
 //        myFunc(svc)

--- a/service/batch/batchiface/interface.go
+++ b/service/batch/batchiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := batch.New(sess)
 //
 //        myFunc(svc)

--- a/service/batch/examples_test.go
+++ b/service/batch/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This example cancels a job with the specified job ID.
 func ExampleBatch_CancelJob_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.CancelJobInput{
 		JobId:  aws.String("1d828f65-7a4d-42e8-996d-3b900ed59dc4"),
 		Reason: aws.String("Cancelling job."),
@@ -62,7 +62,7 @@ func ExampleBatch_CancelJob_shared00() {
 // This example creates a managed compute environment with specific C4 instance types
 // that are launched on demand. The compute environment is called C4OnDemand.
 func ExampleBatch_CreateComputeEnvironment_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.CreateComputeEnvironmentInput{
 		ComputeEnvironmentName: aws.String("C4OnDemand"),
 		ComputeResources: &batch.ComputeResource{
@@ -124,7 +124,7 @@ func ExampleBatch_CreateComputeEnvironment_shared00() {
 // is launched when the Spot bid price is at or below 20% of the On-Demand price for
 // the instance type. The compute environment is called M4Spot.
 func ExampleBatch_CreateComputeEnvironment_shared01() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.CreateComputeEnvironmentInput{
 		ComputeEnvironmentName: aws.String("M4Spot"),
 		ComputeResources: &batch.ComputeResource{
@@ -183,7 +183,7 @@ func ExampleBatch_CreateComputeEnvironment_shared01() {
 // This example creates a job queue called LowPriority that uses the M4Spot compute
 // environment.
 func ExampleBatch_CreateJobQueue_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.CreateJobQueueInput{
 		ComputeEnvironmentOrder: []*batch.ComputeEnvironmentOrder{
 			{
@@ -224,7 +224,7 @@ func ExampleBatch_CreateJobQueue_shared00() {
 // environment with an order of 1 and the M4Spot compute environment with an order of
 // 2.
 func ExampleBatch_CreateJobQueue_shared01() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.CreateJobQueueInput{
 		ComputeEnvironmentOrder: []*batch.ComputeEnvironmentOrder{
 			{
@@ -267,7 +267,7 @@ func ExampleBatch_CreateJobQueue_shared01() {
 //
 // This example deletes the P2OnDemand compute environment.
 func ExampleBatch_DeleteComputeEnvironment_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.DeleteComputeEnvironmentInput{
 		ComputeEnvironment: aws.String("P2OnDemand"),
 	}
@@ -298,7 +298,7 @@ func ExampleBatch_DeleteComputeEnvironment_shared00() {
 //
 // This example deletes the GPGPU job queue.
 func ExampleBatch_DeleteJobQueue_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.DeleteJobQueueInput{
 		JobQueue: aws.String("GPGPU"),
 	}
@@ -329,7 +329,7 @@ func ExampleBatch_DeleteJobQueue_shared00() {
 //
 // This example deregisters a job definition called sleep10.
 func ExampleBatch_DeregisterJobDefinition_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.DeregisterJobDefinitionInput{
 		JobDefinition: aws.String("sleep10"),
 	}
@@ -360,7 +360,7 @@ func ExampleBatch_DeregisterJobDefinition_shared00() {
 //
 // This example describes the P2OnDemand compute environment.
 func ExampleBatch_DescribeComputeEnvironments_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.DescribeComputeEnvironmentsInput{
 		ComputeEnvironments: []*string{
 			aws.String("P2OnDemand"),
@@ -393,7 +393,7 @@ func ExampleBatch_DescribeComputeEnvironments_shared00() {
 //
 // This example describes all of your active job definitions.
 func ExampleBatch_DescribeJobDefinitions_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.DescribeJobDefinitionsInput{
 		Status: aws.String("ACTIVE"),
 	}
@@ -424,7 +424,7 @@ func ExampleBatch_DescribeJobDefinitions_shared00() {
 //
 // This example describes the HighPriority job queue.
 func ExampleBatch_DescribeJobQueues_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.DescribeJobQueuesInput{
 		JobQueues: []*string{
 			aws.String("HighPriority"),
@@ -457,7 +457,7 @@ func ExampleBatch_DescribeJobQueues_shared00() {
 //
 // This example describes a job with the specified job ID.
 func ExampleBatch_DescribeJobs_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.DescribeJobsInput{
 		Jobs: []*string{
 			aws.String("24fa2d7a-64c4-49d2-8b47-f8da4fbde8e9"),
@@ -490,7 +490,7 @@ func ExampleBatch_DescribeJobs_shared00() {
 //
 // This example lists the running jobs in the HighPriority job queue.
 func ExampleBatch_ListJobs_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.ListJobsInput{
 		JobQueue: aws.String("HighPriority"),
 	}
@@ -522,7 +522,7 @@ func ExampleBatch_ListJobs_shared00() {
 // This example lists jobs in the HighPriority job queue that are in the SUBMITTED job
 // status.
 func ExampleBatch_ListJobs_shared01() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.ListJobsInput{
 		JobQueue:  aws.String("HighPriority"),
 		JobStatus: aws.String("SUBMITTED"),
@@ -554,7 +554,7 @@ func ExampleBatch_ListJobs_shared01() {
 //
 // This example registers a job definition for a simple container job.
 func ExampleBatch_RegisterJobDefinition_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.RegisterJobDefinitionInput{
 		ContainerProperties: &batch.ContainerProperties{
 			Command: []*string{
@@ -596,7 +596,7 @@ func ExampleBatch_RegisterJobDefinition_shared00() {
 // This example submits a simple container job called example to the HighPriority job
 // queue.
 func ExampleBatch_SubmitJob_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.SubmitJobInput{
 		JobDefinition: aws.String("sleep60"),
 		JobName:       aws.String("example"),
@@ -629,7 +629,7 @@ func ExampleBatch_SubmitJob_shared00() {
 //
 // This example terminates a job with the specified job ID.
 func ExampleBatch_TerminateJob_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.TerminateJobInput{
 		JobId:  aws.String("61e743ed-35e4-48da-b2de-5c8333821c84"),
 		Reason: aws.String("Terminating job."),
@@ -661,7 +661,7 @@ func ExampleBatch_TerminateJob_shared00() {
 //
 // This example disables the P2OnDemand compute environment so it can be deleted.
 func ExampleBatch_UpdateComputeEnvironment_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.UpdateComputeEnvironmentInput{
 		ComputeEnvironment: aws.String("P2OnDemand"),
 		State:              aws.String("DISABLED"),
@@ -693,7 +693,7 @@ func ExampleBatch_UpdateComputeEnvironment_shared00() {
 //
 // This example disables a job queue so that it can be deleted.
 func ExampleBatch_UpdateJobQueue_shared00() {
-	svc := batch.New(session.New())
+	svc := batch.New(session.Must(session.NewSession()))
 	input := &batch.UpdateJobQueueInput{
 		JobQueue: aws.String("GPGPU"),
 		State:    aws.String("DISABLED"),

--- a/service/braket/braketiface/interface.go
+++ b/service/braket/braketiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := braket.New(sess)
 //
 //        myFunc(svc)

--- a/service/budgets/budgetsiface/interface.go
+++ b/service/budgets/budgetsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := budgets.New(sess)
 //
 //        myFunc(svc)

--- a/service/chime/chimeiface/interface.go
+++ b/service/chime/chimeiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := chime.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloud9/cloud9iface/interface.go
+++ b/service/cloud9/cloud9iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloud9.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloud9/examples_test.go
+++ b/service/cloud9/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 
 func ExampleCloud9_CreateEnvironmentEC2_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.CreateEnvironmentEC2Input{
 		AutomaticStopTimeMinutes: aws.Int64(60),
 		Description:              aws.String("This is my demonstration environment."),
@@ -75,7 +75,7 @@ func ExampleCloud9_CreateEnvironmentEC2_shared00() {
 //
 
 func ExampleCloud9_CreateEnvironmentMembership_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.CreateEnvironmentMembershipInput{
 		EnvironmentId: aws.String("8d9967e2f0624182b74e7690ad69ebEX"),
 		Permissions:   aws.String("read-write"),
@@ -118,7 +118,7 @@ func ExampleCloud9_CreateEnvironmentMembership_shared00() {
 //
 
 func ExampleCloud9_DeleteEnvironment_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.DeleteEnvironmentInput{
 		EnvironmentId: aws.String("8d9967e2f0624182b74e7690ad69ebEX"),
 	}
@@ -159,7 +159,7 @@ func ExampleCloud9_DeleteEnvironment_shared00() {
 //
 
 func ExampleCloud9_DeleteEnvironmentMembership_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.DeleteEnvironmentMembershipInput{
 		EnvironmentId: aws.String("8d9967e2f0624182b74e7690ad69ebEX"),
 		UserArn:       aws.String("arn:aws:iam::123456789012:user/AnotherDemoUser"),
@@ -202,7 +202,7 @@ func ExampleCloud9_DeleteEnvironmentMembership_shared00() {
 // The following example gets information about all of the environment members for the
 // specified AWS Cloud9 development environment.
 func ExampleCloud9_DescribeEnvironmentMemberships_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.DescribeEnvironmentMembershipsInput{
 		EnvironmentId: aws.String("8d9967e2f0624182b74e7690ad69ebEX"),
 	}
@@ -244,7 +244,7 @@ func ExampleCloud9_DescribeEnvironmentMemberships_shared00() {
 // The following example gets information about the owner of the specified AWS Cloud9
 // development environment.
 func ExampleCloud9_DescribeEnvironmentMemberships_shared01() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.DescribeEnvironmentMembershipsInput{
 		EnvironmentId: aws.String("8d9967e2f0624182b74e7690ad69ebEX"),
 		Permissions: []*string{
@@ -289,7 +289,7 @@ func ExampleCloud9_DescribeEnvironmentMemberships_shared01() {
 // The following example gets AWS Cloud9 development environment membership information
 // for the specified user.
 func ExampleCloud9_DescribeEnvironmentMemberships_shared02() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.DescribeEnvironmentMembershipsInput{
 		UserArn: aws.String("arn:aws:iam::123456789012:user/MyDemoUser"),
 	}
@@ -330,7 +330,7 @@ func ExampleCloud9_DescribeEnvironmentMemberships_shared02() {
 //
 
 func ExampleCloud9_DescribeEnvironmentStatus_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.DescribeEnvironmentStatusInput{
 		EnvironmentId: aws.String("8d9967e2f0624182b74e7690ad69ebEX"),
 	}
@@ -371,7 +371,7 @@ func ExampleCloud9_DescribeEnvironmentStatus_shared00() {
 //
 
 func ExampleCloud9_DescribeEnvironments_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.DescribeEnvironmentsInput{
 		EnvironmentIds: []*string{
 			aws.String("8d9967e2f0624182b74e7690ad69ebEX"),
@@ -415,7 +415,7 @@ func ExampleCloud9_DescribeEnvironments_shared00() {
 //
 
 func ExampleCloud9_ListEnvironments_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.ListEnvironmentsInput{}
 
 	result, err := svc.ListEnvironments(input)
@@ -454,7 +454,7 @@ func ExampleCloud9_ListEnvironments_shared00() {
 //
 
 func ExampleCloud9_UpdateEnvironment_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.UpdateEnvironmentInput{
 		Description:   aws.String("This is my changed demonstration environment."),
 		EnvironmentId: aws.String("8d9967e2f0624182b74e7690ad69ebEX"),
@@ -497,7 +497,7 @@ func ExampleCloud9_UpdateEnvironment_shared00() {
 //
 
 func ExampleCloud9_UpdateEnvironmentMembership_shared00() {
-	svc := cloud9.New(session.New())
+	svc := cloud9.New(session.Must(session.NewSession()))
 	input := &cloud9.UpdateEnvironmentMembershipInput{
 		EnvironmentId: aws.String("8d9967e2f0624182b74e7690ad69ebEX"),
 		Permissions:   aws.String("read-only"),

--- a/service/clouddirectory/clouddirectoryiface/interface.go
+++ b/service/clouddirectory/clouddirectoryiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := clouddirectory.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudformation/cloudformationiface/interface.go
+++ b/service/cloudformation/cloudformationiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudformation.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudfront/cloudfrontiface/interface.go
+++ b/service/cloudfront/cloudfrontiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudfront.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudfront/examples_test.go
+++ b/service/cloudfront/examples_test.go
@@ -28,7 +28,7 @@ func parseTime(layout, value string) *time.Time {
 //
 
 func ExampleCloudFront_CreateCloudFrontOriginAccessIdentity_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.CreateCloudFrontOriginAccessIdentityInput{}
 
 	result, err := svc.CreateCloudFrontOriginAccessIdentity(input)
@@ -62,7 +62,7 @@ func ExampleCloudFront_CreateCloudFrontOriginAccessIdentity_shared00() {
 //
 
 func ExampleCloudFront_CreateDistribution_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.CreateDistributionInput{}
 
 	result, err := svc.CreateDistribution(input)
@@ -166,7 +166,7 @@ func ExampleCloudFront_CreateDistribution_shared00() {
 //
 
 func ExampleCloudFront_CreateDistributionWithTags_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.CreateDistributionWithTagsInput{}
 
 	result, err := svc.CreateDistributionWithTags(input)
@@ -272,7 +272,7 @@ func ExampleCloudFront_CreateDistributionWithTags_shared00() {
 //
 
 func ExampleCloudFront_CreateInvalidation_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.CreateInvalidationInput{}
 
 	result, err := svc.CreateInvalidation(input)
@@ -310,7 +310,7 @@ func ExampleCloudFront_CreateInvalidation_shared00() {
 //
 
 func ExampleCloudFront_CreateStreamingDistribution_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.CreateStreamingDistributionInput{}
 
 	result, err := svc.CreateStreamingDistribution(input)
@@ -358,7 +358,7 @@ func ExampleCloudFront_CreateStreamingDistribution_shared00() {
 //
 
 func ExampleCloudFront_DeleteCloudFrontOriginAccessIdentity_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.DeleteCloudFrontOriginAccessIdentityInput{}
 
 	result, err := svc.DeleteCloudFrontOriginAccessIdentity(input)
@@ -392,7 +392,7 @@ func ExampleCloudFront_DeleteCloudFrontOriginAccessIdentity_shared00() {
 //
 
 func ExampleCloudFront_DeleteDistribution_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.DeleteDistributionInput{}
 
 	result, err := svc.DeleteDistribution(input)
@@ -426,7 +426,7 @@ func ExampleCloudFront_DeleteDistribution_shared00() {
 //
 
 func ExampleCloudFront_DeleteStreamingDistribution_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.DeleteStreamingDistributionInput{}
 
 	result, err := svc.DeleteStreamingDistribution(input)
@@ -460,7 +460,7 @@ func ExampleCloudFront_DeleteStreamingDistribution_shared00() {
 //
 
 func ExampleCloudFront_GetCloudFrontOriginAccessIdentity_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.GetCloudFrontOriginAccessIdentityInput{}
 
 	result, err := svc.GetCloudFrontOriginAccessIdentity(input)
@@ -488,7 +488,7 @@ func ExampleCloudFront_GetCloudFrontOriginAccessIdentity_shared00() {
 //
 
 func ExampleCloudFront_GetCloudFrontOriginAccessIdentityConfig_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.GetCloudFrontOriginAccessIdentityConfigInput{}
 
 	result, err := svc.GetCloudFrontOriginAccessIdentityConfig(input)
@@ -516,7 +516,7 @@ func ExampleCloudFront_GetCloudFrontOriginAccessIdentityConfig_shared00() {
 //
 
 func ExampleCloudFront_GetDistribution_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.GetDistributionInput{}
 
 	result, err := svc.GetDistribution(input)
@@ -544,7 +544,7 @@ func ExampleCloudFront_GetDistribution_shared00() {
 //
 
 func ExampleCloudFront_GetDistributionConfig_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.GetDistributionConfigInput{}
 
 	result, err := svc.GetDistributionConfig(input)
@@ -572,7 +572,7 @@ func ExampleCloudFront_GetDistributionConfig_shared00() {
 //
 
 func ExampleCloudFront_GetInvalidation_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.GetInvalidationInput{}
 
 	result, err := svc.GetInvalidation(input)
@@ -602,7 +602,7 @@ func ExampleCloudFront_GetInvalidation_shared00() {
 //
 
 func ExampleCloudFront_GetStreamingDistribution_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.GetStreamingDistributionInput{}
 
 	result, err := svc.GetStreamingDistribution(input)
@@ -630,7 +630,7 @@ func ExampleCloudFront_GetStreamingDistribution_shared00() {
 //
 
 func ExampleCloudFront_GetStreamingDistributionConfig_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.GetStreamingDistributionConfigInput{}
 
 	result, err := svc.GetStreamingDistributionConfig(input)
@@ -658,7 +658,7 @@ func ExampleCloudFront_GetStreamingDistributionConfig_shared00() {
 //
 
 func ExampleCloudFront_ListCloudFrontOriginAccessIdentities_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.ListCloudFrontOriginAccessIdentitiesInput{}
 
 	result, err := svc.ListCloudFrontOriginAccessIdentities(input)
@@ -684,7 +684,7 @@ func ExampleCloudFront_ListCloudFrontOriginAccessIdentities_shared00() {
 //
 
 func ExampleCloudFront_ListDistributions_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.ListDistributionsInput{}
 
 	result, err := svc.ListDistributions(input)
@@ -710,7 +710,7 @@ func ExampleCloudFront_ListDistributions_shared00() {
 //
 
 func ExampleCloudFront_ListDistributionsByWebACLId_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.ListDistributionsByWebACLIdInput{}
 
 	result, err := svc.ListDistributionsByWebACLId(input)
@@ -738,7 +738,7 @@ func ExampleCloudFront_ListDistributionsByWebACLId_shared00() {
 //
 
 func ExampleCloudFront_ListInvalidations_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.ListInvalidationsInput{}
 
 	result, err := svc.ListInvalidations(input)
@@ -768,7 +768,7 @@ func ExampleCloudFront_ListInvalidations_shared00() {
 //
 
 func ExampleCloudFront_ListStreamingDistributions_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.ListStreamingDistributionsInput{}
 
 	result, err := svc.ListStreamingDistributions(input)
@@ -794,7 +794,7 @@ func ExampleCloudFront_ListStreamingDistributions_shared00() {
 //
 
 func ExampleCloudFront_ListTagsForResource_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.ListTagsForResourceInput{}
 
 	result, err := svc.ListTagsForResource(input)
@@ -826,7 +826,7 @@ func ExampleCloudFront_ListTagsForResource_shared00() {
 //
 
 func ExampleCloudFront_TagResource_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.TagResourceInput{}
 
 	result, err := svc.TagResource(input)
@@ -858,7 +858,7 @@ func ExampleCloudFront_TagResource_shared00() {
 //
 
 func ExampleCloudFront_UntagResource_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.UntagResourceInput{}
 
 	result, err := svc.UntagResource(input)
@@ -890,7 +890,7 @@ func ExampleCloudFront_UntagResource_shared00() {
 //
 
 func ExampleCloudFront_UpdateCloudFrontOriginAccessIdentity_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.UpdateCloudFrontOriginAccessIdentityInput{}
 
 	result, err := svc.UpdateCloudFrontOriginAccessIdentity(input)
@@ -930,7 +930,7 @@ func ExampleCloudFront_UpdateCloudFrontOriginAccessIdentity_shared00() {
 //
 
 func ExampleCloudFront_UpdateDistribution_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.UpdateDistributionInput{}
 
 	result, err := svc.UpdateDistribution(input)
@@ -1034,7 +1034,7 @@ func ExampleCloudFront_UpdateDistribution_shared00() {
 //
 
 func ExampleCloudFront_UpdateStreamingDistribution_shared00() {
-	svc := cloudfront.New(session.New())
+	svc := cloudfront.New(session.Must(session.NewSession()))
 	input := &cloudfront.UpdateStreamingDistributionInput{}
 
 	result, err := svc.UpdateStreamingDistribution(input)

--- a/service/cloudhsm/cloudhsmiface/interface.go
+++ b/service/cloudhsm/cloudhsmiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudhsm.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudhsmv2/cloudhsmv2iface/interface.go
+++ b/service/cloudhsmv2/cloudhsmv2iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudhsmv2.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudsearch/cloudsearchiface/interface.go
+++ b/service/cloudsearch/cloudsearchiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudsearch.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudsearchdomain/cloudsearchdomainiface/interface.go
+++ b/service/cloudsearchdomain/cloudsearchdomainiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudsearchdomain.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudtrail/cloudtrailiface/interface.go
+++ b/service/cloudtrail/cloudtrailiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudtrail.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudwatch/cloudwatchiface/interface.go
+++ b/service/cloudwatch/cloudwatchiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudwatch.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudwatchevents/cloudwatcheventsiface/interface.go
+++ b/service/cloudwatchevents/cloudwatcheventsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudwatchevents.New(sess)
 //
 //        myFunc(svc)

--- a/service/cloudwatchlogs/cloudwatchlogsiface/interface.go
+++ b/service/cloudwatchlogs/cloudwatchlogsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cloudwatchlogs.New(sess)
 //
 //        myFunc(svc)

--- a/service/codeartifact/codeartifactiface/interface.go
+++ b/service/codeartifact/codeartifactiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codeartifact.New(sess)
 //
 //        myFunc(svc)

--- a/service/codebuild/codebuildiface/interface.go
+++ b/service/codebuild/codebuildiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codebuild.New(sess)
 //
 //        myFunc(svc)

--- a/service/codebuild/examples_test.go
+++ b/service/codebuild/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The following example gets information about builds with the specified build IDs.
 func ExampleCodeBuild_BatchGetBuilds_shared00() {
-	svc := codebuild.New(session.New())
+	svc := codebuild.New(session.Must(session.NewSession()))
 	input := &codebuild.BatchGetBuildsInput{
 		Ids: []*string{
 			aws.String("codebuild-demo-project:9b0ac37f-d19e-4254-9079-f47e9a389eEX"),

--- a/service/codecommit/codecommitiface/interface.go
+++ b/service/codecommit/codecommitiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codecommit.New(sess)
 //
 //        myFunc(svc)

--- a/service/codedeploy/codedeployiface/interface.go
+++ b/service/codedeploy/codedeployiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codedeploy.New(sess)
 //
 //        myFunc(svc)

--- a/service/codeguruprofiler/codeguruprofileriface/interface.go
+++ b/service/codeguruprofiler/codeguruprofileriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codeguruprofiler.New(sess)
 //
 //        myFunc(svc)

--- a/service/codegurureviewer/codegururevieweriface/interface.go
+++ b/service/codegurureviewer/codegururevieweriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codegurureviewer.New(sess)
 //
 //        myFunc(svc)

--- a/service/codepipeline/codepipelineiface/interface.go
+++ b/service/codepipeline/codepipelineiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codepipeline.New(sess)
 //
 //        myFunc(svc)

--- a/service/codestar/codestariface/interface.go
+++ b/service/codestar/codestariface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codestar.New(sess)
 //
 //        myFunc(svc)

--- a/service/codestarconnections/codestarconnectionsiface/interface.go
+++ b/service/codestarconnections/codestarconnectionsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codestarconnections.New(sess)
 //
 //        myFunc(svc)

--- a/service/codestarnotifications/codestarnotificationsiface/interface.go
+++ b/service/codestarnotifications/codestarnotificationsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := codestarnotifications.New(sess)
 //
 //        myFunc(svc)

--- a/service/cognitoidentity/cognitoidentityiface/interface.go
+++ b/service/cognitoidentity/cognitoidentityiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cognitoidentity.New(sess)
 //
 //        myFunc(svc)

--- a/service/cognitoidentityprovider/cognitoidentityprovideriface/interface.go
+++ b/service/cognitoidentityprovider/cognitoidentityprovideriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cognitoidentityprovider.New(sess)
 //
 //        myFunc(svc)

--- a/service/cognitosync/cognitosynciface/interface.go
+++ b/service/cognitosync/cognitosynciface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := cognitosync.New(sess)
 //
 //        myFunc(svc)

--- a/service/comprehend/comprehendiface/interface.go
+++ b/service/comprehend/comprehendiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := comprehend.New(sess)
 //
 //        myFunc(svc)

--- a/service/comprehendmedical/comprehendmedicaliface/interface.go
+++ b/service/comprehendmedical/comprehendmedicaliface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := comprehendmedical.New(sess)
 //
 //        myFunc(svc)

--- a/service/computeoptimizer/computeoptimizeriface/interface.go
+++ b/service/computeoptimizer/computeoptimizeriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := computeoptimizer.New(sess)
 //
 //        myFunc(svc)

--- a/service/configservice/configserviceiface/interface.go
+++ b/service/configservice/configserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := configservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/connect/connectiface/interface.go
+++ b/service/connect/connectiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := connect.New(sess)
 //
 //        myFunc(svc)

--- a/service/connectparticipant/connectparticipantiface/interface.go
+++ b/service/connectparticipant/connectparticipantiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := connectparticipant.New(sess)
 //
 //        myFunc(svc)

--- a/service/costandusagereportservice/costandusagereportserviceiface/interface.go
+++ b/service/costandusagereportservice/costandusagereportserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := costandusagereportservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/costandusagereportservice/examples_test.go
+++ b/service/costandusagereportservice/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The following example deletes the AWS Cost and Usage report named ExampleReport.
 func ExampleCostandUsageReportService_DeleteReportDefinition_shared00() {
-	svc := costandusagereportservice.New(session.New())
+	svc := costandusagereportservice.New(session.Must(session.NewSession()))
 	input := &costandusagereportservice.DeleteReportDefinitionInput{
 		ReportName: aws.String("ExampleReport"),
 	}
@@ -60,7 +60,7 @@ func ExampleCostandUsageReportService_DeleteReportDefinition_shared00() {
 //
 // The following example lists the AWS Cost and Usage reports for the account.
 func ExampleCostandUsageReportService_DescribeReportDefinitions_shared00() {
-	svc := costandusagereportservice.New(session.New())
+	svc := costandusagereportservice.New(session.Must(session.NewSession()))
 	input := &costandusagereportservice.DescribeReportDefinitionsInput{
 		MaxResults: aws.Int64(5),
 	}
@@ -89,7 +89,7 @@ func ExampleCostandUsageReportService_DescribeReportDefinitions_shared00() {
 //
 // The following example creates a AWS Cost and Usage report named ExampleReport.
 func ExampleCostandUsageReportService_PutReportDefinition_shared00() {
-	svc := costandusagereportservice.New(session.New())
+	svc := costandusagereportservice.New(session.Must(session.NewSession()))
 	input := &costandusagereportservice.PutReportDefinitionInput{
 		ReportDefinition: &costandusagereportservice.ReportDefinition{
 			AdditionalArtifacts: []*string{

--- a/service/costexplorer/costexploreriface/interface.go
+++ b/service/costexplorer/costexploreriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := costexplorer.New(sess)
 //
 //        myFunc(svc)

--- a/service/databasemigrationservice/databasemigrationserviceiface/interface.go
+++ b/service/databasemigrationservice/databasemigrationserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := databasemigrationservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/databasemigrationservice/examples_test.go
+++ b/service/databasemigrationservice/examples_test.go
@@ -32,7 +32,7 @@ func parseTime(layout, value string) *time.Time {
 // reporting to track cost associated with AWS DMS resources, or used in a Condition
 // statement in an IAM policy for AWS DMS.
 func ExampleDatabaseMigrationService_AddTagsToResource_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.AddTagsToResourceInput{
 		ResourceArn: aws.String("arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E"),
 		Tags: []*databasemigrationservice.Tag{
@@ -67,7 +67,7 @@ func ExampleDatabaseMigrationService_AddTagsToResource_shared00() {
 //
 // Creates an endpoint using the provided settings.
 func ExampleDatabaseMigrationService_CreateEndpoint_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.CreateEndpointInput{
 		CertificateArn:            aws.String(""),
 		DatabaseName:              aws.String("testdb"),
@@ -123,7 +123,7 @@ func ExampleDatabaseMigrationService_CreateEndpoint_shared00() {
 //
 // Creates the replication instance using the specified parameters.
 func ExampleDatabaseMigrationService_CreateReplicationInstance_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.CreateReplicationInstanceInput{
 		AllocatedStorage:                 aws.Int64(123),
 		AutoMinorVersionUpgrade:          aws.Bool(true),
@@ -186,7 +186,7 @@ func ExampleDatabaseMigrationService_CreateReplicationInstance_shared00() {
 //
 // Creates a replication subnet group given a list of the subnet IDs in a VPC.
 func ExampleDatabaseMigrationService_CreateReplicationSubnetGroup_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.CreateReplicationSubnetGroupInput{
 		ReplicationSubnetGroupDescription: aws.String("US West subnet group"),
 		ReplicationSubnetGroupIdentifier:  aws.String("us-west-2ab-vpc-215ds366"),
@@ -236,7 +236,7 @@ func ExampleDatabaseMigrationService_CreateReplicationSubnetGroup_shared00() {
 //
 // Creates a replication task using the specified parameters.
 func ExampleDatabaseMigrationService_CreateReplicationTask_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.CreateReplicationTaskInput{
 		CdcStartTime:              parseTime("2006-01-02T15:04:05.999999999Z", "2016-12-14T18:25:43Z"),
 		MigrationType:             aws.String("full-load"),
@@ -288,7 +288,7 @@ func ExampleDatabaseMigrationService_CreateReplicationTask_shared00() {
 //
 // Deletes the specified certificate.
 func ExampleDatabaseMigrationService_DeleteCertificate_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DeleteCertificateInput{
 		CertificateArn: aws.String("arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUSM457DE6XFJCJQ"),
 	}
@@ -319,7 +319,7 @@ func ExampleDatabaseMigrationService_DeleteCertificate_shared00() {
 //
 // Deletes the connection between the replication instance and the endpoint.
 func ExampleDatabaseMigrationService_DeleteConnection_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DeleteConnectionInput{
 		EndpointArn:            aws.String("arn:aws:dms:us-east-1:123456789012:endpoint:RAAR3R22XSH46S3PWLC3NJAWKM"),
 		ReplicationInstanceArn: aws.String("arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ"),
@@ -354,7 +354,7 @@ func ExampleDatabaseMigrationService_DeleteConnection_shared00() {
 // Deletes the specified endpoint. All tasks associated with the endpoint must be deleted
 // before you can delete the endpoint.
 func ExampleDatabaseMigrationService_DeleteEndpoint_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DeleteEndpointInput{
 		EndpointArn: aws.String("arn:aws:dms:us-east-1:123456789012:endpoint:RAAR3R22XSH46S3PWLC3NJAWKM"),
 	}
@@ -386,7 +386,7 @@ func ExampleDatabaseMigrationService_DeleteEndpoint_shared00() {
 // Deletes the specified replication instance. You must delete any migration tasks that
 // are associated with the replication instance before you can delete it.
 func ExampleDatabaseMigrationService_DeleteReplicationInstance_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DeleteReplicationInstanceInput{
 		ReplicationInstanceArn: aws.String("arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ"),
 	}
@@ -417,7 +417,7 @@ func ExampleDatabaseMigrationService_DeleteReplicationInstance_shared00() {
 //
 // Deletes a replication subnet group.
 func ExampleDatabaseMigrationService_DeleteReplicationSubnetGroup_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DeleteReplicationSubnetGroupInput{
 		ReplicationSubnetGroupIdentifier: aws.String("us-west-2ab-vpc-215ds366"),
 	}
@@ -448,7 +448,7 @@ func ExampleDatabaseMigrationService_DeleteReplicationSubnetGroup_shared00() {
 //
 // Deletes the specified replication task.
 func ExampleDatabaseMigrationService_DeleteReplicationTask_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DeleteReplicationTaskInput{
 		ReplicationTaskArn: aws.String("arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ"),
 	}
@@ -482,7 +482,7 @@ func ExampleDatabaseMigrationService_DeleteReplicationTask_shared00() {
 // The description for a quota includes the quota name, current usage toward that quota,
 // and the quota's maximum value. This operation does not take any parameters.
 func ExampleDatabaseMigrationService_DescribeAccountAttributes_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeAccountAttributesInput{}
 
 	result, err := svc.DescribeAccountAttributes(input)
@@ -507,7 +507,7 @@ func ExampleDatabaseMigrationService_DescribeAccountAttributes_shared00() {
 //
 // Provides a description of the certificate.
 func ExampleDatabaseMigrationService_DescribeCertificates_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeCertificatesInput{
 		Filters: []*databasemigrationservice.Filter{
 			{
@@ -547,7 +547,7 @@ func ExampleDatabaseMigrationService_DescribeCertificates_shared00() {
 // Describes the status of the connections that have been made between the replication
 // instance and an endpoint. Connections are created when you test an endpoint.
 func ExampleDatabaseMigrationService_DescribeConnections_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeConnectionsInput{
 		Filters: []*databasemigrationservice.Filter{
 			{
@@ -586,7 +586,7 @@ func ExampleDatabaseMigrationService_DescribeConnections_shared00() {
 //
 // Returns information about the type of endpoints available.
 func ExampleDatabaseMigrationService_DescribeEndpointTypes_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeEndpointTypesInput{
 		Filters: []*databasemigrationservice.Filter{
 			{
@@ -623,7 +623,7 @@ func ExampleDatabaseMigrationService_DescribeEndpointTypes_shared00() {
 //
 // Returns information about the endpoints for your account in the current region.
 func ExampleDatabaseMigrationService_DescribeEndpoints_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeEndpointsInput{
 		Filters: []*databasemigrationservice.Filter{
 			{
@@ -663,7 +663,7 @@ func ExampleDatabaseMigrationService_DescribeEndpoints_shared00() {
 // Returns information about the replication instance types that can be created in the
 // specified region.
 func ExampleDatabaseMigrationService_DescribeOrderableReplicationInstances_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeOrderableReplicationInstancesInput{
 		Marker:     aws.String(""),
 		MaxRecords: aws.Int64(123),
@@ -691,7 +691,7 @@ func ExampleDatabaseMigrationService_DescribeOrderableReplicationInstances_share
 //
 // Returns the status of the refresh-schemas operation.
 func ExampleDatabaseMigrationService_DescribeRefreshSchemasStatus_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeRefreshSchemasStatusInput{
 		EndpointArn: aws.String(""),
 	}
@@ -722,7 +722,7 @@ func ExampleDatabaseMigrationService_DescribeRefreshSchemasStatus_shared00() {
 //
 // Returns the status of the refresh-schemas operation.
 func ExampleDatabaseMigrationService_DescribeReplicationInstances_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeReplicationInstancesInput{
 		Filters: []*databasemigrationservice.Filter{
 			{
@@ -761,7 +761,7 @@ func ExampleDatabaseMigrationService_DescribeReplicationInstances_shared00() {
 //
 // Returns information about the replication subnet groups.
 func ExampleDatabaseMigrationService_DescribeReplicationSubnetGroups_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeReplicationSubnetGroupsInput{
 		Filters: []*databasemigrationservice.Filter{
 			{
@@ -800,7 +800,7 @@ func ExampleDatabaseMigrationService_DescribeReplicationSubnetGroups_shared00() 
 //
 // Returns information about replication tasks for your account in the current region.
 func ExampleDatabaseMigrationService_DescribeReplicationTasks_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeReplicationTasksInput{
 		Filters: []*databasemigrationservice.Filter{
 			{
@@ -839,7 +839,7 @@ func ExampleDatabaseMigrationService_DescribeReplicationTasks_shared00() {
 //
 // Returns information about the schema for the specified endpoint.
 func ExampleDatabaseMigrationService_DescribeSchemas_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeSchemasInput{
 		EndpointArn: aws.String(""),
 		Marker:      aws.String(""),
@@ -873,7 +873,7 @@ func ExampleDatabaseMigrationService_DescribeSchemas_shared00() {
 // Returns table statistics on the database migration task, including table name, rows
 // inserted, rows updated, and rows deleted.
 func ExampleDatabaseMigrationService_DescribeTableStatistics_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.DescribeTableStatisticsInput{
 		Marker:             aws.String(""),
 		MaxRecords:         aws.Int64(123),
@@ -906,7 +906,7 @@ func ExampleDatabaseMigrationService_DescribeTableStatistics_shared00() {
 //
 // Uploads the specified certificate.
 func ExampleDatabaseMigrationService_ImportCertificate_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.ImportCertificateInput{
 		CertificateIdentifier: aws.String(""),
 		CertificatePem:        aws.String(""),
@@ -940,7 +940,7 @@ func ExampleDatabaseMigrationService_ImportCertificate_shared00() {
 //
 // Lists all tags for an AWS DMS resource.
 func ExampleDatabaseMigrationService_ListTagsForResource_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.ListTagsForResourceInput{
 		ResourceArn: aws.String(""),
 	}
@@ -969,7 +969,7 @@ func ExampleDatabaseMigrationService_ListTagsForResource_shared00() {
 //
 // Modifies the specified endpoint.
 func ExampleDatabaseMigrationService_ModifyEndpoint_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.ModifyEndpointInput{
 		CertificateArn:            aws.String(""),
 		DatabaseName:              aws.String(""),
@@ -1019,7 +1019,7 @@ func ExampleDatabaseMigrationService_ModifyEndpoint_shared00() {
 // parameters by specifying these parameters and the new values in the request. Some
 // settings are applied during the maintenance window.
 func ExampleDatabaseMigrationService_ModifyReplicationInstance_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.ModifyReplicationInstanceInput{
 		AllocatedStorage:              aws.Int64(123),
 		AllowMajorVersionUpgrade:      aws.Bool(true),
@@ -1069,7 +1069,7 @@ func ExampleDatabaseMigrationService_ModifyReplicationInstance_shared00() {
 //
 // Modifies the settings for the specified replication subnet group.
 func ExampleDatabaseMigrationService_ModifyReplicationSubnetGroup_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.ModifyReplicationSubnetGroupInput{
 		ReplicationSubnetGroupDescription: aws.String(""),
 		ReplicationSubnetGroupIdentifier:  aws.String(""),
@@ -1111,7 +1111,7 @@ func ExampleDatabaseMigrationService_ModifyReplicationSubnetGroup_shared00() {
 // and can take several minutes. You can check the status of this operation by calling
 // the describe-refresh-schemas-status operation.
 func ExampleDatabaseMigrationService_RefreshSchemas_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.RefreshSchemasInput{
 		EndpointArn:            aws.String(""),
 		ReplicationInstanceArn: aws.String(""),
@@ -1147,7 +1147,7 @@ func ExampleDatabaseMigrationService_RefreshSchemas_shared00() {
 //
 // Removes metadata tags from an AWS DMS resource.
 func ExampleDatabaseMigrationService_RemoveTagsFromResource_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.RemoveTagsFromResourceInput{
 		ResourceArn: aws.String("arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E"),
 	}
@@ -1176,7 +1176,7 @@ func ExampleDatabaseMigrationService_RemoveTagsFromResource_shared00() {
 //
 // Starts the replication task.
 func ExampleDatabaseMigrationService_StartReplicationTask_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.StartReplicationTaskInput{
 		CdcStartTime:             parseTime("2006-01-02T15:04:05.999999999Z", "2016-12-14T13:33:20Z"),
 		ReplicationTaskArn:       aws.String("arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ"),
@@ -1211,7 +1211,7 @@ func ExampleDatabaseMigrationService_StartReplicationTask_shared00() {
 //
 // Stops the replication task.
 func ExampleDatabaseMigrationService_StopReplicationTask_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.StopReplicationTaskInput{
 		ReplicationTaskArn: aws.String("arn:aws:dms:us-east-1:123456789012:endpoint:ASXWXJZLNWNT5HTWCGV2BUJQ7E"),
 	}
@@ -1242,7 +1242,7 @@ func ExampleDatabaseMigrationService_StopReplicationTask_shared00() {
 //
 // Tests the connection between the replication instance and the endpoint.
 func ExampleDatabaseMigrationService_TestConnection_shared00() {
-	svc := databasemigrationservice.New(session.New())
+	svc := databasemigrationservice.New(session.Must(session.NewSession()))
 	input := &databasemigrationservice.TestConnectionInput{
 		EndpointArn:            aws.String("arn:aws:dms:us-east-1:123456789012:endpoint:RAAR3R22XSH46S3PWLC3NJAWKM"),
 		ReplicationInstanceArn: aws.String("arn:aws:dms:us-east-1:123456789012:rep:6UTDJGBOUS3VI3SUWA66XFJCJQ"),

--- a/service/dataexchange/dataexchangeiface/interface.go
+++ b/service/dataexchange/dataexchangeiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := dataexchange.New(sess)
 //
 //        myFunc(svc)

--- a/service/datapipeline/datapipelineiface/interface.go
+++ b/service/datapipeline/datapipelineiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := datapipeline.New(sess)
 //
 //        myFunc(svc)

--- a/service/datasync/datasynciface/interface.go
+++ b/service/datasync/datasynciface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := datasync.New(sess)
 //
 //        myFunc(svc)

--- a/service/dax/daxiface/interface.go
+++ b/service/dax/daxiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := dax.New(sess)
 //
 //        myFunc(svc)

--- a/service/detective/detectiveiface/interface.go
+++ b/service/detective/detectiveiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := detective.New(sess)
 //
 //        myFunc(svc)

--- a/service/devicefarm/devicefarmiface/interface.go
+++ b/service/devicefarm/devicefarmiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := devicefarm.New(sess)
 //
 //        myFunc(svc)

--- a/service/devicefarm/examples_test.go
+++ b/service/devicefarm/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // The following example creates a new device pool named MyDevicePool inside an existing
 // project.
 func ExampleDeviceFarm_CreateDevicePool_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.CreateDevicePoolInput{
 		Description: aws.String("My Android devices"),
 		Name:        aws.String("MyDevicePool"),
@@ -67,7 +67,7 @@ func ExampleDeviceFarm_CreateDevicePool_shared00() {
 //
 // The following example creates a new project named MyProject.
 func ExampleDeviceFarm_CreateProject_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.CreateProjectInput{
 		Name: aws.String("MyProject"),
 	}
@@ -104,7 +104,7 @@ func ExampleDeviceFarm_CreateProject_shared00() {
 //
 // The following example creates a remote access session named MySession.
 func ExampleDeviceFarm_CreateRemoteAccessSession_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.CreateRemoteAccessSessionInput{
 		Configuration: &devicefarm.CreateRemoteAccessSessionConfiguration{
 			BillingMethod: aws.String("METERED"),
@@ -145,7 +145,7 @@ func ExampleDeviceFarm_CreateRemoteAccessSession_shared00() {
 // The following example creates a new Appium Python test package upload inside an existing
 // project.
 func ExampleDeviceFarm_CreateUpload_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.CreateUploadInput{
 		Name:       aws.String("MyAppiumPythonUpload"),
 		ProjectArn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
@@ -182,7 +182,7 @@ func ExampleDeviceFarm_CreateUpload_shared00() {
 //
 // The following example deletes a specific device pool.
 func ExampleDeviceFarm_DeleteDevicePool_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.DeleteDevicePoolInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2::devicepool:123-456-EXAMPLE-GUID"),
 	}
@@ -217,7 +217,7 @@ func ExampleDeviceFarm_DeleteDevicePool_shared00() {
 //
 // The following example deletes a specific project.
 func ExampleDeviceFarm_DeleteProject_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.DeleteProjectInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
 	}
@@ -252,7 +252,7 @@ func ExampleDeviceFarm_DeleteProject_shared00() {
 //
 // The following example deletes a specific remote access session.
 func ExampleDeviceFarm_DeleteRemoteAccessSession_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.DeleteRemoteAccessSessionInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:session:EXAMPLE-GUID-123-456"),
 	}
@@ -287,7 +287,7 @@ func ExampleDeviceFarm_DeleteRemoteAccessSession_shared00() {
 //
 // The following example deletes a specific test run.
 func ExampleDeviceFarm_DeleteRun_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.DeleteRunInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:run:EXAMPLE-GUID-123-456"),
 	}
@@ -322,7 +322,7 @@ func ExampleDeviceFarm_DeleteRun_shared00() {
 //
 // The following example deletes a specific upload.
 func ExampleDeviceFarm_DeleteUpload_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.DeleteUploadInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:upload:EXAMPLE-GUID-123-456"),
 	}
@@ -357,7 +357,7 @@ func ExampleDeviceFarm_DeleteUpload_shared00() {
 //
 // The following example returns information about your Device Farm account settings.
 func ExampleDeviceFarm_GetAccountSettings_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetAccountSettingsInput{}
 
 	result, err := svc.GetAccountSettings(input)
@@ -390,7 +390,7 @@ func ExampleDeviceFarm_GetAccountSettings_shared00() {
 //
 // The following example returns information about a specific device.
 func ExampleDeviceFarm_GetDevice_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetDeviceInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2::device:123EXAMPLE"),
 	}
@@ -426,7 +426,7 @@ func ExampleDeviceFarm_GetDevice_shared00() {
 // The following example returns information about a specific device pool, given a project
 // ARN.
 func ExampleDeviceFarm_GetDevicePool_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetDevicePoolInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
 	}
@@ -462,7 +462,7 @@ func ExampleDeviceFarm_GetDevicePool_shared00() {
 // The following example returns information about the compatibility of a specific device
 // pool, given its ARN.
 func ExampleDeviceFarm_GetDevicePoolCompatibility_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetDevicePoolCompatibilityInput{
 		AppArn:        aws.String("arn:aws:devicefarm:us-west-2::app:123-456-EXAMPLE-GUID"),
 		DevicePoolArn: aws.String("arn:aws:devicefarm:us-west-2::devicepool:123-456-EXAMPLE-GUID"),
@@ -499,7 +499,7 @@ func ExampleDeviceFarm_GetDevicePoolCompatibility_shared00() {
 //
 // The following example returns information about a specific job.
 func ExampleDeviceFarm_GetJob_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetJobInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2::job:123-456-EXAMPLE-GUID"),
 	}
@@ -535,7 +535,7 @@ func ExampleDeviceFarm_GetJob_shared00() {
 // The following example returns information about Device Farm offerings available to
 // your account.
 func ExampleDeviceFarm_GetOfferingStatus_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetOfferingStatusInput{
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE="),
 	}
@@ -572,7 +572,7 @@ func ExampleDeviceFarm_GetOfferingStatus_shared00() {
 //
 // The following example gets information about a specific project.
 func ExampleDeviceFarm_GetProject_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetProjectInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:5e01a8c7-c861-4c0a-b1d5-12345EXAMPLE"),
 	}
@@ -607,7 +607,7 @@ func ExampleDeviceFarm_GetProject_shared00() {
 //
 // The following example gets a specific remote access session.
 func ExampleDeviceFarm_GetRemoteAccessSession_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetRemoteAccessSessionInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:session:EXAMPLE-GUID-123-456"),
 	}
@@ -642,7 +642,7 @@ func ExampleDeviceFarm_GetRemoteAccessSession_shared00() {
 //
 // The following example gets information about a specific test run.
 func ExampleDeviceFarm_GetRun_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetRunInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b1d5-5ec6e6c6dd23/0fcac17b-6122-44d7-ae5a-12345EXAMPLE"),
 	}
@@ -677,7 +677,7 @@ func ExampleDeviceFarm_GetRun_shared00() {
 //
 // The following example gets information about a specific test suite.
 func ExampleDeviceFarm_GetSuite_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetSuiteInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:suite:EXAMPLE-GUID-123-456"),
 	}
@@ -712,7 +712,7 @@ func ExampleDeviceFarm_GetSuite_shared00() {
 //
 // The following example gets information about a specific test.
 func ExampleDeviceFarm_GetTest_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetTestInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:test:EXAMPLE-GUID-123-456"),
 	}
@@ -747,7 +747,7 @@ func ExampleDeviceFarm_GetTest_shared00() {
 //
 // The following example gets information about a specific upload.
 func ExampleDeviceFarm_GetUpload_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.GetUploadInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:upload:EXAMPLE-GUID-123-456"),
 	}
@@ -783,7 +783,7 @@ func ExampleDeviceFarm_GetUpload_shared00() {
 // The following example installs a specific app to a device in a specific remote access
 // session.
 func ExampleDeviceFarm_InstallToRemoteAccessSession_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.InstallToRemoteAccessSessionInput{
 		AppArn:                 aws.String("arn:aws:devicefarm:us-west-2:123456789101:app:EXAMPLE-GUID-123-456"),
 		RemoteAccessSessionArn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:session:EXAMPLE-GUID-123-456"),
@@ -819,7 +819,7 @@ func ExampleDeviceFarm_InstallToRemoteAccessSession_shared00() {
 //
 // The following example lists screenshot artifacts for a specific run.
 func ExampleDeviceFarm_ListArtifacts_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListArtifactsInput{
 		Arn:  aws.String("arn:aws:devicefarm:us-west-2:123456789101:run:EXAMPLE-GUID-123-456"),
 		Type: aws.String("SCREENSHOT"),
@@ -856,7 +856,7 @@ func ExampleDeviceFarm_ListArtifacts_shared00() {
 // The following example returns information about the private device pools in a specific
 // project.
 func ExampleDeviceFarm_ListDevicePools_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListDevicePoolsInput{
 		Arn:  aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
 		Type: aws.String("PRIVATE"),
@@ -893,7 +893,7 @@ func ExampleDeviceFarm_ListDevicePools_shared00() {
 // The following example returns information about the available devices in a specific
 // project.
 func ExampleDeviceFarm_ListDevices_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListDevicesInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
 	}
@@ -928,7 +928,7 @@ func ExampleDeviceFarm_ListDevices_shared00() {
 //
 // The following example returns information about jobs in a specific project.
 func ExampleDeviceFarm_ListJobs_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListJobsInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
 	}
@@ -963,7 +963,7 @@ func ExampleDeviceFarm_ListJobs_shared00() {
 //
 // The following example returns information about Device Farm offering transactions.
 func ExampleDeviceFarm_ListOfferingTransactions_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListOfferingTransactionsInput{
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE="),
 	}
@@ -1000,7 +1000,7 @@ func ExampleDeviceFarm_ListOfferingTransactions_shared00() {
 //
 // The following example returns information about available device offerings.
 func ExampleDeviceFarm_ListOfferings_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListOfferingsInput{
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE="),
 	}
@@ -1037,7 +1037,7 @@ func ExampleDeviceFarm_ListOfferings_shared00() {
 //
 // The following example returns information about the specified project in Device Farm.
 func ExampleDeviceFarm_ListProjects_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListProjectsInput{
 		Arn:       aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:7ad300ed-8183-41a7-bf94-12345EXAMPLE"),
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"),
@@ -1074,7 +1074,7 @@ func ExampleDeviceFarm_ListProjects_shared00() {
 // The following example returns information about a specific Device Farm remote access
 // session.
 func ExampleDeviceFarm_ListRemoteAccessSessions_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListRemoteAccessSessionsInput{
 		Arn:       aws.String("arn:aws:devicefarm:us-west-2:123456789101:session:EXAMPLE-GUID-123-456"),
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE="),
@@ -1110,7 +1110,7 @@ func ExampleDeviceFarm_ListRemoteAccessSessions_shared00() {
 //
 // The following example returns information about a specific test run.
 func ExampleDeviceFarm_ListRuns_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListRunsInput{
 		Arn:       aws.String("arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b1d5-5ec6e6c6dd23/0fcac17b-6122-44d7-ae5a-12345EXAMPLE"),
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"),
@@ -1147,7 +1147,7 @@ func ExampleDeviceFarm_ListRuns_shared00() {
 // The following example returns information about samples, given a specific Device
 // Farm project.
 func ExampleDeviceFarm_ListSamples_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListSamplesInput{
 		Arn:       aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"),
@@ -1184,7 +1184,7 @@ func ExampleDeviceFarm_ListSamples_shared00() {
 // The following example returns information about suites, given a specific Device Farm
 // job.
 func ExampleDeviceFarm_ListSuites_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListSuitesInput{
 		Arn:       aws.String("arn:aws:devicefarm:us-west-2:123456789101:job:EXAMPLE-GUID-123-456"),
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"),
@@ -1221,7 +1221,7 @@ func ExampleDeviceFarm_ListSuites_shared00() {
 // The following example returns information about tests, given a specific Device Farm
 // project.
 func ExampleDeviceFarm_ListTests_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListTestsInput{
 		Arn:       aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"),
@@ -1258,7 +1258,7 @@ func ExampleDeviceFarm_ListTests_shared00() {
 // The following example returns information about unique problems, given a specific
 // Device Farm project.
 func ExampleDeviceFarm_ListUniqueProblems_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListUniqueProblemsInput{
 		Arn:       aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"),
@@ -1295,7 +1295,7 @@ func ExampleDeviceFarm_ListUniqueProblems_shared00() {
 // The following example returns information about uploads, given a specific Device
 // Farm project.
 func ExampleDeviceFarm_ListUploads_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ListUploadsInput{
 		Arn:       aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:EXAMPLE-GUID-123-456"),
 		NextToken: aws.String("RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"),
@@ -1331,7 +1331,7 @@ func ExampleDeviceFarm_ListUploads_shared00() {
 //
 // The following example purchases a specific device slot offering.
 func ExampleDeviceFarm_PurchaseOffering_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.PurchaseOfferingInput{
 		OfferingId: aws.String("D68B3C05-1BA6-4360-BC69-12345EXAMPLE"),
 		Quantity:   aws.Int64(1),
@@ -1369,7 +1369,7 @@ func ExampleDeviceFarm_PurchaseOffering_shared00() {
 //
 // The following example renews a specific device slot offering.
 func ExampleDeviceFarm_RenewOffering_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.RenewOfferingInput{
 		OfferingId: aws.String("D68B3C05-1BA6-4360-BC69-12345EXAMPLE"),
 		Quantity:   aws.Int64(1),
@@ -1407,7 +1407,7 @@ func ExampleDeviceFarm_RenewOffering_shared00() {
 //
 // The following example schedules a test run named MyRun.
 func ExampleDeviceFarm_ScheduleRun_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.ScheduleRunInput{
 		DevicePoolArn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:pool:EXAMPLE-GUID-123-456"),
 		Name:          aws.String("MyRun"),
@@ -1450,7 +1450,7 @@ func ExampleDeviceFarm_ScheduleRun_shared00() {
 //
 // The following example stops a specific test run.
 func ExampleDeviceFarm_StopRun_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.StopRunInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2:123456789101:run:EXAMPLE-GUID-123-456"),
 	}
@@ -1486,7 +1486,7 @@ func ExampleDeviceFarm_StopRun_shared00() {
 // The following example updates the specified device pool with a new name and description.
 // It also enables remote access of devices in the device pool.
 func ExampleDeviceFarm_UpdateDevicePool_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.UpdateDevicePoolInput{
 		Arn:         aws.String("arn:aws:devicefarm:us-west-2::devicepool:082d10e5-d7d7-48a5-ba5c-12345EXAMPLE"),
 		Description: aws.String("NewDescription"),
@@ -1530,7 +1530,7 @@ func ExampleDeviceFarm_UpdateDevicePool_shared00() {
 //
 // The following example updates the specified project with a new name.
 func ExampleDeviceFarm_UpdateProject_shared00() {
-	svc := devicefarm.New(session.New())
+	svc := devicefarm.New(session.Must(session.NewSession()))
 	input := &devicefarm.UpdateProjectInput{
 		Arn:  aws.String("arn:aws:devicefarm:us-west-2:123456789101:project:8f75187d-101e-4625-accc-12345EXAMPLE"),
 		Name: aws.String("NewName"),

--- a/service/directconnect/directconnectiface/interface.go
+++ b/service/directconnect/directconnectiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := directconnect.New(sess)
 //
 //        myFunc(svc)

--- a/service/directoryservice/directoryserviceiface/interface.go
+++ b/service/directoryservice/directoryserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := directoryservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/dlm/dlmiface/interface.go
+++ b/service/dlm/dlmiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := dlm.New(sess)
 //
 //        myFunc(svc)

--- a/service/docdb/docdbiface/interface.go
+++ b/service/docdb/docdbiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := docdb.New(sess)
 //
 //        myFunc(svc)

--- a/service/dynamodb/dynamodbiface/interface.go
+++ b/service/dynamodb/dynamodbiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := dynamodb.New(sess)
 //
 //        myFunc(svc)

--- a/service/dynamodb/examples_test.go
+++ b/service/dynamodb/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // This example reads multiple items from the Music table using a batch of three GetItem
 // requests. Only the AlbumTitle attribute is returned.
 func ExampleDynamoDB_BatchGetItem_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.BatchGetItemInput{
 		RequestItems: map[string]*dynamodb.KeysAndAttributes{
 			"Music": {
@@ -96,7 +96,7 @@ func ExampleDynamoDB_BatchGetItem_shared00() {
 // This example adds three new items to the Music table using a batch of three PutItem
 // requests.
 func ExampleDynamoDB_BatchWriteItem_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.BatchWriteItemInput{
 		RequestItems: map[string][]*dynamodb.WriteRequest{
 			"Music": {
@@ -181,7 +181,7 @@ func ExampleDynamoDB_BatchWriteItem_shared00() {
 //
 // This example creates a table named Music.
 func ExampleDynamoDB_CreateTable_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.CreateTableInput{
 		AttributeDefinitions: []*dynamodb.AttributeDefinition{
 			{
@@ -238,7 +238,7 @@ func ExampleDynamoDB_CreateTable_shared00() {
 //
 // This example deletes an item from the Music table.
 func ExampleDynamoDB_DeleteItem_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.DeleteItemInput{
 		Key: map[string]*dynamodb.AttributeValue{
 			"Artist": {
@@ -287,7 +287,7 @@ func ExampleDynamoDB_DeleteItem_shared00() {
 //
 // This example deletes the Music table.
 func ExampleDynamoDB_DeleteTable_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.DeleteTableInput{
 		TableName: aws.String("Music"),
 	}
@@ -323,7 +323,7 @@ func ExampleDynamoDB_DeleteTable_shared00() {
 // The following example returns the maximum read and write capacity units per table,
 // and for the AWS account, in the current AWS region.
 func ExampleDynamoDB_DescribeLimits_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.DescribeLimitsInput{}
 
 	result, err := svc.DescribeLimits(input)
@@ -350,7 +350,7 @@ func ExampleDynamoDB_DescribeLimits_shared00() {
 //
 // This example describes the Music table.
 func ExampleDynamoDB_DescribeTable_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.DescribeTableInput{
 		TableName: aws.String("Music"),
 	}
@@ -382,7 +382,7 @@ func ExampleDynamoDB_DescribeTable_shared00() {
 // This example retrieves an item from the Music table. The table has a partition key
 // and a sort key (Artist and SongTitle), so you must specify both of these attributes.
 func ExampleDynamoDB_GetItem_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.GetItemInput{
 		Key: map[string]*dynamodb.AttributeValue{
 			"Artist": {
@@ -426,7 +426,7 @@ func ExampleDynamoDB_GetItem_shared00() {
 // This example lists all of the tables associated with the current AWS account and
 // endpoint.
 func ExampleDynamoDB_ListTables_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.ListTablesInput{}
 
 	result, err := svc.ListTables(input)
@@ -453,7 +453,7 @@ func ExampleDynamoDB_ListTables_shared00() {
 //
 // This example adds a new item to the Music table.
 func ExampleDynamoDB_PutItem_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.PutItemInput{
 		Item: map[string]*dynamodb.AttributeValue{
 			"AlbumTitle": {
@@ -508,7 +508,7 @@ func ExampleDynamoDB_PutItem_shared00() {
 // sort key (Artist and SongTitle), but this query only specifies the partition key
 // value. It returns song titles by the artist named "No One You Know".
 func ExampleDynamoDB_Query_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.QueryInput{
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			":v1": {
@@ -552,7 +552,7 @@ func ExampleDynamoDB_Query_shared00() {
 // by the artist "No One You Know". For each item, only the album title and song title
 // are returned.
 func ExampleDynamoDB_Scan_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.ScanInput{
 		ExpressionAttributeNames: map[string]*string{
 			"#AT": aws.String("AlbumTitle"),
@@ -600,7 +600,7 @@ func ExampleDynamoDB_Scan_shared00() {
 // modifies the AlbumTitle attribute. All of the attributes in the item, as they appear
 // after the update, are returned in the response.
 func ExampleDynamoDB_UpdateItem_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.UpdateItemInput{
 		ExpressionAttributeNames: map[string]*string{
 			"#AT": aws.String("AlbumTitle"),
@@ -663,7 +663,7 @@ func ExampleDynamoDB_UpdateItem_shared00() {
 //
 // This example increases the provisioned read and write capacity on the Music table.
 func ExampleDynamoDB_UpdateTable_shared00() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 	input := &dynamodb.UpdateTableInput{
 		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(10),

--- a/service/dynamodb/expression/examples_test.go
+++ b/service/dynamodb/expression/examples_test.go
@@ -16,7 +16,7 @@ import (
 // sort key (Artist and SongTitle), but this query only specifies the partition key
 // value. It returns song titles by the artist named "No One You Know".
 func ExampleBuilder_WithProjection() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 
 	// Construct the Key condition builder
 	keyCond := expression.Key("Artist").Equal(expression.Value("No One You Know"))
@@ -73,7 +73,7 @@ func ExampleBuilder_WithProjection() {
 // sort key (Artist and SongTitle), but this query only specifies the partition key
 // value. It returns song titles by the artist named "No One You Know".
 func ExampleBuilder_WithKeyCondition() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 
 	// Construct the Key condition builder
 	keyCond := expression.Key("Artist").Equal(expression.Value("No One You Know"))
@@ -131,7 +131,7 @@ func ExampleBuilder_WithKeyCondition() {
 // by the artist "No One You Know". For each item, only the album title and song title
 // are returned.
 func ExampleBuilder_WithFilter() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 
 	// Construct the filter builder with a name and value.
 	filt := expression.Name("Artist").Equal(expression.Value("No One You Know"))
@@ -190,7 +190,7 @@ func ExampleBuilder_WithFilter() {
 // modifies the AlbumTitle attribute.  All of the attributes in the item, as they appear
 // after the update, are returned in the response.
 func ExampleBuilder_WithUpdate() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 
 	// Create an update to set two fields in the table.
 	update := expression.Set(
@@ -257,7 +257,7 @@ func ExampleBuilder_WithUpdate() {
 // This example deletes an item from the Music table if the rating is lower than
 // 7.
 func ExampleBuilder_WithCondition() {
-	svc := dynamodb.New(session.New())
+	svc := dynamodb.New(session.Must(session.NewSession()))
 
 	// Create a condition where the Rating field must be less than 7.
 	cond := expression.Name("Rating").LessThan(expression.Value(7))

--- a/service/dynamodbstreams/dynamodbstreamsiface/interface.go
+++ b/service/dynamodbstreams/dynamodbstreamsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := dynamodbstreams.New(sess)
 //
 //        myFunc(svc)

--- a/service/dynamodbstreams/examples_test.go
+++ b/service/dynamodbstreams/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The following example describes a stream with a given stream ARN.
 func ExampleDynamoDBStreams_DescribeStream_shared00() {
-	svc := dynamodbstreams.New(session.New())
+	svc := dynamodbstreams.New(session.Must(session.NewSession()))
 	input := &dynamodbstreams.DescribeStreamInput{
 		StreamArn: aws.String("arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T20:51:10.252"),
 	}
@@ -60,7 +60,7 @@ func ExampleDynamoDBStreams_DescribeStream_shared00() {
 //
 // The following example retrieves all the stream records from a shard.
 func ExampleDynamoDBStreams_GetRecords_shared00() {
-	svc := dynamodbstreams.New(session.New())
+	svc := dynamodbstreams.New(session.Must(session.NewSession()))
 	input := &dynamodbstreams.GetRecordsInput{
 		ShardIterator: aws.String("arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T20:51:10.252|1|AAAAAAAAAAEvJp6D+zaQ...  <remaining characters omitted> ..."),
 	}
@@ -98,7 +98,7 @@ func ExampleDynamoDBStreams_GetRecords_shared00() {
 // The following example returns a shard iterator for the provided stream ARN and shard
 // ID.
 func ExampleDynamoDBStreams_GetShardIterator_shared00() {
-	svc := dynamodbstreams.New(session.New())
+	svc := dynamodbstreams.New(session.Must(session.NewSession()))
 	input := &dynamodbstreams.GetShardIteratorInput{
 		ShardId:           aws.String("00000001414576573621-f55eea83"),
 		ShardIteratorType: aws.String("TRIM_HORIZON"),
@@ -133,7 +133,7 @@ func ExampleDynamoDBStreams_GetShardIterator_shared00() {
 //
 // The following example lists all of the stream ARNs.
 func ExampleDynamoDBStreams_ListStreams_shared00() {
-	svc := dynamodbstreams.New(session.New())
+	svc := dynamodbstreams.New(session.Must(session.NewSession()))
 	input := &dynamodbstreams.ListStreamsInput{}
 
 	result, err := svc.ListStreams(input)

--- a/service/ebs/ebsiface/interface.go
+++ b/service/ebs/ebsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ebs.New(sess)
 //
 //        myFunc(svc)

--- a/service/ec2/ec2iface/interface.go
+++ b/service/ec2/ec2iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ec2.New(sess)
 //
 //        myFunc(svc)

--- a/service/ec2/examples_test.go
+++ b/service/ec2/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This example allocates an Elastic IP address to use with an instance in a VPC.
 func ExampleEC2_AllocateAddress_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AllocateAddressInput{
 		Domain: aws.String("vpc"),
 	}
@@ -56,7 +56,7 @@ func ExampleEC2_AllocateAddress_shared00() {
 //
 // This example allocates an Elastic IP address to use with an instance in EC2-Classic.
 func ExampleEC2_AllocateAddress_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AllocateAddressInput{}
 
 	result, err := svc.AllocateAddress(input)
@@ -82,7 +82,7 @@ func ExampleEC2_AllocateAddress_shared01() {
 // This example assigns the specified secondary private IP address to the specified
 // network interface.
 func ExampleEC2_AssignPrivateIpAddresses_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AssignPrivateIpAddressesInput{
 		NetworkInterfaceId: aws.String("eni-e5aa89a3"),
 		PrivateIpAddresses: []*string{
@@ -115,7 +115,7 @@ func ExampleEC2_AssignPrivateIpAddresses_shared00() {
 // IP addresses in the CIDR block range of the subnet the network interface is associated
 // with.
 func ExampleEC2_AssignPrivateIpAddresses_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AssignPrivateIpAddressesInput{
 		NetworkInterfaceId:             aws.String("eni-e5aa89a3"),
 		SecondaryPrivateIpAddressCount: aws.Int64(2),
@@ -144,7 +144,7 @@ func ExampleEC2_AssignPrivateIpAddresses_shared01() {
 // This example associates the specified Elastic IP address with the specified instance
 // in a VPC.
 func ExampleEC2_AssociateAddress_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AssociateAddressInput{
 		AllocationId: aws.String("eipalloc-64d5890a"),
 		InstanceId:   aws.String("i-0b263919b6498b123"),
@@ -173,7 +173,7 @@ func ExampleEC2_AssociateAddress_shared00() {
 // This example associates the specified Elastic IP address with the specified network
 // interface.
 func ExampleEC2_AssociateAddress_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AssociateAddressInput{
 		AllocationId:       aws.String("eipalloc-64d5890a"),
 		NetworkInterfaceId: aws.String("eni-1a2b3c4d"),
@@ -201,7 +201,7 @@ func ExampleEC2_AssociateAddress_shared01() {
 //
 // This example associates an Elastic IP address with an instance in EC2-Classic.
 func ExampleEC2_AssociateAddress_shared02() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AssociateAddressInput{
 		InstanceId: aws.String("i-07ffe74c7330ebf53"),
 		PublicIp:   aws.String("198.51.100.0"),
@@ -229,7 +229,7 @@ func ExampleEC2_AssociateAddress_shared02() {
 //
 // This example associates the specified DHCP options set with the specified VPC.
 func ExampleEC2_AssociateDhcpOptions_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AssociateDhcpOptionsInput{
 		DhcpOptionsId: aws.String("dopt-d9070ebb"),
 		VpcId:         aws.String("vpc-a01106c2"),
@@ -257,7 +257,7 @@ func ExampleEC2_AssociateDhcpOptions_shared00() {
 //
 // This example associates the default DHCP options set with the specified VPC.
 func ExampleEC2_AssociateDhcpOptions_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AssociateDhcpOptionsInput{
 		DhcpOptionsId: aws.String("default"),
 		VpcId:         aws.String("vpc-a01106c2"),
@@ -286,7 +286,7 @@ func ExampleEC2_AssociateDhcpOptions_shared01() {
 // This example associates an IAM instance profile named admin-role with the specified
 // instance.
 func ExampleEC2_AssociateIamInstanceProfile_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AssociateIamInstanceProfileInput{
 		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{
 			Name: aws.String("admin-role"),
@@ -316,7 +316,7 @@ func ExampleEC2_AssociateIamInstanceProfile_shared00() {
 //
 // This example associates the specified route table with the specified subnet.
 func ExampleEC2_AssociateRouteTable_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AssociateRouteTableInput{
 		RouteTableId: aws.String("rtb-22574640"),
 		SubnetId:     aws.String("subnet-9d4a7b6"),
@@ -344,7 +344,7 @@ func ExampleEC2_AssociateRouteTable_shared00() {
 //
 // This example attaches the specified Internet gateway to the specified VPC.
 func ExampleEC2_AttachInternetGateway_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AttachInternetGatewayInput{
 		InternetGatewayId: aws.String("igw-c0a643a9"),
 		VpcId:             aws.String("vpc-a01106c2"),
@@ -372,7 +372,7 @@ func ExampleEC2_AttachInternetGateway_shared00() {
 //
 // This example attaches the specified network interface to the specified instance.
 func ExampleEC2_AttachNetworkInterface_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AttachNetworkInterfaceInput{
 		DeviceIndex:        aws.Int64(1),
 		InstanceId:         aws.String("i-1234567890abcdef0"),
@@ -402,7 +402,7 @@ func ExampleEC2_AttachNetworkInterface_shared00() {
 // This example attaches a volume (``vol-1234567890abcdef0``) to an instance (``i-01474ef662b89480``)
 // as ``/dev/sdf``.
 func ExampleEC2_AttachVolume_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AttachVolumeInput{
 		Device:     aws.String("/dev/sdf"),
 		InstanceId: aws.String("i-01474ef662b89480"),
@@ -432,7 +432,7 @@ func ExampleEC2_AttachVolume_shared00() {
 // This example adds a rule that grants access to the specified address ranges on TCP
 // port 80.
 func ExampleEC2_AuthorizeSecurityGroupEgress_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AuthorizeSecurityGroupEgressInput{
 		GroupId: aws.String("sg-1a2b3c4d"),
 		IpPermissions: []*ec2.IpPermission{
@@ -472,7 +472,7 @@ func ExampleEC2_AuthorizeSecurityGroupEgress_shared00() {
 // This example adds a rule that grants access to the specified security group on TCP
 // port 80.
 func ExampleEC2_AuthorizeSecurityGroupEgress_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AuthorizeSecurityGroupEgressInput{
 		GroupId: aws.String("sg-1a2b3c4d"),
 		IpPermissions: []*ec2.IpPermission{
@@ -512,7 +512,7 @@ func ExampleEC2_AuthorizeSecurityGroupEgress_shared01() {
 // This example enables inbound traffic on TCP port 22 (SSH). The rule includes a description
 // to help you identify it later.
 func ExampleEC2_AuthorizeSecurityGroupIngress_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId: aws.String("sg-903004f8"),
 		IpPermissions: []*ec2.IpPermission{
@@ -555,7 +555,7 @@ func ExampleEC2_AuthorizeSecurityGroupIngress_shared00() {
 // on the private IP addresses of instances that are associated with the specified security
 // group.
 func ExampleEC2_AuthorizeSecurityGroupIngress_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId: aws.String("sg-111aaa22"),
 		IpPermissions: []*ec2.IpPermission{
@@ -596,7 +596,7 @@ func ExampleEC2_AuthorizeSecurityGroupIngress_shared01() {
 // This example adds an inbound rule that allows RDP traffic from the specified IPv6
 // address range. The rule includes a description to help you identify it later.
 func ExampleEC2_AuthorizeSecurityGroupIngress_shared02() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId: aws.String("sg-123abc12 "),
 		IpPermissions: []*ec2.IpPermission{
@@ -637,7 +637,7 @@ func ExampleEC2_AuthorizeSecurityGroupIngress_shared02() {
 // This example cancels the specified Spot fleet request and terminates its associated
 // Spot Instances.
 func ExampleEC2_CancelSpotFleetRequests_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CancelSpotFleetRequestsInput{
 		SpotFleetRequestIds: []*string{
 			aws.String("sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE"),
@@ -668,7 +668,7 @@ func ExampleEC2_CancelSpotFleetRequests_shared00() {
 // This example cancels the specified Spot fleet request without terminating its associated
 // Spot Instances.
 func ExampleEC2_CancelSpotFleetRequests_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CancelSpotFleetRequestsInput{
 		SpotFleetRequestIds: []*string{
 			aws.String("sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE"),
@@ -698,7 +698,7 @@ func ExampleEC2_CancelSpotFleetRequests_shared01() {
 //
 // This example cancels a Spot Instance request.
 func ExampleEC2_CancelSpotInstanceRequests_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CancelSpotInstanceRequestsInput{
 		SpotInstanceRequestIds: []*string{
 			aws.String("sir-08b93456"),
@@ -728,7 +728,7 @@ func ExampleEC2_CancelSpotInstanceRequests_shared00() {
 // This example determines whether the specified product code is associated with the
 // specified instance.
 func ExampleEC2_ConfirmProductInstance_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ConfirmProductInstanceInput{
 		InstanceId:  aws.String("i-1234567890abcdef0"),
 		ProductCode: aws.String("774F4FF8"),
@@ -756,7 +756,7 @@ func ExampleEC2_ConfirmProductInstance_shared00() {
 //
 // This example copies the specified AMI from the us-east-1 region to the current region.
 func ExampleEC2_CopyImage_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CopyImageInput{
 		Description:   aws.String(""),
 		Name:          aws.String("My server"),
@@ -788,7 +788,7 @@ func ExampleEC2_CopyImage_shared00() {
 // from the ``us-west-2`` region to the ``us-east-1`` region and adds a short description
 // to identify the snapshot.
 func ExampleEC2_CopySnapshot_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CopySnapshotInput{
 		Description:       aws.String("This is my copied snapshot."),
 		DestinationRegion: aws.String("us-east-1"),
@@ -819,7 +819,7 @@ func ExampleEC2_CopySnapshot_shared00() {
 // This example creates a customer gateway with the specified IP address for its outside
 // interface.
 func ExampleEC2_CreateCustomerGateway_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateCustomerGatewayInput{
 		BgpAsn:   aws.Int64(65534),
 		PublicIp: aws.String("12.1.2.3"),
@@ -848,7 +848,7 @@ func ExampleEC2_CreateCustomerGateway_shared00() {
 //
 // This example creates a DHCP options set.
 func ExampleEC2_CreateDhcpOptions_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateDhcpOptionsInput{
 		DhcpConfigurations: []*ec2.NewDhcpConfiguration{
 			{
@@ -884,7 +884,7 @@ func ExampleEC2_CreateDhcpOptions_shared00() {
 // This example creates an AMI from the specified instance and adds an EBS volume with
 // the device name /dev/sdh and an instance store volume with the device name /dev/sdc.
 func ExampleEC2_CreateImage_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateImageInput{
 		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 			{
@@ -926,7 +926,7 @@ func ExampleEC2_CreateImage_shared00() {
 //
 // This example creates an Internet gateway.
 func ExampleEC2_CreateInternetGateway_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateInternetGatewayInput{}
 
 	result, err := svc.CreateInternetGateway(input)
@@ -951,7 +951,7 @@ func ExampleEC2_CreateInternetGateway_shared00() {
 //
 // This example creates a key pair named my-key-pair.
 func ExampleEC2_CreateKeyPair_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateKeyPairInput{
 		KeyName: aws.String("my-key-pair"),
 	}
@@ -980,7 +980,7 @@ func ExampleEC2_CreateKeyPair_shared00() {
 // the instance, assigns a public IP address and an IPv6 address to the instance, and
 // creates a tag for the instance.
 func ExampleEC2_CreateLaunchTemplate_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateLaunchTemplateInput{
 		LaunchTemplateData: &ec2.RequestLaunchTemplateData{
 			ImageId:      aws.String("ami-8c1be5f6"),
@@ -1032,7 +1032,7 @@ func ExampleEC2_CreateLaunchTemplate_shared00() {
 // This example creates a new launch template version based on version 1 of the specified
 // launch template and specifies a different AMI ID.
 func ExampleEC2_CreateLaunchTemplateVersion_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateLaunchTemplateVersionInput{
 		LaunchTemplateData: &ec2.RequestLaunchTemplateData{
 			ImageId: aws.String("ami-c998b6b2"),
@@ -1065,7 +1065,7 @@ func ExampleEC2_CreateLaunchTemplateVersion_shared00() {
 // This example creates a NAT gateway in subnet subnet-1a2b3c4d and associates an Elastic
 // IP address with the allocation ID eipalloc-37fc1a52 with the NAT gateway.
 func ExampleEC2_CreateNatGateway_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateNatGatewayInput{
 		AllocationId: aws.String("eipalloc-37fc1a52"),
 		SubnetId:     aws.String("subnet-1a2b3c4d"),
@@ -1093,7 +1093,7 @@ func ExampleEC2_CreateNatGateway_shared00() {
 //
 // This example creates a network ACL for the specified VPC.
 func ExampleEC2_CreateNetworkAcl_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateNetworkAclInput{
 		VpcId: aws.String("vpc-a01106c2"),
 	}
@@ -1121,7 +1121,7 @@ func ExampleEC2_CreateNetworkAcl_shared00() {
 // This example creates an entry for the specified network ACL. The rule allows ingress
 // traffic from anywhere (0.0.0.0/0) on UDP port 53 (DNS) into any associated subnet.
 func ExampleEC2_CreateNetworkAclEntry_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateNetworkAclEntryInput{
 		CidrBlock:    aws.String("0.0.0.0/0"),
 		Egress:       aws.Bool(false),
@@ -1157,7 +1157,7 @@ func ExampleEC2_CreateNetworkAclEntry_shared00() {
 //
 // This example creates a network interface for the specified subnet.
 func ExampleEC2_CreateNetworkInterface_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateNetworkInterfaceInput{
 		Description: aws.String("my network interface"),
 		Groups: []*string{
@@ -1189,7 +1189,7 @@ func ExampleEC2_CreateNetworkInterface_shared00() {
 //
 // This example creates a placement group with the specified name.
 func ExampleEC2_CreatePlacementGroup_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreatePlacementGroupInput{
 		GroupName: aws.String("my-cluster"),
 		Strategy:  aws.String("cluster"),
@@ -1218,7 +1218,7 @@ func ExampleEC2_CreatePlacementGroup_shared00() {
 // This example creates a route for the specified route table. The route matches all
 // traffic (0.0.0.0/0) and routes it to the specified Internet gateway.
 func ExampleEC2_CreateRoute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateRouteInput{
 		DestinationCidrBlock: aws.String("0.0.0.0/0"),
 		GatewayId:            aws.String("igw-c0a643a9"),
@@ -1247,7 +1247,7 @@ func ExampleEC2_CreateRoute_shared00() {
 //
 // This example creates a route table for the specified VPC.
 func ExampleEC2_CreateRouteTable_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateRouteTableInput{
 		VpcId: aws.String("vpc-a01106c2"),
 	}
@@ -1274,7 +1274,7 @@ func ExampleEC2_CreateRouteTable_shared00() {
 //
 // This example creates a security group for the specified VPC.
 func ExampleEC2_CreateSecurityGroup_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateSecurityGroupInput{
 		Description: aws.String("My security group"),
 		GroupName:   aws.String("my-security-group"),
@@ -1304,7 +1304,7 @@ func ExampleEC2_CreateSecurityGroup_shared00() {
 // This example creates a snapshot of the volume with a volume ID of ``vol-1234567890abcdef0``
 // and a short description to identify the snapshot.
 func ExampleEC2_CreateSnapshot_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateSnapshotInput{
 		Description: aws.String("This is my root volume snapshot."),
 		VolumeId:    aws.String("vol-1234567890abcdef0"),
@@ -1332,7 +1332,7 @@ func ExampleEC2_CreateSnapshot_shared00() {
 //
 // This example creates a Spot Instance data feed for your AWS account.
 func ExampleEC2_CreateSpotDatafeedSubscription_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateSpotDatafeedSubscriptionInput{
 		Bucket: aws.String("my-s3-bucket"),
 		Prefix: aws.String("spotdata"),
@@ -1361,7 +1361,7 @@ func ExampleEC2_CreateSpotDatafeedSubscription_shared00() {
 // This example creates a subnet in the specified VPC with the specified CIDR block.
 // We recommend that you let us select an Availability Zone for you.
 func ExampleEC2_CreateSubnet_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateSubnetInput{
 		CidrBlock: aws.String("10.0.1.0/24"),
 		VpcId:     aws.String("vpc-a01106c2"),
@@ -1390,7 +1390,7 @@ func ExampleEC2_CreateSubnet_shared00() {
 // This example adds the tag Stack=production to the specified image, or overwrites
 // an existing tag for the AMI where the tag key is Stack.
 func ExampleEC2_CreateTags_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateTagsInput{
 		Resources: []*string{
 			aws.String("ami-78a54011"),
@@ -1426,7 +1426,7 @@ func ExampleEC2_CreateTags_shared00() {
 // This example creates an 80 GiB General Purpose (SSD) volume in the Availability Zone
 // ``us-east-1a``.
 func ExampleEC2_CreateVolume_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateVolumeInput{
 		AvailabilityZone: aws.String("us-east-1a"),
 		Size:             aws.Int64(80),
@@ -1456,7 +1456,7 @@ func ExampleEC2_CreateVolume_shared00() {
 // This example creates a new Provisioned IOPS (SSD) volume with 1000 provisioned IOPS
 // from a snapshot in the Availability Zone ``us-east-1a``.
 func ExampleEC2_CreateVolume_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateVolumeInput{
 		AvailabilityZone: aws.String("us-east-1a"),
 		Iops:             aws.Int64(1000),
@@ -1486,7 +1486,7 @@ func ExampleEC2_CreateVolume_shared01() {
 //
 // This example creates a VPC with the specified CIDR block.
 func ExampleEC2_CreateVpc_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.CreateVpcInput{
 		CidrBlock: aws.String("10.0.0.0/16"),
 	}
@@ -1513,7 +1513,7 @@ func ExampleEC2_CreateVpc_shared00() {
 //
 // This example deletes the specified customer gateway.
 func ExampleEC2_DeleteCustomerGateway_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteCustomerGatewayInput{
 		CustomerGatewayId: aws.String("cgw-0e11f167"),
 	}
@@ -1540,7 +1540,7 @@ func ExampleEC2_DeleteCustomerGateway_shared00() {
 //
 // This example deletes the specified DHCP options set.
 func ExampleEC2_DeleteDhcpOptions_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteDhcpOptionsInput{
 		DhcpOptionsId: aws.String("dopt-d9070ebb"),
 	}
@@ -1567,7 +1567,7 @@ func ExampleEC2_DeleteDhcpOptions_shared00() {
 //
 // This example deletes the specified Internet gateway.
 func ExampleEC2_DeleteInternetGateway_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteInternetGatewayInput{
 		InternetGatewayId: aws.String("igw-c0a643a9"),
 	}
@@ -1594,7 +1594,7 @@ func ExampleEC2_DeleteInternetGateway_shared00() {
 //
 // This example deletes the specified key pair.
 func ExampleEC2_DeleteKeyPair_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteKeyPairInput{
 		KeyName: aws.String("my-key-pair"),
 	}
@@ -1621,7 +1621,7 @@ func ExampleEC2_DeleteKeyPair_shared00() {
 //
 // This example deletes the specified launch template.
 func ExampleEC2_DeleteLaunchTemplate_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteLaunchTemplateInput{
 		LaunchTemplateId: aws.String("lt-0abcd290751193123"),
 	}
@@ -1648,7 +1648,7 @@ func ExampleEC2_DeleteLaunchTemplate_shared00() {
 //
 // This example deletes the specified launch template version.
 func ExampleEC2_DeleteLaunchTemplateVersions_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteLaunchTemplateVersionsInput{
 		LaunchTemplateId: aws.String("lt-0abcd290751193123"),
 		Versions: []*string{
@@ -1678,7 +1678,7 @@ func ExampleEC2_DeleteLaunchTemplateVersions_shared00() {
 //
 // This example deletes the specified NAT gateway.
 func ExampleEC2_DeleteNatGateway_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteNatGatewayInput{
 		NatGatewayId: aws.String("nat-04ae55e711cec5680"),
 	}
@@ -1705,7 +1705,7 @@ func ExampleEC2_DeleteNatGateway_shared00() {
 //
 // This example deletes the specified network ACL.
 func ExampleEC2_DeleteNetworkAcl_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteNetworkAclInput{
 		NetworkAclId: aws.String("acl-5fb85d36"),
 	}
@@ -1732,7 +1732,7 @@ func ExampleEC2_DeleteNetworkAcl_shared00() {
 //
 // This example deletes ingress rule number 100 from the specified network ACL.
 func ExampleEC2_DeleteNetworkAclEntry_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteNetworkAclEntryInput{
 		Egress:       aws.Bool(true),
 		NetworkAclId: aws.String("acl-5fb85d36"),
@@ -1761,7 +1761,7 @@ func ExampleEC2_DeleteNetworkAclEntry_shared00() {
 //
 // This example deletes the specified network interface.
 func ExampleEC2_DeleteNetworkInterface_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteNetworkInterfaceInput{
 		NetworkInterfaceId: aws.String("eni-e5aa89a3"),
 	}
@@ -1788,7 +1788,7 @@ func ExampleEC2_DeleteNetworkInterface_shared00() {
 //
 // This example deletes the specified placement group.
 func ExampleEC2_DeletePlacementGroup_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeletePlacementGroupInput{
 		GroupName: aws.String("my-cluster"),
 	}
@@ -1815,7 +1815,7 @@ func ExampleEC2_DeletePlacementGroup_shared00() {
 //
 // This example deletes the specified route from the specified route table.
 func ExampleEC2_DeleteRoute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteRouteInput{
 		DestinationCidrBlock: aws.String("0.0.0.0/0"),
 		RouteTableId:         aws.String("rtb-22574640"),
@@ -1843,7 +1843,7 @@ func ExampleEC2_DeleteRoute_shared00() {
 //
 // This example deletes the specified route table.
 func ExampleEC2_DeleteRouteTable_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteRouteTableInput{
 		RouteTableId: aws.String("rtb-22574640"),
 	}
@@ -1870,7 +1870,7 @@ func ExampleEC2_DeleteRouteTable_shared00() {
 //
 // This example deletes the specified security group.
 func ExampleEC2_DeleteSecurityGroup_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteSecurityGroupInput{
 		GroupId: aws.String("sg-903004f8"),
 	}
@@ -1898,7 +1898,7 @@ func ExampleEC2_DeleteSecurityGroup_shared00() {
 // This example deletes a snapshot with the snapshot ID of ``snap-1234567890abcdef0``.
 // If the command succeeds, no output is returned.
 func ExampleEC2_DeleteSnapshot_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteSnapshotInput{
 		SnapshotId: aws.String("snap-1234567890abcdef0"),
 	}
@@ -1925,7 +1925,7 @@ func ExampleEC2_DeleteSnapshot_shared00() {
 //
 // This example deletes a Spot data feed subscription for the account.
 func ExampleEC2_DeleteSpotDatafeedSubscription_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteSpotDatafeedSubscriptionInput{}
 
 	result, err := svc.DeleteSpotDatafeedSubscription(input)
@@ -1950,7 +1950,7 @@ func ExampleEC2_DeleteSpotDatafeedSubscription_shared00() {
 //
 // This example deletes the specified subnet.
 func ExampleEC2_DeleteSubnet_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteSubnetInput{
 		SubnetId: aws.String("subnet-9d4a7b6c"),
 	}
@@ -1977,7 +1977,7 @@ func ExampleEC2_DeleteSubnet_shared00() {
 //
 // This example deletes the tag Stack=test from the specified image.
 func ExampleEC2_DeleteTags_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteTagsInput{
 		Resources: []*string{
 			aws.String("ami-78a54011"),
@@ -2013,7 +2013,7 @@ func ExampleEC2_DeleteTags_shared00() {
 // This example deletes an available volume with the volume ID of ``vol-049df61146c4d7901``.
 // If the command succeeds, no output is returned.
 func ExampleEC2_DeleteVolume_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteVolumeInput{
 		VolumeId: aws.String("vol-049df61146c4d7901"),
 	}
@@ -2040,7 +2040,7 @@ func ExampleEC2_DeleteVolume_shared00() {
 //
 // This example deletes the specified VPC.
 func ExampleEC2_DeleteVpc_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DeleteVpcInput{
 		VpcId: aws.String("vpc-a01106c2"),
 	}
@@ -2067,7 +2067,7 @@ func ExampleEC2_DeleteVpc_shared00() {
 //
 // This example describes the supported-platforms attribute for your AWS account.
 func ExampleEC2_DescribeAccountAttributes_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeAccountAttributesInput{
 		AttributeNames: []*string{
 			aws.String("supported-platforms"),
@@ -2096,7 +2096,7 @@ func ExampleEC2_DescribeAccountAttributes_shared00() {
 //
 // This example describes the attributes for your AWS account.
 func ExampleEC2_DescribeAccountAttributes_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeAccountAttributesInput{}
 
 	result, err := svc.DescribeAccountAttributes(input)
@@ -2121,7 +2121,7 @@ func ExampleEC2_DescribeAccountAttributes_shared01() {
 //
 // This example describes your Elastic IP addresses.
 func ExampleEC2_DescribeAddresses_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeAddressesInput{}
 
 	result, err := svc.DescribeAddresses(input)
@@ -2146,7 +2146,7 @@ func ExampleEC2_DescribeAddresses_shared00() {
 //
 // This example describes your Elastic IP addresses for use with instances in a VPC.
 func ExampleEC2_DescribeAddresses_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeAddressesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -2180,7 +2180,7 @@ func ExampleEC2_DescribeAddresses_shared01() {
 //
 // This example describes your Elastic IP addresses for use with instances in EC2-Classic.
 func ExampleEC2_DescribeAddresses_shared02() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeAddressesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -2215,7 +2215,7 @@ func ExampleEC2_DescribeAddresses_shared02() {
 // This example describes the Availability Zones that are available to you. The response
 // includes Availability Zones only for the current region.
 func ExampleEC2_DescribeAvailabilityZones_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeAvailabilityZonesInput{}
 
 	result, err := svc.DescribeAvailabilityZones(input)
@@ -2240,7 +2240,7 @@ func ExampleEC2_DescribeAvailabilityZones_shared00() {
 //
 // This example describes the specified customer gateway.
 func ExampleEC2_DescribeCustomerGateways_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeCustomerGatewaysInput{
 		CustomerGatewayIds: []*string{
 			aws.String("cgw-0e11f167"),
@@ -2269,7 +2269,7 @@ func ExampleEC2_DescribeCustomerGateways_shared00() {
 //
 // This example describes the specified DHCP options set.
 func ExampleEC2_DescribeDhcpOptions_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeDhcpOptionsInput{
 		DhcpOptionsIds: []*string{
 			aws.String("dopt-d9070ebb"),
@@ -2298,7 +2298,7 @@ func ExampleEC2_DescribeDhcpOptions_shared00() {
 //
 // This example describes the specified IAM instance profile association.
 func ExampleEC2_DescribeIamInstanceProfileAssociations_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeIamInstanceProfileAssociationsInput{
 		AssociationIds: []*string{
 			aws.String("iip-assoc-0db249b1f25fa24b8"),
@@ -2327,7 +2327,7 @@ func ExampleEC2_DescribeIamInstanceProfileAssociations_shared00() {
 //
 // This example describes the launch permissions for the specified AMI.
 func ExampleEC2_DescribeImageAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeImageAttributeInput{
 		Attribute: aws.String("launchPermission"),
 		ImageId:   aws.String("ami-5731123e"),
@@ -2355,7 +2355,7 @@ func ExampleEC2_DescribeImageAttribute_shared00() {
 //
 // This example describes the specified AMI.
 func ExampleEC2_DescribeImages_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeImagesInput{
 		ImageIds: []*string{
 			aws.String("ami-5731123e"),
@@ -2384,7 +2384,7 @@ func ExampleEC2_DescribeImages_shared00() {
 //
 // This example describes the instance type of the specified instance.
 func ExampleEC2_DescribeInstanceAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeInstanceAttributeInput{
 		Attribute:  aws.String("instanceType"),
 		InstanceId: aws.String("i-1234567890abcdef0"),
@@ -2412,7 +2412,7 @@ func ExampleEC2_DescribeInstanceAttribute_shared00() {
 //
 // This example describes the ``disableApiTermination`` attribute of the specified instance.
 func ExampleEC2_DescribeInstanceAttribute_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeInstanceAttributeInput{
 		Attribute:  aws.String("disableApiTermination"),
 		InstanceId: aws.String("i-1234567890abcdef0"),
@@ -2440,7 +2440,7 @@ func ExampleEC2_DescribeInstanceAttribute_shared01() {
 //
 // This example describes the ``blockDeviceMapping`` attribute of the specified instance.
 func ExampleEC2_DescribeInstanceAttribute_shared02() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeInstanceAttributeInput{
 		Attribute:  aws.String("blockDeviceMapping"),
 		InstanceId: aws.String("i-1234567890abcdef0"),
@@ -2468,7 +2468,7 @@ func ExampleEC2_DescribeInstanceAttribute_shared02() {
 //
 // This example describes the current status of the specified instance.
 func ExampleEC2_DescribeInstanceStatus_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeInstanceStatusInput{
 		InstanceIds: []*string{
 			aws.String("i-1234567890abcdef0"),
@@ -2497,7 +2497,7 @@ func ExampleEC2_DescribeInstanceStatus_shared00() {
 //
 // This example describes the specified instance.
 func ExampleEC2_DescribeInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{
 			aws.String("i-1234567890abcdef0"),
@@ -2526,7 +2526,7 @@ func ExampleEC2_DescribeInstances_shared00() {
 //
 // This example describes the instances with the t2.micro instance type.
 func ExampleEC2_DescribeInstances_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -2560,7 +2560,7 @@ func ExampleEC2_DescribeInstances_shared01() {
 //
 // This example describes the instances with the Purpose=test tag.
 func ExampleEC2_DescribeInstances_shared02() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -2594,7 +2594,7 @@ func ExampleEC2_DescribeInstances_shared02() {
 //
 // This example describes the Internet gateway for the specified VPC.
 func ExampleEC2_DescribeInternetGateways_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeInternetGatewaysInput{
 		Filters: []*ec2.Filter{
 			{
@@ -2628,7 +2628,7 @@ func ExampleEC2_DescribeInternetGateways_shared00() {
 //
 // This example displays the fingerprint for the specified key.
 func ExampleEC2_DescribeKeyPairs_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeKeyPairsInput{
 		KeyNames: []*string{
 			aws.String("my-key-pair"),
@@ -2657,7 +2657,7 @@ func ExampleEC2_DescribeKeyPairs_shared00() {
 //
 // This example describes the versions for the specified launch template.
 func ExampleEC2_DescribeLaunchTemplateVersions_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeLaunchTemplateVersionsInput{
 		LaunchTemplateId: aws.String("068f72b72934aff71"),
 	}
@@ -2684,7 +2684,7 @@ func ExampleEC2_DescribeLaunchTemplateVersions_shared00() {
 //
 // This example describes the specified launch template.
 func ExampleEC2_DescribeLaunchTemplates_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeLaunchTemplatesInput{
 		LaunchTemplateIds: []*string{
 			aws.String("lt-01238c059e3466abc"),
@@ -2713,7 +2713,7 @@ func ExampleEC2_DescribeLaunchTemplates_shared00() {
 //
 // This example describes all of your moving Elastic IP addresses.
 func ExampleEC2_DescribeMovingAddresses_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeMovingAddressesInput{}
 
 	result, err := svc.DescribeMovingAddresses(input)
@@ -2738,7 +2738,7 @@ func ExampleEC2_DescribeMovingAddresses_shared00() {
 //
 // This example describes the NAT gateway for the specified VPC.
 func ExampleEC2_DescribeNatGateways_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeNatGatewaysInput{
 		Filter: []*ec2.Filter{
 			{
@@ -2772,7 +2772,7 @@ func ExampleEC2_DescribeNatGateways_shared00() {
 //
 // This example describes the specified network ACL.
 func ExampleEC2_DescribeNetworkAcls_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeNetworkAclsInput{
 		NetworkAclIds: []*string{
 			aws.String("acl-5fb85d36"),
@@ -2801,7 +2801,7 @@ func ExampleEC2_DescribeNetworkAcls_shared00() {
 //
 // This example describes the attachment attribute of the specified network interface.
 func ExampleEC2_DescribeNetworkInterfaceAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeNetworkInterfaceAttributeInput{
 		Attribute:          aws.String("attachment"),
 		NetworkInterfaceId: aws.String("eni-686ea200"),
@@ -2829,7 +2829,7 @@ func ExampleEC2_DescribeNetworkInterfaceAttribute_shared00() {
 //
 // This example describes the description attribute of the specified network interface.
 func ExampleEC2_DescribeNetworkInterfaceAttribute_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeNetworkInterfaceAttributeInput{
 		Attribute:          aws.String("description"),
 		NetworkInterfaceId: aws.String("eni-686ea200"),
@@ -2857,7 +2857,7 @@ func ExampleEC2_DescribeNetworkInterfaceAttribute_shared01() {
 //
 // This example describes the groupSet attribute of the specified network interface.
 func ExampleEC2_DescribeNetworkInterfaceAttribute_shared02() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeNetworkInterfaceAttributeInput{
 		Attribute:          aws.String("groupSet"),
 		NetworkInterfaceId: aws.String("eni-686ea200"),
@@ -2885,7 +2885,7 @@ func ExampleEC2_DescribeNetworkInterfaceAttribute_shared02() {
 //
 // This example describes the sourceDestCheck attribute of the specified network interface.
 func ExampleEC2_DescribeNetworkInterfaceAttribute_shared03() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeNetworkInterfaceAttributeInput{
 		Attribute:          aws.String("sourceDestCheck"),
 		NetworkInterfaceId: aws.String("eni-686ea200"),
@@ -2913,7 +2913,7 @@ func ExampleEC2_DescribeNetworkInterfaceAttribute_shared03() {
 //
 
 func ExampleEC2_DescribeNetworkInterfaces_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeNetworkInterfacesInput{
 		NetworkInterfaceIds: []*string{
 			aws.String("eni-e5aa89a3"),
@@ -2942,7 +2942,7 @@ func ExampleEC2_DescribeNetworkInterfaces_shared00() {
 //
 // This example describes all the regions that are available to you.
 func ExampleEC2_DescribeRegions_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeRegionsInput{}
 
 	result, err := svc.DescribeRegions(input)
@@ -2967,7 +2967,7 @@ func ExampleEC2_DescribeRegions_shared00() {
 //
 // This example describes the specified route table.
 func ExampleEC2_DescribeRouteTables_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeRouteTablesInput{
 		RouteTableIds: []*string{
 			aws.String("rtb-1f382e7d"),
@@ -2997,7 +2997,7 @@ func ExampleEC2_DescribeRouteTables_shared00() {
 // This example describes a schedule that occurs every week on Sunday, starting on the
 // specified date. Note that the output contains a single schedule as an example.
 func ExampleEC2_DescribeScheduledInstanceAvailability_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeScheduledInstanceAvailabilityInput{
 		FirstSlotStartTimeRange: &ec2.SlotDateTimeRangeRequest{
 			EarliestTime: parseTime("2006-01-02T15:04:05.999999999Z", "2016-01-31T00:00:00Z"),
@@ -3034,7 +3034,7 @@ func ExampleEC2_DescribeScheduledInstanceAvailability_shared00() {
 //
 // This example describes the specified Scheduled Instance.
 func ExampleEC2_DescribeScheduledInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeScheduledInstancesInput{
 		ScheduledInstanceIds: []*string{
 			aws.String("sci-1234-1234-1234-1234-123456789012"),
@@ -3063,7 +3063,7 @@ func ExampleEC2_DescribeScheduledInstances_shared00() {
 //
 // This example describes the security group references for the specified security group.
 func ExampleEC2_DescribeSecurityGroupReferences_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSecurityGroupReferencesInput{
 		GroupId: []*string{
 			aws.String("sg-903004f8"),
@@ -3092,7 +3092,7 @@ func ExampleEC2_DescribeSecurityGroupReferences_shared00() {
 //
 // This example describes the specified security group.
 func ExampleEC2_DescribeSecurityGroups_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSecurityGroupsInput{
 		GroupIds: []*string{
 			aws.String("sg-903004f8"),
@@ -3121,7 +3121,7 @@ func ExampleEC2_DescribeSecurityGroups_shared00() {
 //
 // This example describes the security groups that include the specified tag (Purpose=test).
 func ExampleEC2_DescribeSecurityGroups_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -3156,7 +3156,7 @@ func ExampleEC2_DescribeSecurityGroups_shared01() {
 // This example describes the ``createVolumePermission`` attribute on a snapshot with
 // the snapshot ID of ``snap-066877671789bd71b``.
 func ExampleEC2_DescribeSnapshotAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSnapshotAttributeInput{
 		Attribute:  aws.String("createVolumePermission"),
 		SnapshotId: aws.String("snap-066877671789bd71b"),
@@ -3184,7 +3184,7 @@ func ExampleEC2_DescribeSnapshotAttribute_shared00() {
 //
 // This example describes a snapshot with the snapshot ID of ``snap-1234567890abcdef0``.
 func ExampleEC2_DescribeSnapshots_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSnapshotsInput{
 		SnapshotIds: []*string{
 			aws.String("snap-1234567890abcdef0"),
@@ -3214,7 +3214,7 @@ func ExampleEC2_DescribeSnapshots_shared00() {
 // This example describes all snapshots owned by the ID 012345678910 that are in the
 // ``pending`` status.
 func ExampleEC2_DescribeSnapshots_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSnapshotsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -3251,7 +3251,7 @@ func ExampleEC2_DescribeSnapshots_shared01() {
 //
 // This example describes the Spot Instance datafeed subscription for your AWS account.
 func ExampleEC2_DescribeSpotDatafeedSubscription_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSpotDatafeedSubscriptionInput{}
 
 	result, err := svc.DescribeSpotDatafeedSubscription(input)
@@ -3276,7 +3276,7 @@ func ExampleEC2_DescribeSpotDatafeedSubscription_shared00() {
 //
 // This example lists the Spot Instances associated with the specified Spot fleet.
 func ExampleEC2_DescribeSpotFleetInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSpotFleetInstancesInput{
 		SpotFleetRequestId: aws.String("sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE"),
 	}
@@ -3304,7 +3304,7 @@ func ExampleEC2_DescribeSpotFleetInstances_shared00() {
 // This example returns the history for the specified Spot fleet starting at the specified
 // time.
 func ExampleEC2_DescribeSpotFleetRequestHistory_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSpotFleetRequestHistoryInput{
 		SpotFleetRequestId: aws.String("sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE"),
 		StartTime:          parseTime("2006-01-02T15:04:05.999999999Z", "2015-05-26T00:00:00Z"),
@@ -3332,7 +3332,7 @@ func ExampleEC2_DescribeSpotFleetRequestHistory_shared00() {
 //
 // This example describes the specified Spot fleet request.
 func ExampleEC2_DescribeSpotFleetRequests_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSpotFleetRequestsInput{
 		SpotFleetRequestIds: []*string{
 			aws.String("sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE"),
@@ -3361,7 +3361,7 @@ func ExampleEC2_DescribeSpotFleetRequests_shared00() {
 //
 // This example describes the specified Spot Instance request.
 func ExampleEC2_DescribeSpotInstanceRequests_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSpotInstanceRequestsInput{
 		SpotInstanceRequestIds: []*string{
 			aws.String("sir-08b93456"),
@@ -3391,7 +3391,7 @@ func ExampleEC2_DescribeSpotInstanceRequests_shared00() {
 // This example returns the Spot Price history for m1.xlarge, Linux/UNIX (Amazon VPC)
 // instances for a particular day in January.
 func ExampleEC2_DescribeSpotPriceHistory_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSpotPriceHistoryInput{
 		EndTime: parseTime("2006-01-02T15:04:05.999999999Z", "2014-01-06T08:09:10"),
 		InstanceTypes: []*string{
@@ -3425,7 +3425,7 @@ func ExampleEC2_DescribeSpotPriceHistory_shared00() {
 //
 // This example describes the subnets for the specified VPC.
 func ExampleEC2_DescribeSubnets_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -3459,7 +3459,7 @@ func ExampleEC2_DescribeSubnets_shared00() {
 //
 // This example describes the tags for the specified instance.
 func ExampleEC2_DescribeTags_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeTagsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -3493,7 +3493,7 @@ func ExampleEC2_DescribeTags_shared00() {
 //
 // This example describes the ``autoEnableIo`` attribute of the volume with the ID ``vol-049df61146c4d7901``.
 func ExampleEC2_DescribeVolumeAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeVolumeAttributeInput{
 		Attribute: aws.String("autoEnableIO"),
 		VolumeId:  aws.String("vol-049df61146c4d7901"),
@@ -3521,7 +3521,7 @@ func ExampleEC2_DescribeVolumeAttribute_shared00() {
 //
 // This example describes the status for the volume ``vol-1234567890abcdef0``.
 func ExampleEC2_DescribeVolumeStatus_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeVolumeStatusInput{
 		VolumeIds: []*string{
 			aws.String("vol-1234567890abcdef0"),
@@ -3551,7 +3551,7 @@ func ExampleEC2_DescribeVolumeStatus_shared00() {
 // This example describes the status for all volumes that are impaired. In this example
 // output, there are no impaired volumes.
 func ExampleEC2_DescribeVolumeStatus_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeVolumeStatusInput{
 		Filters: []*ec2.Filter{
 			{
@@ -3585,7 +3585,7 @@ func ExampleEC2_DescribeVolumeStatus_shared01() {
 //
 // This example describes all of your volumes in the default region.
 func ExampleEC2_DescribeVolumes_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeVolumesInput{}
 
 	result, err := svc.DescribeVolumes(input)
@@ -3611,7 +3611,7 @@ func ExampleEC2_DescribeVolumes_shared00() {
 // This example describes all volumes that are both attached to the instance with the
 // ID i-1234567890abcdef0 and set to delete when the instance terminates.
 func ExampleEC2_DescribeVolumes_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeVolumesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -3654,7 +3654,7 @@ func ExampleEC2_DescribeVolumes_shared01() {
 // server resolves DNS hostnames for your instances to their corresponding IP addresses;
 // otherwise, it does not.
 func ExampleEC2_DescribeVpcAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeVpcAttributeInput{
 		Attribute: aws.String("enableDnsSupport"),
 		VpcId:     aws.String("vpc-a01106c2"),
@@ -3684,7 +3684,7 @@ func ExampleEC2_DescribeVpcAttribute_shared00() {
 // whether the instances launched in the VPC get DNS hostnames. If this attribute is
 // true, instances in the VPC get DNS hostnames; otherwise, they do not.
 func ExampleEC2_DescribeVpcAttribute_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeVpcAttributeInput{
 		Attribute: aws.String("enableDnsHostnames"),
 		VpcId:     aws.String("vpc-a01106c2"),
@@ -3712,7 +3712,7 @@ func ExampleEC2_DescribeVpcAttribute_shared01() {
 //
 // This example describes the specified VPC.
 func ExampleEC2_DescribeVpcs_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DescribeVpcsInput{
 		VpcIds: []*string{
 			aws.String("vpc-a01106c2"),
@@ -3741,7 +3741,7 @@ func ExampleEC2_DescribeVpcs_shared00() {
 //
 // This example detaches the specified Internet gateway from the specified VPC.
 func ExampleEC2_DetachInternetGateway_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DetachInternetGatewayInput{
 		InternetGatewayId: aws.String("igw-c0a643a9"),
 		VpcId:             aws.String("vpc-a01106c2"),
@@ -3769,7 +3769,7 @@ func ExampleEC2_DetachInternetGateway_shared00() {
 //
 // This example detaches the specified network interface from its attached instance.
 func ExampleEC2_DetachNetworkInterface_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DetachNetworkInterfaceInput{
 		AttachmentId: aws.String("eni-attach-66c4350a"),
 	}
@@ -3797,7 +3797,7 @@ func ExampleEC2_DetachNetworkInterface_shared00() {
 // This example detaches the volume (``vol-049df61146c4d7901``) from the instance it
 // is attached to.
 func ExampleEC2_DetachVolume_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DetachVolumeInput{
 		VolumeId: aws.String("vol-1234567890abcdef0"),
 	}
@@ -3825,7 +3825,7 @@ func ExampleEC2_DetachVolume_shared00() {
 // This example disables the specified virtual private gateway from propagating static
 // routes to the specified route table.
 func ExampleEC2_DisableVgwRoutePropagation_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DisableVgwRoutePropagationInput{
 		GatewayId:    aws.String("vgw-9a4cacf3"),
 		RouteTableId: aws.String("rtb-22574640"),
@@ -3853,7 +3853,7 @@ func ExampleEC2_DisableVgwRoutePropagation_shared00() {
 //
 // This example disassociates an Elastic IP address from an instance in a VPC.
 func ExampleEC2_DisassociateAddress_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DisassociateAddressInput{
 		AssociationId: aws.String("eipassoc-2bebb745"),
 	}
@@ -3880,7 +3880,7 @@ func ExampleEC2_DisassociateAddress_shared00() {
 //
 // This example disassociates an Elastic IP address from an instance in EC2-Classic.
 func ExampleEC2_DisassociateAddress_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DisassociateAddressInput{
 		PublicIp: aws.String("198.51.100.0"),
 	}
@@ -3907,7 +3907,7 @@ func ExampleEC2_DisassociateAddress_shared01() {
 //
 // This example disassociates the specified IAM instance profile from an instance.
 func ExampleEC2_DisassociateIamInstanceProfile_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DisassociateIamInstanceProfileInput{
 		AssociationId: aws.String("iip-assoc-05020b59952902f5f"),
 	}
@@ -3934,7 +3934,7 @@ func ExampleEC2_DisassociateIamInstanceProfile_shared00() {
 //
 // This example disassociates the specified route table from its associated subnet.
 func ExampleEC2_DisassociateRouteTable_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.DisassociateRouteTableInput{
 		AssociationId: aws.String("rtbassoc-781d0d1a"),
 	}
@@ -3962,7 +3962,7 @@ func ExampleEC2_DisassociateRouteTable_shared00() {
 // This example enables the specified virtual private gateway to propagate static routes
 // to the specified route table.
 func ExampleEC2_EnableVgwRoutePropagation_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.EnableVgwRoutePropagationInput{
 		GatewayId:    aws.String("vgw-9a4cacf3"),
 		RouteTableId: aws.String("rtb-22574640"),
@@ -3990,7 +3990,7 @@ func ExampleEC2_EnableVgwRoutePropagation_shared00() {
 //
 // This example enables I/O on volume ``vol-1234567890abcdef0``.
 func ExampleEC2_EnableVolumeIO_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.EnableVolumeIOInput{
 		VolumeId: aws.String("vol-1234567890abcdef0"),
 	}
@@ -4017,7 +4017,7 @@ func ExampleEC2_EnableVolumeIO_shared00() {
 //
 // This example gets the console output for the specified instance.
 func ExampleEC2_GetConsoleOutput_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.GetConsoleOutputInput{
 		InstanceId: aws.String("i-1234567890abcdef0"),
 	}
@@ -4044,7 +4044,7 @@ func ExampleEC2_GetConsoleOutput_shared00() {
 //
 // This example gets the launch template data for the specified instance.
 func ExampleEC2_GetLaunchTemplateData_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.GetLaunchTemplateDataInput{
 		InstanceId: aws.String("0123d646e8048babc"),
 	}
@@ -4071,7 +4071,7 @@ func ExampleEC2_GetLaunchTemplateData_shared00() {
 //
 // This example makes the specified AMI public.
 func ExampleEC2_ModifyImageAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyImageAttributeInput{
 		ImageId: aws.String("ami-5731123e"),
 		LaunchPermission: &ec2.LaunchPermissionModifications{
@@ -4106,7 +4106,7 @@ func ExampleEC2_ModifyImageAttribute_shared00() {
 // This example grants launch permissions for the specified AMI to the specified AWS
 // account.
 func ExampleEC2_ModifyImageAttribute_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyImageAttributeInput{
 		ImageId: aws.String("ami-5731123e"),
 		LaunchPermission: &ec2.LaunchPermissionModifications{
@@ -4140,7 +4140,7 @@ func ExampleEC2_ModifyImageAttribute_shared01() {
 //
 // This example modifies the instance type of the specified stopped instance.
 func ExampleEC2_ModifyInstanceAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyInstanceAttributeInput{
 		InstanceId: aws.String("i-1234567890abcdef0"),
 		InstanceType: &ec2.AttributeValue{
@@ -4170,7 +4170,7 @@ func ExampleEC2_ModifyInstanceAttribute_shared00() {
 //
 // This example enables enhanced networking for the specified stopped instance.
 func ExampleEC2_ModifyInstanceAttribute_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyInstanceAttributeInput{
 		EnaSupport: &ec2.AttributeBooleanValue{
 			Value: aws.Bool(true),
@@ -4200,7 +4200,7 @@ func ExampleEC2_ModifyInstanceAttribute_shared01() {
 //
 // This example specifies version 2 as the default version of the specified launch template.
 func ExampleEC2_ModifyLaunchTemplate_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyLaunchTemplateInput{
 		DefaultVersion:   aws.String("2"),
 		LaunchTemplateId: aws.String("lt-0abcd290751193123"),
@@ -4228,7 +4228,7 @@ func ExampleEC2_ModifyLaunchTemplate_shared00() {
 //
 // This example modifies the attachment attribute of the specified network interface.
 func ExampleEC2_ModifyNetworkInterfaceAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyNetworkInterfaceAttributeInput{
 		Attachment: &ec2.NetworkInterfaceAttachmentChanges{
 			AttachmentId:        aws.String("eni-attach-43348162"),
@@ -4259,7 +4259,7 @@ func ExampleEC2_ModifyNetworkInterfaceAttribute_shared00() {
 //
 // This example modifies the description attribute of the specified network interface.
 func ExampleEC2_ModifyNetworkInterfaceAttribute_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyNetworkInterfaceAttributeInput{
 		Description: &ec2.AttributeValue{
 			Value: aws.String("My description"),
@@ -4289,7 +4289,7 @@ func ExampleEC2_ModifyNetworkInterfaceAttribute_shared01() {
 //
 // This example command modifies the groupSet attribute of the specified network interface.
 func ExampleEC2_ModifyNetworkInterfaceAttribute_shared02() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyNetworkInterfaceAttributeInput{
 		Groups: []*string{
 			aws.String("sg-903004f8"),
@@ -4321,7 +4321,7 @@ func ExampleEC2_ModifyNetworkInterfaceAttribute_shared02() {
 // This example command modifies the sourceDestCheck attribute of the specified network
 // interface.
 func ExampleEC2_ModifyNetworkInterfaceAttribute_shared03() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyNetworkInterfaceAttributeInput{
 		NetworkInterfaceId: aws.String("eni-686ea200"),
 		SourceDestCheck: &ec2.AttributeBooleanValue{
@@ -4353,7 +4353,7 @@ func ExampleEC2_ModifyNetworkInterfaceAttribute_shared03() {
 // permission for a user with the account ID ``123456789012``. If the command succeeds,
 // no output is returned.
 func ExampleEC2_ModifySnapshotAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifySnapshotAttributeInput{
 		Attribute:     aws.String("createVolumePermission"),
 		OperationType: aws.String("remove"),
@@ -4385,7 +4385,7 @@ func ExampleEC2_ModifySnapshotAttribute_shared00() {
 //
 // This example makes the snapshot ``snap-1234567890abcdef0`` public.
 func ExampleEC2_ModifySnapshotAttribute_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifySnapshotAttributeInput{
 		Attribute: aws.String("createVolumePermission"),
 		GroupNames: []*string{
@@ -4417,7 +4417,7 @@ func ExampleEC2_ModifySnapshotAttribute_shared01() {
 //
 // This example increases the target capacity of the specified Spot fleet request.
 func ExampleEC2_ModifySpotFleetRequest_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifySpotFleetRequestInput{
 		SpotFleetRequestId: aws.String("sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE"),
 		TargetCapacity:     aws.Int64(20),
@@ -4446,7 +4446,7 @@ func ExampleEC2_ModifySpotFleetRequest_shared00() {
 // This example decreases the target capacity of the specified Spot fleet request without
 // terminating any Spot Instances as a result.
 func ExampleEC2_ModifySpotFleetRequest_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifySpotFleetRequestInput{
 		ExcessCapacityTerminationPolicy: aws.String("NoTermination "),
 		SpotFleetRequestId:              aws.String("sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE"),
@@ -4476,7 +4476,7 @@ func ExampleEC2_ModifySpotFleetRequest_shared01() {
 // This example modifies the specified subnet so that all instances launched into this
 // subnet are assigned a public IP address.
 func ExampleEC2_ModifySubnetAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifySubnetAttributeInput{
 		MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{
 			Value: aws.Bool(true),
@@ -4507,7 +4507,7 @@ func ExampleEC2_ModifySubnetAttribute_shared00() {
 // This example sets the ``autoEnableIo`` attribute of the volume with the ID ``vol-1234567890abcdef0``
 // to ``true``. If the command succeeds, no output is returned.
 func ExampleEC2_ModifyVolumeAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyVolumeAttributeInput{
 		AutoEnableIO: &ec2.AttributeBooleanValue{
 			Value: aws.Bool(true),
@@ -4541,7 +4541,7 @@ func ExampleEC2_ModifyVolumeAttribute_shared00() {
 // server resolves DNS hostnames for instances in the VPC to their corresponding IP
 // addresses; otherwise, it does not.
 func ExampleEC2_ModifyVpcAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyVpcAttributeInput{
 		EnableDnsSupport: &ec2.AttributeBooleanValue{
 			Value: aws.Bool(false),
@@ -4573,7 +4573,7 @@ func ExampleEC2_ModifyVpcAttribute_shared00() {
 // whether instances launched in the VPC get DNS hostnames. If this attribute is true,
 // instances in the VPC get DNS hostnames; otherwise, they do not.
 func ExampleEC2_ModifyVpcAttribute_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ModifyVpcAttributeInput{
 		EnableDnsHostnames: &ec2.AttributeBooleanValue{
 			Value: aws.Bool(false),
@@ -4603,7 +4603,7 @@ func ExampleEC2_ModifyVpcAttribute_shared01() {
 //
 // This example moves the specified Elastic IP address to the EC2-VPC platform.
 func ExampleEC2_MoveAddressToVpc_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.MoveAddressToVpcInput{
 		PublicIp: aws.String("54.123.4.56"),
 	}
@@ -4630,7 +4630,7 @@ func ExampleEC2_MoveAddressToVpc_shared00() {
 //
 // This example purchases a Scheduled Instance.
 func ExampleEC2_PurchaseScheduledInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.PurchaseScheduledInstancesInput{
 		PurchaseRequests: []*ec2.PurchaseRequest{
 			{
@@ -4662,7 +4662,7 @@ func ExampleEC2_PurchaseScheduledInstances_shared00() {
 //
 // This example reboots the specified EC2 instance.
 func ExampleEC2_RebootInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RebootInstancesInput{
 		InstanceIds: []*string{
 			aws.String("i-1234567890abcdef5"),
@@ -4691,7 +4691,7 @@ func ExampleEC2_RebootInstances_shared00() {
 //
 // This example releases an Elastic IP address for use with instances in a VPC.
 func ExampleEC2_ReleaseAddress_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ReleaseAddressInput{
 		AllocationId: aws.String("eipalloc-64d5890a"),
 	}
@@ -4718,7 +4718,7 @@ func ExampleEC2_ReleaseAddress_shared00() {
 //
 // This example releases an Elastic IP address for use with instances in EC2-Classic.
 func ExampleEC2_ReleaseAddress_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ReleaseAddressInput{
 		PublicIp: aws.String("198.51.100.0"),
 	}
@@ -4746,7 +4746,7 @@ func ExampleEC2_ReleaseAddress_shared01() {
 // This example associates the specified network ACL with the subnet for the specified
 // network ACL association.
 func ExampleEC2_ReplaceNetworkAclAssociation_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ReplaceNetworkAclAssociationInput{
 		AssociationId: aws.String("aclassoc-e5b95c8c"),
 		NetworkAclId:  aws.String("acl-5fb85d36"),
@@ -4775,7 +4775,7 @@ func ExampleEC2_ReplaceNetworkAclAssociation_shared00() {
 // This example replaces an entry for the specified network ACL. The new rule 100 allows
 // ingress traffic from 203.0.113.12/24 on UDP port 53 (DNS) into any associated subnet.
 func ExampleEC2_ReplaceNetworkAclEntry_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ReplaceNetworkAclEntryInput{
 		CidrBlock:    aws.String("203.0.113.12/24"),
 		Egress:       aws.Bool(false),
@@ -4813,7 +4813,7 @@ func ExampleEC2_ReplaceNetworkAclEntry_shared00() {
 // matches the specified CIDR and sends the traffic to the specified virtual private
 // gateway.
 func ExampleEC2_ReplaceRoute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ReplaceRouteInput{
 		DestinationCidrBlock: aws.String("10.0.0.0/16"),
 		GatewayId:            aws.String("vgw-9a4cacf3"),
@@ -4843,7 +4843,7 @@ func ExampleEC2_ReplaceRoute_shared00() {
 // This example associates the specified route table with the subnet for the specified
 // route table association.
 func ExampleEC2_ReplaceRouteTableAssociation_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ReplaceRouteTableAssociationInput{
 		AssociationId: aws.String("rtbassoc-781d0d1a"),
 		RouteTableId:  aws.String("rtb-22574640"),
@@ -4876,7 +4876,7 @@ func ExampleEC2_ReplaceRouteTableAssociation_shared00() {
 // they do not receive a public IP address by default. Note that you can't specify different
 // subnets from the same Availability Zone in a Spot fleet request.
 func ExampleEC2_RequestSpotFleet_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RequestSpotFleetInput{
 		SpotFleetRequestConfig: &ec2.SpotFleetRequestConfigData{
 			IamFleetRole: aws.String("arn:aws:iam::123456789012:role/my-spot-fleet-role"),
@@ -4928,7 +4928,7 @@ func ExampleEC2_RequestSpotFleet_shared00() {
 // your account supports EC2-Classic, Amazon EC2 launches the instances in EC2-Classic
 // in the Availability Zone.
 func ExampleEC2_RequestSpotFleet_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RequestSpotFleetInput{
 		SpotFleetRequestConfig: &ec2.SpotFleetRequestConfigData{
 			IamFleetRole: aws.String("arn:aws:iam::123456789012:role/my-spot-fleet-role"),
@@ -4979,7 +4979,7 @@ func ExampleEC2_RequestSpotFleet_shared01() {
 // Note that when you specify a network interface, you must include the subnet ID and
 // security group ID using the network interface.
 func ExampleEC2_RequestSpotFleet_shared02() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RequestSpotFleetInput{
 		SpotFleetRequestConfig: &ec2.SpotFleetRequestConfigData{
 			IamFleetRole: aws.String("arn:aws:iam::123456789012:role/my-spot-fleet-role"),
@@ -5033,7 +5033,7 @@ func ExampleEC2_RequestSpotFleet_shared02() {
 // fleet distributes the instances across the launch specifications such that there
 // are 10 instances of each type.
 func ExampleEC2_RequestSpotFleet_shared03() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RequestSpotFleetInput{
 		SpotFleetRequestConfig: &ec2.SpotFleetRequestConfigData{
 			AllocationStrategy: aws.String("diversified"),
@@ -5086,7 +5086,7 @@ func ExampleEC2_RequestSpotFleet_shared03() {
 // supports EC2-Classic, Amazon EC2 launches the instances in EC2-Classic in the specified
 // Availability Zone.
 func ExampleEC2_RequestSpotInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RequestSpotInstancesInput{
 		InstanceCount: aws.Int64(5),
 		LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
@@ -5132,7 +5132,7 @@ func ExampleEC2_RequestSpotInstances_shared00() {
 // If the VPC is a nondefault VPC, the instances do not receive a public IP address
 // by default.
 func ExampleEC2_RequestSpotInstances_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RequestSpotInstancesInput{
 		InstanceCount: aws.Int64(5),
 		LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
@@ -5173,7 +5173,7 @@ func ExampleEC2_RequestSpotInstances_shared01() {
 // This example resets the launchPermission attribute for the specified AMI. By default,
 // AMIs are private.
 func ExampleEC2_ResetImageAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ResetImageAttributeInput{
 		Attribute: aws.String("launchPermission"),
 		ImageId:   aws.String("ami-5731123e"),
@@ -5201,7 +5201,7 @@ func ExampleEC2_ResetImageAttribute_shared00() {
 //
 // This example resets the sourceDestCheck attribute for the specified instance.
 func ExampleEC2_ResetInstanceAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ResetInstanceAttributeInput{
 		Attribute:  aws.String("sourceDestCheck"),
 		InstanceId: aws.String("i-1234567890abcdef0"),
@@ -5230,7 +5230,7 @@ func ExampleEC2_ResetInstanceAttribute_shared00() {
 // This example resets the create volume permissions for snapshot ``snap-1234567890abcdef0``.
 // If the command succeeds, no output is returned.
 func ExampleEC2_ResetSnapshotAttribute_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.ResetSnapshotAttributeInput{
 		Attribute:  aws.String("createVolumePermission"),
 		SnapshotId: aws.String("snap-1234567890abcdef0"),
@@ -5258,7 +5258,7 @@ func ExampleEC2_ResetSnapshotAttribute_shared00() {
 //
 // This example restores the specified Elastic IP address to the EC2-Classic platform.
 func ExampleEC2_RestoreAddressToClassic_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RestoreAddressToClassicInput{
 		PublicIp: aws.String("198.51.100.0"),
 	}
@@ -5286,7 +5286,7 @@ func ExampleEC2_RestoreAddressToClassic_shared00() {
 // This example launches an instance using the specified AMI, instance type, security
 // group, subnet, block device mapping, and tags.
 func ExampleEC2_RunInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RunInstancesInput{
 		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 			{
@@ -5340,7 +5340,7 @@ func ExampleEC2_RunInstances_shared00() {
 //
 // This example launches the specified Scheduled Instance in a VPC.
 func ExampleEC2_RunScheduledInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RunScheduledInstancesInput{
 		InstanceCount: aws.Int64(1),
 		LaunchSpecification: &ec2.ScheduledInstancesLaunchSpecification{
@@ -5386,7 +5386,7 @@ func ExampleEC2_RunScheduledInstances_shared00() {
 //
 // This example launches the specified Scheduled Instance in EC2-Classic.
 func ExampleEC2_RunScheduledInstances_shared01() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.RunScheduledInstancesInput{
 		InstanceCount: aws.Int64(1),
 		LaunchSpecification: &ec2.ScheduledInstancesLaunchSpecification{
@@ -5428,7 +5428,7 @@ func ExampleEC2_RunScheduledInstances_shared01() {
 //
 // This example starts the specified EC2 instance.
 func ExampleEC2_StartInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.StartInstancesInput{
 		InstanceIds: []*string{
 			aws.String("i-1234567890abcdef0"),
@@ -5457,7 +5457,7 @@ func ExampleEC2_StartInstances_shared00() {
 //
 // This example stops the specified EC2 instance.
 func ExampleEC2_StopInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.StopInstancesInput{
 		InstanceIds: []*string{
 			aws.String("i-1234567890abcdef0"),
@@ -5486,7 +5486,7 @@ func ExampleEC2_StopInstances_shared00() {
 //
 // This example terminates the specified EC2 instance.
 func ExampleEC2_TerminateInstances_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.TerminateInstancesInput{
 		InstanceIds: []*string{
 			aws.String("i-1234567890abcdef0"),
@@ -5516,7 +5516,7 @@ func ExampleEC2_TerminateInstances_shared00() {
 // This example unassigns the specified private IP address from the specified network
 // interface.
 func ExampleEC2_UnassignPrivateIpAddresses_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.UnassignPrivateIpAddressesInput{
 		NetworkInterfaceId: aws.String("eni-e5aa89a3"),
 		PrivateIpAddresses: []*string{
@@ -5546,7 +5546,7 @@ func ExampleEC2_UnassignPrivateIpAddresses_shared00() {
 //
 // This example updates the description for the specified security group rule.
 func ExampleEC2_UpdateSecurityGroupRuleDescriptionsEgress_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.UpdateSecurityGroupRuleDescriptionsEgressInput{
 		GroupId: aws.String("sg-123abc12"),
 		IpPermissions: []*ec2.IpPermission{
@@ -5586,7 +5586,7 @@ func ExampleEC2_UpdateSecurityGroupRuleDescriptionsEgress_shared00() {
 //
 // This example updates the description for the specified security group rule.
 func ExampleEC2_UpdateSecurityGroupRuleDescriptionsIngress_shared00() {
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.Must(session.NewSession()))
 	input := &ec2.UpdateSecurityGroupRuleDescriptionsIngressInput{
 		GroupId: aws.String("sg-123abc12"),
 		IpPermissions: []*ec2.IpPermission{

--- a/service/ec2instanceconnect/ec2instanceconnectiface/interface.go
+++ b/service/ec2instanceconnect/ec2instanceconnectiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ec2instanceconnect.New(sess)
 //
 //        myFunc(svc)

--- a/service/ec2instanceconnect/examples_test.go
+++ b/service/ec2instanceconnect/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // The following example pushes a sample SSH public key to the EC2 instance i-abcd1234
 // in AZ us-west-2b for use by the instance OS user ec2-user.
 func ExampleEC2InstanceConnect_SendSSHPublicKey_shared00() {
-	svc := ec2instanceconnect.New(session.New())
+	svc := ec2instanceconnect.New(session.Must(session.NewSession()))
 	input := &ec2instanceconnect.SendSSHPublicKeyInput{
 		AvailabilityZone: aws.String("us-west-2a"),
 		InstanceId:       aws.String("i-abcd1234"),

--- a/service/ecr/ecriface/interface.go
+++ b/service/ecr/ecriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ecr.New(sess)
 //
 //        myFunc(svc)

--- a/service/ecr/examples_test.go
+++ b/service/ecr/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // This example deletes images with the tags precise and trusty in a repository called
 // ubuntu in the default registry for an account.
 func ExampleECR_BatchDeleteImage_shared00() {
-	svc := ecr.New(session.New())
+	svc := ecr.New(session.Must(session.NewSession()))
 	input := &ecr.BatchDeleteImageInput{
 		ImageIds: []*ecr.ImageIdentifier{
 			{
@@ -69,7 +69,7 @@ func ExampleECR_BatchDeleteImage_shared00() {
 // This example obtains information for an image with a specified image digest ID from
 // the repository named ubuntu in the current account.
 func ExampleECR_BatchGetImage_shared00() {
-	svc := ecr.New(session.New())
+	svc := ecr.New(session.Must(session.NewSession()))
 	input := &ecr.BatchGetImageInput{
 		ImageIds: []*ecr.ImageIdentifier{
 			{
@@ -108,7 +108,7 @@ func ExampleECR_BatchGetImage_shared00() {
 // This example creates a repository called nginx-web-app inside the project-a namespace
 // in the default registry for an account.
 func ExampleECR_CreateRepository_shared00() {
-	svc := ecr.New(session.New())
+	svc := ecr.New(session.Must(session.NewSession()))
 	input := &ecr.CreateRepositoryInput{
 		RepositoryName: aws.String("project-a/nginx-web-app"),
 	}
@@ -150,7 +150,7 @@ func ExampleECR_CreateRepository_shared00() {
 // This example force deletes a repository named ubuntu in the default registry for
 // an account. The force parameter is required if the repository contains images.
 func ExampleECR_DeleteRepository_shared00() {
-	svc := ecr.New(session.New())
+	svc := ecr.New(session.Must(session.NewSession()))
 	input := &ecr.DeleteRepositoryInput{
 		Force:          aws.Bool(true),
 		RepositoryName: aws.String("ubuntu"),
@@ -189,7 +189,7 @@ func ExampleECR_DeleteRepository_shared00() {
 // This example deletes the policy associated with the repository named ubuntu in the
 // current account.
 func ExampleECR_DeleteRepositoryPolicy_shared00() {
-	svc := ecr.New(session.New())
+	svc := ecr.New(session.Must(session.NewSession()))
 	input := &ecr.DeleteRepositoryPolicyInput{
 		RepositoryName: aws.String("ubuntu"),
 	}
@@ -225,7 +225,7 @@ func ExampleECR_DeleteRepositoryPolicy_shared00() {
 // The following example obtains a list and description of all repositories in the default
 // registry to which the current user has access.
 func ExampleECR_DescribeRepositories_shared00() {
-	svc := ecr.New(session.New())
+	svc := ecr.New(session.Must(session.NewSession()))
 	input := &ecr.DescribeRepositoriesInput{}
 
 	result, err := svc.DescribeRepositories(input)
@@ -256,7 +256,7 @@ func ExampleECR_DescribeRepositories_shared00() {
 //
 // This example gets an authorization token for your default registry.
 func ExampleECR_GetAuthorizationToken_shared00() {
-	svc := ecr.New(session.New())
+	svc := ecr.New(session.Must(session.NewSession()))
 	input := &ecr.GetAuthorizationTokenInput{}
 
 	result, err := svc.GetAuthorizationToken(input)
@@ -285,7 +285,7 @@ func ExampleECR_GetAuthorizationToken_shared00() {
 //
 // This example obtains the repository policy for the repository named ubuntu.
 func ExampleECR_GetRepositoryPolicy_shared00() {
-	svc := ecr.New(session.New())
+	svc := ecr.New(session.Must(session.NewSession()))
 	input := &ecr.GetRepositoryPolicyInput{
 		RepositoryName: aws.String("ubuntu"),
 	}
@@ -321,7 +321,7 @@ func ExampleECR_GetRepositoryPolicy_shared00() {
 // This example lists all of the images in the repository named ubuntu in the default
 // registry in the current account.
 func ExampleECR_ListImages_shared00() {
-	svc := ecr.New(session.New())
+	svc := ecr.New(session.Must(session.NewSession()))
 	input := &ecr.ListImagesInput{
 		RepositoryName: aws.String("ubuntu"),
 	}

--- a/service/ecs/ecsiface/interface.go
+++ b/service/ecs/ecsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ecs.New(sess)
 //
 //        myFunc(svc)

--- a/service/ecs/examples_test.go
+++ b/service/ecs/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This example creates a cluster in your default region.
 func ExampleECS_CreateCluster_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.CreateClusterInput{
 		ClusterName: aws.String("my_cluster"),
 	}
@@ -64,7 +64,7 @@ func ExampleECS_CreateCluster_shared00() {
 // The service uses the ``hello_world`` task definition and it maintains 10 copies of
 // that task.
 func ExampleECS_CreateService_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.CreateServiceInput{
 		DesiredCount:   aws.Int64(10),
 		ServiceName:    aws.String("ecs-simple-service"),
@@ -111,7 +111,7 @@ func ExampleECS_CreateService_shared00() {
 // The service uses the ``ecs-demo`` task definition and it maintains 10 copies of that
 // task. You must reference an existing load balancer in the same region by its name.
 func ExampleECS_CreateService_shared01() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.CreateServiceInput{
 		DesiredCount: aws.Int64(10),
 		LoadBalancers: []*ecs.LoadBalancer{
@@ -165,7 +165,7 @@ func ExampleECS_CreateService_shared01() {
 // This example deletes the account setting for your user for the specified resource
 // type.
 func ExampleECS_DeleteAccountSetting_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DeleteAccountSettingInput{
 		Name: aws.String("serviceLongArnFormat"),
 	}
@@ -200,7 +200,7 @@ func ExampleECS_DeleteAccountSetting_shared00() {
 // the specified resource type. Only the root user can view or modify the account settings
 // for another user.
 func ExampleECS_DeleteAccountSetting_shared01() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DeleteAccountSettingInput{
 		Name:         aws.String("containerInstanceLongArnFormat"),
 		PrincipalArn: aws.String("arn:aws:iam::<aws_account_id>:user/principalName"),
@@ -234,7 +234,7 @@ func ExampleECS_DeleteAccountSetting_shared01() {
 //
 // This example deletes an empty cluster in your default region.
 func ExampleECS_DeleteCluster_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DeleteClusterInput{
 		Cluster: aws.String("my_cluster"),
 	}
@@ -278,7 +278,7 @@ func ExampleECS_DeleteCluster_shared00() {
 // This example deletes the my-http-service service. The service must have a desired
 // count and running count of 0 before you can delete it.
 func ExampleECS_DeleteService_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DeleteServiceInput{
 		Service: aws.String("my-http-service"),
 	}
@@ -317,7 +317,7 @@ func ExampleECS_DeleteService_shared00() {
 // default region. If there are still tasks running on the container instance, you must
 // either stop those tasks before deregistering, or use the force option.
 func ExampleECS_DeregisterContainerInstance_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DeregisterContainerInstanceInput{
 		Cluster:           aws.String("default"),
 		ContainerInstance: aws.String("container_instance_UUID"),
@@ -354,7 +354,7 @@ func ExampleECS_DeregisterContainerInstance_shared00() {
 //
 // This example provides a description of the specified cluster in your default region.
 func ExampleECS_DescribeClusters_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DescribeClustersInput{
 		Clusters: []*string{
 			aws.String("default"),
@@ -390,7 +390,7 @@ func ExampleECS_DescribeClusters_shared00() {
 // This example provides a description of the specified container instance in your default
 // region, using the container instance UUID as an identifier.
 func ExampleECS_DescribeContainerInstances_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DescribeContainerInstancesInput{
 		Cluster: aws.String("default"),
 		ContainerInstances: []*string{
@@ -428,7 +428,7 @@ func ExampleECS_DescribeContainerInstances_shared00() {
 //
 // This example provides descriptive information about the service named ``ecs-simple-service``.
 func ExampleECS_DescribeServices_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DescribeServicesInput{
 		Services: []*string{
 			aws.String("ecs-simple-service"),
@@ -465,7 +465,7 @@ func ExampleECS_DescribeServices_shared00() {
 //
 // This example provides a description of the specified task definition.
 func ExampleECS_DescribeTaskDefinition_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String("hello_world:8"),
 	}
@@ -499,7 +499,7 @@ func ExampleECS_DescribeTaskDefinition_shared00() {
 // This example provides a description of the specified task, using the task UUID as
 // an identifier.
 func ExampleECS_DescribeTasks_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.DescribeTasksInput{
 		Tasks: []*string{
 			aws.String("c5cba4eb-5dad-405e-96db-71ef8eefe6a8"),
@@ -536,7 +536,7 @@ func ExampleECS_DescribeTasks_shared00() {
 //
 // This example displays the effective account settings for your account.
 func ExampleECS_ListAccountSettings_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListAccountSettingsInput{
 		EffectiveSettings: aws.Bool(true),
 	}
@@ -569,7 +569,7 @@ func ExampleECS_ListAccountSettings_shared00() {
 //
 // This example displays the effective account settings for the specified user or role.
 func ExampleECS_ListAccountSettings_shared01() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListAccountSettingsInput{
 		EffectiveSettings: aws.Bool(true),
 		PrincipalArn:      aws.String("arn:aws:iam::<aws_account_id>:user/principalName"),
@@ -603,7 +603,7 @@ func ExampleECS_ListAccountSettings_shared01() {
 //
 // This example lists all of your available clusters in your default region.
 func ExampleECS_ListClusters_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListClustersInput{}
 
 	result, err := svc.ListClusters(input)
@@ -635,7 +635,7 @@ func ExampleECS_ListClusters_shared00() {
 // This example lists all of your available container instances in the specified cluster
 // in your default region.
 func ExampleECS_ListContainerInstances_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListContainerInstancesInput{
 		Cluster: aws.String("default"),
 	}
@@ -670,7 +670,7 @@ func ExampleECS_ListContainerInstances_shared00() {
 //
 // This example lists the services running in the default cluster for an account.
 func ExampleECS_ListServices_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListServicesInput{}
 
 	result, err := svc.ListServices(input)
@@ -703,7 +703,7 @@ func ExampleECS_ListServices_shared00() {
 //
 // This example lists the tags for the 'dev' cluster.
 func ExampleECS_ListTagsForResource_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListTagsForResourceInput{
 		ResourceArn: aws.String("arn:aws:ecs:region:aws_account_id:cluster/dev"),
 	}
@@ -738,7 +738,7 @@ func ExampleECS_ListTagsForResource_shared00() {
 //
 // This example lists all of your registered task definition families.
 func ExampleECS_ListTaskDefinitionFamilies_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListTaskDefinitionFamiliesInput{}
 
 	result, err := svc.ListTaskDefinitionFamilies(input)
@@ -769,7 +769,7 @@ func ExampleECS_ListTaskDefinitionFamilies_shared00() {
 //
 // This example lists the task definition revisions that start with "hpcc".
 func ExampleECS_ListTaskDefinitionFamilies_shared01() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListTaskDefinitionFamiliesInput{
 		FamilyPrefix: aws.String("hpcc"),
 	}
@@ -802,7 +802,7 @@ func ExampleECS_ListTaskDefinitionFamilies_shared01() {
 //
 // This example lists all of your registered task definitions.
 func ExampleECS_ListTaskDefinitions_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListTaskDefinitionsInput{}
 
 	result, err := svc.ListTaskDefinitions(input)
@@ -833,7 +833,7 @@ func ExampleECS_ListTaskDefinitions_shared00() {
 //
 // This example lists the task definition revisions of a specified family.
 func ExampleECS_ListTaskDefinitions_shared01() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListTaskDefinitionsInput{
 		FamilyPrefix: aws.String("wordpress"),
 	}
@@ -866,7 +866,7 @@ func ExampleECS_ListTaskDefinitions_shared01() {
 //
 // This example lists all of the tasks in a cluster.
 func ExampleECS_ListTasks_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListTasksInput{
 		Cluster: aws.String("default"),
 	}
@@ -904,7 +904,7 @@ func ExampleECS_ListTasks_shared00() {
 // This example lists the tasks of a specified container instance. Specifying a ``containerInstance``
 // value limits the results to tasks that belong to that container instance.
 func ExampleECS_ListTasks_shared01() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.ListTasksInput{
 		Cluster:           aws.String("default"),
 		ContainerInstance: aws.String("f6bbb147-5370-4ace-8c73-c7181ded911f"),
@@ -945,7 +945,7 @@ func ExampleECS_ListTasks_shared01() {
 // then changes apply to the entire AWS account, unless an IAM user or role explicitly
 // overrides these settings for themselves.
 func ExampleECS_PutAccountSetting_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.PutAccountSettingInput{
 		Name:  aws.String("serviceLongArnFormat"),
 		Value: aws.String("enabled"),
@@ -982,7 +982,7 @@ func ExampleECS_PutAccountSetting_shared00() {
 // If you’re using this command as the root user, then changes apply to the entire
 // AWS account, unless an IAM user or role explicitly overrides these settings for themselves.
 func ExampleECS_PutAccountSetting_shared01() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.PutAccountSettingInput{
 		Name:         aws.String("containerInstanceLongArnFormat"),
 		PrincipalArn: aws.String("arn:aws:iam::<aws_account_id>:user/principalName"),
@@ -1019,7 +1019,7 @@ func ExampleECS_PutAccountSetting_shared01() {
 // all IAM users or roles on an account. These changes apply to the entire AWS account,
 // unless an IAM user or role explicitly overrides these settings for themselves.
 func ExampleECS_PutAccountSettingDefault_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.PutAccountSettingDefaultInput{
 		Name:  aws.String("serviceLongArnFormat"),
 		Value: aws.String("enabled"),
@@ -1053,7 +1053,7 @@ func ExampleECS_PutAccountSettingDefault_shared00() {
 //
 // This example registers a task definition to the specified family.
 func ExampleECS_RegisterTaskDefinition_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: []*ecs.ContainerDefinition{
 			{
@@ -1100,7 +1100,7 @@ func ExampleECS_RegisterTaskDefinition_shared00() {
 //
 // This example runs the specified task definition on your default cluster.
 func ExampleECS_RunTask_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.RunTaskInput{
 		Cluster:        aws.String("default"),
 		TaskDefinition: aws.String("sleep360:1"),
@@ -1146,7 +1146,7 @@ func ExampleECS_RunTask_shared00() {
 //
 // This example tags the 'dev' cluster with key 'team' and value 'dev'.
 func ExampleECS_TagResource_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.TagResourceInput{
 		ResourceArn: aws.String("arn:aws:ecs:region:aws_account_id:cluster/dev"),
 		Tags: []*ecs.Tag{
@@ -1189,7 +1189,7 @@ func ExampleECS_TagResource_shared00() {
 //
 // This example deletes the 'team' tag from the 'dev' cluster.
 func ExampleECS_UntagResource_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.UntagResourceInput{
 		ResourceArn: aws.String("arn:aws:ecs:region:aws_account_id:cluster/dev"),
 		TagKeys: []*string{
@@ -1230,7 +1230,7 @@ func ExampleECS_UntagResource_shared00() {
 // This example updates the my-http-service service to use the amazon-ecs-sample task
 // definition.
 func ExampleECS_UpdateService_shared00() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.UpdateServiceInput{
 		Service:        aws.String("my-http-service"),
 		TaskDefinition: aws.String("amazon-ecs-sample"),
@@ -1276,7 +1276,7 @@ func ExampleECS_UpdateService_shared00() {
 //
 // This example updates the desired count of the my-http-service service to 10.
 func ExampleECS_UpdateService_shared01() {
-	svc := ecs.New(session.New())
+	svc := ecs.New(session.Must(session.NewSession()))
 	input := &ecs.UpdateServiceInput{
 		DesiredCount: aws.Int64(10),
 		Service:      aws.String("my-http-service"),

--- a/service/efs/efsiface/interface.go
+++ b/service/efs/efsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := efs.New(sess)
 //
 //        myFunc(svc)

--- a/service/efs/examples_test.go
+++ b/service/efs/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // This operation creates a new file system with the default generalpurpose performance
 // mode.
 func ExampleEFS_CreateFileSystem_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.CreateFileSystemInput{
 		CreationToken:   aws.String("tokenstring"),
 		PerformanceMode: aws.String("generalPurpose"),
@@ -76,7 +76,7 @@ func ExampleEFS_CreateFileSystem_shared00() {
 //
 // This operation creates a new mount target for an EFS file system.
 func ExampleEFS_CreateMountTarget_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.CreateMountTargetInput{
 		FileSystemId: aws.String("fs-01234567"),
 		SubnetId:     aws.String("subnet-1234abcd"),
@@ -128,7 +128,7 @@ func ExampleEFS_CreateMountTarget_shared00() {
 //
 // This operation creates a new tag for an EFS file system.
 func ExampleEFS_CreateTags_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.CreateTagsInput{
 		FileSystemId: aws.String("fs-01234567"),
 		Tags: []*efs.Tag{
@@ -167,7 +167,7 @@ func ExampleEFS_CreateTags_shared00() {
 //
 // This operation deletes an EFS file system.
 func ExampleEFS_DeleteFileSystem_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.DeleteFileSystemInput{
 		FileSystemId: aws.String("fs-01234567"),
 	}
@@ -202,7 +202,7 @@ func ExampleEFS_DeleteFileSystem_shared00() {
 //
 // This operation deletes a mount target.
 func ExampleEFS_DeleteMountTarget_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.DeleteMountTargetInput{
 		MountTargetId: aws.String("fsmt-12340abc"),
 	}
@@ -237,7 +237,7 @@ func ExampleEFS_DeleteMountTarget_shared00() {
 //
 // This operation deletes tags for an EFS file system.
 func ExampleEFS_DeleteTags_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.DeleteTagsInput{
 		FileSystemId: aws.String("fs-01234567"),
 		TagKeys: []*string{
@@ -273,7 +273,7 @@ func ExampleEFS_DeleteTags_shared00() {
 //
 // This operation describes all of the EFS file systems in an account.
 func ExampleEFS_DescribeFileSystems_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.DescribeFileSystemsInput{}
 
 	result, err := svc.DescribeFileSystems(input)
@@ -306,7 +306,7 @@ func ExampleEFS_DescribeFileSystems_shared00() {
 // uses the LifecycleConfiguration object to identify which files to move to the EFS
 // Infrequent Access (IA) storage class.
 func ExampleEFS_DescribeLifecycleConfiguration_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.DescribeLifecycleConfigurationInput{
 		FileSystemId: aws.String("fs-01234567"),
 	}
@@ -339,7 +339,7 @@ func ExampleEFS_DescribeLifecycleConfiguration_shared00() {
 //
 // This operation describes all of the security groups for a file system's mount target.
 func ExampleEFS_DescribeMountTargetSecurityGroups_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.DescribeMountTargetSecurityGroupsInput{
 		MountTargetId: aws.String("fsmt-12340abc"),
 	}
@@ -374,7 +374,7 @@ func ExampleEFS_DescribeMountTargetSecurityGroups_shared00() {
 //
 // This operation describes all of a file system's mount targets.
 func ExampleEFS_DescribeMountTargets_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.DescribeMountTargetsInput{
 		FileSystemId: aws.String("fs-01234567"),
 	}
@@ -411,7 +411,7 @@ func ExampleEFS_DescribeMountTargets_shared00() {
 //
 // This operation describes all of a file system's tags.
 func ExampleEFS_DescribeTags_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.DescribeTagsInput{
 		FileSystemId: aws.String("fs-01234567"),
 	}
@@ -445,7 +445,7 @@ func ExampleEFS_DescribeTags_shared00() {
 // This operation modifies the security groups associated with a mount target for a
 // file system.
 func ExampleEFS_ModifyMountTargetSecurityGroups_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.ModifyMountTargetSecurityGroupsInput{
 		MountTargetId: aws.String("fsmt-12340abc"),
 		SecurityGroups: []*string{
@@ -490,7 +490,7 @@ func ExampleEFS_ModifyMountTargetSecurityGroups_shared00() {
 // system are automatically transitioned to the lower-cost EFS Infrequent Access (IA)
 // storage class. A LifecycleConfiguration applies to all files in a file system.
 func ExampleEFS_PutLifecycleConfiguration_shared00() {
-	svc := efs.New(session.New())
+	svc := efs.New(session.Must(session.NewSession()))
 	input := &efs.PutLifecycleConfigurationInput{
 		FileSystemId: aws.String("fs-01234567"),
 		LifecyclePolicies: []*efs.LifecyclePolicy{

--- a/service/eks/eksiface/interface.go
+++ b/service/eks/eksiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := eks.New(sess)
 //
 //        myFunc(svc)

--- a/service/eks/examples_test.go
+++ b/service/eks/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The following example creates an Amazon EKS cluster called prod.
 func ExampleEKS_CreateCluster_shared00() {
-	svc := eks.New(session.New())
+	svc := eks.New(session.Must(session.NewSession()))
 	input := &eks.CreateClusterInput{
 		ClientRequestToken: aws.String("1d2129a1-3d38-460a-9756-e5b91fddb951"),
 		Name:               aws.String("prod"),
@@ -82,7 +82,7 @@ func ExampleEKS_CreateCluster_shared00() {
 //
 // This example command deletes a cluster named `devel` in your default region.
 func ExampleEKS_DeleteCluster_shared00() {
-	svc := eks.New(session.New())
+	svc := eks.New(session.Must(session.NewSession()))
 	input := &eks.DeleteClusterInput{
 		Name: aws.String("devel"),
 	}
@@ -120,7 +120,7 @@ func ExampleEKS_DeleteCluster_shared00() {
 // This example command provides a description of the specified cluster in your default
 // region.
 func ExampleEKS_DescribeCluster_shared00() {
-	svc := eks.New(session.New())
+	svc := eks.New(session.Must(session.NewSession()))
 	input := &eks.DescribeClusterInput{
 		Name: aws.String("devel"),
 	}
@@ -155,7 +155,7 @@ func ExampleEKS_DescribeCluster_shared00() {
 //
 // This example command lists all of your available clusters in your default region.
 func ExampleEKS_ListClusters_shared00() {
-	svc := eks.New(session.New())
+	svc := eks.New(session.Must(session.NewSession()))
 	input := &eks.ListClustersInput{}
 
 	result, err := svc.ListClusters(input)
@@ -188,7 +188,7 @@ func ExampleEKS_ListClusters_shared00() {
 //
 // This example lists all of the tags for the `beta` cluster.
 func ExampleEKS_ListTagsForResource_shared00() {
-	svc := eks.New(session.New())
+	svc := eks.New(session.Must(session.NewSession()))
 	input := &eks.ListTagsForResourceInput{
 		ResourceArn: aws.String("arn:aws:eks:us-west-2:012345678910:cluster/beta"),
 	}

--- a/service/elasticache/elasticacheiface/interface.go
+++ b/service/elasticache/elasticacheiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := elasticache.New(sess)
 //
 //        myFunc(svc)

--- a/service/elasticache/examples_test.go
+++ b/service/elasticache/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // Adds up to 10 tags, key/value pairs, to a cluster or snapshot resource.
 func ExampleElastiCache_AddTagsToResource_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.AddTagsToResourceInput{
 		ResourceName: aws.String("arn:aws:elasticache:us-east-1:1234567890:cluster:my-mem-cluster"),
 		Tags: []*elasticache.Tag{
@@ -76,7 +76,7 @@ func ExampleElastiCache_AddTagsToResource_shared00() {
 // must be running on Amazon EC2. Amazon EC2 security groups are used as the authorization
 // mechanism.
 func ExampleElastiCache_AuthorizeCacheSecurityGroupIngress_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.AuthorizeCacheSecurityGroupIngressInput{
 		CacheSecurityGroupName:  aws.String("my-sec-grp"),
 		EC2SecurityGroupName:    aws.String("my-ec2-sec-grp"),
@@ -115,7 +115,7 @@ func ExampleElastiCache_AuthorizeCacheSecurityGroupIngress_shared00() {
 //
 // Copies a snapshot to a specified name.
 func ExampleElastiCache_CopySnapshot_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CopySnapshotInput{
 		SourceSnapshotName: aws.String("my-snapshot"),
 		TargetBucket:       aws.String(""),
@@ -156,7 +156,7 @@ func ExampleElastiCache_CopySnapshot_shared00() {
 //
 // Creates a Memcached cluster with 2 nodes.
 func ExampleElastiCache_CreateCacheCluster_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateCacheClusterInput{
 		AZMode:               aws.String("cross-az"),
 		CacheClusterId:       aws.String("my-memcached-cluster"),
@@ -218,7 +218,7 @@ func ExampleElastiCache_CreateCacheCluster_shared00() {
 //
 // Creates a Redis cluster with 1 node.
 func ExampleElastiCache_CreateCacheCluster_shared01() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateCacheClusterInput{
 		AutoMinorVersionUpgrade:   aws.Bool(true),
 		CacheClusterId:            aws.String("my-redis"),
@@ -282,7 +282,7 @@ func ExampleElastiCache_CreateCacheCluster_shared01() {
 //
 // Creates the Amazon ElastiCache parameter group custom-redis2-8.
 func ExampleElastiCache_CreateCacheParameterGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateCacheParameterGroupInput{
 		CacheParameterGroupFamily: aws.String("redis2.8"),
 		CacheParameterGroupName:   aws.String("custom-redis2-8"),
@@ -322,7 +322,7 @@ func ExampleElastiCache_CreateCacheParameterGroup_shared00() {
 // Creates an ElastiCache security group. ElastiCache security groups are only for clusters
 // not running in an AWS VPC.
 func ExampleElastiCache_CreateCacheSecurityGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateCacheSecurityGroupInput{
 		CacheSecurityGroupName: aws.String("my-cache-sec-grp"),
 		Description:            aws.String("Example ElastiCache security group."),
@@ -358,7 +358,7 @@ func ExampleElastiCache_CreateCacheSecurityGroup_shared00() {
 //
 // Creates a new cache subnet group.
 func ExampleElastiCache_CreateCacheSubnetGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateCacheSubnetGroupInput{
 		CacheSubnetGroupDescription: aws.String("Sample subnet group"),
 		CacheSubnetGroupName:        aws.String("my-sn-grp2"),
@@ -399,7 +399,7 @@ func ExampleElastiCache_CreateCacheSubnetGroup_shared00() {
 //
 // Creates a Redis replication group with 3 nodes.
 func ExampleElastiCache_CreateReplicationGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateReplicationGroupInput{
 		AutomaticFailoverEnabled:    aws.Bool(true),
 		CacheNodeType:               aws.String("cache.m3.medium"),
@@ -468,7 +468,7 @@ func ExampleElastiCache_CreateReplicationGroup_shared00() {
 // Creates a Redis (cluster mode enabled) replication group with two shards. One shard
 // has one read replica node and the other shard has two read replicas.
 func ExampleElastiCache_CreateReplicationGroup_shared01() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateReplicationGroupInput{
 		AutoMinorVersionUpgrade: aws.Bool(true),
 		CacheNodeType:           aws.String("cache.m3.medium"),
@@ -556,7 +556,7 @@ func ExampleElastiCache_CreateReplicationGroup_shared01() {
 //
 // Creates a snapshot of a non-clustered Redis cluster that has only one node.
 func ExampleElastiCache_CreateSnapshot_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateSnapshotInput{
 		CacheClusterId: aws.String("onenoderedis"),
 		SnapshotName:   aws.String("snapshot-1"),
@@ -603,7 +603,7 @@ func ExampleElastiCache_CreateSnapshot_shared00() {
 // Creates a snapshot of a non-clustered Redis cluster that has only three nodes, primary
 // and two read-replicas. CacheClusterId must be a specific node in the cluster.
 func ExampleElastiCache_CreateSnapshot_shared01() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateSnapshotInput{
 		CacheClusterId: aws.String("threenoderedis-001"),
 		SnapshotName:   aws.String("snapshot-2"),
@@ -650,7 +650,7 @@ func ExampleElastiCache_CreateSnapshot_shared01() {
 // Creates a snapshot of a clustered Redis cluster that has 2 shards, each with a primary
 // and 4 read-replicas.
 func ExampleElastiCache_CreateSnapshot_shared02() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.CreateSnapshotInput{
 		ReplicationGroupId: aws.String("clusteredredis"),
 		SnapshotName:       aws.String("snapshot-2x5"),
@@ -696,7 +696,7 @@ func ExampleElastiCache_CreateSnapshot_shared02() {
 //
 // Deletes an Amazon ElastiCache cluster.
 func ExampleElastiCache_DeleteCacheCluster_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DeleteCacheClusterInput{
 		CacheClusterId: aws.String("my-memcached"),
 	}
@@ -737,7 +737,7 @@ func ExampleElastiCache_DeleteCacheCluster_shared00() {
 //
 // Deletes the Amazon ElastiCache parameter group custom-mem1-4.
 func ExampleElastiCache_DeleteCacheParameterGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DeleteCacheParameterGroupInput{
 		CacheParameterGroupName: aws.String("custom-mem1-4"),
 	}
@@ -772,7 +772,7 @@ func ExampleElastiCache_DeleteCacheParameterGroup_shared00() {
 //
 // Deletes a cache security group.
 func ExampleElastiCache_DeleteCacheSecurityGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DeleteCacheSecurityGroupInput{
 		CacheSecurityGroupName: aws.String("my-sec-group"),
 	}
@@ -807,7 +807,7 @@ func ExampleElastiCache_DeleteCacheSecurityGroup_shared00() {
 //
 // Deletes the Amazon ElastiCache subnet group my-subnet-group.
 func ExampleElastiCache_DeleteCacheSubnetGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DeleteCacheSubnetGroupInput{
 		CacheSubnetGroupName: aws.String("my-subnet-group"),
 	}
@@ -838,7 +838,7 @@ func ExampleElastiCache_DeleteCacheSubnetGroup_shared00() {
 //
 // Deletes the Amazon ElastiCache replication group my-redis-rg.
 func ExampleElastiCache_DeleteReplicationGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DeleteReplicationGroupInput{
 		ReplicationGroupId:   aws.String("my-redis-rg"),
 		RetainPrimaryCluster: aws.Bool(false),
@@ -880,7 +880,7 @@ func ExampleElastiCache_DeleteReplicationGroup_shared00() {
 //
 // Deletes the Redis snapshot snapshot-20160822.
 func ExampleElastiCache_DeleteSnapshot_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DeleteSnapshotInput{
 		SnapshotName: aws.String("snapshot-20161212"),
 	}
@@ -915,7 +915,7 @@ func ExampleElastiCache_DeleteSnapshot_shared00() {
 //
 // Lists the details for up to 50 cache clusters.
 func ExampleElastiCache_DescribeCacheClusters_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeCacheClustersInput{
 		CacheClusterId: aws.String("my-mem-cluster"),
 	}
@@ -948,7 +948,7 @@ func ExampleElastiCache_DescribeCacheClusters_shared00() {
 //
 // Lists the details for the cache cluster my-mem-cluster.
 func ExampleElastiCache_DescribeCacheClusters_shared01() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeCacheClustersInput{
 		CacheClusterId:    aws.String("my-mem-cluster"),
 		ShowCacheNodeInfo: aws.Bool(true),
@@ -982,7 +982,7 @@ func ExampleElastiCache_DescribeCacheClusters_shared01() {
 //
 // Lists the details for up to 25 Memcached and Redis cache engine versions.
 func ExampleElastiCache_DescribeCacheEngineVersions_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeCacheEngineVersionsInput{}
 
 	result, err := svc.DescribeCacheEngineVersions(input)
@@ -1007,7 +1007,7 @@ func ExampleElastiCache_DescribeCacheEngineVersions_shared00() {
 //
 // Lists the details for up to 50 Redis cache engine versions.
 func ExampleElastiCache_DescribeCacheEngineVersions_shared01() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeCacheEngineVersionsInput{
 		DefaultOnly: aws.Bool(false),
 		Engine:      aws.String("redis"),
@@ -1037,7 +1037,7 @@ func ExampleElastiCache_DescribeCacheEngineVersions_shared01() {
 // Returns a list of cache parameter group descriptions. If a cache parameter group
 // name is specified, the list contains only the descriptions for that group.
 func ExampleElastiCache_DescribeCacheParameterGroups_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeCacheParameterGroupsInput{
 		CacheParameterGroupName: aws.String("custom-mem1-4"),
 	}
@@ -1070,7 +1070,7 @@ func ExampleElastiCache_DescribeCacheParameterGroups_shared00() {
 //
 // Lists up to 100 user parameter values for the parameter group custom.redis2.8.
 func ExampleElastiCache_DescribeCacheParameters_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeCacheParametersInput{
 		CacheParameterGroupName: aws.String("custom-redis2-8"),
 		MaxRecords:              aws.Int64(100),
@@ -1106,7 +1106,7 @@ func ExampleElastiCache_DescribeCacheParameters_shared00() {
 // Returns a list of cache security group descriptions. If a cache security group name
 // is specified, the list contains only the description of that group.
 func ExampleElastiCache_DescribeCacheSecurityGroups_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeCacheSecurityGroupsInput{
 		CacheSecurityGroupName: aws.String("my-sec-group"),
 	}
@@ -1139,7 +1139,7 @@ func ExampleElastiCache_DescribeCacheSecurityGroups_shared00() {
 //
 // Describes up to 25 cache subnet groups.
 func ExampleElastiCache_DescribeCacheSubnetGroups_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeCacheSubnetGroupsInput{
 		MaxRecords: aws.Int64(25),
 	}
@@ -1169,7 +1169,7 @@ func ExampleElastiCache_DescribeCacheSubnetGroups_shared00() {
 // Returns the default engine and system parameter information for the specified cache
 // engine.
 func ExampleElastiCache_DescribeEngineDefaultParameters_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeEngineDefaultParametersInput{
 		CacheParameterGroupFamily: aws.String("redis2.8"),
 		MaxRecords:                aws.Int64(25),
@@ -1201,7 +1201,7 @@ func ExampleElastiCache_DescribeEngineDefaultParameters_shared00() {
 //
 // Describes all the cache-cluster events for the past 120 minutes.
 func ExampleElastiCache_DescribeEvents_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeEventsInput{
 		Duration:   aws.Int64(360),
 		SourceType: aws.String("cache-cluster"),
@@ -1233,7 +1233,7 @@ func ExampleElastiCache_DescribeEvents_shared00() {
 //
 // Describes all the replication-group events from 3:00P to 5:00P on November 11, 2016.
 func ExampleElastiCache_DescribeEvents_shared01() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeEventsInput{
 		StartTime: parseTime("2006-01-02T15:04:05.999999999Z", "2016-12-22T15:00:00.000Z"),
 	}
@@ -1264,7 +1264,7 @@ func ExampleElastiCache_DescribeEvents_shared01() {
 //
 // Returns information about the replication group myreplgroup.
 func ExampleElastiCache_DescribeReplicationGroups_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeReplicationGroupsInput{}
 
 	result, err := svc.DescribeReplicationGroups(input)
@@ -1297,7 +1297,7 @@ func ExampleElastiCache_DescribeReplicationGroups_shared00() {
 // reserved cache node. If the account has no reserved cache nodes, the operation returns
 // an empty list, as shown here.
 func ExampleElastiCache_DescribeReservedCacheNodes_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeReservedCacheNodesInput{
 		MaxRecords: aws.Int64(25),
 	}
@@ -1330,7 +1330,7 @@ func ExampleElastiCache_DescribeReservedCacheNodes_shared00() {
 //
 // Lists available reserved cache node offerings.
 func ExampleElastiCache_DescribeReservedCacheNodesOfferings_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeReservedCacheNodesOfferingsInput{
 		MaxRecords: aws.Int64(20),
 	}
@@ -1364,7 +1364,7 @@ func ExampleElastiCache_DescribeReservedCacheNodesOfferings_shared00() {
 // Lists available reserved cache node offerings for cache.r3.large nodes with a 3 year
 // commitment.
 func ExampleElastiCache_DescribeReservedCacheNodesOfferings_shared01() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeReservedCacheNodesOfferingsInput{
 		CacheNodeType:                aws.String("cache.r3.large"),
 		Duration:                     aws.String("3"),
@@ -1401,7 +1401,7 @@ func ExampleElastiCache_DescribeReservedCacheNodesOfferings_shared01() {
 //
 // Lists available reserved cache node offerings.
 func ExampleElastiCache_DescribeReservedCacheNodesOfferings_shared02() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeReservedCacheNodesOfferingsInput{
 		CacheNodeType:                aws.String(""),
 		Duration:                     aws.String(""),
@@ -1440,7 +1440,7 @@ func ExampleElastiCache_DescribeReservedCacheNodesOfferings_shared02() {
 //
 // Returns information about the snapshot mysnapshot. By default.
 func ExampleElastiCache_DescribeSnapshots_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.DescribeSnapshotsInput{
 		SnapshotName: aws.String("snapshot-20161212"),
 	}
@@ -1476,7 +1476,7 @@ func ExampleElastiCache_DescribeSnapshots_shared00() {
 // Lists all available node types that you can scale your Redis cluster's or replication
 // group's current node type up to.
 func ExampleElastiCache_ListAllowedNodeTypeModifications_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.ListAllowedNodeTypeModificationsInput{
 		ReplicationGroupId: aws.String("myreplgroup"),
 	}
@@ -1512,7 +1512,7 @@ func ExampleElastiCache_ListAllowedNodeTypeModifications_shared00() {
 // Lists all available node types that you can scale your Redis cluster's or replication
 // group's current node type up to.
 func ExampleElastiCache_ListAllowedNodeTypeModifications_shared01() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.ListAllowedNodeTypeModificationsInput{
 		CacheClusterId: aws.String("mycluster"),
 	}
@@ -1549,7 +1549,7 @@ func ExampleElastiCache_ListAllowedNodeTypeModifications_shared01() {
 // tag is a key-value pair where the key is case-sensitive and the value is optional.
 // You can use cost allocation tags to categorize and track your AWS costs.
 func ExampleElastiCache_ListTagsForResource_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.ListTagsForResourceInput{
 		ResourceName: aws.String("arn:aws:elasticache:us-west-2:<my-account-id>:cluster:mycluster"),
 	}
@@ -1582,7 +1582,7 @@ func ExampleElastiCache_ListTagsForResource_shared00() {
 //
 // Copies a snapshot to a specified name.
 func ExampleElastiCache_ModifyCacheCluster_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.ModifyCacheClusterInput{
 		ApplyImmediately:       aws.Bool(true),
 		CacheClusterId:         aws.String("redis-cluster"),
@@ -1634,7 +1634,7 @@ func ExampleElastiCache_ModifyCacheCluster_shared00() {
 // Modifies one or more parameter values in the specified parameter group. You cannot
 // modify any default parameter group.
 func ExampleElastiCache_ModifyCacheParameterGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.ModifyCacheParameterGroupInput{
 		CacheParameterGroupName: aws.String("custom-mem1-4"),
 		ParameterNameValues: []*elasticache.ParameterNameValue{
@@ -1681,7 +1681,7 @@ func ExampleElastiCache_ModifyCacheParameterGroup_shared00() {
 //
 // Modifies an existing ElastiCache subnet group.
 func ExampleElastiCache_ModifyCacheSubnetGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.ModifyCacheSubnetGroupInput{
 		CacheSubnetGroupName: aws.String("my-sn-grp"),
 		SubnetIds: []*string{
@@ -1719,7 +1719,7 @@ func ExampleElastiCache_ModifyCacheSubnetGroup_shared00() {
 //
 
 func ExampleElastiCache_ModifyReplicationGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.ModifyReplicationGroupInput{
 		ApplyImmediately:            aws.Bool(true),
 		ReplicationGroupDescription: aws.String("Modified replication group"),
@@ -1778,7 +1778,7 @@ func ExampleElastiCache_ModifyReplicationGroup_shared00() {
 //
 // Allows you to purchase a reserved cache node offering.
 func ExampleElastiCache_PurchaseReservedCacheNodesOffering_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.PurchaseReservedCacheNodesOfferingInput{
 		ReservedCacheNodesOfferingId: aws.String("1ef01f5b-94ff-433f-a530-61a56bfc8e7a"),
 	}
@@ -1815,7 +1815,7 @@ func ExampleElastiCache_PurchaseReservedCacheNodesOffering_shared00() {
 //
 // Reboots the specified nodes in the names cluster.
 func ExampleElastiCache_RebootCacheCluster_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.RebootCacheClusterInput{
 		CacheClusterId: aws.String("custom-mem1-4  "),
 		CacheNodeIdsToReboot: []*string{
@@ -1851,7 +1851,7 @@ func ExampleElastiCache_RebootCacheCluster_shared00() {
 // Removes tags identified by a list of tag keys from the list of tags on the specified
 // resource.
 func ExampleElastiCache_RemoveTagsFromResource_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.RemoveTagsFromResourceInput{
 		ResourceName: aws.String("arn:aws:elasticache:us-east-1:1234567890:cluster:my-mem-cluster"),
 		TagKeys: []*string{
@@ -1892,7 +1892,7 @@ func ExampleElastiCache_RemoveTagsFromResource_shared00() {
 // Modifies the parameters of a cache parameter group to the engine or system default
 // value.
 func ExampleElastiCache_ResetCacheParameterGroup_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.ResetCacheParameterGroupInput{
 		CacheParameterGroupName: aws.String("custom-mem1-4"),
 		ResetAllParameters:      aws.Bool(true),
@@ -1931,7 +1931,7 @@ func ExampleElastiCache_ResetCacheParameterGroup_shared00() {
 // Returns a list of cache security group descriptions. If a cache security group name
 // is specified, the list contains only the description of that group.
 func ExampleElastiCache_RevokeCacheSecurityGroupIngress_shared00() {
-	svc := elasticache.New(session.New())
+	svc := elasticache.New(session.Must(session.NewSession()))
 	input := &elasticache.RevokeCacheSecurityGroupIngressInput{
 		CacheSecurityGroupName:  aws.String("my-sec-grp"),
 		EC2SecurityGroupName:    aws.String("my-ec2-sec-grp"),

--- a/service/elasticbeanstalk/elasticbeanstalkiface/interface.go
+++ b/service/elasticbeanstalk/elasticbeanstalkiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := elasticbeanstalk.New(sess)
 //
 //        myFunc(svc)

--- a/service/elasticbeanstalk/examples_test.go
+++ b/service/elasticbeanstalk/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // The following code aborts a running application version deployment for an environment
 // named my-env:
 func ExampleElasticBeanstalk_AbortEnvironmentUpdate_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.AbortEnvironmentUpdateInput{
 		EnvironmentName: aws.String("my-env"),
 	}
@@ -59,7 +59,7 @@ func ExampleElasticBeanstalk_AbortEnvironmentUpdate_shared00() {
 //
 // The following operation checks the availability of the subdomain my-cname:
 func ExampleElasticBeanstalk_CheckDNSAvailability_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.CheckDNSAvailabilityInput{
 		CNAMEPrefix: aws.String("my-cname"),
 	}
@@ -86,7 +86,7 @@ func ExampleElasticBeanstalk_CheckDNSAvailability_shared00() {
 //
 // The following operation creates a new application named my-app:
 func ExampleElasticBeanstalk_CreateApplication_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.CreateApplicationInput{
 		ApplicationName: aws.String("my-app"),
 		Description:     aws.String("my application"),
@@ -116,7 +116,7 @@ func ExampleElasticBeanstalk_CreateApplication_shared00() {
 //
 // The following operation creates a new version (v1) of an application named my-app:
 func ExampleElasticBeanstalk_CreateApplicationVersion_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.CreateApplicationVersionInput{
 		ApplicationName:       aws.String("my-app"),
 		AutoCreateApplication: aws.Bool(true),
@@ -162,7 +162,7 @@ func ExampleElasticBeanstalk_CreateApplicationVersion_shared00() {
 // The following operation creates a configuration template named my-app-v1 from the
 // settings applied to an environment with the id e-rpqsewtp2j:
 func ExampleElasticBeanstalk_CreateConfigurationTemplate_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.CreateConfigurationTemplateInput{
 		ApplicationName: aws.String("my-app"),
 		EnvironmentId:   aws.String("e-rpqsewtp2j"),
@@ -198,7 +198,7 @@ func ExampleElasticBeanstalk_CreateConfigurationTemplate_shared00() {
 // The following operation creates a new environment for version v1 of a java application
 // named my-app:
 func ExampleElasticBeanstalk_CreateEnvironment_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.CreateEnvironmentInput{
 		ApplicationName:   aws.String("my-app"),
 		CNAMEPrefix:       aws.String("my-app"),
@@ -234,7 +234,7 @@ func ExampleElasticBeanstalk_CreateEnvironment_shared00() {
 // The following operation creates a new environment for version v1 of a java application
 // named my-app:
 func ExampleElasticBeanstalk_CreateStorageLocation_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.CreateStorageLocationInput{}
 
 	result, err := svc.CreateStorageLocation(input)
@@ -265,7 +265,7 @@ func ExampleElasticBeanstalk_CreateStorageLocation_shared00() {
 //
 // The following operation deletes an application named my-app:
 func ExampleElasticBeanstalk_DeleteApplication_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DeleteApplicationInput{
 		ApplicationName: aws.String("my-app"),
 	}
@@ -295,7 +295,7 @@ func ExampleElasticBeanstalk_DeleteApplication_shared00() {
 // The following operation deletes an application version named 22a0-stage-150819_182129
 // for an application named my-app:
 func ExampleElasticBeanstalk_DeleteApplicationVersion_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DeleteApplicationVersionInput{
 		ApplicationName:    aws.String("my-app"),
 		DeleteSourceBundle: aws.Bool(true),
@@ -333,7 +333,7 @@ func ExampleElasticBeanstalk_DeleteApplicationVersion_shared00() {
 // The following operation deletes a configuration template named my-template for an
 // application named my-app:
 func ExampleElasticBeanstalk_DeleteConfigurationTemplate_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DeleteConfigurationTemplateInput{
 		ApplicationName: aws.String("my-app"),
 		TemplateName:    aws.String("my-template"),
@@ -363,7 +363,7 @@ func ExampleElasticBeanstalk_DeleteConfigurationTemplate_shared00() {
 //
 // The following operation deletes a draft configuration for an environment named my-env:
 func ExampleElasticBeanstalk_DeleteEnvironmentConfiguration_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DeleteEnvironmentConfigurationInput{
 		ApplicationName: aws.String("my-app"),
 		EnvironmentName: aws.String("my-env"),
@@ -392,7 +392,7 @@ func ExampleElasticBeanstalk_DeleteEnvironmentConfiguration_shared00() {
 // The following operation retrieves information about an application version labeled
 // v2:
 func ExampleElasticBeanstalk_DescribeApplicationVersions_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DescribeApplicationVersionsInput{
 		ApplicationName: aws.String("my-app"),
 		VersionLabels: []*string{
@@ -422,7 +422,7 @@ func ExampleElasticBeanstalk_DescribeApplicationVersions_shared00() {
 //
 // The following operation retrieves information about applications in the current region:
 func ExampleElasticBeanstalk_DescribeApplications_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DescribeApplicationsInput{}
 
 	result, err := svc.DescribeApplications(input)
@@ -448,7 +448,7 @@ func ExampleElasticBeanstalk_DescribeApplications_shared00() {
 // The following operation retrieves descriptions of all available configuration options
 // for an environment named my-env:
 func ExampleElasticBeanstalk_DescribeConfigurationOptions_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DescribeConfigurationOptionsInput{
 		ApplicationName: aws.String("my-app"),
 		EnvironmentName: aws.String("my-env"),
@@ -479,7 +479,7 @@ func ExampleElasticBeanstalk_DescribeConfigurationOptions_shared00() {
 // The following operation retrieves configuration settings for an environment named
 // my-env:
 func ExampleElasticBeanstalk_DescribeConfigurationSettings_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DescribeConfigurationSettingsInput{
 		ApplicationName: aws.String("my-app"),
 		EnvironmentName: aws.String("my-env"),
@@ -510,7 +510,7 @@ func ExampleElasticBeanstalk_DescribeConfigurationSettings_shared00() {
 // The following operation retrieves overall health information for an environment named
 // my-env:
 func ExampleElasticBeanstalk_DescribeEnvironmentHealth_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DescribeEnvironmentHealthInput{
 		AttributeNames: []*string{
 			aws.String("All"),
@@ -545,7 +545,7 @@ func ExampleElasticBeanstalk_DescribeEnvironmentHealth_shared00() {
 // The following operation retrieves information about resources in an environment named
 // my-env:
 func ExampleElasticBeanstalk_DescribeEnvironmentResources_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DescribeEnvironmentResourcesInput{
 		EnvironmentName: aws.String("my-env"),
 	}
@@ -574,7 +574,7 @@ func ExampleElasticBeanstalk_DescribeEnvironmentResources_shared00() {
 //
 // The following operation retrieves information about an environment named my-env:
 func ExampleElasticBeanstalk_DescribeEnvironments_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DescribeEnvironmentsInput{
 		EnvironmentNames: []*string{
 			aws.String("my-env"),
@@ -603,7 +603,7 @@ func ExampleElasticBeanstalk_DescribeEnvironments_shared00() {
 //
 // The following operation retrieves events for an environment named my-env:
 func ExampleElasticBeanstalk_DescribeEvents_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DescribeEventsInput{
 		EnvironmentName: aws.String("my-env"),
 	}
@@ -631,7 +631,7 @@ func ExampleElasticBeanstalk_DescribeEvents_shared00() {
 // The following operation retrieves health information for instances in an environment
 // named my-env:
 func ExampleElasticBeanstalk_DescribeInstancesHealth_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.DescribeInstancesHealthInput{
 		AttributeNames: []*string{
 			aws.String("All"),
@@ -666,7 +666,7 @@ func ExampleElasticBeanstalk_DescribeInstancesHealth_shared00() {
 // The following operation lists solution stacks for all currently available platform
 // configurations and any that you have used in the past:
 func ExampleElasticBeanstalk_ListAvailableSolutionStacks_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.ListAvailableSolutionStacksInput{}
 
 	result, err := svc.ListAvailableSolutionStacks(input)
@@ -692,7 +692,7 @@ func ExampleElasticBeanstalk_ListAvailableSolutionStacks_shared00() {
 // The following operation terminates and recreates the resources in an environment
 // named my-env:
 func ExampleElasticBeanstalk_RebuildEnvironment_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.RebuildEnvironmentInput{
 		EnvironmentName: aws.String("my-env"),
 	}
@@ -721,7 +721,7 @@ func ExampleElasticBeanstalk_RebuildEnvironment_shared00() {
 //
 // The following operation requests logs from an environment named my-env:
 func ExampleElasticBeanstalk_RequestEnvironmentInfo_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.RequestEnvironmentInfoInput{
 		EnvironmentName: aws.String("my-env"),
 		InfoType:        aws.String("tail"),
@@ -750,7 +750,7 @@ func ExampleElasticBeanstalk_RequestEnvironmentInfo_shared00() {
 // The following operation restarts application servers on all instances in an environment
 // named my-env:
 func ExampleElasticBeanstalk_RestartAppServer_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.RestartAppServerInput{
 		EnvironmentName: aws.String("my-env"),
 	}
@@ -777,7 +777,7 @@ func ExampleElasticBeanstalk_RestartAppServer_shared00() {
 //
 // The following operation retrieves a link to logs from an environment named my-env:
 func ExampleElasticBeanstalk_RetrieveEnvironmentInfo_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.RetrieveEnvironmentInfoInput{
 		EnvironmentName: aws.String("my-env"),
 		InfoType:        aws.String("tail"),
@@ -805,7 +805,7 @@ func ExampleElasticBeanstalk_RetrieveEnvironmentInfo_shared00() {
 //
 // The following operation swaps the assigned subdomains of two environments:
 func ExampleElasticBeanstalk_SwapEnvironmentCNAMEs_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.SwapEnvironmentCNAMEsInput{
 		DestinationEnvironmentName: aws.String("my-env-green"),
 		SourceEnvironmentName:      aws.String("my-env-blue"),
@@ -833,7 +833,7 @@ func ExampleElasticBeanstalk_SwapEnvironmentCNAMEs_shared00() {
 //
 // The following operation terminates an Elastic Beanstalk environment named my-env:
 func ExampleElasticBeanstalk_TerminateEnvironment_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.TerminateEnvironmentInput{
 		EnvironmentName: aws.String("my-env"),
 	}
@@ -862,7 +862,7 @@ func ExampleElasticBeanstalk_TerminateEnvironment_shared00() {
 //
 // The following operation updates the description of an application named my-app:
 func ExampleElasticBeanstalk_UpdateApplication_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.UpdateApplicationInput{
 		ApplicationName: aws.String("my-app"),
 		Description:     aws.String("my Elastic Beanstalk application"),
@@ -890,7 +890,7 @@ func ExampleElasticBeanstalk_UpdateApplication_shared00() {
 //
 // The following operation updates the description of an application version named 22a0-stage-150819_185942:
 func ExampleElasticBeanstalk_UpdateApplicationVersion_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.UpdateApplicationVersionInput{
 		ApplicationName: aws.String("my-app"),
 		Description:     aws.String("new description"),
@@ -920,7 +920,7 @@ func ExampleElasticBeanstalk_UpdateApplicationVersion_shared00() {
 // The following operation removes the configured CloudWatch custom health metrics configuration
 // ConfigDocument from a saved configuration template named my-template:
 func ExampleElasticBeanstalk_UpdateConfigurationTemplate_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.UpdateConfigurationTemplateInput{
 		ApplicationName: aws.String("my-app"),
 		OptionsToRemove: []*elasticbeanstalk.OptionSpecification{
@@ -959,7 +959,7 @@ func ExampleElasticBeanstalk_UpdateConfigurationTemplate_shared00() {
 // The following operation updates an environment named "my-env" to version "v2" of
 // the application to which it belongs:
 func ExampleElasticBeanstalk_UpdateEnvironment_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.UpdateEnvironmentInput{
 		EnvironmentName: aws.String("my-env"),
 		VersionLabel:    aws.String("v2"),
@@ -991,7 +991,7 @@ func ExampleElasticBeanstalk_UpdateEnvironment_shared00() {
 //
 // The following operation configures several options in the aws:elb:loadbalancer namespace:
 func ExampleElasticBeanstalk_UpdateEnvironment_shared01() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.UpdateEnvironmentInput{
 		EnvironmentName: aws.String("my-env"),
 		OptionSettings: []*elasticbeanstalk.ConfigurationOptionSetting{
@@ -1044,7 +1044,7 @@ func ExampleElasticBeanstalk_UpdateEnvironment_shared01() {
 //
 // The following operation validates a CloudWatch custom metrics config document:
 func ExampleElasticBeanstalk_ValidateConfigurationSettings_shared00() {
-	svc := elasticbeanstalk.New(session.New())
+	svc := elasticbeanstalk.New(session.Must(session.NewSession()))
 	input := &elasticbeanstalk.ValidateConfigurationSettingsInput{
 		ApplicationName: aws.String("my-app"),
 		EnvironmentName: aws.String("my-env"),

--- a/service/elasticinference/elasticinferenceiface/interface.go
+++ b/service/elasticinference/elasticinferenceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := elasticinference.New(sess)
 //
 //        myFunc(svc)

--- a/service/elasticsearchservice/elasticsearchserviceiface/interface.go
+++ b/service/elasticsearchservice/elasticsearchserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := elasticsearchservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/elastictranscoder/elastictranscoderiface/interface.go
+++ b/service/elastictranscoder/elastictranscoderiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := elastictranscoder.New(sess)
 //
 //        myFunc(svc)

--- a/service/elb/elbiface/interface.go
+++ b/service/elb/elbiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := elb.New(sess)
 //
 //        myFunc(svc)

--- a/service/elb/examples_test.go
+++ b/service/elb/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This example adds two tags to the specified load balancer.
 func ExampleELB_AddTags_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.AddTagsInput{
 		LoadBalancerNames: []*string{
 			aws.String("my-load-balancer"),
@@ -74,7 +74,7 @@ func ExampleELB_AddTags_shared00() {
 //
 // This example associates a security group with the specified load balancer in a VPC.
 func ExampleELB_ApplySecurityGroupsToLoadBalancer_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.ApplySecurityGroupsToLoadBalancerInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		SecurityGroups: []*string{
@@ -111,7 +111,7 @@ func ExampleELB_ApplySecurityGroupsToLoadBalancer_shared00() {
 // This example adds the specified subnet to the set of configured subnets for the specified
 // load balancer.
 func ExampleELB_AttachLoadBalancerToSubnets_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.AttachLoadBalancerToSubnetsInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		Subnets: []*string{
@@ -150,7 +150,7 @@ func ExampleELB_AttachLoadBalancerToSubnets_shared00() {
 // This example specifies the health check settings used to evaluate the health of your
 // backend EC2 instances.
 func ExampleELB_ConfigureHealthCheck_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.ConfigureHealthCheckInput{
 		HealthCheck: &elb.HealthCheck{
 			HealthyThreshold:   aws.Int64(2),
@@ -187,7 +187,7 @@ func ExampleELB_ConfigureHealthCheck_shared00() {
 // This example generates a stickiness policy that follows the sticky session lifetimes
 // of the application-generated cookie.
 func ExampleELB_CreateAppCookieStickinessPolicy_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateAppCookieStickinessPolicyInput{
 		CookieName:       aws.String("my-app-cookie"),
 		LoadBalancerName: aws.String("my-load-balancer"),
@@ -225,7 +225,7 @@ func ExampleELB_CreateAppCookieStickinessPolicy_shared00() {
 // This example generates a stickiness policy with sticky session lifetimes controlled
 // by the specified expiration period.
 func ExampleELB_CreateLBCookieStickinessPolicy_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLBCookieStickinessPolicyInput{
 		CookieExpirationPeriod: aws.Int64(60),
 		LoadBalancerName:       aws.String("my-load-balancer"),
@@ -262,7 +262,7 @@ func ExampleELB_CreateLBCookieStickinessPolicy_shared00() {
 //
 // This example creates a load balancer with an HTTP listener in a VPC.
 func ExampleELB_CreateLoadBalancer_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerInput{
 		Listeners: []*elb.Listener{
 			{
@@ -327,7 +327,7 @@ func ExampleELB_CreateLoadBalancer_shared00() {
 //
 // This example creates a load balancer with an HTTP listener in EC2-Classic.
 func ExampleELB_CreateLoadBalancer_shared01() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerInput{
 		AvailabilityZones: []*string{
 			aws.String("us-west-2a"),
@@ -389,7 +389,7 @@ func ExampleELB_CreateLoadBalancer_shared01() {
 //
 // This example creates a load balancer with an HTTPS listener in a VPC.
 func ExampleELB_CreateLoadBalancer_shared02() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerInput{
 		Listeners: []*elb.Listener{
 			{
@@ -461,7 +461,7 @@ func ExampleELB_CreateLoadBalancer_shared02() {
 //
 // This example creates a load balancer with an HTTPS listener in EC2-Classic.
 func ExampleELB_CreateLoadBalancer_shared03() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerInput{
 		AvailabilityZones: []*string{
 			aws.String("us-west-2a"),
@@ -530,7 +530,7 @@ func ExampleELB_CreateLoadBalancer_shared03() {
 //
 // This example creates an internal load balancer with an HTTP listener in a VPC.
 func ExampleELB_CreateLoadBalancer_shared04() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerInput{
 		Listeners: []*elb.Listener{
 			{
@@ -597,7 +597,7 @@ func ExampleELB_CreateLoadBalancer_shared04() {
 // This example creates a listener for your load balancer at port 80 using the HTTP
 // protocol.
 func ExampleELB_CreateLoadBalancerListeners_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerListenersInput{
 		Listeners: []*elb.Listener{
 			{
@@ -643,7 +643,7 @@ func ExampleELB_CreateLoadBalancerListeners_shared00() {
 // This example creates a listener for your load balancer at port 443 using the HTTPS
 // protocol.
 func ExampleELB_CreateLoadBalancerListeners_shared01() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerListenersInput{
 		Listeners: []*elb.Listener{
 			{
@@ -689,7 +689,7 @@ func ExampleELB_CreateLoadBalancerListeners_shared01() {
 //
 // This example creates a policy that enables Proxy Protocol on the specified load balancer.
 func ExampleELB_CreateLoadBalancerPolicy_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerPolicyInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		PolicyAttributes: []*elb.PolicyAttribute{
@@ -734,7 +734,7 @@ func ExampleELB_CreateLoadBalancerPolicy_shared00() {
 //
 // This example creates a public key policy.
 func ExampleELB_CreateLoadBalancerPolicy_shared01() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerPolicyInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		PolicyAttributes: []*elb.PolicyAttribute{
@@ -780,7 +780,7 @@ func ExampleELB_CreateLoadBalancerPolicy_shared01() {
 // This example creates a backend server authentication policy that enables authentication
 // on your backend instance using a public key policy.
 func ExampleELB_CreateLoadBalancerPolicy_shared02() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.CreateLoadBalancerPolicyInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		PolicyAttributes: []*elb.PolicyAttribute{
@@ -825,7 +825,7 @@ func ExampleELB_CreateLoadBalancerPolicy_shared02() {
 //
 // This example deletes the specified load balancer.
 func ExampleELB_DeleteLoadBalancer_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DeleteLoadBalancerInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 	}
@@ -853,7 +853,7 @@ func ExampleELB_DeleteLoadBalancer_shared00() {
 // This example deletes the listener for the specified port from the specified load
 // balancer.
 func ExampleELB_DeleteLoadBalancerListeners_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DeleteLoadBalancerListenersInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		LoadBalancerPorts: []*int64{
@@ -886,7 +886,7 @@ func ExampleELB_DeleteLoadBalancerListeners_shared00() {
 // This example deletes the specified policy from the specified load balancer. The policy
 // must not be enabled on any listener.
 func ExampleELB_DeleteLoadBalancerPolicy_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DeleteLoadBalancerPolicyInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		PolicyName:       aws.String("my-duration-cookie-policy"),
@@ -918,7 +918,7 @@ func ExampleELB_DeleteLoadBalancerPolicy_shared00() {
 //
 // This example deregisters the specified instance from the specified load balancer.
 func ExampleELB_DeregisterInstancesFromLoadBalancer_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DeregisterInstancesFromLoadBalancerInput{
 		Instances: []*elb.Instance{
 			{
@@ -954,7 +954,7 @@ func ExampleELB_DeregisterInstancesFromLoadBalancer_shared00() {
 //
 // This example describes the health of the instances for the specified load balancer.
 func ExampleELB_DescribeInstanceHealth_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DescribeInstanceHealthInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 	}
@@ -985,7 +985,7 @@ func ExampleELB_DescribeInstanceHealth_shared00() {
 //
 // This example describes the attributes of the specified load balancer.
 func ExampleELB_DescribeLoadBalancerAttributes_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DescribeLoadBalancerAttributesInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 	}
@@ -1016,7 +1016,7 @@ func ExampleELB_DescribeLoadBalancerAttributes_shared00() {
 //
 // This example describes the specified policy associated with the specified load balancer.
 func ExampleELB_DescribeLoadBalancerPolicies_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DescribeLoadBalancerPoliciesInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		PolicyNames: []*string{
@@ -1050,7 +1050,7 @@ func ExampleELB_DescribeLoadBalancerPolicies_shared00() {
 //
 // This example describes the specified load balancer policy type.
 func ExampleELB_DescribeLoadBalancerPolicyTypes_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DescribeLoadBalancerPolicyTypesInput{
 		PolicyTypeNames: []*string{
 			aws.String("ProxyProtocolPolicyType"),
@@ -1081,7 +1081,7 @@ func ExampleELB_DescribeLoadBalancerPolicyTypes_shared00() {
 //
 // This example describes the specified load balancer.
 func ExampleELB_DescribeLoadBalancers_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DescribeLoadBalancersInput{
 		LoadBalancerNames: []*string{
 			aws.String("my-load-balancer"),
@@ -1114,7 +1114,7 @@ func ExampleELB_DescribeLoadBalancers_shared00() {
 //
 // This example describes the tags for the specified load balancer.
 func ExampleELB_DescribeTags_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DescribeTagsInput{
 		LoadBalancerNames: []*string{
 			aws.String("my-load-balancer"),
@@ -1145,7 +1145,7 @@ func ExampleELB_DescribeTags_shared00() {
 //
 // This example detaches the specified load balancer from the specified subnet.
 func ExampleELB_DetachLoadBalancerFromSubnets_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DetachLoadBalancerFromSubnetsInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		Subnets: []*string{
@@ -1180,7 +1180,7 @@ func ExampleELB_DetachLoadBalancerFromSubnets_shared00() {
 // This example removes the specified Availability Zone from the set of Availability
 // Zones for the specified load balancer.
 func ExampleELB_DisableAvailabilityZonesForLoadBalancer_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.DisableAvailabilityZonesForLoadBalancerInput{
 		AvailabilityZones: []*string{
 			aws.String("us-west-2a"),
@@ -1214,7 +1214,7 @@ func ExampleELB_DisableAvailabilityZonesForLoadBalancer_shared00() {
 //
 // This example adds the specified Availability Zone to the specified load balancer.
 func ExampleELB_EnableAvailabilityZonesForLoadBalancer_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.EnableAvailabilityZonesForLoadBalancerInput{
 		AvailabilityZones: []*string{
 			aws.String("us-west-2b"),
@@ -1246,7 +1246,7 @@ func ExampleELB_EnableAvailabilityZonesForLoadBalancer_shared00() {
 //
 // This example enables cross-zone load balancing for the specified load balancer.
 func ExampleELB_ModifyLoadBalancerAttributes_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.ModifyLoadBalancerAttributesInput{
 		LoadBalancerAttributes: &elb.LoadBalancerAttributes{
 			CrossZoneLoadBalancing: &elb.CrossZoneLoadBalancing{
@@ -1284,7 +1284,7 @@ func ExampleELB_ModifyLoadBalancerAttributes_shared00() {
 //
 // This example enables connection draining for the specified load balancer.
 func ExampleELB_ModifyLoadBalancerAttributes_shared01() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.ModifyLoadBalancerAttributesInput{
 		LoadBalancerAttributes: &elb.LoadBalancerAttributes{
 			ConnectionDraining: &elb.ConnectionDraining{
@@ -1323,7 +1323,7 @@ func ExampleELB_ModifyLoadBalancerAttributes_shared01() {
 //
 // This example registers the specified instance with the specified load balancer.
 func ExampleELB_RegisterInstancesWithLoadBalancer_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.RegisterInstancesWithLoadBalancerInput{
 		Instances: []*elb.Instance{
 			{
@@ -1359,7 +1359,7 @@ func ExampleELB_RegisterInstancesWithLoadBalancer_shared00() {
 //
 // This example removes the specified tag from the specified load balancer.
 func ExampleELB_RemoveTags_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.RemoveTagsInput{
 		LoadBalancerNames: []*string{
 			aws.String("my-load-balancer"),
@@ -1395,7 +1395,7 @@ func ExampleELB_RemoveTags_shared00() {
 //
 // This example replaces the existing SSL certificate for the specified HTTPS listener.
 func ExampleELB_SetLoadBalancerListenerSSLCertificate_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.SetLoadBalancerListenerSSLCertificateInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		LoadBalancerPort: aws.Int64(443),
@@ -1435,7 +1435,7 @@ func ExampleELB_SetLoadBalancerListenerSSLCertificate_shared00() {
 // This example replaces the policies that are currently associated with the specified
 // port.
 func ExampleELB_SetLoadBalancerPoliciesForBackendServer_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.SetLoadBalancerPoliciesForBackendServerInput{
 		InstancePort:     aws.Int64(80),
 		LoadBalancerName: aws.String("my-load-balancer"),
@@ -1473,7 +1473,7 @@ func ExampleELB_SetLoadBalancerPoliciesForBackendServer_shared00() {
 // This example replaces the policies that are currently associated with the specified
 // listener.
 func ExampleELB_SetLoadBalancerPoliciesOfListener_shared00() {
-	svc := elb.New(session.New())
+	svc := elb.New(session.Must(session.NewSession()))
 	input := &elb.SetLoadBalancerPoliciesOfListenerInput{
 		LoadBalancerName: aws.String("my-load-balancer"),
 		LoadBalancerPort: aws.Int64(80),

--- a/service/elbv2/elbv2iface/interface.go
+++ b/service/elbv2/elbv2iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := elbv2.New(sess)
 //
 //        myFunc(svc)

--- a/service/elbv2/examples_test.go
+++ b/service/elbv2/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This example adds the specified tags to the specified load balancer.
 func ExampleELBV2_AddTags_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.AddTagsInput{
 		ResourceArns: []*string{
 			aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"),
@@ -77,7 +77,7 @@ func ExampleELBV2_AddTags_shared00() {
 // This example creates an HTTP listener for the specified load balancer that forwards
 // requests to the specified target group.
 func ExampleELBV2_CreateListener_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.CreateListenerInput{
 		DefaultActions: []*elbv2.Action{
 			{
@@ -151,7 +151,7 @@ func ExampleELBV2_CreateListener_shared00() {
 // the certificate signed by a certificate authority (CA), and upload the certificate
 // to AWS Identity and Access Management (IAM).
 func ExampleELBV2_CreateListener_shared01() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.CreateListenerInput{
 		Certificates: []*elbv2.Certificate{
 			{
@@ -227,7 +227,7 @@ func ExampleELBV2_CreateListener_shared01() {
 // This example creates an Internet-facing load balancer and enables the Availability
 // Zones for the specified subnets.
 func ExampleELBV2_CreateLoadBalancer_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.CreateLoadBalancerInput{
 		Name: aws.String("my-load-balancer"),
 		Subnets: []*string{
@@ -285,7 +285,7 @@ func ExampleELBV2_CreateLoadBalancer_shared00() {
 // This example creates an internal load balancer and enables the Availability Zones
 // for the specified subnets.
 func ExampleELBV2_CreateLoadBalancer_shared01() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.CreateLoadBalancerInput{
 		Name:   aws.String("my-internal-load-balancer"),
 		Scheme: aws.String("internal"),
@@ -344,7 +344,7 @@ func ExampleELBV2_CreateLoadBalancer_shared01() {
 // This example creates a rule that forwards requests to the specified target group
 // if the URL contains the specified pattern (for example, /img/*).
 func ExampleELBV2_CreateRule_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.CreateRuleInput{
 		Actions: []*elbv2.Action{
 			{
@@ -415,7 +415,7 @@ func ExampleELBV2_CreateRule_shared00() {
 // This example creates a target group that you can use to route traffic to targets
 // using HTTP on port 80. This target group uses the default health check configuration.
 func ExampleELBV2_CreateTargetGroup_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.CreateTargetGroupInput{
 		Name:     aws.String("my-targets"),
 		Port:     aws.Int64(80),
@@ -451,7 +451,7 @@ func ExampleELBV2_CreateTargetGroup_shared00() {
 //
 // This example deletes the specified listener.
 func ExampleELBV2_DeleteListener_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DeleteListenerInput{
 		ListenerArn: aws.String("arn:aws:elasticloadbalancing:ua-west-2:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2"),
 	}
@@ -480,7 +480,7 @@ func ExampleELBV2_DeleteListener_shared00() {
 //
 // This example deletes the specified load balancer.
 func ExampleELBV2_DeleteLoadBalancer_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DeleteLoadBalancerInput{
 		LoadBalancerArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"),
 	}
@@ -513,7 +513,7 @@ func ExampleELBV2_DeleteLoadBalancer_shared00() {
 //
 // This example deletes the specified rule.
 func ExampleELBV2_DeleteRule_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DeleteRuleInput{
 		RuleArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2/1291d13826f405c3"),
 	}
@@ -544,7 +544,7 @@ func ExampleELBV2_DeleteRule_shared00() {
 //
 // This example deletes the specified target group.
 func ExampleELBV2_DeleteTargetGroup_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DeleteTargetGroupInput{
 		TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"),
 	}
@@ -573,7 +573,7 @@ func ExampleELBV2_DeleteTargetGroup_shared00() {
 //
 // This example deregisters the specified instance from the specified target group.
 func ExampleELBV2_DeregisterTargets_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DeregisterTargetsInput{
 		TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"),
 		Targets: []*elbv2.TargetDescription{
@@ -609,7 +609,7 @@ func ExampleELBV2_DeregisterTargets_shared00() {
 //
 // This example describes the specified listener.
 func ExampleELBV2_DescribeListeners_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeListenersInput{
 		ListenerArns: []*string{
 			aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2"),
@@ -644,7 +644,7 @@ func ExampleELBV2_DescribeListeners_shared00() {
 //
 // This example describes the attributes of the specified load balancer.
 func ExampleELBV2_DescribeLoadBalancerAttributes_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeLoadBalancerAttributesInput{
 		LoadBalancerArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"),
 	}
@@ -673,7 +673,7 @@ func ExampleELBV2_DescribeLoadBalancerAttributes_shared00() {
 //
 // This example describes the specified load balancer.
 func ExampleELBV2_DescribeLoadBalancers_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeLoadBalancersInput{
 		LoadBalancerArns: []*string{
 			aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"),
@@ -704,7 +704,7 @@ func ExampleELBV2_DescribeLoadBalancers_shared00() {
 //
 // This example describes the specified rule.
 func ExampleELBV2_DescribeRules_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeRulesInput{
 		RuleArns: []*string{
 			aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2/9683b2d02a6cabee"),
@@ -739,7 +739,7 @@ func ExampleELBV2_DescribeRules_shared00() {
 //
 // This example describes the specified policy used for SSL negotiation.
 func ExampleELBV2_DescribeSSLPolicies_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeSSLPoliciesInput{
 		Names: []*string{
 			aws.String("ELBSecurityPolicy-2015-05"),
@@ -770,7 +770,7 @@ func ExampleELBV2_DescribeSSLPolicies_shared00() {
 //
 // This example describes the tags assigned to the specified load balancer.
 func ExampleELBV2_DescribeTags_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeTagsInput{
 		ResourceArns: []*string{
 			aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"),
@@ -807,7 +807,7 @@ func ExampleELBV2_DescribeTags_shared00() {
 //
 // This example describes the attributes of the specified target group.
 func ExampleELBV2_DescribeTargetGroupAttributes_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeTargetGroupAttributesInput{
 		TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"),
 	}
@@ -836,7 +836,7 @@ func ExampleELBV2_DescribeTargetGroupAttributes_shared00() {
 //
 // This example describes the specified target group.
 func ExampleELBV2_DescribeTargetGroups_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeTargetGroupsInput{
 		TargetGroupArns: []*string{
 			aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"),
@@ -871,7 +871,7 @@ func ExampleELBV2_DescribeTargetGroups_shared00() {
 // One target is healthy but the other is not specified in an action, so it can't receive
 // traffic from the load balancer.
 func ExampleELBV2_DescribeTargetHealth_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"),
 	}
@@ -904,7 +904,7 @@ func ExampleELBV2_DescribeTargetHealth_shared00() {
 //
 // This example describes the health of the specified target. This target is healthy.
 func ExampleELBV2_DescribeTargetHealth_shared01() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"),
 		Targets: []*elbv2.TargetDescription{
@@ -943,7 +943,7 @@ func ExampleELBV2_DescribeTargetHealth_shared01() {
 //
 // This example changes the default action for the specified listener.
 func ExampleELBV2_ModifyListener_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.ModifyListenerInput{
 		DefaultActions: []*elbv2.Action{
 			{
@@ -1010,7 +1010,7 @@ func ExampleELBV2_ModifyListener_shared00() {
 //
 // This example changes the server certificate for the specified HTTPS listener.
 func ExampleELBV2_ModifyListener_shared01() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.ModifyListenerInput{
 		Certificates: []*elbv2.Certificate{
 			{
@@ -1076,7 +1076,7 @@ func ExampleELBV2_ModifyListener_shared01() {
 //
 // This example enables deletion protection for the specified load balancer.
 func ExampleELBV2_ModifyLoadBalancerAttributes_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.ModifyLoadBalancerAttributesInput{
 		Attributes: []*elbv2.LoadBalancerAttribute{
 			{
@@ -1113,7 +1113,7 @@ func ExampleELBV2_ModifyLoadBalancerAttributes_shared00() {
 //
 // This example changes the idle timeout value for the specified load balancer.
 func ExampleELBV2_ModifyLoadBalancerAttributes_shared01() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.ModifyLoadBalancerAttributesInput{
 		Attributes: []*elbv2.LoadBalancerAttribute{
 			{
@@ -1152,7 +1152,7 @@ func ExampleELBV2_ModifyLoadBalancerAttributes_shared01() {
 // bucket must exist in the same region as the load balancer and must have a policy
 // attached that grants access to the Elastic Load Balancing service.
 func ExampleELBV2_ModifyLoadBalancerAttributes_shared02() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.ModifyLoadBalancerAttributesInput{
 		Attributes: []*elbv2.LoadBalancerAttribute{
 			{
@@ -1197,7 +1197,7 @@ func ExampleELBV2_ModifyLoadBalancerAttributes_shared02() {
 //
 // This example modifies the condition for the specified rule.
 func ExampleELBV2_ModifyRule_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.ModifyRuleInput{
 		Conditions: []*elbv2.RuleCondition{
 			{
@@ -1255,7 +1255,7 @@ func ExampleELBV2_ModifyRule_shared00() {
 // This example changes the configuration of the health checks used to evaluate the
 // health of the targets for the specified target group.
 func ExampleELBV2_ModifyTargetGroup_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.ModifyTargetGroupInput{
 		HealthCheckPort:     aws.String("443"),
 		HealthCheckProtocol: aws.String("HTTPS"),
@@ -1289,7 +1289,7 @@ func ExampleELBV2_ModifyTargetGroup_shared00() {
 // This example sets the deregistration delay timeout to the specified value for the
 // specified target group.
 func ExampleELBV2_ModifyTargetGroupAttributes_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.ModifyTargetGroupAttributesInput{
 		Attributes: []*elbv2.TargetGroupAttribute{
 			{
@@ -1326,7 +1326,7 @@ func ExampleELBV2_ModifyTargetGroupAttributes_shared00() {
 //
 // This example registers the specified instances with the specified target group.
 func ExampleELBV2_RegisterTargets_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.RegisterTargetsInput{
 		TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"),
 		Targets: []*elbv2.TargetDescription{
@@ -1371,7 +1371,7 @@ func ExampleELBV2_RegisterTargets_shared00() {
 // multiple ports. This enables you to register ECS containers on the same instance
 // as targets in the target group.
 func ExampleELBV2_RegisterTargets_shared01() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.RegisterTargetsInput{
 		TargetGroupArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-new-targets/3bb63f11dfb0faf9"),
 		Targets: []*elbv2.TargetDescription{
@@ -1416,7 +1416,7 @@ func ExampleELBV2_RegisterTargets_shared01() {
 //
 // This example removes the specified tags from the specified load balancer.
 func ExampleELBV2_RemoveTags_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.RemoveTagsInput{
 		ResourceArns: []*string{
 			aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"),
@@ -1459,7 +1459,7 @@ func ExampleELBV2_RemoveTags_shared00() {
 //
 // This example sets the priority of the specified rule.
 func ExampleELBV2_SetRulePriorities_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.SetRulePrioritiesInput{
 		RulePriorities: []*elbv2.RulePriorityPair{
 			{
@@ -1497,7 +1497,7 @@ func ExampleELBV2_SetRulePriorities_shared00() {
 //
 // This example associates the specified security group with the specified load balancer.
 func ExampleELBV2_SetSecurityGroups_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.SetSecurityGroupsInput{
 		LoadBalancerArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"),
 		SecurityGroups: []*string{
@@ -1534,7 +1534,7 @@ func ExampleELBV2_SetSecurityGroups_shared00() {
 // This example enables the Availability Zones for the specified subnets for the specified
 // load balancer.
 func ExampleELBV2_SetSubnets_shared00() {
-	svc := elbv2.New(session.New())
+	svc := elbv2.New(session.Must(session.NewSession()))
 	input := &elbv2.SetSubnetsInput{
 		LoadBalancerArn: aws.String("arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188"),
 		Subnets: []*string{

--- a/service/emr/emriface/interface.go
+++ b/service/emr/emriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := emr.New(sess)
 //
 //        myFunc(svc)

--- a/service/eventbridge/eventbridgeiface/interface.go
+++ b/service/eventbridge/eventbridgeiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := eventbridge.New(sess)
 //
 //        myFunc(svc)

--- a/service/firehose/firehoseiface/interface.go
+++ b/service/firehose/firehoseiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := firehose.New(sess)
 //
 //        myFunc(svc)

--- a/service/fms/fmsiface/interface.go
+++ b/service/fms/fmsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := fms.New(sess)
 //
 //        myFunc(svc)

--- a/service/forecastqueryservice/forecastqueryserviceiface/interface.go
+++ b/service/forecastqueryservice/forecastqueryserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := forecastqueryservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/forecastservice/forecastserviceiface/interface.go
+++ b/service/forecastservice/forecastserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := forecastservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/frauddetector/frauddetectoriface/interface.go
+++ b/service/frauddetector/frauddetectoriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := frauddetector.New(sess)
 //
 //        myFunc(svc)

--- a/service/fsx/examples_test.go
+++ b/service/fsx/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This operation creates a new backup.
 func ExampleFSx_CreateBackup_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.CreateBackupInput{
 		FileSystemId: aws.String("fs-0498eed5fe91001ec"),
 		Tags: []*fsx.Tag{
@@ -76,7 +76,7 @@ func ExampleFSx_CreateBackup_shared00() {
 //
 // This operation creates a new file system.
 func ExampleFSx_CreateFileSystem_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.CreateFileSystemInput{
 		ClientRequestToken: aws.String("a8ca07e4-61ec-4399-99f4-19853801bcd5"),
 		FileSystemType:     aws.String("WINDOWS"),
@@ -145,7 +145,7 @@ func ExampleFSx_CreateFileSystem_shared00() {
 //
 // This operation creates a new file system from backup.
 func ExampleFSx_CreateFileSystemFromBackup_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.CreateFileSystemFromBackupInput{
 		BackupId:           aws.String("backup-03e3c82e0183b7b6b"),
 		ClientRequestToken: aws.String("f4c94ed7-238d-4c46-93db-48cd62ec33b7"),
@@ -206,7 +206,7 @@ func ExampleFSx_CreateFileSystemFromBackup_shared00() {
 //
 // This operation deletes an Amazon FSx file system backup.
 func ExampleFSx_DeleteBackup_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.DeleteBackupInput{
 		BackupId: aws.String("backup-03e3c82e0183b7b6b"),
 	}
@@ -245,7 +245,7 @@ func ExampleFSx_DeleteBackup_shared00() {
 //
 // This operation deletes an Amazon FSx file system.
 func ExampleFSx_DeleteFileSystem_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.DeleteFileSystemInput{
 		FileSystemId: aws.String("fs-0498eed5fe91001ec"),
 	}
@@ -282,7 +282,7 @@ func ExampleFSx_DeleteFileSystem_shared00() {
 //
 // This operation describes all of the Amazon FSx backups in an account.
 func ExampleFSx_DescribeBackups_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.DescribeBackupsInput{}
 
 	result, err := svc.DescribeBackups(input)
@@ -315,7 +315,7 @@ func ExampleFSx_DescribeBackups_shared00() {
 //
 // This operation describes all of the Amazon FSx file systems in an account.
 func ExampleFSx_DescribeFileSystems_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.DescribeFileSystemsInput{}
 
 	result, err := svc.DescribeFileSystems(input)
@@ -346,7 +346,7 @@ func ExampleFSx_DescribeFileSystems_shared00() {
 //
 // This operation lists tags for an Amazon FSx resource.
 func ExampleFSx_ListTagsForResource_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.ListTagsForResourceInput{
 		ResourceARN: aws.String("arn:aws:fsx:us-east-1:012345678912:file-system/fs-0498eed5fe91001ec"),
 	}
@@ -383,7 +383,7 @@ func ExampleFSx_ListTagsForResource_shared00() {
 //
 // This operation tags an Amazon FSx resource.
 func ExampleFSx_TagResource_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.TagResourceInput{
 		ResourceARN: aws.String("arn:aws:fsx:us-east-1:012345678912:file-system/fs-0498eed5fe91001ec"),
 		Tags: []*fsx.Tag{
@@ -426,7 +426,7 @@ func ExampleFSx_TagResource_shared00() {
 //
 // This operation untags an Amazon FSx resource.
 func ExampleFSx_UntagResource_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.UntagResourceInput{
 		ResourceARN: aws.String("arn:aws:fsx:us-east-1:012345678912:file-system/fs-0498eed5fe91001ec"),
 		TagKeys: []*string{
@@ -466,7 +466,7 @@ func ExampleFSx_UntagResource_shared00() {
 //
 // This operation updates an existing file system.
 func ExampleFSx_UpdateFileSystem_shared00() {
-	svc := fsx.New(session.New())
+	svc := fsx.New(session.Must(session.NewSession()))
 	input := &fsx.UpdateFileSystemInput{
 		FileSystemId: aws.String("fs-0498eed5fe91001ec"),
 		WindowsConfiguration: &fsx.UpdateFileSystemWindowsConfiguration{

--- a/service/fsx/fsxiface/interface.go
+++ b/service/fsx/fsxiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := fsx.New(sess)
 //
 //        myFunc(svc)

--- a/service/gamelift/gameliftiface/interface.go
+++ b/service/gamelift/gameliftiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := gamelift.New(sess)
 //
 //        myFunc(svc)

--- a/service/glacier/examples_test.go
+++ b/service/glacier/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The example deletes an in-progress multipart upload to a vault named my-vault:
 func ExampleGlacier_AbortMultipartUpload_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.AbortMultipartUploadInput{
 		AccountId: aws.String("-"),
 		UploadId:  aws.String("19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR7vgFuJV6NtcV5zpsJ"),
@@ -67,7 +67,7 @@ func ExampleGlacier_AbortMultipartUpload_shared00() {
 // The example aborts the vault locking process if the vault lock is not in the Locked
 // state for the vault named examplevault.
 func ExampleGlacier_AbortVaultLock_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.AbortVaultLockInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("examplevault"),
@@ -103,7 +103,7 @@ func ExampleGlacier_AbortVaultLock_shared00() {
 //
 // The example adds two tags to a my-vault.
 func ExampleGlacier_AddTagsToVault_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.AddTagsToVaultInput{
 		Tags: map[string]*string{
 			"examplekey1": aws.String("examplevalue1"),
@@ -145,7 +145,7 @@ func ExampleGlacier_AddTagsToVault_shared00() {
 //
 // The example completes a multipart upload for a 3 MiB archive.
 func ExampleGlacier_CompleteMultipartUpload_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.CompleteMultipartUploadInput{
 		AccountId:   aws.String("-"),
 		ArchiveSize: aws.String("3145728"),
@@ -185,7 +185,7 @@ func ExampleGlacier_CompleteMultipartUpload_shared00() {
 // The example completes the vault locking process by transitioning the vault lock from
 // the InProgress state to the Locked state.
 func ExampleGlacier_CompleteVaultLock_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.CompleteVaultLockInput{
 		AccountId: aws.String("-"),
 		LockId:    aws.String("AE863rKkWZU53SLW5be4DUcW"),
@@ -222,7 +222,7 @@ func ExampleGlacier_CompleteVaultLock_shared00() {
 //
 // The following example creates a new vault named my-vault.
 func ExampleGlacier_CreateVault_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.CreateVaultInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("my-vault"),
@@ -258,7 +258,7 @@ func ExampleGlacier_CreateVault_shared00() {
 //
 // The example deletes the archive specified by the archive ID.
 func ExampleGlacier_DeleteArchive_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.DeleteArchiveInput{
 		AccountId: aws.String("-"),
 		ArchiveId: aws.String("NkbByEejwEggmBz2fTHgJrg0XBoDfjP4q6iu87-TjhqG6eGoOY9Z8i1_AUyUsuhPAdTqLHy8pTl5nfCFJmDl2yEZONi5L26Omw12vcs01MNGntHEQL8MBfGlqrEXAMPLEArchiveId"),
@@ -295,7 +295,7 @@ func ExampleGlacier_DeleteArchive_shared00() {
 //
 // The example deletes a vault named my-vault:
 func ExampleGlacier_DeleteVault_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.DeleteVaultInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("my-vault"),
@@ -331,7 +331,7 @@ func ExampleGlacier_DeleteVault_shared00() {
 //
 // The example deletes the access policy associated with the vault named examplevault.
 func ExampleGlacier_DeleteVaultAccessPolicy_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.DeleteVaultAccessPolicyInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("examplevault"),
@@ -367,7 +367,7 @@ func ExampleGlacier_DeleteVaultAccessPolicy_shared00() {
 //
 // The example deletes the notification configuration set for the vault named examplevault.
 func ExampleGlacier_DeleteVaultNotifications_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.DeleteVaultNotificationsInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("examplevault"),
@@ -404,7 +404,7 @@ func ExampleGlacier_DeleteVaultNotifications_shared00() {
 // The example returns information about the previously initiated job specified by the
 // job ID.
 func ExampleGlacier_DescribeJob_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.DescribeJobInput{
 		AccountId: aws.String("-"),
 		JobId:     aws.String("zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ejh18CnTS5XW4_XqlNHS61dsO4Cn"),
@@ -441,7 +441,7 @@ func ExampleGlacier_DescribeJob_shared00() {
 //
 // The example retrieves data about a vault named my-vault.
 func ExampleGlacier_DescribeVault_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.DescribeVaultInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("my-vault"),
@@ -477,7 +477,7 @@ func ExampleGlacier_DescribeVault_shared00() {
 //
 // The example returns the current data retrieval policy for the account.
 func ExampleGlacier_GetDataRetrievalPolicy_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.GetDataRetrievalPolicyInput{
 		AccountId: aws.String("-"),
 	}
@@ -511,7 +511,7 @@ func ExampleGlacier_GetDataRetrievalPolicy_shared00() {
 // The example downloads the output of a previously initiated inventory retrieval job
 // that is identified by the job ID.
 func ExampleGlacier_GetJobOutput_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.GetJobOutputInput{
 		AccountId: aws.String("-"),
 		JobId:     aws.String("zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ejh18CnTS5XW4_XqlNHS61dsO4CnMW"),
@@ -549,7 +549,7 @@ func ExampleGlacier_GetJobOutput_shared00() {
 //
 // The example retrieves the access-policy set on the vault named example-vault.
 func ExampleGlacier_GetVaultAccessPolicy_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.GetVaultAccessPolicyInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("example-vault"),
@@ -586,7 +586,7 @@ func ExampleGlacier_GetVaultAccessPolicy_shared00() {
 // The example retrieves the attributes from the lock-policy subresource set on the
 // vault named examplevault.
 func ExampleGlacier_GetVaultLock_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.GetVaultLockInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("examplevault"),
@@ -622,7 +622,7 @@ func ExampleGlacier_GetVaultLock_shared00() {
 //
 // The example retrieves the notification-configuration for the vault named my-vault.
 func ExampleGlacier_GetVaultNotifications_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.GetVaultNotificationsInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("my-vault"),
@@ -658,7 +658,7 @@ func ExampleGlacier_GetVaultNotifications_shared00() {
 //
 // The example initiates an inventory-retrieval job for the vault named examplevault.
 func ExampleGlacier_InitiateJob_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.InitiateJobInput{
 		AccountId: aws.String("-"),
 		JobParameters: &glacier.JobParameters{
@@ -705,7 +705,7 @@ func ExampleGlacier_InitiateJob_shared00() {
 // The example initiates a multipart upload to a vault named my-vault with a part size
 // of 1 MiB (1024 x 1024 bytes) per file.
 func ExampleGlacier_InitiateMultipartUpload_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.InitiateMultipartUploadInput{
 		AccountId: aws.String("-"),
 		PartSize:  aws.String("1048576"),
@@ -742,7 +742,7 @@ func ExampleGlacier_InitiateMultipartUpload_shared00() {
 //
 // The example initiates the vault locking process for the vault named my-vault.
 func ExampleGlacier_InitiateVaultLock_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.InitiateVaultLockInput{
 		AccountId: aws.String("-"),
 		Policy: &glacier.VaultLockPolicy{
@@ -781,7 +781,7 @@ func ExampleGlacier_InitiateVaultLock_shared00() {
 //
 // The example lists jobs for the vault named my-vault.
 func ExampleGlacier_ListJobs_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.ListJobsInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("my-vault"),
@@ -817,7 +817,7 @@ func ExampleGlacier_ListJobs_shared00() {
 //
 // The example lists all the in-progress multipart uploads for the vault named examplevault.
 func ExampleGlacier_ListMultipartUploads_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.ListMultipartUploadsInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("examplevault"),
@@ -853,7 +853,7 @@ func ExampleGlacier_ListMultipartUploads_shared00() {
 //
 // The example lists all the parts of a multipart upload.
 func ExampleGlacier_ListParts_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.ListPartsInput{
 		AccountId: aws.String("-"),
 		UploadId:  aws.String("OW2fM5iVylEpFEMM9_HpKowRapC3vn5sSL39_396UW9zLFUWVrnRHaPjUJddQ5OxSHVXjYtrN47NBZ-khxOjyEXAMPLE"),
@@ -890,7 +890,7 @@ func ExampleGlacier_ListParts_shared00() {
 //
 // The example lists the provisioned capacity units for an account.
 func ExampleGlacier_ListProvisionedCapacity_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.ListProvisionedCapacityInput{
 		AccountId: aws.String("-"),
 	}
@@ -923,7 +923,7 @@ func ExampleGlacier_ListProvisionedCapacity_shared00() {
 //
 // The example lists all the tags attached to the vault examplevault.
 func ExampleGlacier_ListTagsForVault_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.ListTagsForVaultInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("examplevault"),
@@ -959,7 +959,7 @@ func ExampleGlacier_ListTagsForVault_shared00() {
 //
 // The example lists all vaults owned by the specified AWS account.
 func ExampleGlacier_ListVaults_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.ListVaultsInput{
 		AccountId: aws.String("-"),
 		Limit:     aws.String(""),
@@ -996,7 +996,7 @@ func ExampleGlacier_ListVaults_shared00() {
 //
 // The example purchases provisioned capacity unit for an AWS account.
 func ExampleGlacier_PurchaseProvisionedCapacity_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.PurchaseProvisionedCapacityInput{
 		AccountId: aws.String("-"),
 	}
@@ -1031,7 +1031,7 @@ func ExampleGlacier_PurchaseProvisionedCapacity_shared00() {
 //
 // The example removes two tags from the vault named examplevault.
 func ExampleGlacier_RemoveTagsFromVault_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.RemoveTagsFromVaultInput{
 		TagKeys: []*string{
 			aws.String("examplekey1"),
@@ -1071,7 +1071,7 @@ func ExampleGlacier_RemoveTagsFromVault_shared00() {
 //
 // The example sets and then enacts a data retrieval policy.
 func ExampleGlacier_SetDataRetrievalPolicy_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.SetDataRetrievalPolicyInput{
 		Policy: &glacier.DataRetrievalPolicy{
 			Rules: []*glacier.DataRetrievalRule{
@@ -1112,7 +1112,7 @@ func ExampleGlacier_SetDataRetrievalPolicy_shared00() {
 //
 // The example configures an access policy for the vault named examplevault.
 func ExampleGlacier_SetVaultAccessPolicy_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.SetVaultAccessPolicyInput{
 		AccountId: aws.String("-"),
 		Policy: &glacier.VaultAccessPolicy{
@@ -1151,7 +1151,7 @@ func ExampleGlacier_SetVaultAccessPolicy_shared00() {
 //
 // The example sets the examplevault notification configuration.
 func ExampleGlacier_SetVaultNotifications_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.SetVaultNotificationsInput{
 		AccountId: aws.String("-"),
 		VaultName: aws.String("examplevault"),
@@ -1194,7 +1194,7 @@ func ExampleGlacier_SetVaultNotifications_shared00() {
 //
 // The example adds an archive to a vault.
 func ExampleGlacier_UploadArchive_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.UploadArchiveInput{
 		AccountId:          aws.String("-"),
 		ArchiveDescription: aws.String(""),
@@ -1235,7 +1235,7 @@ func ExampleGlacier_UploadArchive_shared00() {
 //
 // The example uploads the first 1 MiB (1024 x 1024 bytes) part of an archive.
 func ExampleGlacier_UploadMultipartPart_shared00() {
-	svc := glacier.New(session.New())
+	svc := glacier.New(session.Must(session.NewSession()))
 	input := &glacier.UploadMultipartPartInput{
 		AccountId: aws.String("-"),
 		Body:      aws.ReadSeekCloser(strings.NewReader("part1")),

--- a/service/glacier/glacieriface/interface.go
+++ b/service/glacier/glacieriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := glacier.New(sess)
 //
 //        myFunc(svc)

--- a/service/globalaccelerator/globalacceleratoriface/interface.go
+++ b/service/globalaccelerator/globalacceleratoriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := globalaccelerator.New(sess)
 //
 //        myFunc(svc)

--- a/service/glue/glueiface/interface.go
+++ b/service/glue/glueiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := glue.New(sess)
 //
 //        myFunc(svc)

--- a/service/greengrass/greengrassiface/interface.go
+++ b/service/greengrass/greengrassiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := greengrass.New(sess)
 //
 //        myFunc(svc)

--- a/service/groundstation/groundstationiface/interface.go
+++ b/service/groundstation/groundstationiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := groundstation.New(sess)
 //
 //        myFunc(svc)

--- a/service/guardduty/guarddutyiface/interface.go
+++ b/service/guardduty/guarddutyiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := guardduty.New(sess)
 //
 //        myFunc(svc)

--- a/service/health/healthiface/interface.go
+++ b/service/health/healthiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := health.New(sess)
 //
 //        myFunc(svc)

--- a/service/honeycode/honeycodeiface/interface.go
+++ b/service/honeycode/honeycodeiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := honeycode.New(sess)
 //
 //        myFunc(svc)

--- a/service/iam/examples_test.go
+++ b/service/iam/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // The following add-client-id-to-open-id-connect-provider command adds the client ID
 // my-application-ID to the OIDC provider named server.example.com:
 func ExampleIAM_AddClientIDToOpenIDConnectProvider_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.AddClientIDToOpenIDConnectProviderInput{
 		ClientID:                 aws.String("my-application-ID"),
 		OpenIDConnectProviderArn: aws.String("arn:aws:iam::123456789012:oidc-provider/server.example.com"),
@@ -67,7 +67,7 @@ func ExampleIAM_AddClientIDToOpenIDConnectProvider_shared00() {
 // The following command adds the role named S3Access to the instance profile named
 // Webserver:
 func ExampleIAM_AddRoleToInstanceProfile_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.AddRoleToInstanceProfileInput{
 		InstanceProfileName: aws.String("Webserver"),
 		RoleName:            aws.String("S3Access"),
@@ -105,7 +105,7 @@ func ExampleIAM_AddRoleToInstanceProfile_shared00() {
 //
 // The following command adds an IAM user named Bob to the IAM group named Admins:
 func ExampleIAM_AddUserToGroup_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.AddUserToGroupInput{
 		GroupName: aws.String("Admins"),
 		UserName:  aws.String("Bob"),
@@ -140,7 +140,7 @@ func ExampleIAM_AddUserToGroup_shared00() {
 // The following command attaches the AWS managed policy named ReadOnlyAccess to the
 // IAM group named Finance.
 func ExampleIAM_AttachGroupPolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.AttachGroupPolicyInput{
 		GroupName: aws.String("Finance"),
 		PolicyArn: aws.String("arn:aws:iam::aws:policy/ReadOnlyAccess"),
@@ -179,7 +179,7 @@ func ExampleIAM_AttachGroupPolicy_shared00() {
 // The following command attaches the AWS managed policy named ReadOnlyAccess to the
 // IAM role named ReadOnlyRole.
 func ExampleIAM_AttachRolePolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.AttachRolePolicyInput{
 		PolicyArn: aws.String("arn:aws:iam::aws:policy/ReadOnlyAccess"),
 		RoleName:  aws.String("ReadOnlyRole"),
@@ -220,7 +220,7 @@ func ExampleIAM_AttachRolePolicy_shared00() {
 // The following command attaches the AWS managed policy named AdministratorAccess to
 // the IAM user named Alice.
 func ExampleIAM_AttachUserPolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.AttachUserPolicyInput{
 		PolicyArn: aws.String("arn:aws:iam::aws:policy/AdministratorAccess"),
 		UserName:  aws.String("Alice"),
@@ -258,7 +258,7 @@ func ExampleIAM_AttachUserPolicy_shared00() {
 //
 // The following command changes the password for the current IAM user.
 func ExampleIAM_ChangePassword_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ChangePasswordInput{
 		NewPassword: aws.String("]35d/{pB9Fo9wJ"),
 		OldPassword: aws.String("3s0K_;xh4~8XXI"),
@@ -299,7 +299,7 @@ func ExampleIAM_ChangePassword_shared00() {
 // The following command creates an access key (access key ID and secret access key)
 // for the IAM user named Bob.
 func ExampleIAM_CreateAccessKey_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.CreateAccessKeyInput{
 		UserName: aws.String("Bob"),
 	}
@@ -332,7 +332,7 @@ func ExampleIAM_CreateAccessKey_shared00() {
 //
 // The following command associates the alias examplecorp to your AWS account.
 func ExampleIAM_CreateAccountAlias_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.CreateAccountAliasInput{
 		AccountAlias: aws.String("examplecorp"),
 	}
@@ -365,7 +365,7 @@ func ExampleIAM_CreateAccountAlias_shared00() {
 //
 // The following command creates an IAM group named Admins.
 func ExampleIAM_CreateGroup_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.CreateGroupInput{
 		GroupName: aws.String("Admins"),
 	}
@@ -401,7 +401,7 @@ func ExampleIAM_CreateGroup_shared00() {
 // The following command creates an instance profile named Webserver that is ready to
 // have a role attached and then be associated with an EC2 instance.
 func ExampleIAM_CreateInstanceProfile_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.CreateInstanceProfileInput{
 		InstanceProfileName: aws.String("Webserver"),
 	}
@@ -435,7 +435,7 @@ func ExampleIAM_CreateInstanceProfile_shared00() {
 // The following command changes IAM user Bob's password and sets the flag that required
 // Bob to change the password the next time he signs in.
 func ExampleIAM_CreateLoginProfile_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.CreateLoginProfileInput{
 		Password:              aws.String("h]6EszR}vJ*m"),
 		PasswordResetRequired: aws.Bool(true),
@@ -475,7 +475,7 @@ func ExampleIAM_CreateLoginProfile_shared00() {
 // The following example defines a new OIDC provider in IAM with a client ID of my-application-id
 // and pointing at the server with a URL of https://server.example.com.
 func ExampleIAM_CreateOpenIDConnectProvider_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.CreateOpenIDConnectProviderInput{
 		ClientIDList: []*string{
 			aws.String("my-application-id"),
@@ -518,7 +518,7 @@ func ExampleIAM_CreateOpenIDConnectProvider_shared00() {
 // that you must convert from JSON to a string. Upon success, the response includes
 // the same policy as a URL-encoded JSON string.
 func ExampleIAM_CreateRole_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.CreateRoleInput{
 		AssumeRolePolicyDocument: aws.String("<Stringified-JSON>"),
 		Path:                     aws.String("/"),
@@ -559,7 +559,7 @@ func ExampleIAM_CreateRole_shared00() {
 //
 // The following create-user command creates an IAM user named Bob in the current account.
 func ExampleIAM_CreateUser_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.CreateUserInput{
 		UserName: aws.String("Bob"),
 	}
@@ -599,7 +599,7 @@ func ExampleIAM_CreateUser_shared00() {
 // The following command deletes one access key (access key ID and secret access key)
 // assigned to the IAM user named Bob.
 func ExampleIAM_DeleteAccessKey_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteAccessKeyInput{
 		AccessKeyId: aws.String("AKIDPMS9RO4H3FEXAMPLE"),
 		UserName:    aws.String("Bob"),
@@ -633,7 +633,7 @@ func ExampleIAM_DeleteAccessKey_shared00() {
 //
 // The following command removes the alias mycompany from the current AWS account:
 func ExampleIAM_DeleteAccountAlias_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteAccountAliasInput{
 		AccountAlias: aws.String("mycompany"),
 	}
@@ -666,7 +666,7 @@ func ExampleIAM_DeleteAccountAlias_shared00() {
 //
 // The following command removes the password policy from the current AWS account:
 func ExampleIAM_DeleteAccountPasswordPolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteAccountPasswordPolicyInput{}
 
 	result, err := svc.DeleteAccountPasswordPolicy(input)
@@ -698,7 +698,7 @@ func ExampleIAM_DeleteAccountPasswordPolicy_shared00() {
 // The following command deletes the policy named ExamplePolicy from the group named
 // Admins:
 func ExampleIAM_DeleteGroupPolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteGroupPolicyInput{
 		GroupName:  aws.String("Admins"),
 		PolicyName: aws.String("ExamplePolicy"),
@@ -732,7 +732,7 @@ func ExampleIAM_DeleteGroupPolicy_shared00() {
 //
 // The following command deletes the instance profile named ExampleInstanceProfile
 func ExampleIAM_DeleteInstanceProfile_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteInstanceProfileInput{
 		InstanceProfileName: aws.String("ExampleInstanceProfile"),
 	}
@@ -767,7 +767,7 @@ func ExampleIAM_DeleteInstanceProfile_shared00() {
 //
 // The following command deletes the password for the IAM user named Bob.
 func ExampleIAM_DeleteLoginProfile_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteLoginProfileInput{
 		UserName: aws.String("Bob"),
 	}
@@ -802,7 +802,7 @@ func ExampleIAM_DeleteLoginProfile_shared00() {
 //
 // The following command removes the role named Test-Role.
 func ExampleIAM_DeleteRole_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteRoleInput{
 		RoleName: aws.String("Test-Role"),
 	}
@@ -842,7 +842,7 @@ func ExampleIAM_DeleteRole_shared00() {
 // The following command removes the policy named ExamplePolicy from the role named
 // Test-Role.
 func ExampleIAM_DeleteRolePolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteRolePolicyInput{
 		PolicyName: aws.String("ExamplePolicy"),
 		RoleName:   aws.String("Test-Role"),
@@ -879,7 +879,7 @@ func ExampleIAM_DeleteRolePolicy_shared00() {
 // The following command deletes the specified signing certificate for the IAM user
 // named Anika.
 func ExampleIAM_DeleteSigningCertificate_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteSigningCertificateInput{
 		CertificateId: aws.String("TA7SMP42TDN5Z26OBPJE7EXAMPLE"),
 		UserName:      aws.String("Anika"),
@@ -913,7 +913,7 @@ func ExampleIAM_DeleteSigningCertificate_shared00() {
 //
 // The following command removes the IAM user named Bob from the current account.
 func ExampleIAM_DeleteUser_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteUserInput{
 		UserName: aws.String("Bob"),
 	}
@@ -951,7 +951,7 @@ func ExampleIAM_DeleteUser_shared00() {
 // The following delete-user-policy command removes the specified policy from the IAM
 // user named Juan:
 func ExampleIAM_DeleteUserPolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteUserPolicyInput{
 		PolicyName: aws.String("ExamplePolicy"),
 		UserName:   aws.String("Juan"),
@@ -986,7 +986,7 @@ func ExampleIAM_DeleteUserPolicy_shared00() {
 // The following delete-virtual-mfa-device command removes the specified MFA device
 // from the current AWS account.
 func ExampleIAM_DeleteVirtualMFADevice_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.DeleteVirtualMFADeviceInput{
 		SerialNumber: aws.String("arn:aws:iam::123456789012:mfa/ExampleName"),
 	}
@@ -1021,7 +1021,7 @@ func ExampleIAM_DeleteVirtualMFADevice_shared00() {
 //
 // The following operation generates a report for the organizational unit ou-rge0-awexample
 func ExampleIAM_GenerateOrganizationsAccessReport_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GenerateOrganizationsAccessReportInput{
 		EntityPath: aws.String("o-a1b2c3d4e5/r-f6g7h8i9j0example/ou-1a2b3c-k9l8m7n6o5example"),
 	}
@@ -1050,7 +1050,7 @@ func ExampleIAM_GenerateOrganizationsAccessReport_shared00() {
 //
 // The following operation generates a report for the policy: ExamplePolicy1
 func ExampleIAM_GenerateServiceLastAccessedDetails_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GenerateServiceLastAccessedDetailsInput{
 		Arn: aws.String("arn:aws:iam::123456789012:policy/ExamplePolicy1"),
 	}
@@ -1082,7 +1082,7 @@ func ExampleIAM_GenerateServiceLastAccessedDetails_shared00() {
 // The following command displays details about the password policy for the current
 // AWS account.
 func ExampleIAM_GetAccountPasswordPolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GetAccountPasswordPolicyInput{}
 
 	result, err := svc.GetAccountPasswordPolicy(input)
@@ -1112,7 +1112,7 @@ func ExampleIAM_GetAccountPasswordPolicy_shared00() {
 // The following command returns information about the IAM entity quotas and usage in
 // the current AWS account.
 func ExampleIAM_GetAccountSummary_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GetAccountSummaryInput{}
 
 	result, err := svc.GetAccountSummary(input)
@@ -1139,7 +1139,7 @@ func ExampleIAM_GetAccountSummary_shared00() {
 //
 // The following command gets information about the instance profile named ExampleInstanceProfile.
 func ExampleIAM_GetInstanceProfile_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GetInstanceProfileInput{
 		InstanceProfileName: aws.String("ExampleInstanceProfile"),
 	}
@@ -1171,7 +1171,7 @@ func ExampleIAM_GetInstanceProfile_shared00() {
 // The following command gets information about the password for the IAM user named
 // Anika.
 func ExampleIAM_GetLoginProfile_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GetLoginProfileInput{
 		UserName: aws.String("Anika"),
 	}
@@ -1202,7 +1202,7 @@ func ExampleIAM_GetLoginProfile_shared00() {
 //
 // The following operation gets details about the report with the job ID: examplea-1234-b567-cde8-90fg123abcd4
 func ExampleIAM_GetOrganizationsAccessReport_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GetOrganizationsAccessReportInput{
 		JobId: aws.String("examplea-1234-b567-cde8-90fg123abcd4"),
 	}
@@ -1231,7 +1231,7 @@ func ExampleIAM_GetOrganizationsAccessReport_shared00() {
 //
 // The following command gets information about the role named Test-Role.
 func ExampleIAM_GetRole_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GetRoleInput{
 		RoleName: aws.String("Test-Role"),
 	}
@@ -1262,7 +1262,7 @@ func ExampleIAM_GetRole_shared00() {
 //
 // The following operation gets details about the report with the job ID: examplef-1305-c245-eba4-71fe298bcda7
 func ExampleIAM_GetServiceLastAccessedDetails_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GetServiceLastAccessedDetailsInput{
 		JobId: aws.String("examplef-1305-c245-eba4-71fe298bcda7"),
 	}
@@ -1294,7 +1294,7 @@ func ExampleIAM_GetServiceLastAccessedDetails_shared00() {
 // The following operation returns details about the entities that attempted to access
 // the IAM service.
 func ExampleIAM_GetServiceLastAccessedDetailsWithEntities_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GetServiceLastAccessedDetailsWithEntitiesInput{
 		JobId:            aws.String("examplef-1305-c245-eba4-71fe298bcda7"),
 		ServiceNamespace: aws.String("iam"),
@@ -1326,7 +1326,7 @@ func ExampleIAM_GetServiceLastAccessedDetailsWithEntities_shared00() {
 //
 // The following command gets information about the IAM user named Bob.
 func ExampleIAM_GetUser_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.GetUserInput{
 		UserName: aws.String("Bob"),
 	}
@@ -1357,7 +1357,7 @@ func ExampleIAM_GetUser_shared00() {
 //
 // The following command lists the access keys IDs for the IAM user named Alice.
 func ExampleIAM_ListAccessKeys_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListAccessKeysInput{
 		UserName: aws.String("Alice"),
 	}
@@ -1388,7 +1388,7 @@ func ExampleIAM_ListAccessKeys_shared00() {
 //
 // The following command lists the aliases for the current account.
 func ExampleIAM_ListAccountAliases_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListAccountAliasesInput{}
 
 	result, err := svc.ListAccountAliases(input)
@@ -1416,7 +1416,7 @@ func ExampleIAM_ListAccountAliases_shared00() {
 // The following command lists the names of in-line policies that are embedded in the
 // IAM group named Admins.
 func ExampleIAM_ListGroupPolicies_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListGroupPoliciesInput{
 		GroupName: aws.String("Admins"),
 	}
@@ -1447,7 +1447,7 @@ func ExampleIAM_ListGroupPolicies_shared00() {
 //
 // The following command lists the IAM groups in the current account:
 func ExampleIAM_ListGroups_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListGroupsInput{}
 
 	result, err := svc.ListGroups(input)
@@ -1474,7 +1474,7 @@ func ExampleIAM_ListGroups_shared00() {
 //
 // The following command displays the groups that the IAM user named Bob belongs to.
 func ExampleIAM_ListGroupsForUser_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListGroupsForUserInput{
 		UserName: aws.String("Bob"),
 	}
@@ -1506,7 +1506,7 @@ func ExampleIAM_ListGroupsForUser_shared00() {
 // The following operation lists policies that allow ExampleUser01 to access IAM or
 // EC2.
 func ExampleIAM_ListPoliciesGrantingServiceAccess_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListPoliciesGrantingServiceAccessInput{
 		Arn: aws.String("arn:aws:iam::123456789012:user/ExampleUser01"),
 		ServiceNamespaces: []*string{
@@ -1541,7 +1541,7 @@ func ExampleIAM_ListPoliciesGrantingServiceAccess_shared00() {
 //
 // The following example shows how to list the tags attached to a role.
 func ExampleIAM_ListRoleTags_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListRoleTagsInput{
 		RoleName: aws.String("taggedrole1"),
 	}
@@ -1572,7 +1572,7 @@ func ExampleIAM_ListRoleTags_shared00() {
 //
 // The following command lists the signing certificates for the IAM user named Bob.
 func ExampleIAM_ListSigningCertificates_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListSigningCertificatesInput{
 		UserName: aws.String("Bob"),
 	}
@@ -1603,7 +1603,7 @@ func ExampleIAM_ListSigningCertificates_shared00() {
 //
 // The following example shows how to list the tags attached to a user.
 func ExampleIAM_ListUserTags_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListUserTagsInput{
 		UserName: aws.String("anika"),
 	}
@@ -1634,7 +1634,7 @@ func ExampleIAM_ListUserTags_shared00() {
 //
 // The following command lists the IAM users in the current account.
 func ExampleIAM_ListUsers_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListUsersInput{}
 
 	result, err := svc.ListUsers(input)
@@ -1662,7 +1662,7 @@ func ExampleIAM_ListUsers_shared00() {
 // The following command lists the virtual MFA devices that have been configured for
 // the current account.
 func ExampleIAM_ListVirtualMFADevices_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.ListVirtualMFADevicesInput{}
 
 	result, err := svc.ListVirtualMFADevices(input)
@@ -1687,7 +1687,7 @@ func ExampleIAM_ListVirtualMFADevices_shared00() {
 //
 // The following command adds a policy named AllPerms to the IAM group named Admins.
 func ExampleIAM_PutGroupPolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.PutGroupPolicyInput{
 		GroupName:      aws.String("Admins"),
 		PolicyDocument: aws.String("{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"),
@@ -1724,7 +1724,7 @@ func ExampleIAM_PutGroupPolicy_shared00() {
 //
 // The following command adds a permissions policy to the role named Test-Role.
 func ExampleIAM_PutRolePolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.PutRolePolicyInput{
 		PolicyDocument: aws.String("{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"*\"}}"),
 		PolicyName:     aws.String("S3AccessPolicy"),
@@ -1763,7 +1763,7 @@ func ExampleIAM_PutRolePolicy_shared00() {
 //
 // The following command attaches a policy to the IAM user named Bob.
 func ExampleIAM_PutUserPolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.PutUserPolicyInput{
 		PolicyDocument: aws.String("{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"),
 		PolicyName:     aws.String("AllAccessPolicy"),
@@ -1801,7 +1801,7 @@ func ExampleIAM_PutUserPolicy_shared00() {
 // The following command removes the role named Test-Role from the instance profile
 // named ExampleInstanceProfile.
 func ExampleIAM_RemoveRoleFromInstanceProfile_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.RemoveRoleFromInstanceProfileInput{
 		InstanceProfileName: aws.String("ExampleInstanceProfile"),
 		RoleName:            aws.String("Test-Role"),
@@ -1837,7 +1837,7 @@ func ExampleIAM_RemoveRoleFromInstanceProfile_shared00() {
 //
 // The following command removes the user named Bob from the IAM group named Admins.
 func ExampleIAM_RemoveUserFromGroup_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.RemoveUserFromGroupInput{
 		GroupName: aws.String("Admins"),
 		UserName:  aws.String("Bob"),
@@ -1872,7 +1872,7 @@ func ExampleIAM_RemoveUserFromGroup_shared00() {
 // The following command sets the STS global endpoint token to version 2. Version 2
 // tokens are valid in all Regions.
 func ExampleIAM_SetSecurityTokenServicePreferences_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.SetSecurityTokenServicePreferencesInput{
 		GlobalEndpointTokenVersion: aws.String("v2Token"),
 	}
@@ -1901,7 +1901,7 @@ func ExampleIAM_SetSecurityTokenServicePreferences_shared00() {
 //
 // The following example shows how to add tags to an existing role.
 func ExampleIAM_TagRole_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.TagRoleInput{
 		RoleName: aws.String("taggedrole"),
 		Tags: []*iam.Tag{
@@ -1948,7 +1948,7 @@ func ExampleIAM_TagRole_shared00() {
 //
 // The following example shows how to add tags to an existing user.
 func ExampleIAM_TagUser_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.TagUserInput{
 		Tags: []*iam.Tag{
 			{
@@ -1996,7 +1996,7 @@ func ExampleIAM_TagUser_shared00() {
 // The following example shows how to remove a tag with the key 'Dept' from a role named
 // 'taggedrole'.
 func ExampleIAM_UntagRole_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UntagRoleInput{
 		RoleName: aws.String("taggedrole"),
 		TagKeys: []*string{
@@ -2033,7 +2033,7 @@ func ExampleIAM_UntagRole_shared00() {
 // The following example shows how to remove tags that are attached to a user named
 // 'anika'.
 func ExampleIAM_UntagUser_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UntagUserInput{
 		TagKeys: []*string{
 			aws.String("Dept"),
@@ -2070,7 +2070,7 @@ func ExampleIAM_UntagUser_shared00() {
 // The following command deactivates the specified access key (access key ID and secret
 // access key) for the IAM user named Bob.
 func ExampleIAM_UpdateAccessKey_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UpdateAccessKeyInput{
 		AccessKeyId: aws.String("AKIAIOSFODNN7EXAMPLE"),
 		Status:      aws.String("Inactive"),
@@ -2106,7 +2106,7 @@ func ExampleIAM_UpdateAccessKey_shared00() {
 // The following command sets the password policy to require a minimum length of eight
 // characters and to require one or more numbers in the password:
 func ExampleIAM_UpdateAccountPasswordPolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UpdateAccountPasswordPolicyInput{
 		MinimumPasswordLength: aws.Int64(8),
 		RequireNumbers:        aws.Bool(true),
@@ -2142,7 +2142,7 @@ func ExampleIAM_UpdateAccountPasswordPolicy_shared00() {
 //
 // The following command updates the role trust policy for the role named Test-Role:
 func ExampleIAM_UpdateAssumeRolePolicy_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UpdateAssumeRolePolicyInput{
 		PolicyDocument: aws.String("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"),
 		RoleName:       aws.String("S3AccessForEC2Instances"),
@@ -2180,7 +2180,7 @@ func ExampleIAM_UpdateAssumeRolePolicy_shared00() {
 //
 // The following command changes the name of the IAM group Test to Test-1.
 func ExampleIAM_UpdateGroup_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UpdateGroupInput{
 		GroupName:    aws.String("Test"),
 		NewGroupName: aws.String("Test-1"),
@@ -2216,7 +2216,7 @@ func ExampleIAM_UpdateGroup_shared00() {
 //
 // The following command creates or changes the password for the IAM user named Bob.
 func ExampleIAM_UpdateLoginProfile_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UpdateLoginProfileInput{
 		Password: aws.String("SomeKindOfPassword123!@#"),
 		UserName: aws.String("Bob"),
@@ -2255,7 +2255,7 @@ func ExampleIAM_UpdateLoginProfile_shared00() {
 // The following command changes the status of a signing certificate for a user named
 // Bob to Inactive.
 func ExampleIAM_UpdateSigningCertificate_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UpdateSigningCertificateInput{
 		CertificateId: aws.String("TA7SMP42TDN5Z26OBPJE7EXAMPLE"),
 		Status:        aws.String("Inactive"),
@@ -2291,7 +2291,7 @@ func ExampleIAM_UpdateSigningCertificate_shared00() {
 // The following command changes the name of the IAM user Bob to Robert. It does not
 // change the user's path.
 func ExampleIAM_UpdateUser_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UpdateUserInput{
 		NewUserName: aws.String("Robert"),
 		UserName:    aws.String("Bob"),
@@ -2332,7 +2332,7 @@ func ExampleIAM_UpdateUser_shared00() {
 // The following upload-server-certificate command uploads a server certificate to your
 // AWS account:
 func ExampleIAM_UploadServerCertificate_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UploadServerCertificateInput{
 		CertificateBody:       aws.String("-----BEGIN CERTIFICATE-----<a very long certificate text string>-----END CERTIFICATE-----"),
 		Path:                  aws.String("/company/servercerts/"),
@@ -2372,7 +2372,7 @@ func ExampleIAM_UploadServerCertificate_shared00() {
 //
 // The following command uploads a signing certificate for the IAM user named Bob.
 func ExampleIAM_UploadSigningCertificate_shared00() {
-	svc := iam.New(session.New())
+	svc := iam.New(session.Must(session.NewSession()))
 	input := &iam.UploadSigningCertificateInput{
 		CertificateBody: aws.String("-----BEGIN CERTIFICATE-----<certificate-body>-----END CERTIFICATE-----"),
 		UserName:        aws.String("Bob"),

--- a/service/iam/iamiface/interface.go
+++ b/service/iam/iamiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iam.New(sess)
 //
 //        myFunc(svc)

--- a/service/identitystore/identitystoreiface/interface.go
+++ b/service/identitystore/identitystoreiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := identitystore.New(sess)
 //
 //        myFunc(svc)

--- a/service/imagebuilder/imagebuilderiface/interface.go
+++ b/service/imagebuilder/imagebuilderiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := imagebuilder.New(sess)
 //
 //        myFunc(svc)

--- a/service/inspector/examples_test.go
+++ b/service/inspector/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // Assigns attributes (key and value pairs) to the findings that are specified by the
 // ARNs of the findings.
 func ExampleInspector_AddAttributesToFindings_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.AddAttributesToFindingsInput{
 		Attributes: []*inspector.Attribute{
 			{
@@ -77,7 +77,7 @@ func ExampleInspector_AddAttributesToFindings_shared00() {
 // by CreateResourceGroup. You can create up to 50 assessment targets per AWS account.
 // You can run up to 500 concurrent agents per AWS account.
 func ExampleInspector_CreateAssessmentTarget_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.CreateAssessmentTargetInput{
 		AssessmentTargetName: aws.String("ExampleAssessmentTarget"),
 		ResourceGroupArn:     aws.String("arn:aws:inspector:us-west-2:123456789012:resourcegroup/0-AB6DMKnv"),
@@ -120,7 +120,7 @@ func ExampleInspector_CreateAssessmentTarget_shared00() {
 // Creates an assessment template for the assessment target that is specified by the
 // ARN of the assessment target.
 func ExampleInspector_CreateAssessmentTemplate_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.CreateAssessmentTemplateInput{
 		AssessmentTargetArn:    aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX"),
 		AssessmentTemplateName: aws.String("ExampleAssessmentTemplate"),
@@ -173,7 +173,7 @@ func ExampleInspector_CreateAssessmentTemplate_shared00() {
 // target. The created resource group is then used to create an Amazon Inspector assessment
 // target.
 func ExampleInspector_CreateResourceGroup_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.CreateResourceGroupInput{
 		ResourceGroupTags: []*inspector.ResourceGroupTag{
 			{
@@ -215,7 +215,7 @@ func ExampleInspector_CreateResourceGroup_shared00() {
 //
 // Deletes the assessment run that is specified by the ARN of the assessment run.
 func ExampleInspector_DeleteAssessmentRun_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DeleteAssessmentRunInput{
 		AssessmentRunArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/0-it5r2S4T/run/0-11LMTAVe"),
 	}
@@ -254,7 +254,7 @@ func ExampleInspector_DeleteAssessmentRun_shared00() {
 //
 // Deletes the assessment target that is specified by the ARN of the assessment target.
 func ExampleInspector_DeleteAssessmentTarget_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DeleteAssessmentTargetInput{
 		AssessmentTargetArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq"),
 	}
@@ -293,7 +293,7 @@ func ExampleInspector_DeleteAssessmentTarget_shared00() {
 //
 // Deletes the assessment template that is specified by the ARN of the assessment template.
 func ExampleInspector_DeleteAssessmentTemplate_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DeleteAssessmentTemplateInput{
 		AssessmentTemplateArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/0-it5r2S4T"),
 	}
@@ -332,7 +332,7 @@ func ExampleInspector_DeleteAssessmentTemplate_shared00() {
 //
 // Describes the assessment runs that are specified by the ARNs of the assessment runs.
 func ExampleInspector_DescribeAssessmentRuns_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DescribeAssessmentRunsInput{
 		AssessmentRunArns: []*string{
 			aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/run/0-MKkpXXPE"),
@@ -366,7 +366,7 @@ func ExampleInspector_DescribeAssessmentRuns_shared00() {
 // Describes the assessment targets that are specified by the ARNs of the assessment
 // targets.
 func ExampleInspector_DescribeAssessmentTargets_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DescribeAssessmentTargetsInput{
 		AssessmentTargetArns: []*string{
 			aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq"),
@@ -400,7 +400,7 @@ func ExampleInspector_DescribeAssessmentTargets_shared00() {
 // Describes the assessment templates that are specified by the ARNs of the assessment
 // templates.
 func ExampleInspector_DescribeAssessmentTemplates_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DescribeAssessmentTemplatesInput{
 		AssessmentTemplateArns: []*string{
 			aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw"),
@@ -433,7 +433,7 @@ func ExampleInspector_DescribeAssessmentTemplates_shared00() {
 //
 // Describes the IAM role that enables Amazon Inspector to access your AWS account.
 func ExampleInspector_DescribeCrossAccountAccessRole_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DescribeCrossAccountAccessRoleInput{}
 
 	result, err := svc.DescribeCrossAccountAccessRole(input)
@@ -460,7 +460,7 @@ func ExampleInspector_DescribeCrossAccountAccessRole_shared00() {
 //
 // Describes the findings that are specified by the ARNs of the findings.
 func ExampleInspector_DescribeFindings_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DescribeFindingsInput{
 		FindingArns: []*string{
 			aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/run/0-MKkpXXPE/finding/0-HwPnsDm4"),
@@ -493,7 +493,7 @@ func ExampleInspector_DescribeFindings_shared00() {
 //
 // Describes the resource groups that are specified by the ARNs of the resource groups.
 func ExampleInspector_DescribeResourceGroups_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DescribeResourceGroupsInput{
 		ResourceGroupArns: []*string{
 			aws.String("arn:aws:inspector:us-west-2:123456789012:resourcegroup/0-PyGXopAI"),
@@ -526,7 +526,7 @@ func ExampleInspector_DescribeResourceGroups_shared00() {
 //
 // Describes the rules packages that are specified by the ARNs of the rules packages.
 func ExampleInspector_DescribeRulesPackages_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.DescribeRulesPackagesInput{
 		RulesPackageArns: []*string{
 			aws.String("arn:aws:inspector:us-west-2:758058086616:rulespackage/0-JJOtZiqQ"),
@@ -559,7 +559,7 @@ func ExampleInspector_DescribeRulesPackages_shared00() {
 //
 // Information about the data that is collected for the specified assessment run.
 func ExampleInspector_GetTelemetryMetadata_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.GetTelemetryMetadataInput{
 		AssessmentRunArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/run/0-MKkpXXPE"),
 	}
@@ -595,7 +595,7 @@ func ExampleInspector_GetTelemetryMetadata_shared00() {
 // Lists the agents of the assessment runs that are specified by the ARNs of the assessment
 // runs.
 func ExampleInspector_ListAssessmentRunAgents_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.ListAssessmentRunAgentsInput{
 		AssessmentRunArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/run/0-MKkpXXPE"),
 		MaxResults:       aws.Int64(123),
@@ -632,7 +632,7 @@ func ExampleInspector_ListAssessmentRunAgents_shared00() {
 // Lists the assessment runs that correspond to the assessment templates that are specified
 // by the ARNs of the assessment templates.
 func ExampleInspector_ListAssessmentRuns_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.ListAssessmentRunsInput{
 		AssessmentTemplateArns: []*string{
 			aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw"),
@@ -670,7 +670,7 @@ func ExampleInspector_ListAssessmentRuns_shared00() {
 //
 // Lists the ARNs of the assessment targets within this AWS account.
 func ExampleInspector_ListAssessmentTargets_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.ListAssessmentTargetsInput{
 		MaxResults: aws.Int64(123),
 	}
@@ -704,7 +704,7 @@ func ExampleInspector_ListAssessmentTargets_shared00() {
 // Lists the assessment templates that correspond to the assessment targets that are
 // specified by the ARNs of the assessment targets.
 func ExampleInspector_ListAssessmentTemplates_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.ListAssessmentTemplatesInput{
 		AssessmentTargetArns: []*string{
 			aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq"),
@@ -743,7 +743,7 @@ func ExampleInspector_ListAssessmentTemplates_shared00() {
 // Lists all the event subscriptions for the assessment template that is specified by
 // the ARN of the assessment template.
 func ExampleInspector_ListEventSubscriptions_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.ListEventSubscriptionsInput{
 		MaxResults:  aws.Int64(123),
 		ResourceArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/0-7sbz2Kz0"),
@@ -780,7 +780,7 @@ func ExampleInspector_ListEventSubscriptions_shared00() {
 // Lists findings that are generated by the assessment runs that are specified by the
 // ARNs of the assessment runs.
 func ExampleInspector_ListFindings_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.ListFindingsInput{
 		AssessmentRunArns: []*string{
 			aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/run/0-MKkpXXPE"),
@@ -818,7 +818,7 @@ func ExampleInspector_ListFindings_shared00() {
 //
 // Lists all available Amazon Inspector rules packages.
 func ExampleInspector_ListRulesPackages_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.ListRulesPackagesInput{
 		MaxResults: aws.Int64(123),
 	}
@@ -851,7 +851,7 @@ func ExampleInspector_ListRulesPackages_shared00() {
 //
 // Lists all tags associated with an assessment template.
 func ExampleInspector_ListTagsForResource_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.ListTagsForResourceInput{
 		ResourceArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-gcwFliYu"),
 	}
@@ -887,7 +887,7 @@ func ExampleInspector_ListTagsForResource_shared00() {
 // Previews the agents installed on the EC2 instances that are part of the specified
 // assessment target.
 func ExampleInspector_PreviewAgents_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.PreviewAgentsInput{
 		MaxResults:       aws.Int64(123),
 		PreviewAgentsArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq"),
@@ -926,7 +926,7 @@ func ExampleInspector_PreviewAgents_shared00() {
 // Registers the IAM role that Amazon Inspector uses to list your EC2 instances at the
 // start of the assessment run or when you call the PreviewAgents action.
 func ExampleInspector_RegisterCrossAccountAccessRole_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.RegisterCrossAccountAccessRoleInput{
 		RoleArn: aws.String("arn:aws:iam::123456789012:role/inspector"),
 	}
@@ -964,7 +964,7 @@ func ExampleInspector_RegisterCrossAccountAccessRole_shared00() {
 // Removes entire attributes (key and value pairs) from the findings that are specified
 // by the ARNs of the findings where an attribute with the specified key exists.
 func ExampleInspector_RemoveAttributesFromFindings_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.RemoveAttributesFromFindingsInput{
 		AttributeKeys: []*string{
 			aws.String("key=Example,value=example"),
@@ -1007,7 +1007,7 @@ func ExampleInspector_RemoveAttributesFromFindings_shared00() {
 // Sets tags (key and value pairs) to the assessment template that is specified by the
 // ARN of the assessment template.
 func ExampleInspector_SetTagsForResource_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.SetTagsForResourceInput{
 		ResourceArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/0-7sbz2Kz0"),
 		Tags: []*inspector.Tag{
@@ -1052,7 +1052,7 @@ func ExampleInspector_SetTagsForResource_shared00() {
 // API to function properly, you must not exceed the limit of running up to 500 concurrent
 // agents per AWS account.
 func ExampleInspector_StartAssessmentRun_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.StartAssessmentRunInput{
 		AssessmentRunName:     aws.String("examplerun"),
 		AssessmentTemplateArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/0-it5r2S4T"),
@@ -1096,7 +1096,7 @@ func ExampleInspector_StartAssessmentRun_shared00() {
 //
 // Stops the assessment run that is specified by the ARN of the assessment run.
 func ExampleInspector_StopAssessmentRun_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.StopAssessmentRunInput{
 		AssessmentRunArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/0-it5r2S4T/run/0-11LMTAVe"),
 	}
@@ -1134,7 +1134,7 @@ func ExampleInspector_StopAssessmentRun_shared00() {
 // Enables the process of sending Amazon Simple Notification Service (SNS) notifications
 // about a specified event to a specified SNS topic.
 func ExampleInspector_SubscribeToEvent_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.SubscribeToEventInput{
 		Event:       aws.String("ASSESSMENT_RUN_COMPLETED"),
 		ResourceArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/0-7sbz2Kz0"),
@@ -1176,7 +1176,7 @@ func ExampleInspector_SubscribeToEvent_shared00() {
 // Disables the process of sending Amazon Simple Notification Service (SNS) notifications
 // about a specified event to a specified SNS topic.
 func ExampleInspector_UnsubscribeFromEvent_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.UnsubscribeFromEventInput{
 		Event:       aws.String("ASSESSMENT_RUN_COMPLETED"),
 		ResourceArn: aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/0-7sbz2Kz0"),
@@ -1215,7 +1215,7 @@ func ExampleInspector_UnsubscribeFromEvent_shared00() {
 //
 // Updates the assessment target that is specified by the ARN of the assessment target.
 func ExampleInspector_UpdateAssessmentTarget_shared00() {
-	svc := inspector.New(session.New())
+	svc := inspector.New(session.Must(session.NewSession()))
 	input := &inspector.UpdateAssessmentTargetInput{
 		AssessmentTargetArn:  aws.String("arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX"),
 		AssessmentTargetName: aws.String("Example"),

--- a/service/inspector/inspectoriface/interface.go
+++ b/service/inspector/inspectoriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := inspector.New(sess)
 //
 //        myFunc(svc)

--- a/service/iot/iotiface/interface.go
+++ b/service/iot/iotiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iot.New(sess)
 //
 //        myFunc(svc)

--- a/service/iot1clickdevicesservice/iot1clickdevicesserviceiface/interface.go
+++ b/service/iot1clickdevicesservice/iot1clickdevicesserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iot1clickdevicesservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/iot1clickprojects/iot1clickprojectsiface/interface.go
+++ b/service/iot1clickprojects/iot1clickprojectsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iot1clickprojects.New(sess)
 //
 //        myFunc(svc)

--- a/service/iotanalytics/iotanalyticsiface/interface.go
+++ b/service/iotanalytics/iotanalyticsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iotanalytics.New(sess)
 //
 //        myFunc(svc)

--- a/service/iotdataplane/iotdataplaneiface/interface.go
+++ b/service/iotdataplane/iotdataplaneiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iotdataplane.New(sess)
 //
 //        myFunc(svc)

--- a/service/iotevents/ioteventsiface/interface.go
+++ b/service/iotevents/ioteventsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iotevents.New(sess)
 //
 //        myFunc(svc)

--- a/service/ioteventsdata/ioteventsdataiface/interface.go
+++ b/service/ioteventsdata/ioteventsdataiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ioteventsdata.New(sess)
 //
 //        myFunc(svc)

--- a/service/iotjobsdataplane/iotjobsdataplaneiface/interface.go
+++ b/service/iotjobsdataplane/iotjobsdataplaneiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iotjobsdataplane.New(sess)
 //
 //        myFunc(svc)

--- a/service/iotsecuretunneling/iotsecuretunnelingiface/interface.go
+++ b/service/iotsecuretunneling/iotsecuretunnelingiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iotsecuretunneling.New(sess)
 //
 //        myFunc(svc)

--- a/service/iotsitewise/iotsitewiseiface/interface.go
+++ b/service/iotsitewise/iotsitewiseiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iotsitewise.New(sess)
 //
 //        myFunc(svc)

--- a/service/iotthingsgraph/iotthingsgraphiface/interface.go
+++ b/service/iotthingsgraph/iotthingsgraphiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := iotthingsgraph.New(sess)
 //
 //        myFunc(svc)

--- a/service/ivs/ivsiface/interface.go
+++ b/service/ivs/ivsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ivs.New(sess)
 //
 //        myFunc(svc)

--- a/service/kafka/kafkaiface/interface.go
+++ b/service/kafka/kafkaiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kafka.New(sess)
 //
 //        myFunc(svc)

--- a/service/kendra/kendraiface/interface.go
+++ b/service/kendra/kendraiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kendra.New(sess)
 //
 //        myFunc(svc)

--- a/service/kinesis/kinesisiface/interface.go
+++ b/service/kinesis/kinesisiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kinesis.New(sess)
 //
 //        myFunc(svc)

--- a/service/kinesisanalytics/kinesisanalyticsiface/interface.go
+++ b/service/kinesisanalytics/kinesisanalyticsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kinesisanalytics.New(sess)
 //
 //        myFunc(svc)

--- a/service/kinesisanalyticsv2/kinesisanalyticsv2iface/interface.go
+++ b/service/kinesisanalyticsv2/kinesisanalyticsv2iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kinesisanalyticsv2.New(sess)
 //
 //        myFunc(svc)

--- a/service/kinesisvideo/kinesisvideoiface/interface.go
+++ b/service/kinesisvideo/kinesisvideoiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kinesisvideo.New(sess)
 //
 //        myFunc(svc)

--- a/service/kinesisvideoarchivedmedia/kinesisvideoarchivedmediaiface/interface.go
+++ b/service/kinesisvideoarchivedmedia/kinesisvideoarchivedmediaiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kinesisvideoarchivedmedia.New(sess)
 //
 //        myFunc(svc)

--- a/service/kinesisvideomedia/kinesisvideomediaiface/interface.go
+++ b/service/kinesisvideomedia/kinesisvideomediaiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kinesisvideomedia.New(sess)
 //
 //        myFunc(svc)

--- a/service/kinesisvideosignalingchannels/kinesisvideosignalingchannelsiface/interface.go
+++ b/service/kinesisvideosignalingchannels/kinesisvideosignalingchannelsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kinesisvideosignalingchannels.New(sess)
 //
 //        myFunc(svc)

--- a/service/kms/examples_test.go
+++ b/service/kms/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The following example cancels deletion of the specified CMK.
 func ExampleKMS_CancelKeyDeletion_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.CancelKeyDeletionInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -66,7 +66,7 @@ func ExampleKMS_CancelKeyDeletion_shared00() {
 //
 // The following example creates an alias for the specified customer master key (CMK).
 func ExampleKMS_CreateAlias_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.CreateAliasInput{
 		AliasName:   aws.String("alias/ExampleAlias"),
 		TargetKeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
@@ -109,7 +109,7 @@ func ExampleKMS_CreateAlias_shared00() {
 // The following example creates a grant that allows the specified IAM role to encrypt
 // data with the specified customer master key (CMK).
 func ExampleKMS_CreateGrant_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.CreateGrantInput{
 		GranteePrincipal: aws.String("arn:aws:iam::111122223333:role/ExampleRole"),
 		KeyId:            aws.String("arn:aws:kms:us-east-2:444455556666:key/1234abcd-12ab-34cd-56ef-1234567890ab"),
@@ -157,7 +157,7 @@ func ExampleKMS_CreateGrant_shared00() {
 //
 // The following example creates a CMK.
 func ExampleKMS_CreateKey_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.CreateKeyInput{
 		Tags: []*kms.Tag{
 			{
@@ -210,7 +210,7 @@ func ExampleKMS_CreateKey_shared00() {
 // The following example decrypts data that was encrypted with a customer master key
 // (CMK) in AWS KMS.
 func ExampleKMS_Decrypt_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.DecryptInput{
 		CiphertextBlob: []byte("<binary data>"),
 	}
@@ -257,7 +257,7 @@ func ExampleKMS_Decrypt_shared00() {
 //
 // The following example deletes the specified alias.
 func ExampleKMS_DeleteAlias_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.DeleteAliasInput{
 		AliasName: aws.String("alias/ExampleAlias"),
 	}
@@ -293,7 +293,7 @@ func ExampleKMS_DeleteAlias_shared00() {
 // The following example deletes the imported key material from the specified customer
 // master key (CMK).
 func ExampleKMS_DeleteImportedKeyMaterial_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.DeleteImportedKeyMaterialInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -332,7 +332,7 @@ func ExampleKMS_DeleteImportedKeyMaterial_shared00() {
 //
 // The following example returns information (metadata) about the specified CMK.
 func ExampleKMS_DescribeKey_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.DescribeKeyInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -367,7 +367,7 @@ func ExampleKMS_DescribeKey_shared00() {
 //
 // The following example disables the specified CMK.
 func ExampleKMS_DisableKey_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.DisableKeyInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -405,7 +405,7 @@ func ExampleKMS_DisableKey_shared00() {
 // The following example disables automatic annual rotation of the key material for
 // the specified CMK.
 func ExampleKMS_DisableKeyRotation_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.DisableKeyRotationInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -446,7 +446,7 @@ func ExampleKMS_DisableKeyRotation_shared00() {
 //
 // The following example enables the specified CMK.
 func ExampleKMS_EnableKey_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.EnableKeyInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -486,7 +486,7 @@ func ExampleKMS_EnableKey_shared00() {
 // The following example enables automatic annual rotation of the key material for the
 // specified CMK.
 func ExampleKMS_EnableKeyRotation_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.EnableKeyRotationInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -527,7 +527,7 @@ func ExampleKMS_EnableKeyRotation_shared00() {
 //
 // The following example encrypts data with the specified customer master key (CMK).
 func ExampleKMS_Encrypt_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.EncryptInput{
 		KeyId:     aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 		Plaintext: []byte("<binary data>"),
@@ -573,7 +573,7 @@ func ExampleKMS_Encrypt_shared00() {
 // in two formats. One is the unencrypted (plainext) data key, and the other is the
 // data key encrypted with the specified customer master key (CMK).
 func ExampleKMS_GenerateDataKey_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.GenerateDataKeyInput{
 		KeyId:   aws.String("alias/ExampleAlias"),
 		KeySpec: aws.String("AES_256"),
@@ -619,7 +619,7 @@ func ExampleKMS_GenerateDataKey_shared00() {
 // key (data key). The data key is encrypted with the specified customer master key
 // (CMK).
 func ExampleKMS_GenerateDataKeyWithoutPlaintext_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.GenerateDataKeyWithoutPlaintextInput{
 		KeyId:   aws.String("alias/ExampleAlias"),
 		KeySpec: aws.String("AES_256"),
@@ -663,7 +663,7 @@ func ExampleKMS_GenerateDataKeyWithoutPlaintext_shared00() {
 //
 // The following example uses AWS KMS to generate 32 bytes of random data.
 func ExampleKMS_GenerateRandom_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.GenerateRandomInput{
 		NumberOfBytes: aws.Int64(32),
 	}
@@ -699,7 +699,7 @@ func ExampleKMS_GenerateRandom_shared00() {
 // The following example retrieves the key policy for the specified customer master
 // key (CMK).
 func ExampleKMS_GetKeyPolicy_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.GetKeyPolicyInput{
 		KeyId:      aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 		PolicyName: aws.String("default"),
@@ -738,7 +738,7 @@ func ExampleKMS_GetKeyPolicy_shared00() {
 // The following example retrieves the status of automatic annual rotation of the key
 // material for the specified CMK.
 func ExampleKMS_GetKeyRotationStatus_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.GetKeyRotationStatusInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -778,7 +778,7 @@ func ExampleKMS_GetKeyRotationStatus_shared00() {
 // The following example retrieves the public key and import token for the specified
 // CMK.
 func ExampleKMS_GetParametersForImport_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.GetParametersForImportInput{
 		KeyId:             aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 		WrappingAlgorithm: aws.String("RSAES_OAEP_SHA_1"),
@@ -819,7 +819,7 @@ func ExampleKMS_GetParametersForImport_shared00() {
 //
 // The following example imports key material into the specified CMK.
 func ExampleKMS_ImportKeyMaterial_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.ImportKeyMaterialInput{
 		EncryptedKeyMaterial: []byte("<binary data>"),
 		ExpirationModel:      aws.String("KEY_MATERIAL_DOES_NOT_EXPIRE"),
@@ -869,7 +869,7 @@ func ExampleKMS_ImportKeyMaterial_shared00() {
 //
 // The following example lists aliases.
 func ExampleKMS_ListAliases_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.ListAliasesInput{}
 
 	result, err := svc.ListAliases(input)
@@ -904,7 +904,7 @@ func ExampleKMS_ListAliases_shared00() {
 //
 // The following example lists grants for the specified CMK.
 func ExampleKMS_ListGrants_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.ListGrantsInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -943,7 +943,7 @@ func ExampleKMS_ListGrants_shared00() {
 //
 // The following example lists key policies for the specified CMK.
 func ExampleKMS_ListKeyPolicies_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.ListKeyPoliciesInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -980,7 +980,7 @@ func ExampleKMS_ListKeyPolicies_shared00() {
 //
 // The following example lists CMKs.
 func ExampleKMS_ListKeys_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.ListKeysInput{}
 
 	result, err := svc.ListKeys(input)
@@ -1011,7 +1011,7 @@ func ExampleKMS_ListKeys_shared00() {
 //
 // The following example lists tags for a CMK.
 func ExampleKMS_ListResourceTags_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.ListResourceTagsInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 	}
@@ -1047,7 +1047,7 @@ func ExampleKMS_ListResourceTags_shared00() {
 // The following example lists the grants that the specified principal (identity) can
 // retire.
 func ExampleKMS_ListRetirableGrants_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.ListRetirableGrantsInput{
 		RetiringPrincipal: aws.String("arn:aws:iam::111122223333:role/ExampleRole"),
 	}
@@ -1084,7 +1084,7 @@ func ExampleKMS_ListRetirableGrants_shared00() {
 //
 // The following example attaches a key policy to the specified CMK.
 func ExampleKMS_PutKeyPolicy_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.PutKeyPolicyInput{
 		KeyId:      aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 		Policy:     aws.String("{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"custom-policy-2016-12-07\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:aws:iam::111122223333:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        },\n        {\n            \"Sid\": \"Allow access for Key Administrators\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": [\n                    \"arn:aws:iam::111122223333:user/ExampleAdminUser\",\n                    \"arn:aws:iam::111122223333:role/ExampleAdminRole\"\n                ]\n            },\n            \"Action\": [\n                \"kms:Create*\",\n                \"kms:Describe*\",\n                \"kms:Enable*\",\n                \"kms:List*\",\n                \"kms:Put*\",\n                \"kms:Update*\",\n                \"kms:Revoke*\",\n                \"kms:Disable*\",\n                \"kms:Get*\",\n                \"kms:Delete*\",\n                \"kms:ScheduleKeyDeletion\",\n                \"kms:CancelKeyDeletion\"\n            ],\n            \"Resource\": \"*\"\n        },\n        {\n            \"Sid\": \"Allow use of the key\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:aws:iam::111122223333:role/ExamplePowerUserRole\"\n            },\n            \"Action\": [\n                \"kms:Encrypt\",\n                \"kms:Decrypt\",\n                \"kms:ReEncrypt*\",\n                \"kms:GenerateDataKey*\",\n                \"kms:DescribeKey\"\n            ],\n            \"Resource\": \"*\"\n        },\n        {\n            \"Sid\": \"Allow attachment of persistent resources\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:aws:iam::111122223333:role/ExamplePowerUserRole\"\n            },\n            \"Action\": [\n                \"kms:CreateGrant\",\n                \"kms:ListGrants\",\n                \"kms:RevokeGrant\"\n            ],\n            \"Resource\": \"*\",\n            \"Condition\": {\n                \"Bool\": {\n                    \"kms:GrantIsForAWSResource\": \"true\"\n                }\n            }\n        }\n    ]\n}\n"),
@@ -1129,7 +1129,7 @@ func ExampleKMS_PutKeyPolicy_shared00() {
 //
 // The following example reencrypts data with the specified CMK.
 func ExampleKMS_ReEncrypt_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.ReEncryptInput{
 		CiphertextBlob:   []byte("<binary data>"),
 		DestinationKeyId: aws.String("0987dcba-09fe-87dc-65ba-ab0987654321"),
@@ -1177,7 +1177,7 @@ func ExampleKMS_ReEncrypt_shared00() {
 //
 // The following example retires a grant.
 func ExampleKMS_RetireGrant_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.RetireGrantInput{
 		GrantId: aws.String("0c237476b39f8bc44e45212e08498fbe3151305030726c0590dd8d3e9f3d6a60"),
 		KeyId:   aws.String("arn:aws:kms:us-east-2:444455556666:key/1234abcd-12ab-34cd-56ef-1234567890ab"),
@@ -1219,7 +1219,7 @@ func ExampleKMS_RetireGrant_shared00() {
 //
 // The following example revokes a grant.
 func ExampleKMS_RevokeGrant_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.RevokeGrantInput{
 		GrantId: aws.String("0c237476b39f8bc44e45212e08498fbe3151305030726c0590dd8d3e9f3d6a60"),
 		KeyId:   aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
@@ -1259,7 +1259,7 @@ func ExampleKMS_RevokeGrant_shared00() {
 //
 // The following example schedules the specified CMK for deletion.
 func ExampleKMS_ScheduleKeyDeletion_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.ScheduleKeyDeletionInput{
 		KeyId:               aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 		PendingWindowInDays: aws.Int64(7),
@@ -1297,7 +1297,7 @@ func ExampleKMS_ScheduleKeyDeletion_shared00() {
 //
 // The following example tags a CMK.
 func ExampleKMS_TagResource_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.TagResourceInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 		Tags: []*kms.Tag{
@@ -1342,7 +1342,7 @@ func ExampleKMS_TagResource_shared00() {
 //
 // The following example removes tags from a CMK.
 func ExampleKMS_UntagResource_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.UntagResourceInput{
 		KeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
 		TagKeys: []*string{
@@ -1384,7 +1384,7 @@ func ExampleKMS_UntagResource_shared00() {
 // The following example updates the specified alias to refer to the specified customer
 // master key (CMK).
 func ExampleKMS_UpdateAlias_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.UpdateAliasInput{
 		AliasName:   aws.String("alias/ExampleAlias"),
 		TargetKeyId: aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),
@@ -1422,7 +1422,7 @@ func ExampleKMS_UpdateAlias_shared00() {
 //
 // The following example updates the description of the specified CMK.
 func ExampleKMS_UpdateKeyDescription_shared00() {
-	svc := kms.New(session.New())
+	svc := kms.New(session.Must(session.NewSession()))
 	input := &kms.UpdateKeyDescriptionInput{
 		Description: aws.String("Example description that indicates the intended use of this CMK."),
 		KeyId:       aws.String("1234abcd-12ab-34cd-56ef-1234567890ab"),

--- a/service/kms/kmsiface/interface.go
+++ b/service/kms/kmsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := kms.New(sess)
 //
 //        myFunc(svc)

--- a/service/lakeformation/lakeformationiface/interface.go
+++ b/service/lakeformation/lakeformationiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := lakeformation.New(sess)
 //
 //        myFunc(svc)

--- a/service/lambda/examples_test.go
+++ b/service/lambda/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // The following example grants permission for the account 223456789012 to use version
 // 1 of a layer named my-layer.
 func ExampleLambda_AddLayerVersionPermission_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.AddLayerVersionPermissionInput{
 		Action:        aws.String("lambda:GetLayerVersion"),
 		LayerName:     aws.String("my-layer"),
@@ -77,7 +77,7 @@ func ExampleLambda_AddLayerVersionPermission_shared00() {
 // my-function for notifications from a bucket named my-bucket-1xpuxmplzrlbh in account
 // 123456789012.
 func ExampleLambda_AddPermission_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.AddPermissionInput{
 		Action:        aws.String("lambda:InvokeFunction"),
 		FunctionName:  aws.String("my-function"),
@@ -124,7 +124,7 @@ func ExampleLambda_AddPermission_shared00() {
 // The following example adds permission for account 223456789012 invoke a Lambda function
 // named my-function.
 func ExampleLambda_AddPermission_shared01() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.AddPermissionInput{
 		Action:       aws.String("lambda:InvokeFunction"),
 		FunctionName: aws.String("my-function"),
@@ -169,7 +169,7 @@ func ExampleLambda_AddPermission_shared01() {
 // The following example creates an alias named LIVE that points to version 1 of the
 // my-function Lambda function.
 func ExampleLambda_CreateAlias_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.CreateAliasInput{
 		Description:     aws.String("alias for live version of function"),
 		FunctionName:    aws.String("my-function"),
@@ -210,7 +210,7 @@ func ExampleLambda_CreateAlias_shared00() {
 // The following example creates a mapping between an SQS queue and the my-function
 // Lambda function.
 func ExampleLambda_CreateEventSourceMapping_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.CreateEventSourceMappingInput{
 		BatchSize:      aws.Int64(5),
 		EventSourceArn: aws.String("arn:aws:sqs:us-west-2:123456789012:my-queue"),
@@ -250,7 +250,7 @@ func ExampleLambda_CreateEventSourceMapping_shared00() {
 // The following example creates a function with a deployment package in Amazon S3 and
 // enables X-Ray tracing and environment variable encryption.
 func ExampleLambda_CreateFunction_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.CreateFunctionInput{
 		Code: &lambda.FunctionCode{
 			S3Bucket: aws.String("my-bucket-1xpuxmplzrlbh"),
@@ -313,7 +313,7 @@ func ExampleLambda_CreateFunction_shared00() {
 //
 // The following example deletes an alias named BLUE from a function named my-function
 func ExampleLambda_DeleteAlias_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.DeleteAliasInput{
 		FunctionName: aws.String("my-function"),
 		Name:         aws.String("BLUE"),
@@ -350,7 +350,7 @@ func ExampleLambda_DeleteAlias_shared00() {
 // The following example deletes an event source mapping. To get a mapping's UUID, use
 // ListEventSourceMappings.
 func ExampleLambda_DeleteEventSourceMapping_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.DeleteEventSourceMappingInput{
 		UUID: aws.String("14e0db71-xmpl-4eb5-b481-8945cf9d10c2"),
 	}
@@ -387,7 +387,7 @@ func ExampleLambda_DeleteEventSourceMapping_shared00() {
 //
 // The following example deletes version 1 of a Lambda function named my-function.
 func ExampleLambda_DeleteFunction_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.DeleteFunctionInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("1"),
@@ -426,7 +426,7 @@ func ExampleLambda_DeleteFunction_shared00() {
 // The following example deletes the reserved concurrent execution limit from a function
 // named my-function.
 func ExampleLambda_DeleteFunctionConcurrency_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.DeleteFunctionConcurrencyInput{
 		FunctionName: aws.String("my-function"),
 	}
@@ -464,7 +464,7 @@ func ExampleLambda_DeleteFunctionConcurrency_shared00() {
 // The following example deletes the asynchronous invocation configuration for the GREEN
 // alias of a function named my-function.
 func ExampleLambda_DeleteFunctionEventInvokeConfig_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.DeleteFunctionEventInvokeConfigInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("GREEN"),
@@ -500,7 +500,7 @@ func ExampleLambda_DeleteFunctionEventInvokeConfig_shared00() {
 //
 // The following example deletes version 2 of a layer named my-layer.
 func ExampleLambda_DeleteLayerVersion_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.DeleteLayerVersionInput{
 		LayerName:     aws.String("my-layer"),
 		VersionNumber: aws.Int64(2),
@@ -533,7 +533,7 @@ func ExampleLambda_DeleteLayerVersion_shared00() {
 // The following example deletes the provisioned concurrency configuration for the GREEN
 // alias of a function named my-function.
 func ExampleLambda_DeleteProvisionedConcurrencyConfig_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.DeleteProvisionedConcurrencyConfigInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("GREEN"),
@@ -572,7 +572,7 @@ func ExampleLambda_DeleteProvisionedConcurrencyConfig_shared00() {
 // This operation takes no parameters and returns details about storage and concurrency
 // quotas in the current Region.
 func ExampleLambda_GetAccountSettings_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetAccountSettingsInput{}
 
 	result, err := svc.GetAccountSettings(input)
@@ -602,7 +602,7 @@ func ExampleLambda_GetAccountSettings_shared00() {
 // The following example returns details about an alias named BLUE for a function named
 // my-function
 func ExampleLambda_GetAlias_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetAliasInput{
 		FunctionName: aws.String("my-function"),
 		Name:         aws.String("BLUE"),
@@ -639,7 +639,7 @@ func ExampleLambda_GetAlias_shared00() {
 // The following example returns details about an event source mapping. To get a mapping's
 // UUID, use ListEventSourceMappings.
 func ExampleLambda_GetEventSourceMapping_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetEventSourceMappingInput{
 		UUID: aws.String("14e0db71-xmpl-4eb5-b481-8945cf9d10c2"),
 	}
@@ -675,7 +675,7 @@ func ExampleLambda_GetEventSourceMapping_shared00() {
 // The following example returns code and configuration details for version 1 of a function
 // named my-function.
 func ExampleLambda_GetFunction_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetFunctionInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("1"),
@@ -712,7 +712,7 @@ func ExampleLambda_GetFunction_shared00() {
 // The following example returns the reserved concurrency setting for a function named
 // my-function.
 func ExampleLambda_GetFunctionConcurrency_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetFunctionConcurrencyInput{
 		FunctionName: aws.String("my-function"),
 	}
@@ -748,7 +748,7 @@ func ExampleLambda_GetFunctionConcurrency_shared00() {
 // The following example returns and configuration details for version 1 of a function
 // named my-function.
 func ExampleLambda_GetFunctionConfiguration_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetFunctionConfigurationInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("1"),
@@ -785,7 +785,7 @@ func ExampleLambda_GetFunctionConfiguration_shared00() {
 // The following example returns the asynchronous invocation configuration for the BLUE
 // alias of a function named my-function.
 func ExampleLambda_GetFunctionEventInvokeConfig_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetFunctionEventInvokeConfigInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("BLUE"),
@@ -821,7 +821,7 @@ func ExampleLambda_GetFunctionEventInvokeConfig_shared00() {
 //
 // The following example returns information for version 1 of a layer named my-layer.
 func ExampleLambda_GetLayerVersion_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetLayerVersionInput{
 		LayerName:     aws.String("my-layer"),
 		VersionNumber: aws.Int64(1),
@@ -858,7 +858,7 @@ func ExampleLambda_GetLayerVersion_shared00() {
 // The following example returns information about the layer version with the specified
 // Amazon Resource Name (ARN).
 func ExampleLambda_GetLayerVersionByArn_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetLayerVersionByArnInput{
 		Arn: aws.String("arn:aws:lambda:ca-central-1:123456789012:layer:blank-python-lib:3"),
 	}
@@ -894,7 +894,7 @@ func ExampleLambda_GetLayerVersionByArn_shared00() {
 // The following example returns the resource-based policy for version 1 of a Lambda
 // function named my-function.
 func ExampleLambda_GetPolicy_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetPolicyInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("1"),
@@ -931,7 +931,7 @@ func ExampleLambda_GetPolicy_shared00() {
 // The following example displays details for the provisioned concurrency configuration
 // for the BLUE alias of the specified function.
 func ExampleLambda_GetProvisionedConcurrencyConfig_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetProvisionedConcurrencyConfigInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("BLUE"),
@@ -970,7 +970,7 @@ func ExampleLambda_GetProvisionedConcurrencyConfig_shared00() {
 // The following example returns details for the provisioned concurrency configuration
 // for the BLUE alias of the specified function.
 func ExampleLambda_GetProvisionedConcurrencyConfig_shared01() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.GetProvisionedConcurrencyConfigInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("BLUE"),
@@ -1009,7 +1009,7 @@ func ExampleLambda_GetProvisionedConcurrencyConfig_shared01() {
 // The following example invokes version 1 of a function named my-function with an empty
 // event payload.
 func ExampleLambda_Invoke_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.InvokeInput{
 		FunctionName: aws.String("my-function"),
 		Payload:      []byte("{}"),
@@ -1090,7 +1090,7 @@ func ExampleLambda_Invoke_shared00() {
 //
 // The following example invokes version 1 of a function named my-function asynchronously.
 func ExampleLambda_Invoke_shared01() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.InvokeInput{
 		FunctionName:   aws.String("my-function"),
 		InvocationType: aws.String("Event"),
@@ -1172,7 +1172,7 @@ func ExampleLambda_Invoke_shared01() {
 //
 // The following example invokes a Lambda function asynchronously
 func ExampleLambda_InvokeAsync_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.InvokeAsyncInput{
 		FunctionName: aws.String("my-function"),
 		InvokeArgs:   aws.ReadSeekCloser(strings.NewReader("{}")),
@@ -1210,7 +1210,7 @@ func ExampleLambda_InvokeAsync_shared00() {
 //
 // The following example returns a list of aliases for a function named my-function.
 func ExampleLambda_ListAliases_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.ListAliasesInput{
 		FunctionName: aws.String("my-function"),
 	}
@@ -1246,7 +1246,7 @@ func ExampleLambda_ListAliases_shared00() {
 // The following example returns a list of the event source mappings for a function
 // named my-function.
 func ExampleLambda_ListEventSourceMappings_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.ListEventSourceMappingsInput{
 		FunctionName: aws.String("my-function"),
 	}
@@ -1282,7 +1282,7 @@ func ExampleLambda_ListEventSourceMappings_shared00() {
 // The following example returns a list of asynchronous invocation configurations for
 // a function named my-function.
 func ExampleLambda_ListFunctionEventInvokeConfigs_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.ListFunctionEventInvokeConfigsInput{
 		FunctionName: aws.String("my-function"),
 	}
@@ -1317,7 +1317,7 @@ func ExampleLambda_ListFunctionEventInvokeConfigs_shared00() {
 //
 // This operation returns a list of Lambda functions.
 func ExampleLambda_ListFunctions_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.ListFunctionsInput{}
 
 	result, err := svc.ListFunctions(input)
@@ -1349,7 +1349,7 @@ func ExampleLambda_ListFunctions_shared00() {
 // The following example displays information about the versions for the layer named
 // blank-java-lib
 func ExampleLambda_ListLayerVersions_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.ListLayerVersionsInput{
 		LayerName: aws.String("blank-java-lib"),
 	}
@@ -1385,7 +1385,7 @@ func ExampleLambda_ListLayerVersions_shared00() {
 // The following example returns information about layers that are compatible with the
 // Python 3.7 runtime.
 func ExampleLambda_ListLayers_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.ListLayersInput{
 		CompatibleRuntime: aws.String("python3.7"),
 	}
@@ -1419,7 +1419,7 @@ func ExampleLambda_ListLayers_shared00() {
 // The following example returns a list of provisioned concurrency configurations for
 // a function named my-function.
 func ExampleLambda_ListProvisionedConcurrencyConfigs_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.ListProvisionedConcurrencyConfigsInput{
 		FunctionName: aws.String("my-function"),
 	}
@@ -1454,7 +1454,7 @@ func ExampleLambda_ListProvisionedConcurrencyConfigs_shared00() {
 //
 // The following example displays the tags attached to the my-function Lambda function.
 func ExampleLambda_ListTags_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.ListTagsInput{
 		Resource: aws.String("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
 	}
@@ -1489,7 +1489,7 @@ func ExampleLambda_ListTags_shared00() {
 //
 // The following example returns a list of versions of a function named my-function
 func ExampleLambda_ListVersionsByFunction_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.ListVersionsByFunctionInput{
 		FunctionName: aws.String("my-function"),
 	}
@@ -1525,7 +1525,7 @@ func ExampleLambda_ListVersionsByFunction_shared00() {
 // The following example creates a new Python library layer version. The command retrieves
 // the layer content a file named layer.zip in the specified S3 bucket.
 func ExampleLambda_PublishLayerVersion_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.PublishLayerVersionInput{
 		CompatibleRuntimes: []*string{
 			aws.String("python3.6"),
@@ -1572,7 +1572,7 @@ func ExampleLambda_PublishLayerVersion_shared00() {
 //
 // This operation publishes a version of a Lambda function
 func ExampleLambda_PublishVersion_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.PublishVersionInput{
 		CodeSha256:   aws.String(""),
 		Description:  aws.String(""),
@@ -1616,7 +1616,7 @@ func ExampleLambda_PublishVersion_shared00() {
 // The following example configures 100 reserved concurrent executions for the my-function
 // function.
 func ExampleLambda_PutFunctionConcurrency_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.PutFunctionConcurrencyInput{
 		FunctionName:                 aws.String("my-function"),
 		ReservedConcurrentExecutions: aws.Int64(100),
@@ -1655,7 +1655,7 @@ func ExampleLambda_PutFunctionConcurrency_shared00() {
 // The following example sets a maximum event age of one hour and disables retries for
 // the specified function.
 func ExampleLambda_PutFunctionEventInvokeConfig_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.PutFunctionEventInvokeConfigInput{
 		FunctionName:             aws.String("my-function"),
 		MaximumEventAgeInSeconds: aws.Int64(3600),
@@ -1693,7 +1693,7 @@ func ExampleLambda_PutFunctionEventInvokeConfig_shared00() {
 // The following example allocates 100 provisioned concurrency for the BLUE alias of
 // the specified function.
 func ExampleLambda_PutProvisionedConcurrencyConfig_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.PutProvisionedConcurrencyConfigInput{
 		FunctionName:                    aws.String("my-function"),
 		ProvisionedConcurrentExecutions: aws.Int64(100),
@@ -1732,7 +1732,7 @@ func ExampleLambda_PutProvisionedConcurrencyConfig_shared00() {
 //
 // The following example deletes permission for an account to configure a layer version.
 func ExampleLambda_RemoveLayerVersionPermission_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.RemoveLayerVersionPermissionInput{
 		LayerName:     aws.String("my-layer"),
 		StatementId:   aws.String("xaccount"),
@@ -1772,7 +1772,7 @@ func ExampleLambda_RemoveLayerVersionPermission_shared00() {
 // The following example removes a permissions statement named xaccount from the PROD
 // alias of a function named my-function.
 func ExampleLambda_RemovePermission_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.RemovePermissionInput{
 		FunctionName: aws.String("my-function"),
 		Qualifier:    aws.String("PROD"),
@@ -1812,7 +1812,7 @@ func ExampleLambda_RemovePermission_shared00() {
 // The following example adds a tag with the key name DEPARTMENT and a value of 'Department
 // A' to the specified Lambda function.
 func ExampleLambda_TagResource_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.TagResourceInput{
 		Resource: aws.String("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
 		Tags: map[string]*string{
@@ -1853,7 +1853,7 @@ func ExampleLambda_TagResource_shared00() {
 // The following example removes the tag with the key name DEPARTMENT tag from the my-function
 // Lambda function.
 func ExampleLambda_UntagResource_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.UntagResourceInput{
 		Resource: aws.String("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
 		TagKeys: []*string{
@@ -1894,7 +1894,7 @@ func ExampleLambda_UntagResource_shared00() {
 // The following example updates the alias named BLUE to send 30% of traffic to version
 // 2 and 70% to version 1.
 func ExampleLambda_UpdateAlias_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.UpdateAliasInput{
 		FunctionName:    aws.String("my-function"),
 		FunctionVersion: aws.String("2"),
@@ -1940,7 +1940,7 @@ func ExampleLambda_UpdateAlias_shared00() {
 //
 // This operation updates a Lambda function event source mapping
 func ExampleLambda_UpdateEventSourceMapping_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.UpdateEventSourceMappingInput{
 		BatchSize:    aws.Int64(123),
 		Enabled:      aws.Bool(true),
@@ -1984,7 +1984,7 @@ func ExampleLambda_UpdateEventSourceMapping_shared00() {
 // function named my-function with the contents of the specified zip file in Amazon
 // S3.
 func ExampleLambda_UpdateFunctionCode_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.UpdateFunctionCodeInput{
 		FunctionName: aws.String("my-function"),
 		S3Bucket:     aws.String("my-bucket-1xpuxmplzrlbh"),
@@ -2028,7 +2028,7 @@ func ExampleLambda_UpdateFunctionCode_shared00() {
 // The following example modifies the memory size to be 256 MB for the unpublished ($LATEST)
 // version of a function named my-function.
 func ExampleLambda_UpdateFunctionConfiguration_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.UpdateFunctionConfigurationInput{
 		FunctionName: aws.String("my-function"),
 		MemorySize:   aws.Int64(256),
@@ -2069,7 +2069,7 @@ func ExampleLambda_UpdateFunctionConfiguration_shared00() {
 // The following example adds an on-failure destination to the existing asynchronous
 // invocation configuration for a function named my-function.
 func ExampleLambda_UpdateFunctionEventInvokeConfig_shared00() {
-	svc := lambda.New(session.New())
+	svc := lambda.New(session.Must(session.NewSession()))
 	input := &lambda.UpdateFunctionEventInvokeConfigInput{
 		DestinationConfig: &lambda.DestinationConfig{
 			OnFailure: &lambda.OnFailure{

--- a/service/lambda/lambdaiface/interface.go
+++ b/service/lambda/lambdaiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := lambda.New(sess)
 //
 //        myFunc(svc)

--- a/service/lexmodelbuildingservice/examples_test.go
+++ b/service/lexmodelbuildingservice/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This example shows how to get configuration information for a bot.
 func ExampleLexModelBuildingService_GetBot_shared00() {
-	svc := lexmodelbuildingservice.New(session.New())
+	svc := lexmodelbuildingservice.New(session.Must(session.NewSession()))
 	input := &lexmodelbuildingservice.GetBotInput{
 		Name:           aws.String("DocOrderPizza"),
 		VersionOrAlias: aws.String("$LATEST"),
@@ -65,7 +65,7 @@ func ExampleLexModelBuildingService_GetBot_shared00() {
 //
 // This example shows how to get a list of all of the bots in your account.
 func ExampleLexModelBuildingService_GetBots_shared00() {
-	svc := lexmodelbuildingservice.New(session.New())
+	svc := lexmodelbuildingservice.New(session.Must(session.NewSession()))
 	input := &lexmodelbuildingservice.GetBotsInput{
 		MaxResults: aws.Int64(5),
 		NextToken:  aws.String(""),
@@ -101,7 +101,7 @@ func ExampleLexModelBuildingService_GetBots_shared00() {
 //
 // This example shows how to get information about an intent.
 func ExampleLexModelBuildingService_GetIntent_shared00() {
-	svc := lexmodelbuildingservice.New(session.New())
+	svc := lexmodelbuildingservice.New(session.Must(session.NewSession()))
 	input := &lexmodelbuildingservice.GetIntentInput{
 		Name:    aws.String("DocOrderPizza"),
 		Version: aws.String("$LATEST"),
@@ -137,7 +137,7 @@ func ExampleLexModelBuildingService_GetIntent_shared00() {
 //
 // This example shows how to get a list of all of the intents in your account.
 func ExampleLexModelBuildingService_GetIntents_shared00() {
-	svc := lexmodelbuildingservice.New(session.New())
+	svc := lexmodelbuildingservice.New(session.Must(session.NewSession()))
 	input := &lexmodelbuildingservice.GetIntentsInput{
 		MaxResults: aws.Int64(10),
 		NextToken:  aws.String(""),
@@ -173,7 +173,7 @@ func ExampleLexModelBuildingService_GetIntents_shared00() {
 //
 // This example shows how to get information about a slot type.
 func ExampleLexModelBuildingService_GetSlotType_shared00() {
-	svc := lexmodelbuildingservice.New(session.New())
+	svc := lexmodelbuildingservice.New(session.Must(session.NewSession()))
 	input := &lexmodelbuildingservice.GetSlotTypeInput{
 		Name:    aws.String("DocPizzaCrustType"),
 		Version: aws.String("$LATEST"),
@@ -209,7 +209,7 @@ func ExampleLexModelBuildingService_GetSlotType_shared00() {
 //
 // This example shows how to get a list of all of the slot types in your account.
 func ExampleLexModelBuildingService_GetSlotTypes_shared00() {
-	svc := lexmodelbuildingservice.New(session.New())
+	svc := lexmodelbuildingservice.New(session.Must(session.NewSession()))
 	input := &lexmodelbuildingservice.GetSlotTypesInput{
 		MaxResults: aws.Int64(10),
 		NextToken:  aws.String(""),
@@ -245,7 +245,7 @@ func ExampleLexModelBuildingService_GetSlotTypes_shared00() {
 //
 // This example shows how to create a bot for ordering pizzas.
 func ExampleLexModelBuildingService_PutBot_shared00() {
-	svc := lexmodelbuildingservice.New(session.New())
+	svc := lexmodelbuildingservice.New(session.Must(session.NewSession()))
 	input := &lexmodelbuildingservice.PutBotInput{
 		AbortStatement: &lexmodelbuildingservice.Statement{
 			Messages: []*lexmodelbuildingservice.Message{
@@ -318,7 +318,7 @@ func ExampleLexModelBuildingService_PutBot_shared00() {
 //
 // This example shows how to create an intent for ordering pizzas.
 func ExampleLexModelBuildingService_PutIntent_shared00() {
-	svc := lexmodelbuildingservice.New(session.New())
+	svc := lexmodelbuildingservice.New(session.Must(session.NewSession()))
 	input := &lexmodelbuildingservice.PutIntentInput{
 		ConclusionStatement: &lexmodelbuildingservice.Statement{
 			Messages: []*lexmodelbuildingservice.Message{
@@ -481,7 +481,7 @@ func ExampleLexModelBuildingService_PutIntent_shared00() {
 //
 // This example shows how to create a slot type that describes pizza sauces.
 func ExampleLexModelBuildingService_PutSlotType_shared00() {
-	svc := lexmodelbuildingservice.New(session.New())
+	svc := lexmodelbuildingservice.New(session.Must(session.NewSession()))
 	input := &lexmodelbuildingservice.PutSlotTypeInput{
 		Description: aws.String("Available pizza sauces"),
 		EnumerationValues: []*lexmodelbuildingservice.EnumerationValue{

--- a/service/lexmodelbuildingservice/lexmodelbuildingserviceiface/interface.go
+++ b/service/lexmodelbuildingservice/lexmodelbuildingserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := lexmodelbuildingservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/lexruntimeservice/lexruntimeserviceiface/interface.go
+++ b/service/lexruntimeservice/lexruntimeserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := lexruntimeservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/licensemanager/licensemanageriface/interface.go
+++ b/service/licensemanager/licensemanageriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := licensemanager.New(sess)
 //
 //        myFunc(svc)

--- a/service/lightsail/lightsailiface/interface.go
+++ b/service/lightsail/lightsailiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := lightsail.New(sess)
 //
 //        myFunc(svc)

--- a/service/machinelearning/machinelearningiface/interface.go
+++ b/service/machinelearning/machinelearningiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := machinelearning.New(sess)
 //
 //        myFunc(svc)

--- a/service/macie/macieiface/interface.go
+++ b/service/macie/macieiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := macie.New(sess)
 //
 //        myFunc(svc)

--- a/service/macie2/macie2iface/interface.go
+++ b/service/macie2/macie2iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := macie2.New(sess)
 //
 //        myFunc(svc)

--- a/service/managedblockchain/managedblockchainiface/interface.go
+++ b/service/managedblockchain/managedblockchainiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := managedblockchain.New(sess)
 //
 //        myFunc(svc)

--- a/service/marketplacecatalog/marketplacecatalogiface/interface.go
+++ b/service/marketplacecatalog/marketplacecatalogiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := marketplacecatalog.New(sess)
 //
 //        myFunc(svc)

--- a/service/marketplacecommerceanalytics/marketplacecommerceanalyticsiface/interface.go
+++ b/service/marketplacecommerceanalytics/marketplacecommerceanalyticsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := marketplacecommerceanalytics.New(sess)
 //
 //        myFunc(svc)

--- a/service/marketplaceentitlementservice/marketplaceentitlementserviceiface/interface.go
+++ b/service/marketplaceentitlementservice/marketplaceentitlementserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := marketplaceentitlementservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/marketplacemetering/marketplacemeteringiface/interface.go
+++ b/service/marketplacemetering/marketplacemeteringiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := marketplacemetering.New(sess)
 //
 //        myFunc(svc)

--- a/service/mediaconnect/mediaconnectiface/interface.go
+++ b/service/mediaconnect/mediaconnectiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mediaconnect.New(sess)
 //
 //        myFunc(svc)

--- a/service/mediaconvert/mediaconvertiface/interface.go
+++ b/service/mediaconvert/mediaconvertiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mediaconvert.New(sess)
 //
 //        myFunc(svc)

--- a/service/medialive/medialiveiface/interface.go
+++ b/service/medialive/medialiveiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := medialive.New(sess)
 //
 //        myFunc(svc)

--- a/service/mediapackage/mediapackageiface/interface.go
+++ b/service/mediapackage/mediapackageiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mediapackage.New(sess)
 //
 //        myFunc(svc)

--- a/service/mediapackagevod/mediapackagevodiface/interface.go
+++ b/service/mediapackagevod/mediapackagevodiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mediapackagevod.New(sess)
 //
 //        myFunc(svc)

--- a/service/mediastore/mediastoreiface/interface.go
+++ b/service/mediastore/mediastoreiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mediastore.New(sess)
 //
 //        myFunc(svc)

--- a/service/mediastoredata/mediastoredataiface/interface.go
+++ b/service/mediastoredata/mediastoredataiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mediastoredata.New(sess)
 //
 //        myFunc(svc)

--- a/service/mediatailor/mediatailoriface/interface.go
+++ b/service/mediatailor/mediatailoriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mediatailor.New(sess)
 //
 //        myFunc(svc)

--- a/service/migrationhub/migrationhubiface/interface.go
+++ b/service/migrationhub/migrationhubiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := migrationhub.New(sess)
 //
 //        myFunc(svc)

--- a/service/migrationhubconfig/migrationhubconfigiface/interface.go
+++ b/service/migrationhubconfig/migrationhubconfigiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := migrationhubconfig.New(sess)
 //
 //        myFunc(svc)

--- a/service/mobile/mobileiface/interface.go
+++ b/service/mobile/mobileiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mobile.New(sess)
 //
 //        myFunc(svc)

--- a/service/mobileanalytics/mobileanalyticsiface/interface.go
+++ b/service/mobileanalytics/mobileanalyticsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mobileanalytics.New(sess)
 //
 //        myFunc(svc)

--- a/service/mq/mqiface/interface.go
+++ b/service/mq/mqiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mq.New(sess)
 //
 //        myFunc(svc)

--- a/service/mturk/mturkiface/interface.go
+++ b/service/mturk/mturkiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := mturk.New(sess)
 //
 //        myFunc(svc)

--- a/service/neptune/neptuneiface/interface.go
+++ b/service/neptune/neptuneiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := neptune.New(sess)
 //
 //        myFunc(svc)

--- a/service/networkmanager/networkmanageriface/interface.go
+++ b/service/networkmanager/networkmanageriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := networkmanager.New(sess)
 //
 //        myFunc(svc)

--- a/service/opsworks/opsworksiface/interface.go
+++ b/service/opsworks/opsworksiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := opsworks.New(sess)
 //
 //        myFunc(svc)

--- a/service/opsworkscm/opsworkscmiface/interface.go
+++ b/service/opsworkscm/opsworkscmiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := opsworkscm.New(sess)
 //
 //        myFunc(svc)

--- a/service/organizations/examples_test.go
+++ b/service/organizations/examples_test.go
@@ -31,7 +31,7 @@ func parseTime(layout, value string) *time.Time {
 // to join his organization. The following example shows Juan's account accepting the
 // handshake and thus agreeing to the invitation.
 func ExampleOrganizations_AcceptHandshake_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.AcceptHandshakeInput{
 		HandshakeId: aws.String("h-examplehandshakeid111"),
 	}
@@ -80,7 +80,7 @@ func ExampleOrganizations_AcceptHandshake_shared00() {
 //
 // The following example shows how to attach a service control policy (SCP) to an OU:
 func ExampleOrganizations_AttachPolicy_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.AttachPolicyInput{
 		PolicyId: aws.String("p-examplepolicyid111"),
 		TargetId: aws.String("ou-examplerootid111-exampleouid111"),
@@ -134,7 +134,7 @@ func ExampleOrganizations_AttachPolicy_shared00() {
 //
 // The following example shows how to attach a service control policy (SCP) to an account:
 func ExampleOrganizations_AttachPolicy_shared01() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.AttachPolicyInput{
 		PolicyId: aws.String("p-examplepolicyid111"),
 		TargetId: aws.String("333333333333"),
@@ -190,7 +190,7 @@ func ExampleOrganizations_AttachPolicy_shared01() {
 // changes his mind and decides to cancel the invitation before Susan accepts it. The
 // following example shows Bill's cancellation:
 func ExampleOrganizations_CancelHandshake_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.CancelHandshakeInput{
 		HandshakeId: aws.String("h-examplehandshakeid111"),
 	}
@@ -238,7 +238,7 @@ func ExampleOrganizations_CancelHandshake_shared00() {
 // the roleName parameter is not used. AWS Organizations sends Susan a "Welcome to AWS"
 // email:
 func ExampleOrganizations_CreateAccount_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.CreateAccountInput{
 		AccountName: aws.String("Production Account"),
 		Email:       aws.String("susan@example.com"),
@@ -287,7 +287,7 @@ func ExampleOrganizations_CreateAccount_shared00() {
 // organization. Because he does not specify a feature set, the new organization defaults
 // to all features enabled and service control policies enabled on the root:
 func ExampleOrganizations_CreateOrganization_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.CreateOrganizationInput{}
 
 	result, err := svc.CreateOrganization(input)
@@ -330,7 +330,7 @@ func ExampleOrganizations_CreateOrganization_shared00() {
 // 111111111111, and configures the organization to support only the consolidated billing
 // feature set:
 func ExampleOrganizations_CreateOrganization_shared01() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.CreateOrganizationInput{
 		FeatureSet: aws.String("CONSOLIDATED_BILLING"),
 	}
@@ -374,7 +374,7 @@ func ExampleOrganizations_CreateOrganization_shared01() {
 // The following example shows how to create an OU that is named AccountingOU. The new
 // OU is directly under the root.:
 func ExampleOrganizations_CreateOrganizationalUnit_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.CreateOrganizationalUnitInput{
 		Name:     aws.String("AccountingOU"),
 		ParentId: aws.String("r-examplerootid111"),
@@ -424,7 +424,7 @@ func ExampleOrganizations_CreateOrganizationalUnit_shared00() {
 // embedded double quotes in the JSON policy are treated as literals in the parameter,
 // which itself is surrounded by double quotes:
 func ExampleOrganizations_CreatePolicy_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.CreatePolicyInput{
 		Content:     aws.String("{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":{\\\"Effect\\\":\\\"Allow\\\",\\\"Action\\\":\\\"s3:*\\\"}}"),
 		Description: aws.String("Enables admins of attached accounts to delegate all S3 permissions"),
@@ -478,7 +478,7 @@ func ExampleOrganizations_CreatePolicy_shared00() {
 // The DeclineHandshake operation returns a handshake object, showing that the state
 // is now DECLINED:
 func ExampleOrganizations_DeclineHandshake_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DeclineHandshakeInput{
 		HandshakeId: aws.String("h-examplehandshakeid111"),
 	}
@@ -522,7 +522,7 @@ func ExampleOrganizations_DeclineHandshake_shared00() {
 // The following example shows how to delete an OU. The example assumes that you previously
 // removed all accounts and other OUs from the OU:
 func ExampleOrganizations_DeleteOrganizationalUnit_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DeleteOrganizationalUnitInput{
 		OrganizationalUnitId: aws.String("ou-examplerootid111-exampleouid111"),
 	}
@@ -566,7 +566,7 @@ func ExampleOrganizations_DeleteOrganizationalUnit_shared00() {
 // The following example shows how to delete a policy from an organization. The example
 // assumes that you previously detached the policy from all entities:
 func ExampleOrganizations_DeletePolicy_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DeletePolicyInput{
 		PolicyId: aws.String("p-examplepolicyid111"),
 	}
@@ -612,7 +612,7 @@ func ExampleOrganizations_DeletePolicy_shared00() {
 // The following example shows a user in the master account (111111111111) asking for
 // details about account 555555555555:
 func ExampleOrganizations_DescribeAccount_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DescribeAccountInput{
 		AccountId: aws.String("555555555555"),
 	}
@@ -654,7 +654,7 @@ func ExampleOrganizations_DescribeAccount_shared00() {
 // from the organization's master account. In the example, the specified "createAccountRequestId"
 // comes from the response of the original call to "CreateAccount":
 func ExampleOrganizations_DescribeCreateAccountStatus_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DescribeCreateAccountStatusInput{
 		CreateAccountRequestId: aws.String("car-exampleaccountcreationrequestid"),
 	}
@@ -697,7 +697,7 @@ func ExampleOrganizations_DescribeCreateAccountStatus_shared00() {
 // ID comes either from the original call to "InviteAccountToOrganization", or from
 // a call to "ListHandshakesForAccount" or "ListHandshakesForOrganization":
 func ExampleOrganizations_DescribeHandshake_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DescribeHandshakeInput{
 		HandshakeId: aws.String("h-examplehandshakeid111"),
 	}
@@ -736,7 +736,7 @@ func ExampleOrganizations_DescribeHandshake_shared00() {
 //
 // The following example shows how to request information about the current user's organization:/n/n
 func ExampleOrganizations_DescribeOrganization_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DescribeOrganizationInput{}
 
 	result, err := svc.DescribeOrganization(input)
@@ -771,7 +771,7 @@ func ExampleOrganizations_DescribeOrganization_shared00() {
 //
 // The following example shows how to request details about an OU:/n/n
 func ExampleOrganizations_DescribeOrganizationalUnit_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DescribeOrganizationalUnitInput{
 		OrganizationalUnitId: aws.String("ou-examplerootid111-exampleouid111"),
 	}
@@ -810,7 +810,7 @@ func ExampleOrganizations_DescribeOrganizationalUnit_shared00() {
 //
 // The following example shows how to request information about a policy:/n/n
 func ExampleOrganizations_DescribePolicy_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DescribePolicyInput{
 		PolicyId: aws.String("p-examplepolicyid111"),
 	}
@@ -851,7 +851,7 @@ func ExampleOrganizations_DescribePolicy_shared00() {
 //
 // The following example shows how to detach a policy from an OU:/n/n
 func ExampleOrganizations_DetachPolicy_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DetachPolicyInput{
 		PolicyId: aws.String("p-examplepolicyid111"),
 		TargetId: aws.String("ou-examplerootid111-exampleouid111"),
@@ -905,7 +905,7 @@ func ExampleOrganizations_DetachPolicy_shared00() {
 // type in a root. The response shows that the PolicyTypes response element no longer
 // includes SERVICE_CONTROL_POLICY:/n/n
 func ExampleOrganizations_DisablePolicyType_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.DisablePolicyTypeInput{
 		PolicyType: aws.String("SERVICE_CONTROL_POLICY"),
 		RootId:     aws.String("r-examplerootid111"),
@@ -961,7 +961,7 @@ func ExampleOrganizations_DisablePolicyType_shared00() {
 // finalize the change to enable all features, and those with appropriate permissions
 // can create policies and apply them to roots, OUs, and accounts:/n/n
 func ExampleOrganizations_EnableAllFeatures_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.EnableAllFeaturesInput{}
 
 	result, err := svc.EnableAllFeatures(input)
@@ -1002,7 +1002,7 @@ func ExampleOrganizations_EnableAllFeatures_shared00() {
 // type in a root. The output shows a root object with a PolicyTypes response element
 // showing that SCPs are now enabled:/n/n
 func ExampleOrganizations_EnablePolicyType_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.EnablePolicyTypeInput{
 		PolicyType: aws.String("SERVICE_CONTROL_POLICY"),
 		RootId:     aws.String("r-examplerootid111"),
@@ -1055,7 +1055,7 @@ func ExampleOrganizations_EnablePolicyType_shared00() {
 // The following example shows the admin of the master account owned by bill@example.com
 // inviting the account owned by juan@example.com to join an organization.
 func ExampleOrganizations_InviteAccountToOrganization_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.InviteAccountToOrganizationInput{
 		Notes: aws.String("This is a request for Juan's account to join Bill's organization"),
 		Target: &organizations.HandshakeParty{
@@ -1106,7 +1106,7 @@ func ExampleOrganizations_InviteAccountToOrganization_shared00() {
 //
 // TThe following example shows how to remove your member account from an organization:
 func ExampleOrganizations_LeaveOrganization_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.LeaveOrganizationInput{}
 
 	result, err := svc.LeaveOrganization(input)
@@ -1149,7 +1149,7 @@ func ExampleOrganizations_LeaveOrganization_shared00() {
 //
 // The following example shows you how to request a list of the accounts in an organization:
 func ExampleOrganizations_ListAccounts_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListAccountsInput{}
 
 	result, err := svc.ListAccounts(input)
@@ -1184,7 +1184,7 @@ func ExampleOrganizations_ListAccounts_shared00() {
 //
 // The following example shows how to request a list of the accounts in an OU:/n/n
 func ExampleOrganizations_ListAccountsForParent_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListAccountsForParentInput{
 		ParentId: aws.String("ou-examplerootid111-exampleouid111"),
 	}
@@ -1224,7 +1224,7 @@ func ExampleOrganizations_ListAccountsForParent_shared00() {
 // The following example shows how to request a list of the child OUs in a parent root
 // or OU:/n/n
 func ExampleOrganizations_ListChildren_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListChildrenInput{
 		ChildType: aws.String("ORGANIZATIONAL_UNIT"),
 		ParentId:  aws.String("ou-examplerootid111-exampleouid111"),
@@ -1265,7 +1265,7 @@ func ExampleOrganizations_ListChildren_shared00() {
 // The following example shows a user requesting a list of only the completed account
 // creation requests made for the current organization:
 func ExampleOrganizations_ListCreateAccountStatus_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListCreateAccountStatusInput{
 		States: []*string{
 			aws.String("SUCCEEDED"),
@@ -1307,7 +1307,7 @@ func ExampleOrganizations_ListCreateAccountStatus_shared00() {
 // The following example shows a user requesting a list of only the in-progress account
 // creation requests made for the current organization:
 func ExampleOrganizations_ListCreateAccountStatus_shared01() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListCreateAccountStatusInput{
 		States: []*string{
 			aws.String("IN_PROGRESS"),
@@ -1349,7 +1349,7 @@ func ExampleOrganizations_ListCreateAccountStatus_shared01() {
 // The following example shows you how to get a list of handshakes that are associated
 // with the account of the credentials used to call the operation:
 func ExampleOrganizations_ListHandshakesForAccount_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListHandshakesForAccountInput{}
 
 	result, err := svc.ListHandshakesForAccount(input)
@@ -1385,7 +1385,7 @@ func ExampleOrganizations_ListHandshakesForAccount_shared00() {
 // The following example shows you how to get a list of handshakes associated with the
 // current organization:
 func ExampleOrganizations_ListHandshakesForOrganization_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListHandshakesForOrganizationInput{}
 
 	result, err := svc.ListHandshakesForOrganization(input)
@@ -1422,7 +1422,7 @@ func ExampleOrganizations_ListHandshakesForOrganization_shared00() {
 //
 // The following example shows how to get a list of OUs in a specified root:/n/n
 func ExampleOrganizations_ListOrganizationalUnitsForParent_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListOrganizationalUnitsForParentInput{
 		ParentId: aws.String("r-examplerootid111"),
 	}
@@ -1461,7 +1461,7 @@ func ExampleOrganizations_ListOrganizationalUnitsForParent_shared00() {
 //
 // The following example shows how to list the root or OUs that contain account 444444444444:/n/n
 func ExampleOrganizations_ListParents_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListParentsInput{
 		ChildId: aws.String("444444444444"),
 	}
@@ -1500,7 +1500,7 @@ func ExampleOrganizations_ListParents_shared00() {
 //
 // The following example shows how to get a list of service control policies (SCPs):/n/n
 func ExampleOrganizations_ListPolicies_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListPoliciesInput{
 		Filter: aws.String("SERVICE_CONTROL_POLICY"),
 	}
@@ -1542,7 +1542,7 @@ func ExampleOrganizations_ListPolicies_shared00() {
 // The returned list does not include policies that apply to the account because of
 // inheritance from its location in an OU hierarchy:/n/n
 func ExampleOrganizations_ListPoliciesForTarget_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListPoliciesForTargetInput{
 		Filter:   aws.String("SERVICE_CONTROL_POLICY"),
 		TargetId: aws.String("444444444444"),
@@ -1584,7 +1584,7 @@ func ExampleOrganizations_ListPoliciesForTarget_shared00() {
 //
 // The following example shows how to get the list of the roots in the current organization:/n/n
 func ExampleOrganizations_ListRoots_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListRootsInput{}
 
 	result, err := svc.ListRoots(input)
@@ -1620,7 +1620,7 @@ func ExampleOrganizations_ListRoots_shared00() {
 // The following example shows how to get the list of roots, OUs, and accounts to which
 // the specified policy is attached:/n/n
 func ExampleOrganizations_ListTargetsForPolicy_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.ListTargetsForPolicyInput{
 		PolicyId: aws.String("p-FullAWSAccess"),
 	}
@@ -1661,7 +1661,7 @@ func ExampleOrganizations_ListTargetsForPolicy_shared00() {
 //
 // The following example shows how to move a member account from the root to an OU:/n/n
 func ExampleOrganizations_MoveAccount_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.MoveAccountInput{
 		AccountId:           aws.String("333333333333"),
 		DestinationParentId: aws.String("ou-examplerootid111-exampleouid111"),
@@ -1710,7 +1710,7 @@ func ExampleOrganizations_MoveAccount_shared00() {
 //
 // The following example shows you how to remove an account from an organization:
 func ExampleOrganizations_RemoveAccountFromOrganization_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.RemoveAccountFromOrganizationInput{
 		AccountId: aws.String("333333333333"),
 	}
@@ -1755,7 +1755,7 @@ func ExampleOrganizations_RemoveAccountFromOrganization_shared00() {
 //
 // The following example shows how to rename an OU. The output confirms the new name:/n/n
 func ExampleOrganizations_UpdateOrganizationalUnit_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.UpdateOrganizationalUnitInput{
 		Name:                 aws.String("AccountingOU"),
 		OrganizationalUnitId: aws.String("ou-examplerootid111-exampleouid111"),
@@ -1800,7 +1800,7 @@ func ExampleOrganizations_UpdateOrganizationalUnit_shared00() {
 // The following example shows how to rename a policy and give it a new description
 // and new content. The output confirms the new name and description text:/n/n
 func ExampleOrganizations_UpdatePolicy_shared00() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.UpdatePolicyInput{
 		Description: aws.String("This description replaces the original."),
 		Name:        aws.String("Renamed-Policy"),
@@ -1855,7 +1855,7 @@ func ExampleOrganizations_UpdatePolicy_shared00() {
 // example with a new JSON policy text string that allows S3 actions instead of EC2
 // actions:/n/n
 func ExampleOrganizations_UpdatePolicy_shared01() {
-	svc := organizations.New(session.New())
+	svc := organizations.New(session.Must(session.NewSession()))
 	input := &organizations.UpdatePolicyInput{
 		Content:  aws.String("{ \\\"Version\\\": \\\"2012-10-17\\\", \\\"Statement\\\": {\\\"Effect\\\": \\\"Allow\\\", \\\"Action\\\": \\\"s3:*\\\", \\\"Resource\\\": \\\"*\\\" } }"),
 		PolicyId: aws.String("p-examplepolicyid111"),

--- a/service/organizations/organizationsiface/interface.go
+++ b/service/organizations/organizationsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := organizations.New(sess)
 //
 //        myFunc(svc)

--- a/service/outposts/outpostsiface/interface.go
+++ b/service/outposts/outpostsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := outposts.New(sess)
 //
 //        myFunc(svc)

--- a/service/personalize/personalizeiface/interface.go
+++ b/service/personalize/personalizeiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := personalize.New(sess)
 //
 //        myFunc(svc)

--- a/service/personalizeevents/personalizeeventsiface/interface.go
+++ b/service/personalizeevents/personalizeeventsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := personalizeevents.New(sess)
 //
 //        myFunc(svc)

--- a/service/personalizeruntime/personalizeruntimeiface/interface.go
+++ b/service/personalizeruntime/personalizeruntimeiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := personalizeruntime.New(sess)
 //
 //        myFunc(svc)

--- a/service/pi/piiface/interface.go
+++ b/service/pi/piiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := pi.New(sess)
 //
 //        myFunc(svc)

--- a/service/pinpoint/pinpointiface/interface.go
+++ b/service/pinpoint/pinpointiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := pinpoint.New(sess)
 //
 //        myFunc(svc)

--- a/service/pinpointemail/pinpointemailiface/interface.go
+++ b/service/pinpointemail/pinpointemailiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := pinpointemail.New(sess)
 //
 //        myFunc(svc)

--- a/service/pinpointsmsvoice/pinpointsmsvoiceiface/interface.go
+++ b/service/pinpointsmsvoice/pinpointsmsvoiceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := pinpointsmsvoice.New(sess)
 //
 //        myFunc(svc)

--- a/service/polly/examples_test.go
+++ b/service/polly/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // Deletes a specified pronunciation lexicon stored in an AWS Region.
 func ExamplePolly_DeleteLexicon_shared00() {
-	svc := polly.New(session.New())
+	svc := polly.New(session.Must(session.NewSession()))
 	input := &polly.DeleteLexiconInput{
 		Name: aws.String("example"),
 	}
@@ -62,7 +62,7 @@ func ExamplePolly_DeleteLexicon_shared00() {
 // Displayed languages are those within the specified language code. If no language
 // code is specified, voices for all available languages are displayed.
 func ExamplePolly_DescribeVoices_shared00() {
-	svc := polly.New(session.New())
+	svc := polly.New(session.Must(session.NewSession()))
 	input := &polly.DescribeVoicesInput{
 		LanguageCode: aws.String("en-GB"),
 	}
@@ -93,7 +93,7 @@ func ExamplePolly_DescribeVoices_shared00() {
 //
 // Returns the content of the specified pronunciation lexicon stored in an AWS Region.
 func ExamplePolly_GetLexicon_shared00() {
-	svc := polly.New(session.New())
+	svc := polly.New(session.Must(session.NewSession()))
 	input := &polly.GetLexiconInput{
 		Name: aws.String(""),
 	}
@@ -124,7 +124,7 @@ func ExamplePolly_GetLexicon_shared00() {
 //
 // Returns a list of pronunciation lexicons stored in an AWS Region.
 func ExamplePolly_ListLexicons_shared00() {
-	svc := polly.New(session.New())
+	svc := polly.New(session.Must(session.NewSession()))
 	input := &polly.ListLexiconsInput{}
 
 	result, err := svc.ListLexicons(input)
@@ -153,7 +153,7 @@ func ExamplePolly_ListLexicons_shared00() {
 //
 // Stores a pronunciation lexicon in an AWS Region.
 func ExamplePolly_PutLexicon_shared00() {
-	svc := polly.New(session.New())
+	svc := polly.New(session.Must(session.NewSession()))
 	input := &polly.PutLexiconInput{
 		Content: aws.String("file://example.pls"),
 		Name:    aws.String("W3C"),
@@ -195,7 +195,7 @@ func ExamplePolly_PutLexicon_shared00() {
 //
 // Synthesizes plain text or SSML into a file of human-like speech.
 func ExamplePolly_SynthesizeSpeech_shared00() {
-	svc := polly.New(session.New())
+	svc := polly.New(session.Must(session.NewSession()))
 	input := &polly.SynthesizeSpeechInput{
 		LexiconNames: []*string{
 			aws.String("example"),

--- a/service/polly/pollyiface/interface.go
+++ b/service/polly/pollyiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := polly.New(sess)
 //
 //        myFunc(svc)

--- a/service/pricing/examples_test.go
+++ b/service/pricing/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 
 func ExamplePricing_DescribeServices_shared00() {
-	svc := pricing.New(session.New())
+	svc := pricing.New(session.Must(session.NewSession()))
 	input := &pricing.DescribeServicesInput{
 		FormatVersion: aws.String("aws_v1"),
 		MaxResults:    aws.Int64(1),
@@ -68,7 +68,7 @@ func ExamplePricing_DescribeServices_shared00() {
 //
 // This operation returns a list of values available for the given attribute.
 func ExamplePricing_GetAttributeValues_shared00() {
-	svc := pricing.New(session.New())
+	svc := pricing.New(session.Must(session.NewSession()))
 	input := &pricing.GetAttributeValuesInput{
 		AttributeName: aws.String("volumeType"),
 		MaxResults:    aws.Int64(2),
@@ -107,7 +107,7 @@ func ExamplePricing_GetAttributeValues_shared00() {
 //
 // This operation returns a list of products that match the given criteria.
 func ExamplePricing_GetProducts_shared00() {
-	svc := pricing.New(session.New())
+	svc := pricing.New(session.Must(session.NewSession()))
 	input := &pricing.GetProductsInput{
 		Filters: []*pricing.Filter{
 			{

--- a/service/pricing/pricingiface/interface.go
+++ b/service/pricing/pricingiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := pricing.New(sess)
 //
 //        myFunc(svc)

--- a/service/qldb/qldbiface/interface.go
+++ b/service/qldb/qldbiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := qldb.New(sess)
 //
 //        myFunc(svc)

--- a/service/qldbsession/qldbsessioniface/interface.go
+++ b/service/qldbsession/qldbsessioniface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := qldbsession.New(sess)
 //
 //        myFunc(svc)

--- a/service/quicksight/quicksightiface/interface.go
+++ b/service/quicksight/quicksightiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := quicksight.New(sess)
 //
 //        myFunc(svc)

--- a/service/ram/ramiface/interface.go
+++ b/service/ram/ramiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ram.New(sess)
 //
 //        myFunc(svc)

--- a/service/rds/examples_test.go
+++ b/service/rds/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This example add a source identifier to an event notification subscription.
 func ExampleRDS_AddSourceIdentifierToSubscription_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.AddSourceIdentifierToSubscriptionInput{
 		SourceIdentifier: aws.String("mymysqlinstance"),
 		SubscriptionName: aws.String("mymysqleventsubscription"),
@@ -61,7 +61,7 @@ func ExampleRDS_AddSourceIdentifierToSubscription_shared00() {
 //
 // This example adds a tag to an option group.
 func ExampleRDS_AddTagsToResource_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.AddTagsToResourceInput{
 		ResourceName: aws.String("arn:aws:rds:us-east-1:992648334831:og:mymysqloptiongroup"),
 		Tags: []*rds.Tag{
@@ -104,7 +104,7 @@ func ExampleRDS_AddTagsToResource_shared00() {
 //
 // This example immediately applies a pending system update to a DB instance.
 func ExampleRDS_ApplyPendingMaintenanceAction_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ApplyPendingMaintenanceActionInput{
 		ApplyAction:        aws.String("system-update"),
 		OptInType:          aws.String("immediate"),
@@ -140,7 +140,7 @@ func ExampleRDS_ApplyPendingMaintenanceAction_shared00() {
 // This example authorizes access to the specified security group by the specified CIDR
 // block.
 func ExampleRDS_AuthorizeDBSecurityGroupIngress_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.AuthorizeDBSecurityGroupIngressInput{
 		CIDRIP:              aws.String("203.0.113.5/32"),
 		DBSecurityGroupName: aws.String("mydbsecuritygroup"),
@@ -176,7 +176,7 @@ func ExampleRDS_AuthorizeDBSecurityGroupIngress_shared00() {
 //
 // This example copies a DB cluster parameter group.
 func ExampleRDS_CopyDBClusterParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CopyDBClusterParameterGroupInput{
 		SourceDBClusterParameterGroupIdentifier:  aws.String("mydbclusterparametergroup"),
 		TargetDBClusterParameterGroupDescription: aws.String("My DB cluster parameter group copy"),
@@ -212,7 +212,7 @@ func ExampleRDS_CopyDBClusterParameterGroup_shared00() {
 // The following example copies an automated snapshot of a DB cluster to a new DB cluster
 // snapshot.
 func ExampleRDS_CopyDBClusterSnapshot_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CopyDBClusterSnapshotInput{
 		SourceDBClusterSnapshotIdentifier: aws.String("rds:sample-cluster-2016-09-14-10-38"),
 		TargetDBClusterSnapshotIdentifier: aws.String("cluster-snapshot-copy-1"),
@@ -252,7 +252,7 @@ func ExampleRDS_CopyDBClusterSnapshot_shared00() {
 //
 // This example copies a DB parameter group.
 func ExampleRDS_CopyDBParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CopyDBParameterGroupInput{
 		SourceDBParameterGroupIdentifier:  aws.String("mymysqlparametergroup"),
 		TargetDBParameterGroupDescription: aws.String("My MySQL parameter group copy"),
@@ -287,7 +287,7 @@ func ExampleRDS_CopyDBParameterGroup_shared00() {
 //
 // This example copies a DB snapshot.
 func ExampleRDS_CopyDBSnapshot_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CopyDBSnapshotInput{
 		SourceDBSnapshotIdentifier: aws.String("mydbsnapshot"),
 		TargetDBSnapshotIdentifier: aws.String("mydbsnapshot-copy"),
@@ -325,7 +325,7 @@ func ExampleRDS_CopyDBSnapshot_shared00() {
 //
 // This example copies an option group.
 func ExampleRDS_CopyOptionGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CopyOptionGroupInput{
 		SourceOptionGroupIdentifier:  aws.String("mymysqloptiongroup"),
 		TargetOptionGroupDescription: aws.String("My MySQL option group copy"),
@@ -360,7 +360,7 @@ func ExampleRDS_CopyOptionGroup_shared00() {
 //
 // This example creates a DB cluster.
 func ExampleRDS_CreateDBCluster_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateDBClusterInput{
 		AvailabilityZones: []*string{
 			aws.String("us-east-1a"),
@@ -435,7 +435,7 @@ func ExampleRDS_CreateDBCluster_shared00() {
 //
 // This example creates a DB cluster parameter group.
 func ExampleRDS_CreateDBClusterParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateDBClusterParameterGroupInput{
 		DBClusterParameterGroupName: aws.String("mydbclusterparametergroup"),
 		DBParameterGroupFamily:      aws.String("aurora5.6"),
@@ -468,7 +468,7 @@ func ExampleRDS_CreateDBClusterParameterGroup_shared00() {
 //
 // This example creates a DB cluster snapshot.
 func ExampleRDS_CreateDBClusterSnapshot_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateDBClusterSnapshotInput{
 		DBClusterIdentifier:         aws.String("mydbcluster"),
 		DBClusterSnapshotIdentifier: aws.String("mydbclustersnapshot"),
@@ -506,7 +506,7 @@ func ExampleRDS_CreateDBClusterSnapshot_shared00() {
 //
 // This example creates a DB instance.
 func ExampleRDS_CreateDBInstance_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateDBInstanceInput{
 		AllocatedStorage:     aws.Int64(5),
 		DBInstanceClass:      aws.String("db.t2.micro"),
@@ -576,7 +576,7 @@ func ExampleRDS_CreateDBInstance_shared00() {
 //
 // This example creates a DB instance read replica.
 func ExampleRDS_CreateDBInstanceReadReplica_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateDBInstanceReadReplicaInput{
 		AvailabilityZone:           aws.String("us-east-1a"),
 		CopyTagsToSnapshot:         aws.Bool(true),
@@ -653,7 +653,7 @@ func ExampleRDS_CreateDBInstanceReadReplica_shared00() {
 //
 // This example creates a DB parameter group.
 func ExampleRDS_CreateDBParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateDBParameterGroupInput{
 		DBParameterGroupFamily: aws.String("mysql5.6"),
 		DBParameterGroupName:   aws.String("mymysqlparametergroup"),
@@ -686,7 +686,7 @@ func ExampleRDS_CreateDBParameterGroup_shared00() {
 //
 // This example creates a DB security group.
 func ExampleRDS_CreateDBSecurityGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateDBSecurityGroupInput{
 		DBSecurityGroupDescription: aws.String("My DB security group"),
 		DBSecurityGroupName:        aws.String("mydbsecuritygroup"),
@@ -720,7 +720,7 @@ func ExampleRDS_CreateDBSecurityGroup_shared00() {
 //
 // This example creates a DB snapshot.
 func ExampleRDS_CreateDBSnapshot_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateDBSnapshotInput{
 		DBInstanceIdentifier: aws.String("mymysqlinstance"),
 		DBSnapshotIdentifier: aws.String("mydbsnapshot"),
@@ -756,7 +756,7 @@ func ExampleRDS_CreateDBSnapshot_shared00() {
 //
 // This example creates a DB subnet group.
 func ExampleRDS_CreateDBSubnetGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateDBSubnetGroupInput{
 		DBSubnetGroupDescription: aws.String("My DB subnet group"),
 		DBSubnetGroupName:        aws.String("mydbsubnetgroup"),
@@ -798,7 +798,7 @@ func ExampleRDS_CreateDBSubnetGroup_shared00() {
 //
 // This example creates an event notification subscription.
 func ExampleRDS_CreateEventSubscription_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateEventSubscriptionInput{
 		Enabled: aws.Bool(true),
 		EventCategories: []*string{
@@ -848,7 +848,7 @@ func ExampleRDS_CreateEventSubscription_shared00() {
 //
 // This example creates an option group.
 func ExampleRDS_CreateOptionGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.CreateOptionGroupInput{
 		EngineName:             aws.String("MySQL"),
 		MajorEngineVersion:     aws.String("5.6"),
@@ -882,7 +882,7 @@ func ExampleRDS_CreateOptionGroup_shared00() {
 //
 // This example deletes the specified DB cluster.
 func ExampleRDS_DeleteDBCluster_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteDBClusterInput{
 		DBClusterIdentifier: aws.String("mydbcluster"),
 		SkipFinalSnapshot:   aws.Bool(true),
@@ -920,7 +920,7 @@ func ExampleRDS_DeleteDBCluster_shared00() {
 //
 // This example deletes the specified DB cluster parameter group.
 func ExampleRDS_DeleteDBClusterParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteDBClusterParameterGroupInput{
 		DBClusterParameterGroupName: aws.String("mydbclusterparametergroup"),
 	}
@@ -951,7 +951,7 @@ func ExampleRDS_DeleteDBClusterParameterGroup_shared00() {
 //
 // This example deletes the specified DB cluster snapshot.
 func ExampleRDS_DeleteDBClusterSnapshot_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteDBClusterSnapshotInput{
 		DBClusterSnapshotIdentifier: aws.String("mydbclustersnapshot"),
 	}
@@ -982,7 +982,7 @@ func ExampleRDS_DeleteDBClusterSnapshot_shared00() {
 //
 // This example deletes the specified DB instance.
 func ExampleRDS_DeleteDBInstance_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteDBInstanceInput{
 		DBInstanceIdentifier: aws.String("mymysqlinstance"),
 		SkipFinalSnapshot:    aws.Bool(true),
@@ -1022,7 +1022,7 @@ func ExampleRDS_DeleteDBInstance_shared00() {
 //
 // The following example deletes a DB parameter group.
 func ExampleRDS_DeleteDBParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteDBParameterGroupInput{
 		DBParameterGroupName: aws.String("mydbparamgroup3"),
 	}
@@ -1053,7 +1053,7 @@ func ExampleRDS_DeleteDBParameterGroup_shared00() {
 //
 // The following example deletes a DB security group.
 func ExampleRDS_DeleteDBSecurityGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteDBSecurityGroupInput{
 		DBSecurityGroupName: aws.String("mysecgroup"),
 	}
@@ -1084,7 +1084,7 @@ func ExampleRDS_DeleteDBSecurityGroup_shared00() {
 //
 // This example deletes the specified DB snapshot.
 func ExampleRDS_DeleteDBSnapshot_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteDBSnapshotInput{
 		DBSnapshotIdentifier: aws.String("mydbsnapshot"),
 	}
@@ -1115,7 +1115,7 @@ func ExampleRDS_DeleteDBSnapshot_shared00() {
 //
 // This example deletes the specified DB subnetgroup.
 func ExampleRDS_DeleteDBSubnetGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteDBSubnetGroupInput{
 		DBSubnetGroupName: aws.String("mydbsubnetgroup"),
 	}
@@ -1148,7 +1148,7 @@ func ExampleRDS_DeleteDBSubnetGroup_shared00() {
 //
 // This example deletes the specified DB event subscription.
 func ExampleRDS_DeleteEventSubscription_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteEventSubscriptionInput{
 		SubscriptionName: aws.String("myeventsubscription"),
 	}
@@ -1179,7 +1179,7 @@ func ExampleRDS_DeleteEventSubscription_shared00() {
 //
 // This example deletes the specified option group.
 func ExampleRDS_DeleteOptionGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DeleteOptionGroupInput{
 		OptionGroupName: aws.String("mydboptiongroup"),
 	}
@@ -1210,7 +1210,7 @@ func ExampleRDS_DeleteOptionGroup_shared00() {
 //
 // This example lists account attributes.
 func ExampleRDS_DescribeAccountAttributes_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeAccountAttributesInput{}
 
 	result, err := svc.DescribeAccountAttributes(input)
@@ -1235,7 +1235,7 @@ func ExampleRDS_DescribeAccountAttributes_shared00() {
 //
 // This example lists up to 20 certificates for the specified certificate identifier.
 func ExampleRDS_DescribeCertificates_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeCertificatesInput{
 		CertificateIdentifier: aws.String("rds-ca-2015"),
 		MaxRecords:            aws.Int64(20),
@@ -1265,7 +1265,7 @@ func ExampleRDS_DescribeCertificates_shared00() {
 //
 // This example lists settings for the specified DB cluster parameter group.
 func ExampleRDS_DescribeDBClusterParameterGroups_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBClusterParameterGroupsInput{
 		DBClusterParameterGroupName: aws.String("mydbclusterparametergroup"),
 	}
@@ -1294,7 +1294,7 @@ func ExampleRDS_DescribeDBClusterParameterGroups_shared00() {
 //
 // This example lists system parameters for the specified DB cluster parameter group.
 func ExampleRDS_DescribeDBClusterParameters_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBClusterParametersInput{
 		DBClusterParameterGroupName: aws.String("mydbclusterparametergroup"),
 		Source:                      aws.String("system"),
@@ -1324,7 +1324,7 @@ func ExampleRDS_DescribeDBClusterParameters_shared00() {
 //
 // This example lists attributes for the specified DB cluster snapshot.
 func ExampleRDS_DescribeDBClusterSnapshotAttributes_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBClusterSnapshotAttributesInput{
 		DBClusterSnapshotIdentifier: aws.String("mydbclustersnapshot"),
 	}
@@ -1353,7 +1353,7 @@ func ExampleRDS_DescribeDBClusterSnapshotAttributes_shared00() {
 //
 // This example lists settings for the specified, manually-created cluster snapshot.
 func ExampleRDS_DescribeDBClusterSnapshots_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBClusterSnapshotsInput{
 		DBClusterSnapshotIdentifier: aws.String("mydbclustersnapshot"),
 		SnapshotType:                aws.String("manual"),
@@ -1383,7 +1383,7 @@ func ExampleRDS_DescribeDBClusterSnapshots_shared00() {
 //
 // This example lists settings for the specified DB cluster.
 func ExampleRDS_DescribeDBClusters_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBClustersInput{
 		DBClusterIdentifier: aws.String("mynewdbcluster"),
 	}
@@ -1412,7 +1412,7 @@ func ExampleRDS_DescribeDBClusters_shared00() {
 //
 // This example lists settings for the specified DB engine version.
 func ExampleRDS_DescribeDBEngineVersions_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBEngineVersionsInput{
 		DBParameterGroupFamily:     aws.String("mysql5.6"),
 		DefaultOnly:                aws.Bool(true),
@@ -1443,7 +1443,7 @@ func ExampleRDS_DescribeDBEngineVersions_shared00() {
 //
 // This example lists settings for the specified DB instance.
 func ExampleRDS_DescribeDBInstances_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBInstancesInput{
 		DBInstanceIdentifier: aws.String("mymysqlinstance"),
 	}
@@ -1473,7 +1473,7 @@ func ExampleRDS_DescribeDBInstances_shared00() {
 // This example lists matching log file names for the specified DB instance, file name
 // pattern, last write date in POSIX time with milleseconds, and minimum file size.
 func ExampleRDS_DescribeDBLogFiles_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBLogFilesInput{
 		DBInstanceIdentifier: aws.String("mymysqlinstance"),
 		FileLastWritten:      aws.Int64(1470873600000),
@@ -1505,7 +1505,7 @@ func ExampleRDS_DescribeDBLogFiles_shared00() {
 //
 // This example lists information about the specified DB parameter group.
 func ExampleRDS_DescribeDBParameterGroups_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBParameterGroupsInput{
 		DBParameterGroupName: aws.String("mymysqlparametergroup"),
 	}
@@ -1535,7 +1535,7 @@ func ExampleRDS_DescribeDBParameterGroups_shared00() {
 // This example lists information for up to the first 20 system parameters for the specified
 // DB parameter group.
 func ExampleRDS_DescribeDBParameters_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBParametersInput{
 		DBParameterGroupName: aws.String("mymysqlparametergroup"),
 		MaxRecords:           aws.Int64(20),
@@ -1566,7 +1566,7 @@ func ExampleRDS_DescribeDBParameters_shared00() {
 //
 // This example lists settings for the specified security group.
 func ExampleRDS_DescribeDBSecurityGroups_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBSecurityGroupsInput{
 		DBSecurityGroupName: aws.String("mydbsecuritygroup"),
 	}
@@ -1595,7 +1595,7 @@ func ExampleRDS_DescribeDBSecurityGroups_shared00() {
 //
 // This example lists attributes for the specified DB snapshot.
 func ExampleRDS_DescribeDBSnapshotAttributes_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBSnapshotAttributesInput{
 		DBSnapshotIdentifier: aws.String("mydbsnapshot"),
 	}
@@ -1624,7 +1624,7 @@ func ExampleRDS_DescribeDBSnapshotAttributes_shared00() {
 //
 // This example lists all manually-created, shared snapshots for the specified DB instance.
 func ExampleRDS_DescribeDBSnapshots_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBSnapshotsInput{
 		DBInstanceIdentifier: aws.String("mymysqlinstance"),
 		IncludePublic:        aws.Bool(false),
@@ -1656,7 +1656,7 @@ func ExampleRDS_DescribeDBSnapshots_shared00() {
 //
 // This example lists information about the specified DB subnet group.
 func ExampleRDS_DescribeDBSubnetGroups_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeDBSubnetGroupsInput{
 		DBSubnetGroupName: aws.String("mydbsubnetgroup"),
 	}
@@ -1685,7 +1685,7 @@ func ExampleRDS_DescribeDBSubnetGroups_shared00() {
 //
 // This example lists default parameters for the specified DB cluster engine.
 func ExampleRDS_DescribeEngineDefaultClusterParameters_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeEngineDefaultClusterParametersInput{
 		DBParameterGroupFamily: aws.String("aurora5.6"),
 	}
@@ -1712,7 +1712,7 @@ func ExampleRDS_DescribeEngineDefaultClusterParameters_shared00() {
 //
 // This example lists default parameters for the specified DB engine.
 func ExampleRDS_DescribeEngineDefaultParameters_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeEngineDefaultParametersInput{
 		DBParameterGroupFamily: aws.String("mysql5.6"),
 	}
@@ -1739,7 +1739,7 @@ func ExampleRDS_DescribeEngineDefaultParameters_shared00() {
 //
 // This example lists all DB instance event categories.
 func ExampleRDS_DescribeEventCategories_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeEventCategoriesInput{
 		SourceType: aws.String("db-instance"),
 	}
@@ -1766,7 +1766,7 @@ func ExampleRDS_DescribeEventCategories_shared00() {
 //
 // This example lists information for the specified DB event notification subscription.
 func ExampleRDS_DescribeEventSubscriptions_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeEventSubscriptionsInput{
 		SubscriptionName: aws.String("mymysqleventsubscription"),
 	}
@@ -1796,7 +1796,7 @@ func ExampleRDS_DescribeEventSubscriptions_shared00() {
 // This example lists information for all backup-related events for the specified DB
 // instance for the past 7 days (7 days * 24 hours * 60 minutes = 10,080 minutes).
 func ExampleRDS_DescribeEvents_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeEventsInput{
 		Duration: aws.Int64(10080),
 		EventCategories: []*string{
@@ -1829,7 +1829,7 @@ func ExampleRDS_DescribeEvents_shared00() {
 // This example lists information for all option group options for the specified DB
 // engine.
 func ExampleRDS_DescribeOptionGroupOptions_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeOptionGroupOptionsInput{
 		EngineName:         aws.String("mysql"),
 		MajorEngineVersion: aws.String("5.6"),
@@ -1857,7 +1857,7 @@ func ExampleRDS_DescribeOptionGroupOptions_shared00() {
 //
 // This example lists information for all option groups for the specified DB engine.
 func ExampleRDS_DescribeOptionGroups_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeOptionGroupsInput{
 		EngineName:         aws.String("mysql"),
 		MajorEngineVersion: aws.String("5.6"),
@@ -1888,7 +1888,7 @@ func ExampleRDS_DescribeOptionGroups_shared00() {
 // This example lists information for all orderable DB instance options for the specified
 // DB engine, engine version, DB instance class, license model, and VPC settings.
 func ExampleRDS_DescribeOrderableDBInstanceOptions_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeOrderableDBInstanceOptionsInput{
 		DBInstanceClass: aws.String("db.t2.micro"),
 		Engine:          aws.String("mysql"),
@@ -1920,7 +1920,7 @@ func ExampleRDS_DescribeOrderableDBInstanceOptions_shared00() {
 // This example lists information for all pending maintenance actions for the specified
 // DB instance.
 func ExampleRDS_DescribePendingMaintenanceActions_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribePendingMaintenanceActionsInput{
 		ResourceIdentifier: aws.String("arn:aws:rds:us-east-1:992648334831:db:mymysqlinstance"),
 	}
@@ -1950,7 +1950,7 @@ func ExampleRDS_DescribePendingMaintenanceActions_shared00() {
 // This example lists information for all reserved DB instances for the specified DB
 // instance class, duration, product, offering type, and availability zone settings.
 func ExampleRDS_DescribeReservedDBInstances_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeReservedDBInstancesInput{
 		DBInstanceClass:    aws.String("db.t2.micro"),
 		Duration:           aws.String("1y"),
@@ -1984,7 +1984,7 @@ func ExampleRDS_DescribeReservedDBInstances_shared00() {
 // This example lists information for all reserved DB instance offerings for the specified
 // DB instance class, duration, product, offering type, and availability zone settings.
 func ExampleRDS_DescribeReservedDBInstancesOfferings_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeReservedDBInstancesOfferingsInput{
 		DBInstanceClass:    aws.String("db.t2.micro"),
 		Duration:           aws.String("1y"),
@@ -2017,7 +2017,7 @@ func ExampleRDS_DescribeReservedDBInstancesOfferings_shared00() {
 //
 // To list the AWS regions where a Read Replica can be created.
 func ExampleRDS_DescribeSourceRegions_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DescribeSourceRegionsInput{}
 
 	result, err := svc.DescribeSourceRegions(input)
@@ -2042,7 +2042,7 @@ func ExampleRDS_DescribeSourceRegions_shared00() {
 //
 // This example lists information for the specified log file for the specified DB instance.
 func ExampleRDS_DownloadDBLogFilePortion_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.DownloadDBLogFilePortionInput{
 		DBInstanceIdentifier: aws.String("mymysqlinstance"),
 		LogFileName:          aws.String("mysqlUpgrade"),
@@ -2075,7 +2075,7 @@ func ExampleRDS_DownloadDBLogFilePortion_shared00() {
 // This example performs a failover for the specified DB cluster to the specified DB
 // instance.
 func ExampleRDS_FailoverDBCluster_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.FailoverDBClusterInput{
 		DBClusterIdentifier:        aws.String("myaurorainstance-cluster"),
 		TargetDBInstanceIdentifier: aws.String("myaurorareplica"),
@@ -2110,7 +2110,7 @@ func ExampleRDS_FailoverDBCluster_shared00() {
 // This example lists information about all tags associated with the specified DB option
 // group.
 func ExampleRDS_ListTagsForResource_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ListTagsForResourceInput{
 		ResourceName: aws.String("arn:aws:rds:us-east-1:992648334831:og:mymysqloptiongroup"),
 	}
@@ -2147,7 +2147,7 @@ func ExampleRDS_ListTagsForResource_shared00() {
 //
 // This example changes the specified settings for the specified DB cluster.
 func ExampleRDS_ModifyDBCluster_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ModifyDBClusterInput{
 		ApplyImmediately:           aws.Bool(true),
 		DBClusterIdentifier:        aws.String("mydbcluster"),
@@ -2204,7 +2204,7 @@ func ExampleRDS_ModifyDBCluster_shared00() {
 // This example immediately changes the specified setting for the specified DB cluster
 // parameter group.
 func ExampleRDS_ModifyDBClusterParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ModifyDBClusterParameterGroupInput{
 		DBClusterParameterGroupName: aws.String("mydbclusterparametergroup"),
 		Parameters: []*rds.Parameter{
@@ -2243,7 +2243,7 @@ func ExampleRDS_ModifyDBClusterParameterGroup_shared00() {
 // The following example gives two AWS accounts access to a manual DB cluster snapshot
 // and ensures that the DB cluster snapshot is private by removing the value "all".
 func ExampleRDS_ModifyDBClusterSnapshotAttribute_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ModifyDBClusterSnapshotAttributeInput{
 		AttributeName:               aws.String("restore"),
 		DBClusterSnapshotIdentifier: aws.String("manual-cluster-snapshot1"),
@@ -2284,7 +2284,7 @@ func ExampleRDS_ModifyDBClusterSnapshotAttribute_shared00() {
 //
 // This example immediately changes the specified settings for the specified DB instance.
 func ExampleRDS_ModifyDBInstance_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ModifyDBInstanceInput{
 		AllocatedStorage:           aws.Int64(10),
 		ApplyImmediately:           aws.Bool(true),
@@ -2357,7 +2357,7 @@ func ExampleRDS_ModifyDBInstance_shared00() {
 // This example immediately changes the specified setting for the specified DB parameter
 // group.
 func ExampleRDS_ModifyDBParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ModifyDBParameterGroupInput{
 		DBParameterGroupName: aws.String("mymysqlparametergroup"),
 		Parameters: []*rds.Parameter{
@@ -2395,7 +2395,7 @@ func ExampleRDS_ModifyDBParameterGroup_shared00() {
 //
 // This example adds the specified attribute for the specified DB snapshot.
 func ExampleRDS_ModifyDBSnapshotAttribute_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ModifyDBSnapshotAttributeInput{
 		AttributeName:        aws.String("restore"),
 		DBSnapshotIdentifier: aws.String("mydbsnapshot"),
@@ -2432,7 +2432,7 @@ func ExampleRDS_ModifyDBSnapshotAttribute_shared00() {
 //
 // This example changes the specified setting for the specified DB subnet group.
 func ExampleRDS_ModifyDBSubnetGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ModifyDBSubnetGroupInput{
 		DBSubnetGroupName: aws.String("mydbsubnetgroup"),
 		SubnetIds: []*string{
@@ -2473,7 +2473,7 @@ func ExampleRDS_ModifyDBSubnetGroup_shared00() {
 //
 // This example changes the specified setting for the specified event notification subscription.
 func ExampleRDS_ModifyEventSubscription_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ModifyEventSubscriptionInput{
 		Enabled: aws.Bool(true),
 		EventCategories: []*string{
@@ -2518,7 +2518,7 @@ func ExampleRDS_ModifyEventSubscription_shared00() {
 //
 // The following example adds an option to an option group.
 func ExampleRDS_ModifyOptionGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ModifyOptionGroupInput{
 		ApplyImmediately: aws.Bool(true),
 		OptionGroupName:  aws.String("myawsuser-og02"),
@@ -2559,7 +2559,7 @@ func ExampleRDS_ModifyOptionGroup_shared00() {
 // This example promotes the specified read replica and sets its backup retention period
 // and preferred backup window.
 func ExampleRDS_PromoteReadReplica_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.PromoteReadReplicaInput{
 		BackupRetentionPeriod: aws.Int64(1),
 		DBInstanceIdentifier:  aws.String("mydbreadreplica"),
@@ -2593,7 +2593,7 @@ func ExampleRDS_PromoteReadReplica_shared00() {
 // This example purchases a reserved DB instance offering that matches the specified
 // settings.
 func ExampleRDS_PurchaseReservedDBInstancesOffering_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.PurchaseReservedDBInstancesOfferingInput{
 		ReservedDBInstanceId:          aws.String("myreservationid"),
 		ReservedDBInstancesOfferingId: aws.String("fb29428a-646d-4390-850e-5fe89926e727"),
@@ -2627,7 +2627,7 @@ func ExampleRDS_PurchaseReservedDBInstancesOffering_shared00() {
 //
 // This example reboots the specified DB instance without forcing a failover.
 func ExampleRDS_RebootDBInstance_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.RebootDBInstanceInput{
 		DBInstanceIdentifier: aws.String("mymysqlinstance"),
 		ForceFailover:        aws.Bool(false),
@@ -2660,7 +2660,7 @@ func ExampleRDS_RebootDBInstance_shared00() {
 // This example removes the specified source identifier from the specified DB event
 // subscription.
 func ExampleRDS_RemoveSourceIdentifierFromSubscription_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.RemoveSourceIdentifierFromSubscriptionInput{
 		SourceIdentifier: aws.String("mymysqlinstance"),
 		SubscriptionName: aws.String("myeventsubscription"),
@@ -2692,7 +2692,7 @@ func ExampleRDS_RemoveSourceIdentifierFromSubscription_shared00() {
 //
 // This example removes the specified tag associated with the specified DB option group.
 func ExampleRDS_RemoveTagsFromResource_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.RemoveTagsFromResourceInput{
 		ResourceName: aws.String("arn:aws:rds:us-east-1:992648334831:og:mydboptiongroup"),
 		TagKeys: []*string{
@@ -2733,7 +2733,7 @@ func ExampleRDS_RemoveTagsFromResource_shared00() {
 // This example resets all parameters for the specified DB cluster parameter group to
 // their default values.
 func ExampleRDS_ResetDBClusterParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ResetDBClusterParameterGroupInput{
 		DBClusterParameterGroupName: aws.String("mydbclusterparametergroup"),
 		ResetAllParameters:          aws.Bool(true),
@@ -2766,7 +2766,7 @@ func ExampleRDS_ResetDBClusterParameterGroup_shared00() {
 // This example resets all parameters for the specified DB parameter group to their
 // default values.
 func ExampleRDS_ResetDBParameterGroup_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.ResetDBParameterGroupInput{
 		DBParameterGroupName: aws.String("mydbparametergroup"),
 		ResetAllParameters:   aws.Bool(true),
@@ -2798,7 +2798,7 @@ func ExampleRDS_ResetDBParameterGroup_shared00() {
 //
 // The following example restores an Amazon Aurora DB cluster from a DB cluster snapshot.
 func ExampleRDS_RestoreDBClusterFromSnapshot_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.RestoreDBClusterFromSnapshotInput{
 		DBClusterIdentifier: aws.String("restored-cluster1"),
 		Engine:              aws.String("aurora"),
@@ -2862,7 +2862,7 @@ func ExampleRDS_RestoreDBClusterFromSnapshot_shared00() {
 // The following example restores a DB cluster to a new DB cluster at a point in time
 // from the source DB cluster.
 func ExampleRDS_RestoreDBClusterToPointInTime_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.RestoreDBClusterToPointInTimeInput{
 		DBClusterIdentifier:       aws.String("sample-restored-cluster1"),
 		RestoreToTime:             parseTime("2006-01-02T15:04:05.999999999Z", "2016-09-13T18:45:00Z"),
@@ -2927,7 +2927,7 @@ func ExampleRDS_RestoreDBClusterToPointInTime_shared00() {
 //
 // The following example restores a DB instance from a DB snapshot.
 func ExampleRDS_RestoreDBInstanceFromDBSnapshot_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.RestoreDBInstanceFromDBSnapshotInput{
 		DBInstanceIdentifier: aws.String("mysqldb-restored"),
 		DBSnapshotIdentifier: aws.String("rds:mysqldb-2014-04-22-08-15"),
@@ -2996,7 +2996,7 @@ func ExampleRDS_RestoreDBInstanceFromDBSnapshot_shared00() {
 // The following example restores a DB instance to a new DB instance at a point in time
 // from the source DB instance.
 func ExampleRDS_RestoreDBInstanceToPointInTime_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.RestoreDBInstanceToPointInTimeInput{
 		RestoreTime:                parseTime("2006-01-02T15:04:05.999999999Z", "2016-09-13T18:45:00Z"),
 		SourceDBInstanceIdentifier: aws.String("mysql-sample"),
@@ -3070,7 +3070,7 @@ func ExampleRDS_RestoreDBInstanceToPointInTime_shared00() {
 // This example revokes ingress for the specified CIDR block associated with the specified
 // DB security group.
 func ExampleRDS_RevokeDBSecurityGroupIngress_shared00() {
-	svc := rds.New(session.New())
+	svc := rds.New(session.Must(session.NewSession()))
 	input := &rds.RevokeDBSecurityGroupIngressInput{
 		CIDRIP:              aws.String("203.0.113.5/32"),
 		DBSecurityGroupName: aws.String("mydbsecuritygroup"),

--- a/service/rds/rdsiface/interface.go
+++ b/service/rds/rdsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := rds.New(sess)
 //
 //        myFunc(svc)

--- a/service/rdsdataservice/rdsdataserviceiface/interface.go
+++ b/service/rdsdataservice/rdsdataserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := rdsdataservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/redshift/redshiftiface/interface.go
+++ b/service/redshift/redshiftiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := redshift.New(sess)
 //
 //        myFunc(svc)

--- a/service/rekognition/examples_test.go
+++ b/service/rekognition/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // This operation compares the largest face detected in the source image with each face
 // detected in the target image.
 func ExampleRekognition_CompareFaces_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.CompareFacesInput{
 		SimilarityThreshold: aws.Float64(90.000000),
 		SourceImage: &rekognition.Image{
@@ -85,7 +85,7 @@ func ExampleRekognition_CompareFaces_shared00() {
 //
 // This operation creates a Rekognition collection for storing image data.
 func ExampleRekognition_CreateCollection_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.CreateCollectionInput{
 		CollectionId: aws.String("myphotos"),
 	}
@@ -124,7 +124,7 @@ func ExampleRekognition_CreateCollection_shared00() {
 //
 // This operation deletes a Rekognition collection.
 func ExampleRekognition_DeleteCollection_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.DeleteCollectionInput{
 		CollectionId: aws.String("myphotos"),
 	}
@@ -163,7 +163,7 @@ func ExampleRekognition_DeleteCollection_shared00() {
 //
 // This operation deletes one or more faces from a Rekognition collection.
 func ExampleRekognition_DeleteFaces_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.DeleteFacesInput{
 		CollectionId: aws.String("myphotos"),
 		FaceIds: []*string{
@@ -205,7 +205,7 @@ func ExampleRekognition_DeleteFaces_shared00() {
 //
 // This operation detects faces in an image stored in an AWS S3 bucket.
 func ExampleRekognition_DetectFaces_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.DetectFacesInput{
 		Image: &rekognition.Image{
 			S3Object: &rekognition.S3Object{
@@ -253,7 +253,7 @@ func ExampleRekognition_DetectFaces_shared00() {
 //
 // This operation detects labels in the supplied image
 func ExampleRekognition_DetectLabels_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.DetectLabelsInput{
 		Image: &rekognition.Image{
 			S3Object: &rekognition.S3Object{
@@ -304,7 +304,7 @@ func ExampleRekognition_DetectLabels_shared00() {
 // This operation detects faces in an image and adds them to the specified Rekognition
 // collection.
 func ExampleRekognition_IndexFaces_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.IndexFacesInput{
 		CollectionId:    aws.String("myphotos"),
 		ExternalImageId: aws.String("myphotoid"),
@@ -356,7 +356,7 @@ func ExampleRekognition_IndexFaces_shared00() {
 //
 // This operation returns a list of Rekognition collections.
 func ExampleRekognition_ListCollections_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.ListCollectionsInput{}
 
 	result, err := svc.ListCollections(input)
@@ -395,7 +395,7 @@ func ExampleRekognition_ListCollections_shared00() {
 //
 // This operation lists the faces in a Rekognition collection.
 func ExampleRekognition_ListFaces_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.ListFacesInput{
 		CollectionId: aws.String("myphotos"),
 		MaxResults:   aws.Int64(20),
@@ -438,7 +438,7 @@ func ExampleRekognition_ListFaces_shared00() {
 // This operation searches for matching faces in the collection the supplied face belongs
 // to.
 func ExampleRekognition_SearchFaces_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.SearchFacesInput{
 		CollectionId:       aws.String("myphotos"),
 		FaceId:             aws.String("70008e50-75e4-55d0-8e80-363fb73b3a14"),
@@ -481,7 +481,7 @@ func ExampleRekognition_SearchFaces_shared00() {
 // This operation searches for faces in a Rekognition collection that match the largest
 // face in an S3 bucket stored image.
 func ExampleRekognition_SearchFacesByImage_shared00() {
-	svc := rekognition.New(session.New())
+	svc := rekognition.New(session.Must(session.NewSession()))
 	input := &rekognition.SearchFacesByImageInput{
 		CollectionId:       aws.String("myphotos"),
 		FaceMatchThreshold: aws.Float64(95.000000),

--- a/service/rekognition/rekognitioniface/interface.go
+++ b/service/rekognition/rekognitioniface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := rekognition.New(sess)
 //
 //        myFunc(svc)

--- a/service/resourcegroups/resourcegroupsiface/interface.go
+++ b/service/resourcegroups/resourcegroupsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := resourcegroups.New(sess)
 //
 //        myFunc(svc)

--- a/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface/interface.go
+++ b/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := resourcegroupstaggingapi.New(sess)
 //
 //        myFunc(svc)

--- a/service/robomaker/robomakeriface/interface.go
+++ b/service/robomaker/robomakeriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := robomaker.New(sess)
 //
 //        myFunc(svc)

--- a/service/route53/examples_test.go
+++ b/service/route53/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // The following example associates the VPC with ID vpc-1a2b3c4d with the hosted zone
 // with ID Z3M3LMPEXAMPLE.
 func ExampleRoute53_AssociateVPCWithHostedZone_shared00() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.AssociateVPCWithHostedZoneInput{
 		Comment:      aws.String(""),
 		HostedZoneId: aws.String("Z3M3LMPEXAMPLE"),
@@ -79,7 +79,7 @@ func ExampleRoute53_AssociateVPCWithHostedZone_shared00() {
 // The following example creates a resource record set that routes Internet traffic
 // to a resource with an IP address of 192.0.2.44.
 func ExampleRoute53_ChangeResourceRecordSets_shared00() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -136,7 +136,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared00() {
 // a Weight of 100 will get 1/3rd of traffic (100/100+200), and the other resource will
 // get the rest of the traffic for example.com.
 func ExampleRoute53_ChangeResourceRecordSets_shared01() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -211,7 +211,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared01() {
 // The following example creates an alias resource record set that routes traffic to
 // a CloudFront distribution.
 func ExampleRoute53_ChangeResourceRecordSets_shared02() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -268,7 +268,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared02() {
 // traffic (100/100+200), and the other resource will get the rest of the traffic for
 // example.com.
 func ExampleRoute53_ChangeResourceRecordSets_shared03() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -340,7 +340,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared03() {
 // to EC2 instances. Traffic for example.com is routed either to the Ohio region or
 // the Oregon region, depending on the latency between the user and those regions.
 func ExampleRoute53_ChangeResourceRecordSets_shared04() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -416,7 +416,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared04() {
 // for example.com to ELB load balancers. Requests are routed either to the Ohio region
 // or the Oregon region, depending on the latency between the user and those regions.
 func ExampleRoute53_ChangeResourceRecordSets_shared05() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -489,7 +489,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared05() {
 // in the Ohio region. If that resource is unavailable, traffic is routed to the secondary
 // resource, in the Oregon region.
 func ExampleRoute53_ChangeResourceRecordSets_shared06() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -566,7 +566,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared06() {
 // primary resource, in the Ohio region. If that resource is unavailable, traffic is
 // routed to the secondary resource, in the Oregon region.
 func ExampleRoute53_ChangeResourceRecordSets_shared07() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -639,7 +639,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared07() {
 // Traffic is routed to one of four IP addresses, for North America (NA), for South
 // America (SA), for Europe (EU), and for all other locations (*).
 func ExampleRoute53_ChangeResourceRecordSets_shared08() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -752,7 +752,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared08() {
 // North America (NA), for South America (SA), for Europe (EU), and for all other locations
 // (*).
 func ExampleRoute53_ChangeResourceRecordSets_shared09() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeResourceRecordSetsInput{
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
@@ -859,7 +859,7 @@ func ExampleRoute53_ChangeResourceRecordSets_shared09() {
 // The following example adds two tags and removes one tag from the hosted zone with
 // ID Z3M3LMPEXAMPLE.
 func ExampleRoute53_ChangeTagsForResource_shared00() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.ChangeTagsForResourceInput{
 		AddTags: []*route53.Tag{
 			{
@@ -910,7 +910,7 @@ func ExampleRoute53_ChangeTagsForResource_shared00() {
 //
 // The following example gets information about the Z3M3LMPEXAMPLE hosted zone.
 func ExampleRoute53_GetHostedZone_shared00() {
-	svc := route53.New(session.New())
+	svc := route53.New(session.Must(session.NewSession()))
 	input := &route53.GetHostedZoneInput{
 		Id: aws.String("Z3M3LMPEXAMPLE"),
 	}

--- a/service/route53/route53iface/interface.go
+++ b/service/route53/route53iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := route53.New(sess)
 //
 //        myFunc(svc)

--- a/service/route53domains/route53domainsiface/interface.go
+++ b/service/route53domains/route53domainsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := route53domains.New(sess)
 //
 //        myFunc(svc)

--- a/service/route53resolver/route53resolveriface/interface.go
+++ b/service/route53resolver/route53resolveriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := route53resolver.New(sess)
 //
 //        myFunc(svc)

--- a/service/s3/examples_test.go
+++ b/service/s3/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The following example aborts a multipart upload.
 func ExampleS3_AbortMultipartUpload_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.AbortMultipartUploadInput{
 		Bucket:   aws.String("examplebucket"),
 		Key:      aws.String("bigobject"),
@@ -60,7 +60,7 @@ func ExampleS3_AbortMultipartUpload_shared00() {
 //
 // The following example completes a multipart upload.
 func ExampleS3_CompleteMultipartUpload_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.CompleteMultipartUploadInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("bigobject"),
@@ -101,7 +101,7 @@ func ExampleS3_CompleteMultipartUpload_shared00() {
 //
 // The following example copies an object from one bucket to another.
 func ExampleS3_CopyObject_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.CopyObjectInput{
 		Bucket:     aws.String("destinationbucket"),
 		CopySource: aws.String("/sourcebucket/HappyFacejpg"),
@@ -132,7 +132,7 @@ func ExampleS3_CopyObject_shared00() {
 //
 // The following example creates a bucket.
 func ExampleS3_CreateBucket_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.CreateBucketInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -164,7 +164,7 @@ func ExampleS3_CreateBucket_shared00() {
 // The following example creates a bucket. The request specifies an AWS region where
 // to create the bucket.
 func ExampleS3_CreateBucket_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.CreateBucketInput{
 		Bucket: aws.String("examplebucket"),
 		CreateBucketConfiguration: &s3.CreateBucketConfiguration{
@@ -198,7 +198,7 @@ func ExampleS3_CreateBucket_shared01() {
 //
 // The following example initiates a multipart upload.
 func ExampleS3_CreateMultipartUpload_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.CreateMultipartUploadInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("largeobject"),
@@ -226,7 +226,7 @@ func ExampleS3_CreateMultipartUpload_shared00() {
 //
 // The following example deletes the specified bucket.
 func ExampleS3_DeleteBucket_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteBucketInput{
 		Bucket: aws.String("forrandall2"),
 	}
@@ -253,7 +253,7 @@ func ExampleS3_DeleteBucket_shared00() {
 //
 // The following example deletes CORS configuration on a bucket.
 func ExampleS3_DeleteBucketCors_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteBucketCorsInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -280,7 +280,7 @@ func ExampleS3_DeleteBucketCors_shared00() {
 //
 // The following example deletes lifecycle configuration on a bucket.
 func ExampleS3_DeleteBucketLifecycle_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteBucketLifecycleInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -307,7 +307,7 @@ func ExampleS3_DeleteBucketLifecycle_shared00() {
 //
 // The following example deletes bucket policy on the specified bucket.
 func ExampleS3_DeleteBucketPolicy_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteBucketPolicyInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -334,7 +334,7 @@ func ExampleS3_DeleteBucketPolicy_shared00() {
 //
 // The following example deletes replication configuration set on bucket.
 func ExampleS3_DeleteBucketReplication_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteBucketReplicationInput{
 		Bucket: aws.String("example"),
 	}
@@ -361,7 +361,7 @@ func ExampleS3_DeleteBucketReplication_shared00() {
 //
 // The following example deletes bucket tags.
 func ExampleS3_DeleteBucketTagging_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteBucketTaggingInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -388,7 +388,7 @@ func ExampleS3_DeleteBucketTagging_shared00() {
 //
 // The following example deletes bucket website configuration.
 func ExampleS3_DeleteBucketWebsite_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteBucketWebsiteInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -415,7 +415,7 @@ func ExampleS3_DeleteBucketWebsite_shared00() {
 //
 // The following example deletes an object from a non-versioned bucket.
 func ExampleS3_DeleteObject_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteObjectInput{
 		Bucket: aws.String("ExampleBucket"),
 		Key:    aws.String("HappyFace.jpg"),
@@ -443,7 +443,7 @@ func ExampleS3_DeleteObject_shared00() {
 //
 // The following example deletes an object from an S3 bucket.
 func ExampleS3_DeleteObject_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteObjectInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("objectkey.jpg"),
@@ -473,7 +473,7 @@ func ExampleS3_DeleteObject_shared01() {
 // bucket is versioning enabled, the operation removes tag set from the latest object
 // version.
 func ExampleS3_DeleteObjectTagging_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteObjectTaggingInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("HappyFace.jpg"),
@@ -502,7 +502,7 @@ func ExampleS3_DeleteObjectTagging_shared00() {
 // The following example removes tag set associated with the specified object version.
 // The request specifies both the object key and object version.
 func ExampleS3_DeleteObjectTagging_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteObjectTaggingInput{
 		Bucket:    aws.String("examplebucket"),
 		Key:       aws.String("HappyFace.jpg"),
@@ -533,7 +533,7 @@ func ExampleS3_DeleteObjectTagging_shared01() {
 // the request does not specify the object version to delete. In this case, all versions
 // remain in the bucket and S3 adds a delete marker.
 func ExampleS3_DeleteObjects_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteObjectsInput{
 		Bucket: aws.String("examplebucket"),
 		Delete: &s3.Delete{
@@ -573,7 +573,7 @@ func ExampleS3_DeleteObjects_shared00() {
 // versions. S3 deletes specific object versions and returns the key and versions of
 // deleted objects in the response.
 func ExampleS3_DeleteObjects_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.DeleteObjectsInput{
 		Bucket: aws.String("examplebucket"),
 		Delete: &s3.Delete{
@@ -614,7 +614,7 @@ func ExampleS3_DeleteObjects_shared01() {
 // The following example returns cross-origin resource sharing (CORS) configuration
 // set on a bucket.
 func ExampleS3_GetBucketCors_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketCorsInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -641,7 +641,7 @@ func ExampleS3_GetBucketCors_shared00() {
 //
 // The following example gets ACL on the specified bucket.
 func ExampleS3_GetBucketLifecycle_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketLifecycleInput{
 		Bucket: aws.String("acl1"),
 	}
@@ -668,7 +668,7 @@ func ExampleS3_GetBucketLifecycle_shared00() {
 //
 // The following example retrieves lifecycle configuration on set on a bucket.
 func ExampleS3_GetBucketLifecycleConfiguration_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketLifecycleConfigurationInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -695,7 +695,7 @@ func ExampleS3_GetBucketLifecycleConfiguration_shared00() {
 //
 // The following example returns bucket location.
 func ExampleS3_GetBucketLocation_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketLocationInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -722,7 +722,7 @@ func ExampleS3_GetBucketLocation_shared00() {
 //
 // The following example returns notification configuration set on a bucket.
 func ExampleS3_GetBucketNotification_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketNotificationConfigurationRequest{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -749,7 +749,7 @@ func ExampleS3_GetBucketNotification_shared00() {
 //
 // The following example returns notification configuration set on a bucket.
 func ExampleS3_GetBucketNotification_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketNotificationConfigurationRequest{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -776,7 +776,7 @@ func ExampleS3_GetBucketNotification_shared01() {
 //
 // The following example returns bucket policy associated with a bucket.
 func ExampleS3_GetBucketPolicy_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketPolicyInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -803,7 +803,7 @@ func ExampleS3_GetBucketPolicy_shared00() {
 //
 // The following example returns replication configuration set on a bucket.
 func ExampleS3_GetBucketReplication_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketReplicationInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -830,7 +830,7 @@ func ExampleS3_GetBucketReplication_shared00() {
 //
 // The following example retrieves bucket versioning configuration.
 func ExampleS3_GetBucketRequestPayment_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketRequestPaymentInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -857,7 +857,7 @@ func ExampleS3_GetBucketRequestPayment_shared00() {
 //
 // The following example returns tag set associated with a bucket
 func ExampleS3_GetBucketTagging_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketTaggingInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -884,7 +884,7 @@ func ExampleS3_GetBucketTagging_shared00() {
 //
 // The following example retrieves bucket versioning configuration.
 func ExampleS3_GetBucketVersioning_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketVersioningInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -911,7 +911,7 @@ func ExampleS3_GetBucketVersioning_shared00() {
 //
 // The following example retrieves website configuration of a bucket.
 func ExampleS3_GetBucketWebsite_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetBucketWebsiteInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -938,7 +938,7 @@ func ExampleS3_GetBucketWebsite_shared00() {
 //
 // The following example retrieves an object for an S3 bucket.
 func ExampleS3_GetObject_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetObjectInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("HappyFace.jpg"),
@@ -969,7 +969,7 @@ func ExampleS3_GetObject_shared00() {
 // The following example retrieves an object for an S3 bucket. The request specifies
 // the range header to retrieve a specific byte range.
 func ExampleS3_GetObject_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetObjectInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("SampleFile.txt"),
@@ -1000,7 +1000,7 @@ func ExampleS3_GetObject_shared01() {
 //
 // The following example retrieves access control list (ACL) of an object.
 func ExampleS3_GetObjectAcl_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetObjectAclInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("HappyFace.jpg"),
@@ -1031,7 +1031,7 @@ func ExampleS3_GetObjectAcl_shared00() {
 // The following example retrieves tag set of an object. The request specifies object
 // version.
 func ExampleS3_GetObjectTagging_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetObjectTaggingInput{
 		Bucket:    aws.String("examplebucket"),
 		Key:       aws.String("exampleobject"),
@@ -1060,7 +1060,7 @@ func ExampleS3_GetObjectTagging_shared00() {
 //
 // The following example retrieves tag set of an object.
 func ExampleS3_GetObjectTagging_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetObjectTaggingInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("HappyFace.jpg"),
@@ -1088,7 +1088,7 @@ func ExampleS3_GetObjectTagging_shared01() {
 //
 // The following example retrieves torrent files of an object.
 func ExampleS3_GetObjectTorrent_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.GetObjectTorrentInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("HappyFace.jpg"),
@@ -1116,7 +1116,7 @@ func ExampleS3_GetObjectTorrent_shared00() {
 //
 // This operation checks to see if a bucket exists.
 func ExampleS3_HeadBucket_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.HeadBucketInput{
 		Bucket: aws.String("acl1"),
 	}
@@ -1145,7 +1145,7 @@ func ExampleS3_HeadBucket_shared00() {
 //
 // The following example retrieves an object metadata.
 func ExampleS3_HeadObject_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.HeadObjectInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("HappyFace.jpg"),
@@ -1176,7 +1176,7 @@ func ExampleS3_HeadObject_shared00() {
 // two object version, S3 returns NextToken in the response. You can specify this token
 // value in your next request to fetch next set of object versions.
 func ExampleS3_ListBuckets_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.ListBucketsInput{}
 
 	result, err := svc.ListBuckets(input)
@@ -1202,7 +1202,7 @@ func ExampleS3_ListBuckets_shared00() {
 // The following example specifies the upload-id-marker and key-marker from previous
 // truncated response to retrieve next setup of multipart uploads.
 func ExampleS3_ListMultipartUploads_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.ListMultipartUploadsInput{
 		Bucket:         aws.String("examplebucket"),
 		KeyMarker:      aws.String("nextkeyfrompreviousresponse"),
@@ -1232,7 +1232,7 @@ func ExampleS3_ListMultipartUploads_shared00() {
 //
 // The following example lists in-progress multipart uploads on a specific bucket.
 func ExampleS3_ListMultipartUploads_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.ListMultipartUploadsInput{
 		Bucket: aws.String("examplebucket"),
 	}
@@ -1262,7 +1262,7 @@ func ExampleS3_ListMultipartUploads_shared01() {
 // two object version, S3 returns NextToken in the response. You can specify this token
 // value in your next request to fetch next set of object versions.
 func ExampleS3_ListObjectVersions_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.ListObjectVersionsInput{
 		Bucket: aws.String("examplebucket"),
 		Prefix: aws.String("HappyFace.jpg"),
@@ -1290,7 +1290,7 @@ func ExampleS3_ListObjectVersions_shared00() {
 //
 // The following example list two objects in a bucket.
 func ExampleS3_ListObjects_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.ListObjectsInput{
 		Bucket:  aws.String("examplebucket"),
 		MaxKeys: aws.Int64(2),
@@ -1321,7 +1321,7 @@ func ExampleS3_ListObjects_shared00() {
 // The following example retrieves object list. The request specifies max keys to limit
 // response to include only 2 object keys.
 func ExampleS3_ListObjectsV2_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.ListObjectsV2Input{
 		Bucket:  aws.String("examplebucket"),
 		MaxKeys: aws.Int64(2),
@@ -1351,7 +1351,7 @@ func ExampleS3_ListObjectsV2_shared00() {
 //
 // The following example lists parts uploaded for a specific multipart upload.
 func ExampleS3_ListParts_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.ListPartsInput{
 		Bucket:   aws.String("examplebucket"),
 		Key:      aws.String("bigobject"),
@@ -1383,7 +1383,7 @@ func ExampleS3_ListParts_shared00() {
 // Because this is a replace operation, you must specify all the grants in your request.
 // To incrementally add or remove ACL grants, you might use the console.
 func ExampleS3_PutBucketAcl_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketAclInput{
 		Bucket:           aws.String("examplebucket"),
 		GrantFullControl: aws.String("id=examplee7a2f25102679df27bb0ae12b3f85be6f290b936c4393484"),
@@ -1413,7 +1413,7 @@ func ExampleS3_PutBucketAcl_shared00() {
 // The following example enables PUT, POST, and DELETE requests from www.example.com,
 // and enables GET requests from any domain.
 func ExampleS3_PutBucketCors_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketCorsInput{
 		Bucket: aws.String(""),
 		CORSConfiguration: &s3.CORSConfiguration{
@@ -1474,7 +1474,7 @@ func ExampleS3_PutBucketCors_shared00() {
 // The following example replaces existing lifecycle configuration, if any, on the specified
 // bucket.
 func ExampleS3_PutBucketLifecycleConfiguration_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketLifecycleConfigurationInput{
 		Bucket: aws.String("examplebucket"),
 		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
@@ -1523,7 +1523,7 @@ func ExampleS3_PutBucketLifecycleConfiguration_shared00() {
 // to deliver logs to the destination bucket, it needs permission for the READ_ACP action
 // which the policy grants.
 func ExampleS3_PutBucketLogging_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketLoggingInput{
 		Bucket: aws.String("sourcebucket"),
 		BucketLoggingStatus: &s3.BucketLoggingStatus{
@@ -1566,7 +1566,7 @@ func ExampleS3_PutBucketLogging_shared00() {
 // The following example sets notification configuration on a bucket to publish the
 // object created events to an SNS topic.
 func ExampleS3_PutBucketNotificationConfiguration_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketNotificationConfigurationInput{
 		Bucket: aws.String("examplebucket"),
 		NotificationConfiguration: &s3.NotificationConfiguration{
@@ -1603,7 +1603,7 @@ func ExampleS3_PutBucketNotificationConfiguration_shared00() {
 //
 // The following example sets a permission policy on a bucket.
 func ExampleS3_PutBucketPolicy_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketPolicyInput{
 		Bucket: aws.String("examplebucket"),
 		Policy: aws.String("{\"Version\": \"2012-10-17\", \"Statement\": [{ \"Sid\": \"id-1\",\"Effect\": \"Allow\",\"Principal\": {\"AWS\": \"arn:aws:iam::123456789012:root\"}, \"Action\": [ \"s3:PutObject\",\"s3:PutObjectAcl\"], \"Resource\": [\"arn:aws:s3:::acl3/*\" ] } ]}"),
@@ -1631,7 +1631,7 @@ func ExampleS3_PutBucketPolicy_shared00() {
 //
 // The following example sets replication configuration on a bucket.
 func ExampleS3_PutBucketReplication_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketReplicationInput{
 		Bucket: aws.String("examplebucket"),
 		ReplicationConfiguration: &s3.ReplicationConfiguration{
@@ -1672,7 +1672,7 @@ func ExampleS3_PutBucketReplication_shared00() {
 // The following example sets request payment configuration on a bucket so that person
 // requesting the download is charged.
 func ExampleS3_PutBucketRequestPayment_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketRequestPaymentInput{
 		Bucket: aws.String("examplebucket"),
 		RequestPaymentConfiguration: &s3.RequestPaymentConfiguration{
@@ -1702,7 +1702,7 @@ func ExampleS3_PutBucketRequestPayment_shared00() {
 //
 // The following example sets tags on a bucket. Any existing tags are replaced.
 func ExampleS3_PutBucketTagging_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketTaggingInput{
 		Bucket: aws.String("examplebucket"),
 		Tagging: &s3.Tagging{
@@ -1742,7 +1742,7 @@ func ExampleS3_PutBucketTagging_shared00() {
 // The following example sets versioning configuration on bucket. The configuration
 // enables versioning on the bucket.
 func ExampleS3_PutBucketVersioning_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketVersioningInput{
 		Bucket: aws.String("examplebucket"),
 		VersioningConfiguration: &s3.VersioningConfiguration{
@@ -1773,7 +1773,7 @@ func ExampleS3_PutBucketVersioning_shared00() {
 //
 // The following example adds website configuration to a bucket.
 func ExampleS3_PutBucketWebsite_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutBucketWebsiteInput{
 		Bucket: aws.String("examplebucket"),
 		WebsiteConfiguration: &s3.WebsiteConfiguration{
@@ -1810,7 +1810,7 @@ func ExampleS3_PutBucketWebsite_shared00() {
 // (access control list) to all READ access to authenticated users. If the bucket is
 // versioning enabled, S3 returns version ID in response.
 func ExampleS3_PutObject_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutObjectInput{
 		ACL:    aws.String("authenticated-read"),
 		Body:   aws.ReadSeekCloser(strings.NewReader("filetoupload")),
@@ -1842,7 +1842,7 @@ func ExampleS3_PutObject_shared00() {
 // file is specified using Windows file syntax. S3 returns VersionId of the newly created
 // object.
 func ExampleS3_PutObject_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutObjectInput{
 		Body:   aws.ReadSeekCloser(strings.NewReader("HappyFace.jpg")),
 		Bucket: aws.String("examplebucket"),
@@ -1872,7 +1872,7 @@ func ExampleS3_PutObject_shared01() {
 // The following example creates an object. If the bucket is versioning enabled, S3
 // returns version ID in response.
 func ExampleS3_PutObject_shared02() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutObjectInput{
 		Body:   aws.ReadSeekCloser(strings.NewReader("filetoupload")),
 		Bucket: aws.String("examplebucket"),
@@ -1902,7 +1902,7 @@ func ExampleS3_PutObject_shared02() {
 // The following example uploads an object. The request specifies optional object tags.
 // The bucket is versioned, therefore S3 returns version ID of the newly created object.
 func ExampleS3_PutObject_shared03() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutObjectInput{
 		Body:    aws.ReadSeekCloser(strings.NewReader("c:\\HappyFace.jpg")),
 		Bucket:  aws.String("examplebucket"),
@@ -1933,7 +1933,7 @@ func ExampleS3_PutObject_shared03() {
 // The following example uploads an object. The request specifies optional request headers
 // to directs S3 to use specific storage class and use server-side encryption.
 func ExampleS3_PutObject_shared04() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutObjectInput{
 		Body:                 aws.ReadSeekCloser(strings.NewReader("HappyFace.jpg")),
 		Bucket:               aws.String("examplebucket"),
@@ -1965,7 +1965,7 @@ func ExampleS3_PutObject_shared04() {
 // The following example creates an object. The request also specifies optional metadata.
 // If the bucket is versioning enabled, S3 returns version ID in response.
 func ExampleS3_PutObject_shared05() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutObjectInput{
 		Body:   aws.ReadSeekCloser(strings.NewReader("filetoupload")),
 		Bucket: aws.String("examplebucket"),
@@ -2000,7 +2000,7 @@ func ExampleS3_PutObject_shared05() {
 // encryption option. The request also specifies optional object tags. If the bucket
 // is versioning enabled, S3 returns version ID in response.
 func ExampleS3_PutObject_shared06() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutObjectInput{
 		Body:                 aws.ReadSeekCloser(strings.NewReader("filetoupload")),
 		Bucket:               aws.String("examplebucket"),
@@ -2032,7 +2032,7 @@ func ExampleS3_PutObject_shared06() {
 // The following example adds grants to an object ACL. The first permission grants user1
 // and user2 FULL_CONTROL and the AllUsers group READ permission.
 func ExampleS3_PutObjectAcl_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutObjectAclInput{
 		AccessControlPolicy: &s3.AccessControlPolicy{},
 		Bucket:              aws.String("examplebucket"),
@@ -2065,7 +2065,7 @@ func ExampleS3_PutObjectAcl_shared00() {
 //
 // The following example adds tags to an existing object.
 func ExampleS3_PutObjectTagging_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.PutObjectTaggingInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("HappyFace.jpg"),
@@ -2106,7 +2106,7 @@ func ExampleS3_PutObjectTagging_shared00() {
 // The following example restores for one day an archived copy of an object back into
 // Amazon S3 bucket.
 func ExampleS3_RestoreObject_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.RestoreObjectInput{
 		Bucket: aws.String("examplebucket"),
 		Key:    aws.String("archivedobjectkey"),
@@ -2144,7 +2144,7 @@ func ExampleS3_RestoreObject_shared00() {
 // a file name for the part data. The Upload ID is same that is returned by the initiate
 // multipart upload.
 func ExampleS3_UploadPart_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.UploadPartInput{
 		Body:       aws.ReadSeekCloser(strings.NewReader("fileToUpload")),
 		Bucket:     aws.String("examplebucket"),
@@ -2176,7 +2176,7 @@ func ExampleS3_UploadPart_shared00() {
 // The following example uploads a part of a multipart upload by copying data from an
 // existing object as data source.
 func ExampleS3_UploadPartCopy_shared00() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.UploadPartCopyInput{
 		Bucket:     aws.String("examplebucket"),
 		CopySource: aws.String("/bucketname/sourceobjectkey"),
@@ -2208,7 +2208,7 @@ func ExampleS3_UploadPartCopy_shared00() {
 // The following example uploads a part of a multipart upload by copying a specified
 // byte range from an existing object as data source.
 func ExampleS3_UploadPartCopy_shared01() {
-	svc := s3.New(session.New())
+	svc := s3.New(session.Must(session.NewSession()))
 	input := &s3.UploadPartCopyInput{
 		Bucket:          aws.String("examplebucket"),
 		CopySource:      aws.String("/bucketname/sourceobjectkey"),

--- a/service/s3/s3iface/interface.go
+++ b/service/s3/s3iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := s3.New(sess)
 //
 //        myFunc(svc)

--- a/service/s3control/s3controliface/interface.go
+++ b/service/s3control/s3controliface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := s3control.New(sess)
 //
 //        myFunc(svc)

--- a/service/sagemaker/sagemakeriface/interface.go
+++ b/service/sagemaker/sagemakeriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := sagemaker.New(sess)
 //
 //        myFunc(svc)

--- a/service/sagemakerruntime/sagemakerruntimeiface/interface.go
+++ b/service/sagemakerruntime/sagemakerruntimeiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := sagemakerruntime.New(sess)
 //
 //        myFunc(svc)

--- a/service/savingsplans/savingsplansiface/interface.go
+++ b/service/savingsplans/savingsplansiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := savingsplans.New(sess)
 //
 //        myFunc(svc)

--- a/service/schemas/schemasiface/interface.go
+++ b/service/schemas/schemasiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := schemas.New(sess)
 //
 //        myFunc(svc)

--- a/service/secretsmanager/examples_test.go
+++ b/service/secretsmanager/examples_test.go
@@ -31,7 +31,7 @@ func parseTime(layout, value string) *time.Time {
 // the RotationEnabled field to false and cancels all scheduled rotations. To resume
 // scheduled rotations, you must re-enable rotation by calling the rotate-secret operation.
 func ExampleSecretsManager_CancelRotateSecret_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.CancelRotateSecretInput{
 		SecretId: aws.String("MyTestDatabaseSecret"),
 	}
@@ -67,7 +67,7 @@ func ExampleSecretsManager_CancelRotateSecret_shared00() {
 // The following example shows how to create a secret. The credentials stored in the
 // encrypted secret value are retrieved from a file on disk named mycreds.json.
 func ExampleSecretsManager_CreateSecret_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.CreateSecretInput{
 		ClientRequestToken: aws.String("EXAMPLE1-90ab-cdef-fedc-ba987SECRET1"),
 		Description:        aws.String("My test database secret created with the CLI"),
@@ -116,7 +116,7 @@ func ExampleSecretsManager_CreateSecret_shared00() {
 // The following example shows how to delete the resource-based policy that is attached
 // to a secret.
 func ExampleSecretsManager_DeleteResourcePolicy_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.DeleteResourcePolicyInput{
 		SecretId: aws.String("MyTestDatabaseSecret"),
 	}
@@ -152,7 +152,7 @@ func ExampleSecretsManager_DeleteResourcePolicy_shared00() {
 // date and time in the DeletionDate response field has passed, you can no longer recover
 // this secret with restore-secret.
 func ExampleSecretsManager_DeleteSecret_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.DeleteSecretInput{
 		RecoveryWindowInDays: aws.Int64(7),
 		SecretId:             aws.String("MyTestDatabaseSecret1"),
@@ -188,7 +188,7 @@ func ExampleSecretsManager_DeleteSecret_shared00() {
 //
 // The following example shows how to get the details about a secret.
 func ExampleSecretsManager_DescribeSecret_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.DescribeSecretInput{
 		SecretId: aws.String("MyTestDatabaseSecret"),
 	}
@@ -221,7 +221,7 @@ func ExampleSecretsManager_DescribeSecret_shared00() {
 // includes the optional flags to require spaces and at least one character of each
 // included type. It specifies a length of 20 characters.
 func ExampleSecretsManager_GetRandomPassword_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.GetRandomPasswordInput{
 		IncludeSpace:            aws.Bool(true),
 		PasswordLength:          aws.Int64(20),
@@ -257,7 +257,7 @@ func ExampleSecretsManager_GetRandomPassword_shared00() {
 // The following example shows how to retrieve the resource-based policy that is attached
 // to a secret.
 func ExampleSecretsManager_GetResourcePolicy_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.GetResourcePolicyInput{
 		SecretId: aws.String("MyTestDatabaseSecret"),
 	}
@@ -293,7 +293,7 @@ func ExampleSecretsManager_GetResourcePolicy_shared00() {
 // the AWSCURRENT version of the secret, then you can omit the VersionStage parameter
 // because it defaults to AWSCURRENT.
 func ExampleSecretsManager_GetSecretValue_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.GetSecretValueInput{
 		SecretId:     aws.String("MyTestDatabaseSecret"),
 		VersionStage: aws.String("AWSPREVIOUS"),
@@ -332,7 +332,7 @@ func ExampleSecretsManager_GetSecretValue_shared00() {
 // The following example shows how to retrieve a list of all of the versions of a secret,
 // including those without any staging labels.
 func ExampleSecretsManager_ListSecretVersionIds_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.ListSecretVersionIdsInput{
 		IncludeDeprecated: aws.Bool(true),
 		SecretId:          aws.String("MyTestDatabaseSecret"),
@@ -366,7 +366,7 @@ func ExampleSecretsManager_ListSecretVersionIds_shared00() {
 //
 // The following example shows how to list all of the secrets in your account.
 func ExampleSecretsManager_ListSecrets_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.ListSecretsInput{}
 
 	result, err := svc.ListSecrets(input)
@@ -397,7 +397,7 @@ func ExampleSecretsManager_ListSecrets_shared00() {
 //
 // The following example shows how to add a resource-based policy to a secret.
 func ExampleSecretsManager_PutResourcePolicy_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.PutResourcePolicyInput{
 		ResourcePolicy: aws.String("{\n\"Version\":\"2012-10-17\",\n\"Statement\":[{\n\"Effect\":\"Allow\",\n\"Principal\":{\n\"AWS\":\"arn:aws:iam::123456789012:root\"\n},\n\"Action\":\"secretsmanager:GetSecretValue\",\n\"Resource\":\"*\"\n}]\n}"),
 		SecretId:       aws.String("MyTestDatabaseSecret"),
@@ -438,7 +438,7 @@ func ExampleSecretsManager_PutResourcePolicy_shared00() {
 // The following example shows how to create a new version of the secret. Alternatively,
 // you can use the update-secret command.
 func ExampleSecretsManager_PutSecretValue_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.PutSecretValueInput{
 		ClientRequestToken: aws.String("EXAMPLE2-90ab-cdef-fedc-ba987EXAMPLE"),
 		SecretId:           aws.String("MyTestDatabaseSecret"),
@@ -482,7 +482,7 @@ func ExampleSecretsManager_PutSecretValue_shared00() {
 // The following example shows how to restore a secret that you previously scheduled
 // for deletion.
 func ExampleSecretsManager_RestoreSecret_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.RestoreSecretInput{
 		SecretId: aws.String("MyTestDatabaseSecret"),
 	}
@@ -520,7 +520,7 @@ func ExampleSecretsManager_RestoreSecret_shared00() {
 // rotation. The first rotation happens immediately upon completion of this command.
 // The rotation function runs asynchronously in the background.
 func ExampleSecretsManager_RotateSecret_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.RotateSecretInput{
 		RotationLambdaARN: aws.String("arn:aws:lambda:us-west-2:123456789012:function:MyTestDatabaseRotationLambda"),
 		RotationRules: &secretsmanager.RotationRulesType{
@@ -561,7 +561,7 @@ func ExampleSecretsManager_RotateSecret_shared00() {
 // function. It assumes that the specified secret already has rotation configured. The
 // rotation function runs asynchronously in the background.
 func ExampleSecretsManager_RotateSecret_shared01() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.RotateSecretInput{
 		SecretId: aws.String("MyTestDatabaseSecret"),
 	}
@@ -598,7 +598,7 @@ func ExampleSecretsManager_RotateSecret_shared01() {
 // secret. There is no output from this API. To see the result, use the DescribeSecret
 // operation.
 func ExampleSecretsManager_TagResource_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.TagResourceInput{
 		SecretId: aws.String("MyExampleSecret"),
 		Tags: []*secretsmanager.Tag{
@@ -645,7 +645,7 @@ func ExampleSecretsManager_TagResource_shared00() {
 // each, both the tag and the associated value are removed. There is no output from
 // this API. To see the result, use the DescribeSecret operation.
 func ExampleSecretsManager_UntagResource_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.UntagResourceInput{
 		SecretId: aws.String("MyTestDatabaseSecret"),
 		TagKeys: []*string{
@@ -684,7 +684,7 @@ func ExampleSecretsManager_UntagResource_shared00() {
 //
 // The following example shows how to modify the description of a secret.
 func ExampleSecretsManager_UpdateSecret_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.UpdateSecretInput{
 		ClientRequestToken: aws.String("EXAMPLE1-90ab-cdef-fedc-ba987EXAMPLE"),
 		Description:        aws.String("This is a new description for the secret."),
@@ -732,7 +732,7 @@ func ExampleSecretsManager_UpdateSecret_shared00() {
 // This example shows how to update the KMS customer managed key (CMK) used to encrypt
 // the secret value. The KMS CMK must be in the same region as the secret.
 func ExampleSecretsManager_UpdateSecret_shared01() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.UpdateSecretInput{
 		KmsKeyId: aws.String("arn:aws:kms:us-west-2:123456789012:key/EXAMPLE2-90ab-cdef-fedc-ba987EXAMPLE"),
 		SecretId: aws.String("MyTestDatabaseSecret"),
@@ -779,7 +779,7 @@ func ExampleSecretsManager_UpdateSecret_shared01() {
 // The following example shows how to create a new version of the secret by updating
 // the SecretString field. Alternatively, you can use the put-secret-value operation.
 func ExampleSecretsManager_UpdateSecret_shared02() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.UpdateSecretInput{
 		SecretId:     aws.String("MyTestDatabaseSecret"),
 		SecretString: aws.String("{JSON STRING WITH CREDENTIALS}"),
@@ -827,7 +827,7 @@ func ExampleSecretsManager_UpdateSecret_shared02() {
 // You can review the results by running the operation ListSecretVersionIds and viewing
 // the VersionStages response field for the affected version.
 func ExampleSecretsManager_UpdateSecretVersionStage_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.UpdateSecretVersionStageInput{
 		MoveToVersionId: aws.String("EXAMPLE1-90ab-cdef-fedc-ba987SECRET1"),
 		SecretId:        aws.String("MyTestDatabaseSecret"),
@@ -868,7 +868,7 @@ func ExampleSecretsManager_UpdateSecretVersionStage_shared00() {
 // a version of a secret. You can review the results by running the operation ListSecretVersionIds
 // and viewing the VersionStages response field for the affected version.
 func ExampleSecretsManager_UpdateSecretVersionStage_shared01() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.UpdateSecretVersionStageInput{
 		RemoveFromVersionId: aws.String("EXAMPLE1-90ab-cdef-fedc-ba987SECRET1"),
 		SecretId:            aws.String("MyTestDatabaseSecret"),
@@ -910,7 +910,7 @@ func ExampleSecretsManager_UpdateSecretVersionStage_shared01() {
 // the operation ListSecretVersionIds and viewing the VersionStages response field for
 // the affected version.
 func ExampleSecretsManager_UpdateSecretVersionStage_shared02() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.UpdateSecretVersionStageInput{
 		MoveToVersionId:     aws.String("EXAMPLE2-90ab-cdef-fedc-ba987SECRET2"),
 		RemoveFromVersionId: aws.String("EXAMPLE1-90ab-cdef-fedc-ba987SECRET1"),
@@ -950,7 +950,7 @@ func ExampleSecretsManager_UpdateSecretVersionStage_shared02() {
 //
 // The following example shows how to validate a resource-based policy to a secret.
 func ExampleSecretsManager_ValidateResourcePolicy_shared00() {
-	svc := secretsmanager.New(session.New())
+	svc := secretsmanager.New(session.Must(session.NewSession()))
 	input := &secretsmanager.ValidateResourcePolicyInput{
 		ResourcePolicy: aws.String("{\n\"Version\":\"2012-10-17\",\n\"Statement\":[{\n\"Effect\":\"Allow\",\n\"Principal\":{\n\"AWS\":\"arn:aws:iam::123456789012:root\"\n},\n\"Action\":\"secretsmanager:GetSecretValue\",\n\"Resource\":\"*\"\n}]\n}"),
 		SecretId:       aws.String("MyTestDatabaseSecret"),

--- a/service/secretsmanager/secretsmanageriface/interface.go
+++ b/service/secretsmanager/secretsmanageriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := secretsmanager.New(sess)
 //
 //        myFunc(svc)

--- a/service/securityhub/securityhubiface/interface.go
+++ b/service/securityhub/securityhubiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := securityhub.New(sess)
 //
 //        myFunc(svc)

--- a/service/serverlessapplicationrepository/serverlessapplicationrepositoryiface/interface.go
+++ b/service/serverlessapplicationrepository/serverlessapplicationrepositoryiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := serverlessapplicationrepository.New(sess)
 //
 //        myFunc(svc)

--- a/service/servicecatalog/servicecatalogiface/interface.go
+++ b/service/servicecatalog/servicecatalogiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := servicecatalog.New(sess)
 //
 //        myFunc(svc)

--- a/service/servicediscovery/examples_test.go
+++ b/service/servicediscovery/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // This example creates an HTTP namespace.
 func ExampleServiceDiscovery_CreateHttpNamespace_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.CreateHttpNamespaceInput{
 		CreatorRequestId: aws.String("example-creator-request-id-0001"),
 		Description:      aws.String("Example.com AWS Cloud Map HTTP Namespace"),
@@ -68,7 +68,7 @@ func ExampleServiceDiscovery_CreateHttpNamespace_shared00() {
 //
 // Example: Create private DNS namespace
 func ExampleServiceDiscovery_CreatePrivateDnsNamespace_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.CreatePrivateDnsNamespaceInput{
 		CreatorRequestId: aws.String("eedd6892-50f3-41b2-8af9-611d6e1d1a8c"),
 		Name:             aws.String("example.com"),
@@ -107,7 +107,7 @@ func ExampleServiceDiscovery_CreatePrivateDnsNamespace_shared00() {
 //
 // This example creates a public namespace based on DNS.
 func ExampleServiceDiscovery_CreatePublicDnsNamespace_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.CreatePublicDnsNamespaceInput{
 		CreatorRequestId: aws.String("example-creator-request-id-0003"),
 		Description:      aws.String("Example.com AWS Cloud Map Public DNS Namespace"),
@@ -146,7 +146,7 @@ func ExampleServiceDiscovery_CreatePublicDnsNamespace_shared00() {
 //
 // Example: Create service
 func ExampleServiceDiscovery_CreateService_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.CreateServiceInput{
 		CreatorRequestId: aws.String("567c1193-6b00-4308-bd57-ad38a8822d25"),
 		DnsConfig: &servicediscovery.DnsConfig{
@@ -195,7 +195,7 @@ func ExampleServiceDiscovery_CreateService_shared00() {
 //
 // Example: Delete namespace
 func ExampleServiceDiscovery_DeleteNamespace_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.DeleteNamespaceInput{
 		Id: aws.String("ns-ylexjili4cdxy3xm"),
 	}
@@ -230,7 +230,7 @@ func ExampleServiceDiscovery_DeleteNamespace_shared00() {
 //
 // Example: Delete service
 func ExampleServiceDiscovery_DeleteService_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.DeleteServiceInput{
 		Id: aws.String("srv-p5zdwlg5uvvzjita"),
 	}
@@ -263,7 +263,7 @@ func ExampleServiceDiscovery_DeleteService_shared00() {
 //
 // Example: Deregister a service instance
 func ExampleServiceDiscovery_DeregisterInstance_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.DeregisterInstanceInput{
 		InstanceId: aws.String("myservice-53"),
 		ServiceId:  aws.String("srv-p5zdwlg5uvvzjita"),
@@ -301,7 +301,7 @@ func ExampleServiceDiscovery_DeregisterInstance_shared00() {
 //
 // Example: Discover registered instances
 func ExampleServiceDiscovery_DiscoverInstances_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.DiscoverInstancesInput{
 		HealthStatus:  aws.String("ALL"),
 		MaxResults:    aws.Int64(10),
@@ -339,7 +339,7 @@ func ExampleServiceDiscovery_DiscoverInstances_shared00() {
 //
 // This example gets information about a specified instance.
 func ExampleServiceDiscovery_GetInstance_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.GetInstanceInput{
 		InstanceId: aws.String("i-abcd1234"),
 		ServiceId:  aws.String("srv-e4anhexample0004"),
@@ -374,7 +374,7 @@ func ExampleServiceDiscovery_GetInstance_shared00() {
 // This example gets the current health status of one or more instances that are associate
 // with a specified service.
 func ExampleServiceDiscovery_GetInstancesHealthStatus_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.GetInstancesHealthStatusInput{
 		ServiceId: aws.String("srv-e4anhexample0004"),
 	}
@@ -407,7 +407,7 @@ func ExampleServiceDiscovery_GetInstancesHealthStatus_shared00() {
 //
 // This example gets information about a specified namespace.
 func ExampleServiceDiscovery_GetNamespace_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.GetNamespaceInput{
 		Id: aws.String("ns-e4anhexample0004"),
 	}
@@ -438,7 +438,7 @@ func ExampleServiceDiscovery_GetNamespace_shared00() {
 //
 // Example: Get operation result
 func ExampleServiceDiscovery_GetOperation_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.GetOperationInput{
 		OperationId: aws.String("gv4g5meo7ndmeh4fqskygvk23d2fijwa-k9302yzd"),
 	}
@@ -469,7 +469,7 @@ func ExampleServiceDiscovery_GetOperation_shared00() {
 //
 // This example gets the settings for a specified service.
 func ExampleServiceDiscovery_GetService_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.GetServiceInput{
 		Id: aws.String("srv-e4anhexample0004"),
 	}
@@ -500,7 +500,7 @@ func ExampleServiceDiscovery_GetService_shared00() {
 //
 // Example: List service instances
 func ExampleServiceDiscovery_ListInstances_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.ListInstancesInput{
 		ServiceId: aws.String("srv-qzpwvt2tfqcegapy"),
 	}
@@ -531,7 +531,7 @@ func ExampleServiceDiscovery_ListInstances_shared00() {
 //
 // Example: List namespaces
 func ExampleServiceDiscovery_ListNamespaces_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.ListNamespacesInput{}
 
 	result, err := svc.ListNamespaces(input)
@@ -558,7 +558,7 @@ func ExampleServiceDiscovery_ListNamespaces_shared00() {
 //
 // This example gets the operations that have a STATUS of either PENDING or SUCCESS.
 func ExampleServiceDiscovery_ListOperations_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.ListOperationsInput{
 		Filters: []*servicediscovery.OperationFilter{
 			{
@@ -596,7 +596,7 @@ func ExampleServiceDiscovery_ListOperations_shared00() {
 //
 // Example: List services
 func ExampleServiceDiscovery_ListServices_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.ListServicesInput{}
 
 	result, err := svc.ListServices(input)
@@ -623,7 +623,7 @@ func ExampleServiceDiscovery_ListServices_shared00() {
 //
 // This example lists the tags of a resource.
 func ExampleServiceDiscovery_ListTagsForResource_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.ListTagsForResourceInput{
 		ResourceARN: aws.String("arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-ylexjili4cdxy3xm"),
 	}
@@ -654,7 +654,7 @@ func ExampleServiceDiscovery_ListTagsForResource_shared00() {
 //
 // Example: Register Instance
 func ExampleServiceDiscovery_RegisterInstance_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.RegisterInstanceInput{
 		Attributes: map[string]*string{
 			"AWS_INSTANCE_IPV4": aws.String("172.2.1.3"),
@@ -697,7 +697,7 @@ func ExampleServiceDiscovery_RegisterInstance_shared00() {
 //
 // This example adds "Department" and "Project" tags to a resource.
 func ExampleServiceDiscovery_TagResource_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.TagResourceInput{
 		ResourceARN: aws.String("arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-ylexjili4cdxy3xm"),
 		Tags: []*servicediscovery.Tag{
@@ -740,7 +740,7 @@ func ExampleServiceDiscovery_TagResource_shared00() {
 //
 // This example removes the "Department" and "Project" tags from a resource.
 func ExampleServiceDiscovery_UntagResource_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.UntagResourceInput{
 		ResourceARN: aws.String("arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-ylexjili4cdxy3xm"),
 		TagKeys: []*string{
@@ -776,7 +776,7 @@ func ExampleServiceDiscovery_UntagResource_shared00() {
 // This example submits a request to change the health status of an instance associated
 // with a service with a custom health check to HEALTHY.
 func ExampleServiceDiscovery_UpdateInstanceCustomHealthStatus_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.UpdateInstanceCustomHealthStatusInput{
 		InstanceId: aws.String("i-abcd1234"),
 		ServiceId:  aws.String("srv-e4anhexample0004"),
@@ -814,7 +814,7 @@ func ExampleServiceDiscovery_UpdateInstanceCustomHealthStatus_shared00() {
 // This example submits a request to replace the DnsConfig and HealthCheckConfig settings
 // of a specified service.
 func ExampleServiceDiscovery_UpdateService_shared00() {
-	svc := servicediscovery.New(session.New())
+	svc := servicediscovery.New(session.Must(session.NewSession()))
 	input := &servicediscovery.UpdateServiceInput{
 		Id: aws.String("srv-e4anhexample0004"),
 		Service: &servicediscovery.ServiceChange{

--- a/service/servicediscovery/servicediscoveryiface/interface.go
+++ b/service/servicediscovery/servicediscoveryiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := servicediscovery.New(sess)
 //
 //        myFunc(svc)

--- a/service/servicequotas/servicequotasiface/interface.go
+++ b/service/servicequotas/servicequotasiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := servicequotas.New(sess)
 //
 //        myFunc(svc)

--- a/service/ses/examples_test.go
+++ b/service/ses/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The following example creates a receipt rule set by cloning an existing one:
 func ExampleSES_CloneReceiptRuleSet_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.CloneReceiptRuleSetInput{
 		OriginalRuleSetName: aws.String("RuleSetToClone"),
 		RuleSetName:         aws.String("RuleSetToCreate"),
@@ -63,7 +63,7 @@ func ExampleSES_CloneReceiptRuleSet_shared00() {
 //
 // The following example creates a new IP address filter:
 func ExampleSES_CreateReceiptFilter_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.CreateReceiptFilterInput{
 		Filter: &ses.ReceiptFilter{
 			IpFilter: &ses.ReceiptIpFilter{
@@ -100,7 +100,7 @@ func ExampleSES_CreateReceiptFilter_shared00() {
 //
 // The following example creates a new receipt rule:
 func ExampleSES_CreateReceiptRule_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.CreateReceiptRuleInput{
 		After: aws.String(""),
 		Rule: &ses.ReceiptRule{
@@ -156,7 +156,7 @@ func ExampleSES_CreateReceiptRule_shared00() {
 //
 // The following example creates an empty receipt rule set:
 func ExampleSES_CreateReceiptRuleSet_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.CreateReceiptRuleSetInput{
 		RuleSetName: aws.String("MyRuleSet"),
 	}
@@ -188,7 +188,7 @@ func ExampleSES_CreateReceiptRuleSet_shared00() {
 // The following example deletes an identity from the list of identities that have been
 // submitted for verification with Amazon SES:
 func ExampleSES_DeleteIdentity_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.DeleteIdentityInput{
 		Identity: aws.String("user@example.com"),
 	}
@@ -215,7 +215,7 @@ func ExampleSES_DeleteIdentity_shared00() {
 //
 // The following example deletes a sending authorization policy for an identity:
 func ExampleSES_DeleteIdentityPolicy_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.DeleteIdentityPolicyInput{
 		Identity:   aws.String("user@example.com"),
 		PolicyName: aws.String("MyPolicy"),
@@ -243,7 +243,7 @@ func ExampleSES_DeleteIdentityPolicy_shared00() {
 //
 // The following example deletes an IP address filter:
 func ExampleSES_DeleteReceiptFilter_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.DeleteReceiptFilterInput{
 		FilterName: aws.String("MyFilter"),
 	}
@@ -270,7 +270,7 @@ func ExampleSES_DeleteReceiptFilter_shared00() {
 //
 // The following example deletes a receipt rule:
 func ExampleSES_DeleteReceiptRule_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.DeleteReceiptRuleInput{
 		RuleName:    aws.String("MyRule"),
 		RuleSetName: aws.String("MyRuleSet"),
@@ -300,7 +300,7 @@ func ExampleSES_DeleteReceiptRule_shared00() {
 //
 // The following example deletes a receipt rule set:
 func ExampleSES_DeleteReceiptRuleSet_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.DeleteReceiptRuleSetInput{
 		RuleSetName: aws.String("MyRuleSet"),
 	}
@@ -330,7 +330,7 @@ func ExampleSES_DeleteReceiptRuleSet_shared00() {
 // The following example deletes an email address from the list of identities that have
 // been submitted for verification with Amazon SES:
 func ExampleSES_DeleteVerifiedEmailAddress_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.DeleteVerifiedEmailAddressInput{
 		EmailAddress: aws.String("user@example.com"),
 	}
@@ -358,7 +358,7 @@ func ExampleSES_DeleteVerifiedEmailAddress_shared00() {
 // The following example returns the metadata and receipt rules for the receipt rule
 // set that is currently active:
 func ExampleSES_DescribeActiveReceiptRuleSet_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.DescribeActiveReceiptRuleSetInput{}
 
 	result, err := svc.DescribeActiveReceiptRuleSet(input)
@@ -383,7 +383,7 @@ func ExampleSES_DescribeActiveReceiptRuleSet_shared00() {
 //
 // The following example returns the details of a receipt rule:
 func ExampleSES_DescribeReceiptRule_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.DescribeReceiptRuleInput{
 		RuleName:    aws.String("MyRule"),
 		RuleSetName: aws.String("MyRuleSet"),
@@ -415,7 +415,7 @@ func ExampleSES_DescribeReceiptRule_shared00() {
 //
 // The following example returns the metadata and receipt rules of a receipt rule set:
 func ExampleSES_DescribeReceiptRuleSet_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.DescribeReceiptRuleSetInput{
 		RuleSetName: aws.String("MyRuleSet"),
 	}
@@ -445,7 +445,7 @@ func ExampleSES_DescribeReceiptRuleSet_shared00() {
 // The following example returns if sending status for an account is enabled. (true
 // / false):
 func ExampleSES_GetAccountSendingEnabled_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.GetAccountSendingEnabledInput{}
 
 	result, err := svc.GetAccountSendingEnabled(input)
@@ -471,7 +471,7 @@ func ExampleSES_GetAccountSendingEnabled_shared00() {
 // The following example retrieves the Amazon SES Easy DKIM attributes for a list of
 // identities:
 func ExampleSES_GetIdentityDkimAttributes_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.GetIdentityDkimAttributesInput{
 		Identities: []*string{
 			aws.String("example.com"),
@@ -501,7 +501,7 @@ func ExampleSES_GetIdentityDkimAttributes_shared00() {
 //
 // The following example returns the custom MAIL FROM attributes for an identity:
 func ExampleSES_GetIdentityMailFromDomainAttributes_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.GetIdentityMailFromDomainAttributesInput{
 		Identities: []*string{
 			aws.String("example.com"),
@@ -530,7 +530,7 @@ func ExampleSES_GetIdentityMailFromDomainAttributes_shared00() {
 //
 // The following example returns the notification attributes for an identity:
 func ExampleSES_GetIdentityNotificationAttributes_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.GetIdentityNotificationAttributesInput{
 		Identities: []*string{
 			aws.String("example.com"),
@@ -559,7 +559,7 @@ func ExampleSES_GetIdentityNotificationAttributes_shared00() {
 //
 // The following example returns a sending authorization policy for an identity:
 func ExampleSES_GetIdentityPolicies_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.GetIdentityPoliciesInput{
 		Identity: aws.String("example.com"),
 		PolicyNames: []*string{
@@ -590,7 +590,7 @@ func ExampleSES_GetIdentityPolicies_shared00() {
 // The following example returns the verification status and the verification token
 // for a domain identity:
 func ExampleSES_GetIdentityVerificationAttributes_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.GetIdentityVerificationAttributesInput{
 		Identities: []*string{
 			aws.String("example.com"),
@@ -619,7 +619,7 @@ func ExampleSES_GetIdentityVerificationAttributes_shared00() {
 //
 // The following example returns the Amazon SES sending limits for an AWS account:
 func ExampleSES_GetSendQuota_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.GetSendQuotaInput{}
 
 	result, err := svc.GetSendQuota(input)
@@ -644,7 +644,7 @@ func ExampleSES_GetSendQuota_shared00() {
 //
 // The following example returns Amazon SES sending statistics:
 func ExampleSES_GetSendStatistics_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.GetSendStatisticsInput{}
 
 	result, err := svc.GetSendStatistics(input)
@@ -670,7 +670,7 @@ func ExampleSES_GetSendStatistics_shared00() {
 // The following example lists the email address identities that have been submitted
 // for verification with Amazon SES:
 func ExampleSES_ListIdentities_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.ListIdentitiesInput{
 		IdentityType: aws.String("EmailAddress"),
 		MaxItems:     aws.Int64(123),
@@ -700,7 +700,7 @@ func ExampleSES_ListIdentities_shared00() {
 // The following example returns a list of sending authorization policies that are attached
 // to an identity:
 func ExampleSES_ListIdentityPolicies_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.ListIdentityPoliciesInput{
 		Identity: aws.String("example.com"),
 	}
@@ -728,7 +728,7 @@ func ExampleSES_ListIdentityPolicies_shared00() {
 // The following example lists the IP address filters that are associated with an AWS
 // account:
 func ExampleSES_ListReceiptFilters_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.ListReceiptFiltersInput{}
 
 	result, err := svc.ListReceiptFilters(input)
@@ -753,7 +753,7 @@ func ExampleSES_ListReceiptFilters_shared00() {
 //
 // The following example lists the receipt rule sets that exist under an AWS account:
 func ExampleSES_ListReceiptRuleSets_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.ListReceiptRuleSetsInput{
 		NextToken: aws.String(""),
 	}
@@ -781,7 +781,7 @@ func ExampleSES_ListReceiptRuleSets_shared00() {
 // The following example lists all email addresses that have been submitted for verification
 // with Amazon SES:
 func ExampleSES_ListVerifiedEmailAddresses_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.ListVerifiedEmailAddressesInput{}
 
 	result, err := svc.ListVerifiedEmailAddresses(input)
@@ -806,7 +806,7 @@ func ExampleSES_ListVerifiedEmailAddresses_shared00() {
 //
 // The following example adds a sending authorization policy to an identity:
 func ExampleSES_PutIdentityPolicy_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.PutIdentityPolicyInput{
 		Identity:   aws.String("example.com"),
 		Policy:     aws.String("{\"Version\":\"2008-10-17\",\"Statement\":[{\"Sid\":\"stmt1469123904194\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:root\"},\"Action\":[\"ses:SendEmail\",\"ses:SendRawEmail\"],\"Resource\":\"arn:aws:ses:us-east-1:EXAMPLE65304:identity/example.com\"}]}"),
@@ -837,7 +837,7 @@ func ExampleSES_PutIdentityPolicy_shared00() {
 //
 // The following example reorders the receipt rules within a receipt rule set:
 func ExampleSES_ReorderReceiptRuleSet_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.ReorderReceiptRuleSetInput{
 		RuleNames: []*string{
 			aws.String("MyRule"),
@@ -872,7 +872,7 @@ func ExampleSES_ReorderReceiptRuleSet_shared00() {
 //
 // The following example sends a formatted email:
 func ExampleSES_SendEmail_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.SendEmailInput{
 		Destination: &ses.Destination{
 			CcAddresses: []*string{
@@ -937,7 +937,7 @@ func ExampleSES_SendEmail_shared00() {
 //
 // The following example sends an email with an attachment:
 func ExampleSES_SendRawEmail_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.SendRawEmailInput{
 		FromArn: aws.String(""),
 		RawMessage: &ses.RawMessage{
@@ -980,7 +980,7 @@ func ExampleSES_SendRawEmail_shared00() {
 //
 // The following example sets the active receipt rule set:
 func ExampleSES_SetActiveReceiptRuleSet_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.SetActiveReceiptRuleSetInput{
 		RuleSetName: aws.String("RuleSetToActivate"),
 	}
@@ -1010,7 +1010,7 @@ func ExampleSES_SetActiveReceiptRuleSet_shared00() {
 // The following example configures Amazon SES to Easy DKIM-sign the email sent from
 // an identity:
 func ExampleSES_SetIdentityDkimEnabled_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.SetIdentityDkimEnabledInput{
 		DkimEnabled: aws.Bool(true),
 		Identity:    aws.String("user@example.com"),
@@ -1039,7 +1039,7 @@ func ExampleSES_SetIdentityDkimEnabled_shared00() {
 // The following example configures Amazon SES to forward an identity's bounces and
 // complaints via email:
 func ExampleSES_SetIdentityFeedbackForwardingEnabled_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.SetIdentityFeedbackForwardingEnabledInput{
 		ForwardingEnabled: aws.Bool(true),
 		Identity:          aws.String("user@example.com"),
@@ -1068,7 +1068,7 @@ func ExampleSES_SetIdentityFeedbackForwardingEnabled_shared00() {
 // The following example configures Amazon SES to include the original email headers
 // in the Amazon SNS bounce notifications for an identity:
 func ExampleSES_SetIdentityHeadersInNotificationsEnabled_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.SetIdentityHeadersInNotificationsEnabledInput{
 		Enabled:          aws.Bool(true),
 		Identity:         aws.String("user@example.com"),
@@ -1098,7 +1098,7 @@ func ExampleSES_SetIdentityHeadersInNotificationsEnabled_shared00() {
 // The following example configures Amazon SES to use a custom MAIL FROM domain for
 // an identity:
 func ExampleSES_SetIdentityMailFromDomain_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.SetIdentityMailFromDomainInput{
 		BehaviorOnMXFailure: aws.String("UseDefaultValue"),
 		Identity:            aws.String("user@example.com"),
@@ -1129,7 +1129,7 @@ func ExampleSES_SetIdentityMailFromDomain_shared00() {
 // bounce, complaint, and/or delivery notifications for emails sent with the specified
 // identity as the Source:
 func ExampleSES_SetIdentityNotificationTopic_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.SetIdentityNotificationTopicInput{
 		Identity:         aws.String("user@example.com"),
 		NotificationType: aws.String("Bounce"),
@@ -1158,7 +1158,7 @@ func ExampleSES_SetIdentityNotificationTopic_shared00() {
 //
 // The following example sets the position of a receipt rule in a receipt rule set:
 func ExampleSES_SetReceiptRulePosition_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.SetReceiptRulePositionInput{
 		After:       aws.String("PutRuleAfterThisRule"),
 		RuleName:    aws.String("RuleToReposition"),
@@ -1191,7 +1191,7 @@ func ExampleSES_SetReceiptRulePosition_shared00() {
 //
 // The following example updated the sending status for this account.
 func ExampleSES_UpdateAccountSendingEnabled_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.UpdateAccountSendingEnabledInput{
 		Enabled: aws.Bool(true),
 	}
@@ -1218,7 +1218,7 @@ func ExampleSES_UpdateAccountSendingEnabled_shared00() {
 //
 // Set the reputationMetricsEnabled flag for a specific configuration set.
 func ExampleSES_UpdateConfigurationSetReputationMetricsEnabled_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.UpdateConfigurationSetReputationMetricsEnabledInput{
 		ConfigurationSetName: aws.String("foo"),
 		Enabled:              aws.Bool(true),
@@ -1248,7 +1248,7 @@ func ExampleSES_UpdateConfigurationSetReputationMetricsEnabled_shared00() {
 //
 // Set the sending enabled flag for a specific configuration set.
 func ExampleSES_UpdateConfigurationSetSendingEnabled_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.UpdateConfigurationSetSendingEnabledInput{
 		ConfigurationSetName: aws.String("foo"),
 		Enabled:              aws.Bool(true),
@@ -1278,7 +1278,7 @@ func ExampleSES_UpdateConfigurationSetSendingEnabled_shared00() {
 //
 // The following example updates a receipt rule to use an Amazon S3 action:
 func ExampleSES_UpdateReceiptRule_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.UpdateReceiptRuleInput{
 		Rule: &ses.ReceiptRule{
 			Actions: []*ses.ReceiptAction{
@@ -1332,7 +1332,7 @@ func ExampleSES_UpdateReceiptRule_shared00() {
 // The following example generates DKIM tokens for a domain that has been verified with
 // Amazon SES:
 func ExampleSES_VerifyDomainDkim_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.VerifyDomainDkimInput{
 		Domain: aws.String("example.com"),
 	}
@@ -1359,7 +1359,7 @@ func ExampleSES_VerifyDomainDkim_shared00() {
 //
 // The following example starts the domain verification process with Amazon SES:
 func ExampleSES_VerifyDomainIdentity_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.VerifyDomainIdentityInput{
 		Domain: aws.String("example.com"),
 	}
@@ -1386,7 +1386,7 @@ func ExampleSES_VerifyDomainIdentity_shared00() {
 //
 // The following example starts the email address verification process with Amazon SES:
 func ExampleSES_VerifyEmailAddress_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.VerifyEmailAddressInput{
 		EmailAddress: aws.String("user@example.com"),
 	}
@@ -1413,7 +1413,7 @@ func ExampleSES_VerifyEmailAddress_shared00() {
 //
 // The following example starts the email address verification process with Amazon SES:
 func ExampleSES_VerifyEmailIdentity_shared00() {
-	svc := ses.New(session.New())
+	svc := ses.New(session.Must(session.NewSession()))
 	input := &ses.VerifyEmailIdentityInput{
 		EmailAddress: aws.String("user@example.com"),
 	}

--- a/service/ses/sesiface/interface.go
+++ b/service/ses/sesiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ses.New(sess)
 //
 //        myFunc(svc)

--- a/service/sesv2/sesv2iface/interface.go
+++ b/service/sesv2/sesv2iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := sesv2.New(sess)
 //
 //        myFunc(svc)

--- a/service/sfn/sfniface/interface.go
+++ b/service/sfn/sfniface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := sfn.New(sess)
 //
 //        myFunc(svc)

--- a/service/shield/shieldiface/interface.go
+++ b/service/shield/shieldiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := shield.New(sess)
 //
 //        myFunc(svc)

--- a/service/signer/signeriface/interface.go
+++ b/service/signer/signeriface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := signer.New(sess)
 //
 //        myFunc(svc)

--- a/service/simpledb/simpledbiface/interface.go
+++ b/service/simpledb/simpledbiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := simpledb.New(sess)
 //
 //        myFunc(svc)

--- a/service/sms/smsiface/interface.go
+++ b/service/sms/smsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := sms.New(sess)
 //
 //        myFunc(svc)

--- a/service/snowball/examples_test.go
+++ b/service/snowball/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 // This operation cancels a cluster job. You can only cancel a cluster job while it's
 // in the AwaitingQuorum status.
 func ExampleSnowball_CancelCluster_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.CancelClusterInput{
 		ClusterId: aws.String("CID123e4567-e89b-12d3-a456-426655440000"),
 	}
@@ -64,7 +64,7 @@ func ExampleSnowball_CancelCluster_shared00() {
 // This operation cancels a job. You can only cancel a job before its JobState value
 // changes to PreparingAppliance.
 func ExampleSnowball_CancelJob_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.CancelJobInput{
 		JobId: aws.String("JID123e4567-e89b-12d3-a456-426655440000"),
 	}
@@ -99,7 +99,7 @@ func ExampleSnowball_CancelJob_shared00() {
 // of creation. The address you provide must be located within the serviceable area
 // of your region. If the address is invalid or unsupported, then an exception is thrown.
 func ExampleSnowball_CreateAddress_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.CreateAddressInput{
 		Address: &snowball.Address{
 			City:            aws.String("Seattle"),
@@ -141,7 +141,7 @@ func ExampleSnowball_CreateAddress_shared00() {
 // action separately to create the jobs for each of these nodes. The cluster does not
 // ship until these five node jobs have been created.
 func ExampleSnowball_CreateCluster_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.CreateClusterInput{
 		AddressId:   aws.String("ADID1234ab12-3eec-4eb3-9be6-9374c10eb51b"),
 		Description: aws.String("MyCluster"),
@@ -197,7 +197,7 @@ func ExampleSnowball_CreateCluster_shared00() {
 // only need to provide the clusterId value; the other job attributes are inherited
 // from the cluster.
 func ExampleSnowball_CreateJob_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.CreateJobInput{
 		AddressId:   aws.String("ADID1234ab12-3eec-4eb3-9be6-9374c10eb51b"),
 		Description: aws.String("My Job"),
@@ -252,7 +252,7 @@ func ExampleSnowball_CreateJob_shared00() {
 //
 // This operation describes an address for a job.
 func ExampleSnowball_DescribeAddress_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.DescribeAddressInput{
 		AddressId: aws.String("ADID1234ab12-3eec-4eb3-9be6-9374c10eb51b"),
 	}
@@ -283,7 +283,7 @@ func ExampleSnowball_DescribeAddress_shared00() {
 // Calling this API in one of the US regions will return addresses from the list of
 // all addresses associated with this account in all US regions.
 func ExampleSnowball_DescribeAddresses_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.DescribeAddressesInput{}
 
 	result, err := svc.DescribeAddresses(input)
@@ -313,7 +313,7 @@ func ExampleSnowball_DescribeAddresses_shared00() {
 // Returns information about a specific cluster including shipping information, cluster
 // status, and other important metadata.
 func ExampleSnowball_DescribeCluster_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.DescribeClusterInput{
 		ClusterId: aws.String("CID123e4567-e89b-12d3-a456-426655440000"),
 	}
@@ -342,7 +342,7 @@ func ExampleSnowball_DescribeCluster_shared00() {
 //
 // This operation describes a job you've created for AWS Snowball.
 func ExampleSnowball_DescribeJob_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.DescribeJobInput{
 		JobId: aws.String("JID123e4567-e89b-12d3-a456-426655440000"),
 	}
@@ -387,7 +387,7 @@ func ExampleSnowball_DescribeJob_shared00() {
 // The credentials of a given job, including its manifest file and unlock code, expire
 // 90 days after the job is created.
 func ExampleSnowball_GetJobManifest_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.GetJobManifestInput{
 		JobId: aws.String("JID123e4567-e89b-12d3-a456-426655440000"),
 	}
@@ -429,7 +429,7 @@ func ExampleSnowball_GetJobManifest_shared00() {
 // prevent unauthorized parties from gaining access to the Snowball associated with
 // that job.
 func ExampleSnowball_GetJobUnlockCode_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.GetJobUnlockCodeInput{
 		JobId: aws.String("JID123e4567-e89b-12d3-a456-426655440000"),
 	}
@@ -464,7 +464,7 @@ func ExampleSnowball_GetJobUnlockCode_shared00() {
 // The default service limit for the number of Snowballs that you can have at one time
 // is 1. If you want to increase your service limit, contact AWS Support.
 func ExampleSnowball_GetSnowballUsage_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.GetSnowballUsageInput{}
 
 	result, err := svc.GetSnowballUsage(input)
@@ -491,7 +491,7 @@ func ExampleSnowball_GetSnowballUsage_shared00() {
 // object is for a job in the specified cluster and contains a job's state, a job's
 // ID, and other information.
 func ExampleSnowball_ListClusterJobs_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.ListClusterJobsInput{
 		ClusterId: aws.String("CID123e4567-e89b-12d3-a456-426655440000"),
 	}
@@ -523,7 +523,7 @@ func ExampleSnowball_ListClusterJobs_shared00() {
 // Returns an array of ClusterListEntry objects of the specified length. Each ClusterListEntry
 // object contains a cluster's state, a cluster's ID, and other important status information.
 func ExampleSnowball_ListClusters_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.ListClustersInput{}
 
 	result, err := svc.ListClusters(input)
@@ -554,7 +554,7 @@ func ExampleSnowball_ListClusters_shared00() {
 // the US regions will return jobs from the list of all jobs associated with this account
 // in all US regions.
 func ExampleSnowball_ListJobs_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.ListJobsInput{}
 
 	result, err := svc.ListJobs(input)
@@ -583,7 +583,7 @@ func ExampleSnowball_ListJobs_shared00() {
 // changes to a different state, usually within 60 minutes of it being created, this
 // action is no longer available.
 func ExampleSnowball_UpdateCluster_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.UpdateClusterInput{
 		AddressId:   aws.String("ADID1234ab12-3eec-4eb3-9be6-9374c10eb51b"),
 		ClusterId:   aws.String("CID123e4567-e89b-12d3-a456-426655440000"),
@@ -624,7 +624,7 @@ func ExampleSnowball_UpdateCluster_shared00() {
 // to a different job state, usually within 60 minutes of the job being created, this
 // action is no longer available.
 func ExampleSnowball_UpdateJob_shared00() {
-	svc := snowball.New(session.New())
+	svc := snowball.New(session.Must(session.NewSession()))
 	input := &snowball.UpdateJobInput{
 		AddressId:                  aws.String("ADID1234ab12-3eec-4eb3-9be6-9374c10eb51b"),
 		Description:                aws.String("Upgraded to Edge, shipped to Finance Dept, and requested faster shipping speed - TS."),

--- a/service/snowball/snowballiface/interface.go
+++ b/service/snowball/snowballiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := snowball.New(sess)
 //
 //        myFunc(svc)

--- a/service/sns/snsiface/interface.go
+++ b/service/sns/snsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := sns.New(sess)
 //
 //        myFunc(svc)

--- a/service/sqs/sqsiface/interface.go
+++ b/service/sqs/sqsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := sqs.New(sess)
 //
 //        myFunc(svc)

--- a/service/ssm/ssmiface/interface.go
+++ b/service/ssm/ssmiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ssm.New(sess)
 //
 //        myFunc(svc)

--- a/service/sso/ssoiface/interface.go
+++ b/service/sso/ssoiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := sso.New(sess)
 //
 //        myFunc(svc)

--- a/service/ssooidc/ssooidciface/interface.go
+++ b/service/ssooidc/ssooidciface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := ssooidc.New(sess)
 //
 //        myFunc(svc)

--- a/service/storagegateway/examples_test.go
+++ b/service/storagegateway/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // Activates the gateway you previously deployed on your host.
 func ExampleStorageGateway_ActivateGateway_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.ActivateGatewayInput{
 		ActivationKey:     aws.String("29AV1-3OFV9-VVIUB-NKT0I-LRO6V"),
 		GatewayName:       aws.String("My_Gateway"),
@@ -66,7 +66,7 @@ func ExampleStorageGateway_ActivateGateway_shared00() {
 //
 // The following example shows a request that activates a gateway-stored volume.
 func ExampleStorageGateway_AddCache_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.AddCacheInput{
 		DiskIds: []*string{
 			aws.String("pci-0000:03:00.0-scsi-0:0:0:0"),
@@ -101,7 +101,7 @@ func ExampleStorageGateway_AddCache_shared00() {
 //
 // Adds one or more tags to the specified resource.
 func ExampleStorageGateway_AddTagsToResource_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.AddTagsToResourceInput{
 		ResourceARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-11A2222B"),
 		Tags: []*storagegateway.Tag{
@@ -138,7 +138,7 @@ func ExampleStorageGateway_AddTagsToResource_shared00() {
 //
 // Configures one or more gateway local disks as upload buffer for a specified gateway.
 func ExampleStorageGateway_AddUploadBuffer_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.AddUploadBufferInput{
 		DiskIds: []*string{
 			aws.String("pci-0000:03:00.0-scsi-0:0:0:0"),
@@ -174,7 +174,7 @@ func ExampleStorageGateway_AddUploadBuffer_shared00() {
 // Configures one or more gateway local disks as working storage for a gateway. (Working
 // storage is also referred to as upload buffer.)
 func ExampleStorageGateway_AddWorkingStorage_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.AddWorkingStorageInput{
 		DiskIds: []*string{
 			aws.String("pci-0000:03:00.0-scsi-0:0:0:0"),
@@ -210,7 +210,7 @@ func ExampleStorageGateway_AddWorkingStorage_shared00() {
 // Cancels archiving of a virtual tape to the virtual tape shelf (VTS) after the archiving
 // process is initiated.
 func ExampleStorageGateway_CancelArchival_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.CancelArchivalInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 		TapeARN:    aws.String("arn:aws:storagegateway:us-east-1:999999999999:tape/AMZN01A2A4"),
@@ -243,7 +243,7 @@ func ExampleStorageGateway_CancelArchival_shared00() {
 // Cancels retrieval of a virtual tape from the virtual tape shelf (VTS) to a gateway
 // after the retrieval process is initiated.
 func ExampleStorageGateway_CancelRetrieval_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.CancelRetrievalInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 		TapeARN:    aws.String("arn:aws:storagegateway:us-east-1:999999999999:tape/AMZN01A2A4"),
@@ -275,7 +275,7 @@ func ExampleStorageGateway_CancelRetrieval_shared00() {
 //
 // Creates a cached volume on a specified cached gateway.
 func ExampleStorageGateway_CreateCachediSCSIVolume_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.CreateCachediSCSIVolumeInput{
 		ClientToken:        aws.String("cachedvol112233"),
 		GatewayARN:         aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
@@ -311,7 +311,7 @@ func ExampleStorageGateway_CreateCachediSCSIVolume_shared00() {
 //
 // Initiates an ad-hoc snapshot of a gateway volume.
 func ExampleStorageGateway_CreateSnapshot_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.CreateSnapshotInput{
 		SnapshotDescription: aws.String("My root volume snapshot as of 10/03/2017"),
 		VolumeARN:           aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/volume/vol-1122AABB"),
@@ -345,7 +345,7 @@ func ExampleStorageGateway_CreateSnapshot_shared00() {
 //
 // Initiates a snapshot of a gateway from a volume recovery point.
 func ExampleStorageGateway_CreateSnapshotFromVolumeRecoveryPoint_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.CreateSnapshotFromVolumeRecoveryPointInput{
 		SnapshotDescription: aws.String("My root volume snapshot as of 2017-06-30T10:10:10.000Z"),
 		VolumeARN:           aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/volume/vol-1122AABB"),
@@ -379,7 +379,7 @@ func ExampleStorageGateway_CreateSnapshotFromVolumeRecoveryPoint_shared00() {
 //
 // Creates a stored volume on a specified stored gateway.
 func ExampleStorageGateway_CreateStorediSCSIVolume_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.CreateStorediSCSIVolumeInput{
 		DiskId:               aws.String("pci-0000:03:00.0-scsi-0:0:0:0"),
 		GatewayARN:           aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
@@ -415,7 +415,7 @@ func ExampleStorageGateway_CreateStorediSCSIVolume_shared00() {
 //
 // Creates a virtual tape by using your own barcode.
 func ExampleStorageGateway_CreateTapeWithBarcode_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.CreateTapeWithBarcodeInput{
 		GatewayARN:      aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B"),
 		TapeBarcode:     aws.String("TEST12345"),
@@ -448,7 +448,7 @@ func ExampleStorageGateway_CreateTapeWithBarcode_shared00() {
 //
 // Creates one or more virtual tapes.
 func ExampleStorageGateway_CreateTapes_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.CreateTapesInput{
 		ClientToken:       aws.String("77777"),
 		GatewayARN:        aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B"),
@@ -484,7 +484,7 @@ func ExampleStorageGateway_CreateTapes_shared00() {
 // Deletes the bandwidth rate limits of a gateway; either the upload or download limit,
 // or both.
 func ExampleStorageGateway_DeleteBandwidthRateLimit_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DeleteBandwidthRateLimitInput{
 		BandwidthType: aws.String("All"),
 		GatewayARN:    aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
@@ -517,7 +517,7 @@ func ExampleStorageGateway_DeleteBandwidthRateLimit_shared00() {
 // Deletes Challenge-Handshake Authentication Protocol (CHAP) credentials for a specified
 // iSCSI target and initiator pair.
 func ExampleStorageGateway_DeleteChapCredentials_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DeleteChapCredentialsInput{
 		InitiatorName: aws.String("iqn.1991-05.com.microsoft:computername.domain.example.com"),
 		TargetARN:     aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/target/iqn.1997-05.com.amazon:myvolume"),
@@ -549,7 +549,7 @@ func ExampleStorageGateway_DeleteChapCredentials_shared00() {
 //
 // This operation deletes the gateway, but not the gateway's VM from the host computer.
 func ExampleStorageGateway_DeleteGateway_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DeleteGatewayInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -580,7 +580,7 @@ func ExampleStorageGateway_DeleteGateway_shared00() {
 //
 // This action enables you to delete a snapshot schedule for a volume.
 func ExampleStorageGateway_DeleteSnapshotSchedule_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DeleteSnapshotScheduleInput{
 		VolumeARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/volume/vol-1122AABB"),
 	}
@@ -611,7 +611,7 @@ func ExampleStorageGateway_DeleteSnapshotSchedule_shared00() {
 //
 // This example deletes the specified virtual tape.
 func ExampleStorageGateway_DeleteTape_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DeleteTapeInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:204469490176:gateway/sgw-12A3456B"),
 		TapeARN:    aws.String("arn:aws:storagegateway:us-east-1:204469490176:tape/TEST05A2A0"),
@@ -643,7 +643,7 @@ func ExampleStorageGateway_DeleteTape_shared00() {
 //
 // Deletes the specified virtual tape from the virtual tape shelf (VTS).
 func ExampleStorageGateway_DeleteTapeArchive_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DeleteTapeArchiveInput{
 		TapeARN: aws.String("arn:aws:storagegateway:us-east-1:204469490176:tape/TEST05A2A0"),
 	}
@@ -675,7 +675,7 @@ func ExampleStorageGateway_DeleteTapeArchive_shared00() {
 // Deletes the specified gateway volume that you previously created using the CreateCachediSCSIVolume
 // or CreateStorediSCSIVolume API.
 func ExampleStorageGateway_DeleteVolume_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DeleteVolumeInput{
 		VolumeARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/volume/vol-1122AABB"),
 	}
@@ -707,7 +707,7 @@ func ExampleStorageGateway_DeleteVolume_shared00() {
 // Returns a value for a bandwidth rate limit if set. If not set, then only the gateway
 // ARN is returned.
 func ExampleStorageGateway_DescribeBandwidthRateLimit_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeBandwidthRateLimitInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -738,7 +738,7 @@ func ExampleStorageGateway_DescribeBandwidthRateLimit_shared00() {
 //
 // Returns information about the cache of a gateway.
 func ExampleStorageGateway_DescribeCache_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeCacheInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -769,7 +769,7 @@ func ExampleStorageGateway_DescribeCache_shared00() {
 //
 // Returns a description of the gateway cached iSCSI volumes specified in the request.
 func ExampleStorageGateway_DescribeCachediSCSIVolumes_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeCachediSCSIVolumesInput{
 		VolumeARNs: []*string{
 			aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/volume/vol-1122AABB"),
@@ -803,7 +803,7 @@ func ExampleStorageGateway_DescribeCachediSCSIVolumes_shared00() {
 // Returns an array of Challenge-Handshake Authentication Protocol (CHAP) credentials
 // information for a specified iSCSI target, one for each target-initiator pair.
 func ExampleStorageGateway_DescribeChapCredentials_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeChapCredentialsInput{
 		TargetARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/target/iqn.1997-05.com.amazon:myvolume"),
 	}
@@ -835,7 +835,7 @@ func ExampleStorageGateway_DescribeChapCredentials_shared00() {
 // Returns metadata about a gateway such as its name, network interfaces, configured
 // time zone, and the state (whether the gateway is running or not).
 func ExampleStorageGateway_DescribeGatewayInformation_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeGatewayInformationInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -867,7 +867,7 @@ func ExampleStorageGateway_DescribeGatewayInformation_shared00() {
 // Returns your gateway's weekly maintenance start time including the day and time of
 // the week.
 func ExampleStorageGateway_DescribeMaintenanceStartTime_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeMaintenanceStartTimeInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -899,7 +899,7 @@ func ExampleStorageGateway_DescribeMaintenanceStartTime_shared00() {
 // Describes the snapshot schedule for the specified gateway volume including intervals
 // at which snapshots are automatically initiated.
 func ExampleStorageGateway_DescribeSnapshotSchedule_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeSnapshotScheduleInput{
 		VolumeARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/volume/vol-1122AABB"),
 	}
@@ -931,7 +931,7 @@ func ExampleStorageGateway_DescribeSnapshotSchedule_shared00() {
 // Returns the description of the gateway volumes specified in the request belonging
 // to the same gateway.
 func ExampleStorageGateway_DescribeStorediSCSIVolumes_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeStorediSCSIVolumesInput{
 		VolumeARNs: []*string{
 			aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/volume/vol-1122AABB"),
@@ -964,7 +964,7 @@ func ExampleStorageGateway_DescribeStorediSCSIVolumes_shared00() {
 //
 // Returns a description of specified virtual tapes in the virtual tape shelf (VTS).
 func ExampleStorageGateway_DescribeTapeArchives_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeTapeArchivesInput{
 		Limit:  aws.Int64(123),
 		Marker: aws.String("1"),
@@ -1001,7 +1001,7 @@ func ExampleStorageGateway_DescribeTapeArchives_shared00() {
 // Returns a list of virtual tape recovery points that are available for the specified
 // gateway-VTL.
 func ExampleStorageGateway_DescribeTapeRecoveryPoints_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeTapeRecoveryPointsInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 		Limit:      aws.Int64(1),
@@ -1035,7 +1035,7 @@ func ExampleStorageGateway_DescribeTapeRecoveryPoints_shared00() {
 // Returns a description of the specified Amazon Resource Name (ARN) of virtual tapes.
 // If a TapeARN is not specified, returns a description of all virtual tapes.
 func ExampleStorageGateway_DescribeTapes_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeTapesInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B"),
 		Limit:      aws.Int64(2),
@@ -1073,7 +1073,7 @@ func ExampleStorageGateway_DescribeTapes_shared00() {
 // Returns information about the upload buffer of a gateway including disk IDs and the
 // amount of upload buffer space allocated/used.
 func ExampleStorageGateway_DescribeUploadBuffer_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeUploadBufferInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -1105,7 +1105,7 @@ func ExampleStorageGateway_DescribeUploadBuffer_shared00() {
 // Returns information about the upload buffer of a gateway including disk IDs and the
 // amount of upload buffer space allocated and used.
 func ExampleStorageGateway_DescribeUploadBuffer_shared01() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeUploadBufferInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -1136,7 +1136,7 @@ func ExampleStorageGateway_DescribeUploadBuffer_shared01() {
 //
 // Returns a description of virtual tape library (VTL) devices for the specified gateway.
 func ExampleStorageGateway_DescribeVTLDevices_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeVTLDevicesInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B"),
 		Limit:      aws.Int64(123),
@@ -1171,7 +1171,7 @@ func ExampleStorageGateway_DescribeVTLDevices_shared00() {
 // operation is deprecated in cached-volumes API version (20120630). Use DescribeUploadBuffer
 // instead.
 func ExampleStorageGateway_DescribeWorkingStorage_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DescribeWorkingStorageInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -1203,7 +1203,7 @@ func ExampleStorageGateway_DescribeWorkingStorage_shared00() {
 // Disables a gateway when the gateway is no longer functioning. Use this operation
 // for a gateway-VTL that is not reachable or not functioning.
 func ExampleStorageGateway_DisableGateway_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.DisableGatewayInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -1235,7 +1235,7 @@ func ExampleStorageGateway_DisableGateway_shared00() {
 // Lists gateways owned by an AWS account in a specified region as requested. Results
 // are sorted by gateway ARN up to a maximum of 100 gateways.
 func ExampleStorageGateway_ListGateways_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.ListGatewaysInput{
 		Limit:  aws.Int64(2),
 		Marker: aws.String("1"),
@@ -1268,7 +1268,7 @@ func ExampleStorageGateway_ListGateways_shared00() {
 // The request returns a list of all disks, specifying which are configured as working
 // storage, cache storage, or stored volume or not configured at all.
 func ExampleStorageGateway_ListLocalDisks_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.ListLocalDisksInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -1299,7 +1299,7 @@ func ExampleStorageGateway_ListLocalDisks_shared00() {
 //
 // Lists the tags that have been added to the specified resource.
 func ExampleStorageGateway_ListTagsForResource_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.ListTagsForResourceInput{
 		Limit:       aws.Int64(1),
 		Marker:      aws.String("1"),
@@ -1333,7 +1333,7 @@ func ExampleStorageGateway_ListTagsForResource_shared00() {
 // Lists the recovery points for a specified gateway in which all data of the volume
 // is consistent and can be used to create a snapshot.
 func ExampleStorageGateway_ListVolumeRecoveryPoints_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.ListVolumeRecoveryPointsInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -1365,7 +1365,7 @@ func ExampleStorageGateway_ListVolumeRecoveryPoints_shared00() {
 // Lists the iSCSI stored volumes of a gateway. Results are sorted by volume ARN up
 // to a maximum of 100 volumes.
 func ExampleStorageGateway_ListVolumes_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.ListVolumesInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 		Limit:      aws.Int64(2),
@@ -1399,7 +1399,7 @@ func ExampleStorageGateway_ListVolumes_shared00() {
 // Lists the iSCSI stored volumes of a gateway. Removes one or more tags from the specified
 // resource.
 func ExampleStorageGateway_RemoveTagsFromResource_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.RemoveTagsFromResourceInput{
 		ResourceARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-11A2222B"),
 		TagKeys: []*string{
@@ -1435,7 +1435,7 @@ func ExampleStorageGateway_RemoveTagsFromResource_shared00() {
 // Resets all cache disks that have encountered a error and makes the disks available
 // for reconfiguration as cache storage.
 func ExampleStorageGateway_ResetCache_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.ResetCacheInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-13B4567C"),
 	}
@@ -1467,7 +1467,7 @@ func ExampleStorageGateway_ResetCache_shared00() {
 // Retrieves an archived virtual tape from the virtual tape shelf (VTS) to a gateway-VTL.
 // Virtual tapes archived in the VTS are not associated with any gateway.
 func ExampleStorageGateway_RetrieveTapeArchive_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.RetrieveTapeArchiveInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B"),
 		TapeARN:    aws.String("arn:aws:storagegateway:us-east-1:999999999999:tape/TEST0AA2AF"),
@@ -1499,7 +1499,7 @@ func ExampleStorageGateway_RetrieveTapeArchive_shared00() {
 //
 // Retrieves the recovery point for the specified virtual tape.
 func ExampleStorageGateway_RetrieveTapeRecoveryPoint_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.RetrieveTapeRecoveryPointInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B"),
 		TapeARN:    aws.String("arn:aws:storagegateway:us-east-1:999999999999:tape/TEST0AA2AF"),
@@ -1531,7 +1531,7 @@ func ExampleStorageGateway_RetrieveTapeRecoveryPoint_shared00() {
 //
 // Sets the password for your VM local console.
 func ExampleStorageGateway_SetLocalConsolePassword_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.SetLocalConsolePasswordInput{
 		GatewayARN:           aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B"),
 		LocalConsolePassword: aws.String("PassWordMustBeAtLeast6Chars."),
@@ -1564,7 +1564,7 @@ func ExampleStorageGateway_SetLocalConsolePassword_shared00() {
 // This operation shuts down the gateway service component running in the storage gateway's
 // virtual machine (VM) and not the VM.
 func ExampleStorageGateway_ShutdownGateway_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.ShutdownGatewayInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B"),
 	}
@@ -1595,7 +1595,7 @@ func ExampleStorageGateway_ShutdownGateway_shared00() {
 //
 // Starts a gateway service that was previously shut down.
 func ExampleStorageGateway_StartGateway_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.StartGatewayInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B"),
 	}
@@ -1628,7 +1628,7 @@ func ExampleStorageGateway_StartGateway_shared00() {
 // rate limit can be set, or either one of the two. If a new limit is not set, the existing
 // rate limit remains.
 func ExampleStorageGateway_UpdateBandwidthRateLimit_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.UpdateBandwidthRateLimitInput{
 		AverageDownloadRateLimitInBitsPerSec: aws.Int64(102400),
 		AverageUploadRateLimitInBitsPerSec:   aws.Int64(51200),
@@ -1662,7 +1662,7 @@ func ExampleStorageGateway_UpdateBandwidthRateLimit_shared00() {
 // Updates the Challenge-Handshake Authentication Protocol (CHAP) credentials for a
 // specified iSCSI target.
 func ExampleStorageGateway_UpdateChapCredentials_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.UpdateChapCredentialsInput{
 		InitiatorName:                 aws.String("iqn.1991-05.com.microsoft:computername.domain.example.com"),
 		SecretToAuthenticateInitiator: aws.String("111111111111"),
@@ -1696,7 +1696,7 @@ func ExampleStorageGateway_UpdateChapCredentials_shared00() {
 //
 // Updates a gateway's metadata, which includes the gateway's name and time zone.
 func ExampleStorageGateway_UpdateGatewayInformation_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.UpdateGatewayInformationInput{
 		GatewayARN:      aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 		GatewayName:     aws.String("MyGateway2"),
@@ -1730,7 +1730,7 @@ func ExampleStorageGateway_UpdateGatewayInformation_shared00() {
 // Updates the gateway virtual machine (VM) software. The request immediately triggers
 // the software update.
 func ExampleStorageGateway_UpdateGatewaySoftwareNow_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.UpdateGatewaySoftwareNowInput{
 		GatewayARN: aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
 	}
@@ -1762,7 +1762,7 @@ func ExampleStorageGateway_UpdateGatewaySoftwareNow_shared00() {
 // Updates a gateway's weekly maintenance start time information, including day and
 // time of the week. The maintenance time is in your gateway's time zone.
 func ExampleStorageGateway_UpdateMaintenanceStartTime_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.UpdateMaintenanceStartTimeInput{
 		DayOfWeek:    aws.Int64(2),
 		GatewayARN:   aws.String("arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B"),
@@ -1796,7 +1796,7 @@ func ExampleStorageGateway_UpdateMaintenanceStartTime_shared00() {
 //
 // Updates a snapshot schedule configured for a gateway volume.
 func ExampleStorageGateway_UpdateSnapshotSchedule_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.UpdateSnapshotScheduleInput{
 		Description:       aws.String("Hourly snapshot"),
 		RecurrenceInHours: aws.Int64(1),
@@ -1830,7 +1830,7 @@ func ExampleStorageGateway_UpdateSnapshotSchedule_shared00() {
 //
 // Updates the type of medium changer in a gateway-VTL after a gateway-VTL is activated.
 func ExampleStorageGateway_UpdateVTLDeviceType_shared00() {
-	svc := storagegateway.New(session.New())
+	svc := storagegateway.New(session.Must(session.NewSession()))
 	input := &storagegateway.UpdateVTLDeviceTypeInput{
 		DeviceType:   aws.String("Medium Changer"),
 		VTLDeviceARN: aws.String("arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B/device/AMZN_SGW-1FAD4876_MEDIACHANGER_00001"),

--- a/service/storagegateway/storagegatewayiface/interface.go
+++ b/service/storagegateway/storagegatewayiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := storagegateway.New(sess)
 //
 //        myFunc(svc)

--- a/service/sts/examples_test.go
+++ b/service/sts/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 
 func ExampleSTS_AssumeRole_shared00() {
-	svc := sts.New(session.New())
+	svc := sts.New(session.Must(session.NewSession()))
 	input := &sts.AssumeRoleInput{
 		ExternalId:      aws.String("123ABC"),
 		Policy:          aws.String("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Action\":\"s3:ListAllMyBuckets\",\"Resource\":\"*\"}]}"),
@@ -83,7 +83,7 @@ func ExampleSTS_AssumeRole_shared00() {
 //
 
 func ExampleSTS_AssumeRoleWithSAML_shared00() {
-	svc := sts.New(session.New())
+	svc := sts.New(session.Must(session.NewSession()))
 	input := &sts.AssumeRoleWithSAMLInput{
 		DurationSeconds: aws.Int64(3600),
 		PrincipalArn:    aws.String("arn:aws:iam::123456789012:saml-provider/SAML-test"),
@@ -125,7 +125,7 @@ func ExampleSTS_AssumeRoleWithSAML_shared00() {
 //
 
 func ExampleSTS_AssumeRoleWithWebIdentity_shared00() {
-	svc := sts.New(session.New())
+	svc := sts.New(session.Must(session.NewSession()))
 	input := &sts.AssumeRoleWithWebIdentityInput{
 		DurationSeconds:  aws.Int64(3600),
 		Policy:           aws.String("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Action\":\"s3:ListAllMyBuckets\",\"Resource\":\"*\"}]}"),
@@ -171,7 +171,7 @@ func ExampleSTS_AssumeRoleWithWebIdentity_shared00() {
 //
 
 func ExampleSTS_DecodeAuthorizationMessage_shared00() {
-	svc := sts.New(session.New())
+	svc := sts.New(session.Must(session.NewSession()))
 	input := &sts.DecodeAuthorizationMessageInput{
 		EncodedMessage: aws.String("<encoded-message>"),
 	}
@@ -201,7 +201,7 @@ func ExampleSTS_DecodeAuthorizationMessage_shared00() {
 // This example shows a request and response made with the credentials for a user named
 // Alice in the AWS account 123456789012.
 func ExampleSTS_GetCallerIdentity_shared00() {
-	svc := sts.New(session.New())
+	svc := sts.New(session.Must(session.NewSession()))
 	input := &sts.GetCallerIdentityInput{}
 
 	result, err := svc.GetCallerIdentity(input)
@@ -228,7 +228,7 @@ func ExampleSTS_GetCallerIdentity_shared00() {
 // by AssumeRole. The name of the assumed role is my-role-name, and the RoleSessionName
 // is set to my-role-session-name.
 func ExampleSTS_GetCallerIdentity_shared01() {
-	svc := sts.New(session.New())
+	svc := sts.New(session.Must(session.NewSession()))
 	input := &sts.GetCallerIdentityInput{}
 
 	result, err := svc.GetCallerIdentity(input)
@@ -254,7 +254,7 @@ func ExampleSTS_GetCallerIdentity_shared01() {
 // This example shows a request and response made with temporary credentials created
 // by using GetFederationToken. The Name parameter is set to my-federated-user-name.
 func ExampleSTS_GetCallerIdentity_shared02() {
-	svc := sts.New(session.New())
+	svc := sts.New(session.Must(session.NewSession()))
 	input := &sts.GetCallerIdentityInput{}
 
 	result, err := svc.GetCallerIdentity(input)
@@ -279,7 +279,7 @@ func ExampleSTS_GetCallerIdentity_shared02() {
 //
 
 func ExampleSTS_GetFederationToken_shared00() {
-	svc := sts.New(session.New())
+	svc := sts.New(session.Must(session.NewSession()))
 	input := &sts.GetFederationTokenInput{
 		DurationSeconds: aws.Int64(3600),
 		Name:            aws.String("testFedUserSession"),
@@ -324,7 +324,7 @@ func ExampleSTS_GetFederationToken_shared00() {
 //
 
 func ExampleSTS_GetSessionToken_shared00() {
-	svc := sts.New(session.New())
+	svc := sts.New(session.Must(session.NewSession()))
 	input := &sts.GetSessionTokenInput{
 		DurationSeconds: aws.Int64(3600),
 		SerialNumber:    aws.String("YourMFASerialNumber"),

--- a/service/sts/stsiface/interface.go
+++ b/service/sts/stsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := sts.New(sess)
 //
 //        myFunc(svc)

--- a/service/support/supportiface/interface.go
+++ b/service/support/supportiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := support.New(sess)
 //
 //        myFunc(svc)

--- a/service/swf/swfiface/interface.go
+++ b/service/swf/swfiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := swf.New(sess)
 //
 //        myFunc(svc)

--- a/service/synthetics/syntheticsiface/interface.go
+++ b/service/synthetics/syntheticsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := synthetics.New(sess)
 //
 //        myFunc(svc)

--- a/service/textract/textractiface/interface.go
+++ b/service/textract/textractiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := textract.New(sess)
 //
 //        myFunc(svc)

--- a/service/transcribeservice/transcribeserviceiface/interface.go
+++ b/service/transcribeservice/transcribeserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := transcribeservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/transcribestreamingservice/transcribestreamingserviceiface/interface.go
+++ b/service/transcribestreamingservice/transcribestreamingserviceiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := transcribestreamingservice.New(sess)
 //
 //        myFunc(svc)

--- a/service/transfer/transferiface/interface.go
+++ b/service/transfer/transferiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := transfer.New(sess)
 //
 //        myFunc(svc)

--- a/service/translate/translateiface/interface.go
+++ b/service/translate/translateiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := translate.New(sess)
 //
 //        myFunc(svc)

--- a/service/waf/examples_test.go
+++ b/service/waf/examples_test.go
@@ -29,7 +29,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The following example creates an IP match set named MyIPSetFriendlyName.
 func ExampleWAF_CreateIPSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.CreateIPSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Name:        aws.String("MyIPSetFriendlyName"),
@@ -69,7 +69,7 @@ func ExampleWAF_CreateIPSet_shared00() {
 //
 // The following example creates a rule named WAFByteHeaderRule.
 func ExampleWAF_CreateRule_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.CreateRuleInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		MetricName:  aws.String("WAFByteHeaderRule"),
@@ -114,7 +114,7 @@ func ExampleWAF_CreateRule_shared00() {
 //
 // The following example creates size constraint set named MySampleSizeConstraintSet.
 func ExampleWAF_CreateSizeConstraintSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.CreateSizeConstraintSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Name:        aws.String("MySampleSizeConstraintSet"),
@@ -154,7 +154,7 @@ func ExampleWAF_CreateSizeConstraintSet_shared00() {
 //
 // The following example creates a SQL injection match set named MySQLInjectionMatchSet.
 func ExampleWAF_CreateSqlInjectionMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.CreateSqlInjectionMatchSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Name:        aws.String("MySQLInjectionMatchSet"),
@@ -194,7 +194,7 @@ func ExampleWAF_CreateSqlInjectionMatchSet_shared00() {
 //
 // The following example creates a web ACL named CreateExample.
 func ExampleWAF_CreateWebACL_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.CreateWebACLInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		DefaultAction: &waf.WafAction{
@@ -244,7 +244,7 @@ func ExampleWAF_CreateWebACL_shared00() {
 //
 // The following example creates an XSS match set named MySampleXssMatchSet.
 func ExampleWAF_CreateXssMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.CreateXssMatchSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Name:        aws.String("MySampleXssMatchSet"),
@@ -284,7 +284,7 @@ func ExampleWAF_CreateXssMatchSet_shared00() {
 //
 // The following example deletes a byte match set with the ID exampleIDs3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_DeleteByteMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.DeleteByteMatchSetInput{
 		ByteMatchSetId: aws.String("exampleIDs3t-46da-4fdb-b8d5-abc321j569j5"),
 		ChangeToken:    aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
@@ -324,7 +324,7 @@ func ExampleWAF_DeleteByteMatchSet_shared00() {
 //
 // The following example deletes an IP match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_DeleteIPSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.DeleteIPSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		IPSetId:     aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -364,7 +364,7 @@ func ExampleWAF_DeleteIPSet_shared00() {
 //
 // The following example deletes a rule with the ID WAFRule-1-Example.
 func ExampleWAF_DeleteRule_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.DeleteRuleInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		RuleId:      aws.String("WAFRule-1-Example"),
@@ -408,7 +408,7 @@ func ExampleWAF_DeleteRule_shared00() {
 //
 // The following example deletes a size constraint set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_DeleteSizeConstraintSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.DeleteSizeConstraintSetInput{
 		ChangeToken:         aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		SizeConstraintSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -448,7 +448,7 @@ func ExampleWAF_DeleteSizeConstraintSet_shared00() {
 //
 // The following example deletes a SQL injection match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_DeleteSqlInjectionMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.DeleteSqlInjectionMatchSetInput{
 		ChangeToken:            aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		SqlInjectionMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -488,7 +488,7 @@ func ExampleWAF_DeleteSqlInjectionMatchSet_shared00() {
 //
 // The following example deletes a web ACL with the ID example-46da-4444-5555-example.
 func ExampleWAF_DeleteWebACL_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.DeleteWebACLInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		WebACLId:    aws.String("example-46da-4444-5555-example"),
@@ -532,7 +532,7 @@ func ExampleWAF_DeleteWebACL_shared00() {
 //
 // The following example deletes an XSS match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_DeleteXssMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.DeleteXssMatchSetInput{
 		ChangeToken:   aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		XssMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -572,7 +572,7 @@ func ExampleWAF_DeleteXssMatchSet_shared00() {
 //
 // The following example returns the details of a byte match set with the ID exampleIDs3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_GetByteMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetByteMatchSetInput{
 		ByteMatchSetId: aws.String("exampleIDs3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -606,7 +606,7 @@ func ExampleWAF_GetByteMatchSet_shared00() {
 // The following example returns a change token to use for a create, update or delete
 // operation.
 func ExampleWAF_GetChangeToken_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetChangeTokenInput{}
 
 	result, err := svc.GetChangeToken(input)
@@ -633,7 +633,7 @@ func ExampleWAF_GetChangeToken_shared00() {
 //
 // The following example returns the status of a change token with the ID abcd12f2-46da-4fdb-b8d5-fbd4c466928f.
 func ExampleWAF_GetChangeTokenStatus_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetChangeTokenStatusInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 	}
@@ -664,7 +664,7 @@ func ExampleWAF_GetChangeTokenStatus_shared00() {
 //
 // The following example returns the details of an IP match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_GetIPSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetIPSetInput{
 		IPSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -697,7 +697,7 @@ func ExampleWAF_GetIPSet_shared00() {
 //
 // The following example returns the details of a rule with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_GetRule_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetRuleInput{
 		RuleId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -732,7 +732,7 @@ func ExampleWAF_GetRule_shared00() {
 // that AWS WAF randomly selects from among the first 5,000 requests that your AWS resource
 // received between the time period 2016-09-27T15:50Z to 2016-09-27T15:50Z.
 func ExampleWAF_GetSampledRequests_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetSampledRequestsInput{
 		MaxItems: aws.Int64(100),
 		RuleId:   aws.String("WAFRule-1-Example"),
@@ -770,7 +770,7 @@ func ExampleWAF_GetSampledRequests_shared00() {
 // The following example returns the details of a size constraint match set with the
 // ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_GetSizeConstraintSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetSizeConstraintSetInput{
 		SizeConstraintSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -804,7 +804,7 @@ func ExampleWAF_GetSizeConstraintSet_shared00() {
 // The following example returns the details of a SQL injection match set with the ID
 // example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_GetSqlInjectionMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetSqlInjectionMatchSetInput{
 		SqlInjectionMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -837,7 +837,7 @@ func ExampleWAF_GetSqlInjectionMatchSet_shared00() {
 //
 // The following example returns the details of a web ACL with the ID createwebacl-1472061481310.
 func ExampleWAF_GetWebACL_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetWebACLInput{
 		WebACLId: aws.String("createwebacl-1472061481310"),
 	}
@@ -870,7 +870,7 @@ func ExampleWAF_GetWebACL_shared00() {
 //
 // The following example returns the details of an XSS match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_GetXssMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.GetXssMatchSetInput{
 		XssMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -903,7 +903,7 @@ func ExampleWAF_GetXssMatchSet_shared00() {
 //
 // The following example returns an array of up to 100 IP match sets.
 func ExampleWAF_ListIPSets_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.ListIPSetsInput{
 		Limit: aws.Int64(100),
 	}
@@ -934,7 +934,7 @@ func ExampleWAF_ListIPSets_shared00() {
 //
 // The following example returns an array of up to 100 rules.
 func ExampleWAF_ListRules_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.ListRulesInput{
 		Limit: aws.Int64(100),
 	}
@@ -965,7 +965,7 @@ func ExampleWAF_ListRules_shared00() {
 //
 // The following example returns an array of up to 100 size contraint match sets.
 func ExampleWAF_ListSizeConstraintSets_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.ListSizeConstraintSetsInput{
 		Limit: aws.Int64(100),
 	}
@@ -996,7 +996,7 @@ func ExampleWAF_ListSizeConstraintSets_shared00() {
 //
 // The following example returns an array of up to 100 SQL injection match sets.
 func ExampleWAF_ListSqlInjectionMatchSets_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.ListSqlInjectionMatchSetsInput{
 		Limit: aws.Int64(100),
 	}
@@ -1027,7 +1027,7 @@ func ExampleWAF_ListSqlInjectionMatchSets_shared00() {
 //
 // The following example returns an array of up to 100 web ACLs.
 func ExampleWAF_ListWebACLs_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.ListWebACLsInput{
 		Limit: aws.Int64(100),
 	}
@@ -1058,7 +1058,7 @@ func ExampleWAF_ListWebACLs_shared00() {
 //
 // The following example returns an array of up to 100 XSS match sets.
 func ExampleWAF_ListXssMatchSets_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.ListXssMatchSetsInput{
 		Limit: aws.Int64(100),
 	}
@@ -1090,7 +1090,7 @@ func ExampleWAF_ListXssMatchSets_shared00() {
 // The following example deletes a ByteMatchTuple object (filters) in an byte match
 // set with the ID exampleIDs3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_UpdateByteMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.UpdateByteMatchSetInput{
 		ByteMatchSetId: aws.String("exampleIDs3t-46da-4fdb-b8d5-abc321j569j5"),
 		ChangeToken:    aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
@@ -1149,7 +1149,7 @@ func ExampleWAF_UpdateByteMatchSet_shared00() {
 // The following example deletes an IPSetDescriptor object in an IP match set with the
 // ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_UpdateIPSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.UpdateIPSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		IPSetId:     aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -1204,7 +1204,7 @@ func ExampleWAF_UpdateIPSet_shared00() {
 //
 // The following example deletes a Predicate object in a rule with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_UpdateRule_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.UpdateRuleInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		RuleId:      aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -1261,7 +1261,7 @@ func ExampleWAF_UpdateRule_shared00() {
 // The following example deletes a SizeConstraint object (filters) in a size constraint
 // set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_UpdateSizeConstraintSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.UpdateSizeConstraintSetInput{
 		ChangeToken:         aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		SizeConstraintSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -1321,7 +1321,7 @@ func ExampleWAF_UpdateSizeConstraintSet_shared00() {
 // The following example deletes a SqlInjectionMatchTuple object (filters) in a SQL
 // injection match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_UpdateSqlInjectionMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.UpdateSqlInjectionMatchSetInput{
 		ChangeToken:            aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		SqlInjectionMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -1376,7 +1376,7 @@ func ExampleWAF_UpdateSqlInjectionMatchSet_shared00() {
 //
 // The following example deletes an ActivatedRule object in a WebACL with the ID webacl-1472061481310.
 func ExampleWAF_UpdateWebACL_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.UpdateWebACLInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		DefaultAction: &waf.WafAction{
@@ -1440,7 +1440,7 @@ func ExampleWAF_UpdateWebACL_shared00() {
 // The following example deletes an XssMatchTuple object (filters) in an XssMatchSet
 // with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAF_UpdateXssMatchSet_shared00() {
-	svc := waf.New(session.New())
+	svc := waf.New(session.Must(session.NewSession()))
 	input := &waf.UpdateXssMatchSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Updates: []*waf.XssMatchSetUpdate{

--- a/service/waf/wafiface/interface.go
+++ b/service/waf/wafiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := waf.New(sess)
 //
 //        myFunc(svc)

--- a/service/wafregional/examples_test.go
+++ b/service/wafregional/examples_test.go
@@ -30,7 +30,7 @@ func parseTime(layout, value string) *time.Time {
 //
 // The following example creates an IP match set named MyIPSetFriendlyName.
 func ExampleWAFRegional_CreateIPSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.CreateIPSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Name:        aws.String("MyIPSetFriendlyName"),
@@ -70,7 +70,7 @@ func ExampleWAFRegional_CreateIPSet_shared00() {
 //
 // The following example creates a rule named WAFByteHeaderRule.
 func ExampleWAFRegional_CreateRule_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.CreateRuleInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		MetricName:  aws.String("WAFByteHeaderRule"),
@@ -115,7 +115,7 @@ func ExampleWAFRegional_CreateRule_shared00() {
 //
 // The following example creates size constraint set named MySampleSizeConstraintSet.
 func ExampleWAFRegional_CreateSizeConstraintSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.CreateSizeConstraintSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Name:        aws.String("MySampleSizeConstraintSet"),
@@ -155,7 +155,7 @@ func ExampleWAFRegional_CreateSizeConstraintSet_shared00() {
 //
 // The following example creates a SQL injection match set named MySQLInjectionMatchSet.
 func ExampleWAFRegional_CreateSqlInjectionMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.CreateSqlInjectionMatchSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Name:        aws.String("MySQLInjectionMatchSet"),
@@ -195,7 +195,7 @@ func ExampleWAFRegional_CreateSqlInjectionMatchSet_shared00() {
 //
 // The following example creates a web ACL named CreateExample.
 func ExampleWAFRegional_CreateWebACL_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.CreateWebACLInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		DefaultAction: &waf.WafAction{
@@ -245,7 +245,7 @@ func ExampleWAFRegional_CreateWebACL_shared00() {
 //
 // The following example creates an XSS match set named MySampleXssMatchSet.
 func ExampleWAFRegional_CreateXssMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.CreateXssMatchSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Name:        aws.String("MySampleXssMatchSet"),
@@ -285,7 +285,7 @@ func ExampleWAFRegional_CreateXssMatchSet_shared00() {
 //
 // The following example deletes a byte match set with the ID exampleIDs3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_DeleteByteMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.DeleteByteMatchSetInput{
 		ByteMatchSetId: aws.String("exampleIDs3t-46da-4fdb-b8d5-abc321j569j5"),
 		ChangeToken:    aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
@@ -325,7 +325,7 @@ func ExampleWAFRegional_DeleteByteMatchSet_shared00() {
 //
 // The following example deletes an IP match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_DeleteIPSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.DeleteIPSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		IPSetId:     aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -365,7 +365,7 @@ func ExampleWAFRegional_DeleteIPSet_shared00() {
 //
 // The following example deletes a rule with the ID WAFRule-1-Example.
 func ExampleWAFRegional_DeleteRule_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.DeleteRuleInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		RuleId:      aws.String("WAFRule-1-Example"),
@@ -409,7 +409,7 @@ func ExampleWAFRegional_DeleteRule_shared00() {
 //
 // The following example deletes a size constraint set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_DeleteSizeConstraintSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.DeleteSizeConstraintSetInput{
 		ChangeToken:         aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		SizeConstraintSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -449,7 +449,7 @@ func ExampleWAFRegional_DeleteSizeConstraintSet_shared00() {
 //
 // The following example deletes a SQL injection match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_DeleteSqlInjectionMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.DeleteSqlInjectionMatchSetInput{
 		ChangeToken:            aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		SqlInjectionMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -489,7 +489,7 @@ func ExampleWAFRegional_DeleteSqlInjectionMatchSet_shared00() {
 //
 // The following example deletes a web ACL with the ID example-46da-4444-5555-example.
 func ExampleWAFRegional_DeleteWebACL_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.DeleteWebACLInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		WebACLId:    aws.String("example-46da-4444-5555-example"),
@@ -533,7 +533,7 @@ func ExampleWAFRegional_DeleteWebACL_shared00() {
 //
 // The following example deletes an XSS match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_DeleteXssMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.DeleteXssMatchSetInput{
 		ChangeToken:   aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		XssMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -573,7 +573,7 @@ func ExampleWAFRegional_DeleteXssMatchSet_shared00() {
 //
 // The following example returns the details of a byte match set with the ID exampleIDs3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_GetByteMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetByteMatchSetInput{
 		ByteMatchSetId: aws.String("exampleIDs3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -607,7 +607,7 @@ func ExampleWAFRegional_GetByteMatchSet_shared00() {
 // The following example returns a change token to use for a create, update or delete
 // operation.
 func ExampleWAFRegional_GetChangeToken_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetChangeTokenInput{}
 
 	result, err := svc.GetChangeToken(input)
@@ -634,7 +634,7 @@ func ExampleWAFRegional_GetChangeToken_shared00() {
 //
 // The following example returns the status of a change token with the ID abcd12f2-46da-4fdb-b8d5-fbd4c466928f.
 func ExampleWAFRegional_GetChangeTokenStatus_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetChangeTokenStatusInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 	}
@@ -665,7 +665,7 @@ func ExampleWAFRegional_GetChangeTokenStatus_shared00() {
 //
 // The following example returns the details of an IP match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_GetIPSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetIPSetInput{
 		IPSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -698,7 +698,7 @@ func ExampleWAFRegional_GetIPSet_shared00() {
 //
 // The following example returns the details of a rule with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_GetRule_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetRuleInput{
 		RuleId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -733,7 +733,7 @@ func ExampleWAFRegional_GetRule_shared00() {
 // that AWS WAF randomly selects from among the first 5,000 requests that your AWS resource
 // received between the time period 2016-09-27T15:50Z to 2016-09-27T15:50Z.
 func ExampleWAFRegional_GetSampledRequests_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetSampledRequestsInput{
 		MaxItems: aws.Int64(100),
 		RuleId:   aws.String("WAFRule-1-Example"),
@@ -771,7 +771,7 @@ func ExampleWAFRegional_GetSampledRequests_shared00() {
 // The following example returns the details of a size constraint match set with the
 // ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_GetSizeConstraintSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetSizeConstraintSetInput{
 		SizeConstraintSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -805,7 +805,7 @@ func ExampleWAFRegional_GetSizeConstraintSet_shared00() {
 // The following example returns the details of a SQL injection match set with the ID
 // example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_GetSqlInjectionMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetSqlInjectionMatchSetInput{
 		SqlInjectionMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -838,7 +838,7 @@ func ExampleWAFRegional_GetSqlInjectionMatchSet_shared00() {
 //
 // The following example returns the details of a web ACL with the ID createwebacl-1472061481310.
 func ExampleWAFRegional_GetWebACL_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetWebACLInput{
 		WebACLId: aws.String("createwebacl-1472061481310"),
 	}
@@ -871,7 +871,7 @@ func ExampleWAFRegional_GetWebACL_shared00() {
 //
 // The following example returns the details of an XSS match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_GetXssMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.GetXssMatchSetInput{
 		XssMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
 	}
@@ -904,7 +904,7 @@ func ExampleWAFRegional_GetXssMatchSet_shared00() {
 //
 // The following example returns an array of up to 100 IP match sets.
 func ExampleWAFRegional_ListIPSets_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.ListIPSetsInput{
 		Limit: aws.Int64(100),
 	}
@@ -935,7 +935,7 @@ func ExampleWAFRegional_ListIPSets_shared00() {
 //
 // The following example returns an array of up to 100 rules.
 func ExampleWAFRegional_ListRules_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.ListRulesInput{
 		Limit: aws.Int64(100),
 	}
@@ -966,7 +966,7 @@ func ExampleWAFRegional_ListRules_shared00() {
 //
 // The following example returns an array of up to 100 size contraint match sets.
 func ExampleWAFRegional_ListSizeConstraintSets_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.ListSizeConstraintSetsInput{
 		Limit: aws.Int64(100),
 	}
@@ -997,7 +997,7 @@ func ExampleWAFRegional_ListSizeConstraintSets_shared00() {
 //
 // The following example returns an array of up to 100 SQL injection match sets.
 func ExampleWAFRegional_ListSqlInjectionMatchSets_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.ListSqlInjectionMatchSetsInput{
 		Limit: aws.Int64(100),
 	}
@@ -1028,7 +1028,7 @@ func ExampleWAFRegional_ListSqlInjectionMatchSets_shared00() {
 //
 // The following example returns an array of up to 100 web ACLs.
 func ExampleWAFRegional_ListWebACLs_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.ListWebACLsInput{
 		Limit: aws.Int64(100),
 	}
@@ -1059,7 +1059,7 @@ func ExampleWAFRegional_ListWebACLs_shared00() {
 //
 // The following example returns an array of up to 100 XSS match sets.
 func ExampleWAFRegional_ListXssMatchSets_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.ListXssMatchSetsInput{
 		Limit: aws.Int64(100),
 	}
@@ -1091,7 +1091,7 @@ func ExampleWAFRegional_ListXssMatchSets_shared00() {
 // The following example deletes a ByteMatchTuple object (filters) in an byte match
 // set with the ID exampleIDs3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_UpdateByteMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.UpdateByteMatchSetInput{
 		ByteMatchSetId: aws.String("exampleIDs3t-46da-4fdb-b8d5-abc321j569j5"),
 		ChangeToken:    aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
@@ -1150,7 +1150,7 @@ func ExampleWAFRegional_UpdateByteMatchSet_shared00() {
 // The following example deletes an IPSetDescriptor object in an IP match set with the
 // ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_UpdateIPSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.UpdateIPSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		IPSetId:     aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -1205,7 +1205,7 @@ func ExampleWAFRegional_UpdateIPSet_shared00() {
 //
 // The following example deletes a Predicate object in a rule with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_UpdateRule_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.UpdateRuleInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		RuleId:      aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -1262,7 +1262,7 @@ func ExampleWAFRegional_UpdateRule_shared00() {
 // The following example deletes a SizeConstraint object (filters) in a size constraint
 // set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_UpdateSizeConstraintSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.UpdateSizeConstraintSetInput{
 		ChangeToken:         aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		SizeConstraintSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -1322,7 +1322,7 @@ func ExampleWAFRegional_UpdateSizeConstraintSet_shared00() {
 // The following example deletes a SqlInjectionMatchTuple object (filters) in a SQL
 // injection match set with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_UpdateSqlInjectionMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.UpdateSqlInjectionMatchSetInput{
 		ChangeToken:            aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		SqlInjectionMatchSetId: aws.String("example1ds3t-46da-4fdb-b8d5-abc321j569j5"),
@@ -1377,7 +1377,7 @@ func ExampleWAFRegional_UpdateSqlInjectionMatchSet_shared00() {
 //
 // The following example deletes an ActivatedRule object in a WebACL with the ID webacl-1472061481310.
 func ExampleWAFRegional_UpdateWebACL_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.UpdateWebACLInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		DefaultAction: &waf.WafAction{
@@ -1441,7 +1441,7 @@ func ExampleWAFRegional_UpdateWebACL_shared00() {
 // The following example deletes an XssMatchTuple object (filters) in an XssMatchSet
 // with the ID example1ds3t-46da-4fdb-b8d5-abc321j569j5.
 func ExampleWAFRegional_UpdateXssMatchSet_shared00() {
-	svc := wafregional.New(session.New())
+	svc := wafregional.New(session.Must(session.NewSession()))
 	input := &waf.UpdateXssMatchSetInput{
 		ChangeToken: aws.String("abcd12f2-46da-4fdb-b8d5-fbd4c466928f"),
 		Updates: []*waf.XssMatchSetUpdate{

--- a/service/wafregional/wafregionaliface/interface.go
+++ b/service/wafregional/wafregionaliface/interface.go
@@ -31,7 +31,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := wafregional.New(sess)
 //
 //        myFunc(svc)

--- a/service/wafv2/wafv2iface/interface.go
+++ b/service/wafv2/wafv2iface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := wafv2.New(sess)
 //
 //        myFunc(svc)

--- a/service/workdocs/workdocsiface/interface.go
+++ b/service/workdocs/workdocsiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := workdocs.New(sess)
 //
 //        myFunc(svc)

--- a/service/worklink/worklinkiface/interface.go
+++ b/service/worklink/worklinkiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := worklink.New(sess)
 //
 //        myFunc(svc)

--- a/service/workmail/workmailiface/interface.go
+++ b/service/workmail/workmailiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := workmail.New(sess)
 //
 //        myFunc(svc)

--- a/service/workmailmessageflow/workmailmessageflowiface/interface.go
+++ b/service/workmailmessageflow/workmailmessageflowiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := workmailmessageflow.New(sess)
 //
 //        myFunc(svc)

--- a/service/workspaces/workspacesiface/interface.go
+++ b/service/workspaces/workspacesiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := workspaces.New(sess)
 //
 //        myFunc(svc)

--- a/service/xray/xrayiface/interface.go
+++ b/service/xray/xrayiface/interface.go
@@ -30,7 +30,7 @@ import (
 //    }
 //
 //    func main() {
-//        sess := session.New()
+//        sess := session.Must(session.NewSession())
 //        svc := xray.New(sess)
 //
 //        myFunc(svc)


### PR DESCRIPTION
## Reason for the change
There is a comment in `aws\session\session.go`.
```
Deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.
```
But It stil remains in a lot of place.

## Details of the change
Replace `session.New()` => `session.Must(session.NewSession())`

Almost all is simply `session.New()` with no args.

**Places that using `session.New()` with some args are below.**
* example\service\rds\rdsutils\authentication\iam_authentication.go:30
* example\service\s3\concatObjects\concatObjects.go:60
* example\service\s3\sync\sync.go:105

## postscript
If it's too much trouble to check, I might have to break it up into smaller pieces.