### PR TITLE
service/s3/s3manager:  Prefer using allocated slices from pool over allocating new ones.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `service/s3/s3manager`:  Prefer using allocated slices from pool over allocating new ones. ([#3534](https://github.com/aws/aws-sdk-go/pull/3534))
 
 ### SDK Bugs

--- a/service/s3/s3manager/pool.go
+++ b/service/s3/s3manager/pool.go
@@ -60,6 +60,14 @@ func (p *maxSlicePool) Get(ctx aws.Context) (*[]byte, error) {
 				return nil, errZeroCapacity
 			}
 			return bs, nil
+		case <-ctx.Done():
+			p.mtx.RUnlock()
+			return nil, ctx.Err()
+		default:
+			// pass
+		}
+
+		select {
 		case _, ok := <-p.allocations:
 			p.mtx.RUnlock()
 			if !ok {


### PR DESCRIPTION
Problem:
S3 uploader could allocate more memory than it is actually needed.
Added unit test should showcase the problem

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
