### PR TITLE
`service/kinesis`: Reverts temp test skipped for kinesis

### DIFF
--- a/service/kinesis/cust_integ_eventstream_test.go
+++ b/service/kinesis/cust_integ_eventstream_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestInteg_SubscribeToShard(t *testing.T) {
-	// TODO: enable test
-	t.Skip("temporarily disabled test for release")
 	desc, err := svc.DescribeStream(&kinesis.DescribeStreamInput{
 		StreamName: &streamName,
 	})

--- a/service/kinesis/cust_integ_shared_test.go
+++ b/service/kinesis/cust_integ_shared_test.go
@@ -99,19 +99,18 @@ func TestMain(m *testing.M) {
 		}
 		fallthrough
 	case "test":
-		// TODO: temporarily commenting this step for release.
-		// records = createRecords(numRecords, recordSize)
-		// if err := putRecords(streamName, records, svc); err != nil {
-		// 	panic(err)
-		// }
-		// time.Sleep(time.Second)
-		//
-		// var exitCode int
-		// defer func() {
-		// 	os.Exit(exitCode)
-		// }()
-		//
-		// exitCode = m.Run()
+		records = createRecords(numRecords, recordSize)
+		if err := putRecords(streamName, records, svc); err != nil {
+			panic(err)
+		}
+		time.Sleep(time.Second)
+
+		var exitCode int
+		defer func() {
+			os.Exit(exitCode)
+		}()
+
+		exitCode = m.Run()
 
 		if mode != "all" {
 			break


### PR DESCRIPTION
Reverts test skipped as a part of https://github.com/aws/aws-sdk-go/pull/3529. 

Tested Integ test with our test account. The tests succeed.