### PR TITLE
Add NatGatewayDeleted waiter

### DIFF
--- a/models/apis/ec2/2016-11-15/waiters-2.json
+++ b/models/apis/ec2/2016-11-15/waiters-2.json
@@ -335,6 +335,24 @@
         }
       ]
     },
+    "NatGatewayDeleted": {
+      "operation": "DescribeNatGateways",
+      "delay": 15,
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "state": "success",
+          "matcher": "pathAll",
+          "expected": "deleted",
+          "argument": "NatGateways[].State"
+        },
+        {
+          "state": "success",
+          "matcher": "error",
+          "expected": "NatGatewayNotFound"
+        }
+      ]
+    },
     "NetworkInterfaceAvailable": {
       "operation": "DescribeNetworkInterfaces",
       "delay": 20,


### PR DESCRIPTION
Since deleting a NAT gateway takes a little while it's useful to have a waiter since it can otherwise lead to dependency failures to delete other resources like VPC.

Fixes: #3552