### PR TITLE
Fixing anchor links on README and CONTRIBUTING pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ effectively respond to your bug report or contribution.
 
 Jump To:
 
-* [Bug Reports](_#Bug-Reports_)
-* [Code Contributions](_#Code-Contributions_)
+* [Bug Reports](#Bug-Reports)
+* [Code Contributions](#Code-Contributions)
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ information about the latest bug fixes, updates, and features added to the SDK.
 We [announced](https://aws.amazon.com/blogs/developer/aws-sdk-for-go-2-0-developer-preview/) the Developer Preview for the [v2 AWS SDK for Go](https://github.com/aws/aws-sdk-go-v2). The v2 SDK source is available at https://github.com/aws/aws-sdk-go-v2, and add it to your project with `go get github.com/aws/aws-sdk-go-v2`. Check out the v2 SDK's [changes and updates](https://github.com/aws/aws-sdk-go-v2/blob/master/CHANGELOG.md), and let us know what you think. We want your feedback.
 
 Jump To:
-* [Getting Started](_#Getting-Started_)
-* [Quick Examples](_#Quick-Examples_)
-* [Getting Help](_#Getting-Help_)
-* [Contributing](_#Contributing_)
-* [More Resources](_#Resources_)
+* [Getting Started](#Getting-Started)
+* [Quick Examples](#Quick-Examples)
+* [Getting Help](#Getting-Help)
+* [Contributing](#Contributing)
+* [More Resources](#Resources)
 
 ## Getting Started
 


### PR DESCRIPTION
The anchor links on README.md and CONTRIBUTING.md were broken with underscores and returned 404 on GitHub's UI. This change fixes it.