### PR TITLE
fix race condition in credentials.GetWithContext

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,4 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/credentials`: Fixed a race condition checking if credentials are expired. ([#3524](https://github.com/aws/aws-sdk-go/issues/3524))

--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -50,7 +50,7 @@ package credentials
 
 import (
 	"fmt"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -207,7 +207,8 @@ func (e *Expiry) ExpiresAt() time.Time {
 // first instance of the credentials Value. All calls to Get() after that
 // will return the cached credentials Value until IsExpired() returns true.
 type Credentials struct {
-	creds atomic.Value
+	mu    sync.RWMutex
+	creds Value
 	sf    singleflight.Group
 
 	provider Provider
@@ -218,7 +219,6 @@ func NewCredentials(provider Provider) *Credentials {
 	c := &Credentials{
 		provider: provider,
 	}
-	c.creds.Store(Value{})
 	return c
 }
 
@@ -235,8 +235,13 @@ func NewCredentials(provider Provider) *Credentials {
 //
 // Passed in Context is equivalent to aws.Context, and context.Context.
 func (c *Credentials) GetWithContext(ctx Context) (Value, error) {
-	if curCreds := c.creds.Load(); !c.isExpired(curCreds) {
-		return curCreds.(Value), nil
+	// The provider will record the expiration time internally without holding the write lock.
+	// However, we only fetch credentials while c.creds is the zero value (Value{}), and
+	// currentCreds will only consult the provider if c.creds is NOT the zero value.
+	// Thus holding the read lock here is sufficient for thread-safety.
+	curCreds, ok := c.currentCreds()
+	if ok {
+		return curCreds, nil
 	}
 
 	// Cannot pass context down to the actual retrieve, because the first
@@ -254,18 +259,41 @@ func (c *Credentials) GetWithContext(ctx Context) (Value, error) {
 	}
 }
 
-func (c *Credentials) singleRetrieve(ctx Context) (creds interface{}, err error) {
-	if curCreds := c.creds.Load(); !c.isExpired(curCreds) {
-		return curCreds.(Value), nil
+func (c *Credentials) singleRetrieve(ctx Context) (interface{}, error) {
+	// Another thread may have gotten new credentials between this thread releasing the read lock
+	// and acquiring the write lock. Double check the credentials are still expired to be safe.
+	creds, ok := func() (Value, bool) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		creds, ok := c.currentCredsLocked()
+		if ok {
+			return creds, true
+		}
+
+		// If the credentials are still expired, set them to the zero value before
+		// calling Retrieve or RetrieveWithContext.
+		// This prevents a race condition where currentCredsLocked sees the old credentials
+		// but the new expiration time.
+		c.creds = Value{}
+		return Value{}, false
+	}()
+
+	if ok {
+		return creds, nil
 	}
 
+	var err error
 	if p, ok := c.provider.(ProviderWithContext); ok {
 		creds, err = p.RetrieveWithContext(ctx)
 	} else {
 		creds, err = c.provider.Retrieve()
 	}
+
 	if err == nil {
-		c.creds.Store(creds)
+		c.mu.Lock()
+		c.creds = creds
+		c.mu.Unlock()
 	}
 
 	return creds, err
@@ -290,7 +318,9 @@ func (c *Credentials) Get() (Value, error) {
 // This will override the Provider's expired state, and force Credentials
 // to call the Provider's Retrieve().
 func (c *Credentials) Expire() {
-	c.creds.Store(Value{})
+	c.mu.Lock()
+	c.creds = Value{}
+	c.mu.Unlock()
 }
 
 // IsExpired returns if the credentials are no longer valid, and need
@@ -299,25 +329,34 @@ func (c *Credentials) Expire() {
 // If the Credentials were forced to be expired with Expire() this will
 // reflect that override.
 func (c *Credentials) IsExpired() bool {
-	return c.isExpired(c.creds.Load())
+	_, ok := c.currentCreds()
+	return !ok
 }
 
-// isExpired helper method wrapping the definition of expired credentials.
-func (c *Credentials) isExpired(creds interface{}) bool {
-	return creds == nil || creds.(Value) == Value{} || c.provider.IsExpired()
+func (c *Credentials) currentCreds() (creds Value, ok bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.currentCredsLocked()
+}
+
+func (c *Credentials) currentCredsLocked() (creds Value, ok bool) {
+	return c.creds, c.creds != Value{} && !c.provider.IsExpired()
 }
 
 // ExpiresAt provides access to the functionality of the Expirer interface of
 // the underlying Provider, if it supports that interface.  Otherwise, it returns
 // an error.
 func (c *Credentials) ExpiresAt() (time.Time, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	expirer, ok := c.provider.(Expirer)
 	if !ok {
 		return time.Time{}, awserr.New("ProviderNotExpirer",
-			fmt.Sprintf("provider %s does not support ExpiresAt()", c.creds.Load().(Value).ProviderName),
+			fmt.Sprintf("provider %s does not support ExpiresAt()", c.creds.ProviderName),
 			nil)
 	}
-	if c.creds.Load().(Value) == (Value{}) {
+	if c.creds == (Value{}) {
 		// set expiration time to the distant past
 		return time.Time{}, nil
 	}


### PR DESCRIPTION
Resolves a race condition in `GetWithContext`. Fixes #3524.