### PR TITLE
Clear monotonic clock when setting credential expiration values.

### DIFF
--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -173,7 +173,9 @@ type Expiry struct {
 // the expiration time given to ensure no requests are made with expired
 // tokens.
 func (e *Expiry) SetExpiration(expiration time.Time, window time.Duration) {
-	e.expiration = expiration
+	// Passed in expirations should have the monotonic clock values stripped.
+	// This ensures time comparisons will be based on wall-time.
+	e.expiration = expiration.Truncate(0)
 	if window > 0 {
 		e.expiration = e.expiration.Add(-window)
 	}

--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -175,7 +175,7 @@ type Expiry struct {
 func (e *Expiry) SetExpiration(expiration time.Time, window time.Duration) {
 	// Passed in expirations should have the monotonic clock values stripped.
 	// This ensures time comparisons will be based on wall-time.
-	e.expiration = expiration.Truncate(0)
+	e.expiration = expiration.Round(0)
 	if window > 0 {
 		e.expiration = e.expiration.Add(-window)
 	}

--- a/aws/ec2metadata/token_provider.go
+++ b/aws/ec2metadata/token_provider.go
@@ -87,6 +87,7 @@ func (t *tokenProvider) enableTokenProviderHandler(r *request.Request) {
 	// If the error code status is 401, we enable the token provider
 	if e, ok := r.Error.(awserr.RequestFailure); ok && e != nil &&
 		e.StatusCode() == http.StatusUnauthorized {
+		t.token.Store(ec2Token{})
 		atomic.StoreUint32(&t.disabled, 0)
 	}
 }


### PR DESCRIPTION
Ensures that the monotonic clock readings are removed from times when used with the `credentials.Expiry` type.