### PR TITLE
Fixes ini file parsing for cases when Right Hand Value is missed in the last statement of the ini file

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `internal/ini`: Fixes ini file parsing for cases when Right Hand Value is missed in the last statement of the ini file ([#3596](https://github.com/aws/aws-sdk-go/pull/3596)) 
+  * related to [#2800](https://github.com/aws/aws-sdk-go/issues/2800)

--- a/internal/ini/ini_parser.go
+++ b/internal/ini/ini_parser.go
@@ -63,9 +63,9 @@ var parseTable = map[ASTKind]map[TokenType]int{
 		TokenNone:    MarkCompleteState,
 	},
 	ASTKindEqualExpr: map[TokenType]int{
-		TokenLit: ValueState,
-		TokenWS:  SkipTokenState,
-		TokenNL:  SkipState,
+		TokenLit:     ValueState,
+		TokenWS:      SkipTokenState,
+		TokenNL:      SkipState,
 		TokenNone:    SkipState,
 	},
 	ASTKindStatement: map[TokenType]int{

--- a/internal/ini/ini_parser.go
+++ b/internal/ini/ini_parser.go
@@ -66,6 +66,7 @@ var parseTable = map[ASTKind]map[TokenType]int{
 		TokenLit: ValueState,
 		TokenWS:  SkipTokenState,
 		TokenNL:  SkipState,
+		TokenNone:    SkipState,
 	},
 	ASTKindStatement: map[TokenType]int{
 		TokenLit:     SectionState,

--- a/internal/ini/ini_parser_test.go
+++ b/internal/ini/ini_parser_test.go
@@ -289,6 +289,19 @@ output = json
 				newExprStatement(outputEQExpr),
 			},
 		},
+		{
+			name: "missing section statement as the last statement in the file",
+			r: bytes.NewBuffer([]byte(
+				`[default]
+region = us-west-2
+s3 =`)),
+			expectedStack: []AST{
+				newCompletedSectionStatement(
+					defaultProfileStmt,
+				),
+				newExprStatement(noQuotesRegionEQRegion),
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/internal/ini/ini_parser_test.go
+++ b/internal/ini/ini_parser_test.go
@@ -290,7 +290,7 @@ output = json
 			},
 		},
 		{
-			name: "missing section statement as the last statement in the file",
+			name: "missing right hand expression in the last statement in the file",
 			r: bytes.NewBuffer([]byte(
 				`[default]
 region = us-west-2


### PR DESCRIPTION
Hello, 

This is a bugfix for the INI parser that fails to parse an INI file like:

```
[default]
region = us-west-2
s3 =
```

Notice the absence of the empty line at the end of the file. 

There was a previously closed bug addressing a similar issue - https://github.com/aws/aws-sdk-go/issues/2800, but the corner case when the right-hand value is missed in the last statement is still failing. 

In my case, it was critical (granted adding a newline at the end of the file also fixes it) as I had a `~/.aws/config` written as described in AWS Docs here: https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-pagination.html : 

```
[default]
cli_pager=
```

Please note, that in this case an `ASTKindSkipStatement` statement is not added in the resulting AST. If the desired behaviour would be to still have it - I can try to figure out how to add it.  
