### PR TITLE
service/s3control: Fix GetAccessPointPolicy, DeleteAccessPointPolicy, and PutAccessPointPolicy operations not routing properly for S3 on Outposts

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `s3control`: Fixes bug in SDK that caused GetAccessPointPolicy, DeleteAccessPointPolicy, and PutAccessPointPolicy operations to not route properly for S3 on Outposts. ([#3599](https://github.com/aws/aws-sdk-go/pull/3599))
+  * Fixes [#3598](https://github.com/aws/aws-sdk-go/issues/3598).

--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -224,11 +224,11 @@ func s3ControlCustomizations(a *API) error {
 
 			// List of input shapes that use accesspoint names as arnable fields
 			accessPointNameArnables := map[string]struct{}{
-				"GetAccessPointInput":     {},
-				"DeleteAccessPointInput":  {},
-				"PutAccessPointPolicy":    {},
-				"GetAccessPointPolicy":    {},
-				"DeleteAccessPointPolicy": {},
+				"GetAccessPointInput":          {},
+				"DeleteAccessPointInput":       {},
+				"PutAccessPointPolicyInput":    {},
+				"GetAccessPointPolicyInput":    {},
+				"DeleteAccessPointPolicyInput": {},
 			}
 
 			var endpointARNShape *ShapeRef


### PR DESCRIPTION
Reference: https://github.com/aws/aws-sdk-go/issues/3598