### PR TITLE
`s3control`: Fixes bug in customization applied on access-point operations

### DIFF
--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -226,9 +226,9 @@ func s3ControlCustomizations(a *API) error {
 			accessPointNameArnables := map[string]struct{}{
 				"GetAccessPointInput":     {},
 				"DeleteAccessPointInput":  {},
-				"PutAccessPointPolicy":    {},
-				"GetAccessPointPolicy":    {},
-				"DeleteAccessPointPolicy": {},
+				"PutAccessPointPolicyInput":    {},
+				"GetAccessPointPolicyInput":    {},
+				"DeleteAccessPointPolicyInput": {},
 			}
 
 			var endpointARNShape *ShapeRef


### PR DESCRIPTION
This PR fixes a bug in customization on S3Control client. The bug resulted in SDK not accepting ARNs for operations `GetAccessPointPolicy`, `DeleteAccessPointPolicy`, and `PutAccessPointPolicy`. 


