### PR TITLE
Pass context to endpoint discovery requests

### DIFF
--- a/private/model/api/codegentest/service/awsendpointdiscoverytest/api.go
+++ b/private/model/api/codegentest/service/awsendpointdiscoverytest/api.go
@@ -97,7 +97,7 @@ func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 		Operation: d.Params["op"],
 	}
 
-	resp, err := d.Client.DescribeEndpoints(input)
+	resp, err := d.Client.DescribeEndpointsWithContext(d.req.Context(), input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -481,7 +481,7 @@ func (d *discoverer{{ .ExportedName }}) Discover() (crr.Endpoint, error) {
 		{{ end -}}
 	}
 
-	resp, err := d.Client.{{ .API.EndpointDiscoveryOp.Name }}(input)
+	resp, err := d.Client.{{ .API.EndpointDiscoveryOp.Name }}WithContext(d.req.Context(), input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -1801,7 +1801,7 @@ type discovererDescribeEndpoints struct {
 func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 	input := &DescribeEndpointsInput{}
 
-	resp, err := d.Client.DescribeEndpoints(input)
+	resp, err := d.Client.DescribeEndpointsWithContext(d.req.Context(), input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}

--- a/service/timestreamquery/api.go
+++ b/service/timestreamquery/api.go
@@ -245,7 +245,7 @@ type discovererDescribeEndpoints struct {
 func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 	input := &DescribeEndpointsInput{}
 
-	resp, err := d.Client.DescribeEndpoints(input)
+	resp, err := d.Client.DescribeEndpointsWithContext(d.req.Context(), input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}

--- a/service/timestreamwrite/api.go
+++ b/service/timestreamwrite/api.go
@@ -762,7 +762,7 @@ type discovererDescribeEndpoints struct {
 func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 	input := &DescribeEndpointsInput{}
 
-	resp, err := d.Client.DescribeEndpoints(input)
+	resp, err := d.Client.DescribeEndpointsWithContext(d.req.Context(), input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}


### PR DESCRIPTION
# Problem

Currently, the SDK calls endpoint discovery API such as `DescribeEndpoints()` with no `context.Context`.

This causes some problems such as:

- no cancellation propagation happens
- cannot adopt other context-aware tools such as aws-xray-sdk-go

# Solution

Call `DescribeEndpointsWithContext` with endpoint discovery struct's context instead of `DescribeEndpoints()`

---

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
