### PR TITLE
Add a workaround to correct the endpoint for EC2 running in AWS China

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/endpoints` Add a workaround for AWS China EC2
+* Add a workaround to correct the endpoint for EC2 running in AWS China. This will allow your application to make API calls to EC2 service in AWS China.
+* Fix problems like [#2079](https://github.com/aws/aws-sdk-go/issues/2079), [#1957](https://github.com/aws/aws-sdk-go/issues/1957), but the corrected endpoint is `ec2.{region}.amazonaws.com`

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-* `aws/endpoints` Add a workaround for AWS China EC2
+* `aws/endpoints` Add a workaround for AWS China EC2([#3662](https://github.com/aws/aws-sdk-go/pull/3662))
 * Add a workaround to correct the endpoint for EC2 running in AWS China. This will allow your application to make API calls to EC2 service in AWS China.
 * Fix problems like [#2079](https://github.com/aws/aws-sdk-go/issues/2079), [#1957](https://github.com/aws/aws-sdk-go/issues/1957), but the corrected endpoint is `ec2.{region}.amazonaws.com`

--- a/aws/endpoints/decode.go
+++ b/aws/endpoints/decode.go
@@ -87,6 +87,7 @@ func decodeV3Endpoints(modelDef modelDefinition, opts DecodeModelOptions) (Resol
 		custRmIotDataService(p)
 		custFixAppAutoscalingChina(p)
 		custFixAppAutoscalingUsGov(p)
+		custFixEc2China(p)
 	}
 
 	return ps, nil
@@ -171,6 +172,27 @@ func custFixAppAutoscalingChina(p *partition) {
 	const expectHostname = `autoscaling.{region}.amazonaws.com`
 	if e, a := s.Defaults.Hostname, expectHostname; e != a {
 		fmt.Printf("custFixAppAutoscalingChina: ignoring customization, expected %s, got %s\n", e, a)
+		return
+	}
+
+	s.Defaults.Hostname = expectHostname + ".cn"
+	p.Services[serviceName] = s
+}
+
+func custFixEc2China(p *partition) {
+	if p.ID != "aws-cn" {
+		return
+	}
+
+	const serviceName = "ec2"
+	s, ok := p.Services[serviceName]
+	if !ok {
+		return
+	}
+
+	const expectHostname = `ec2.{region}.amazonaws.com`
+	if e, a := s.Defaults.Hostname, expectHostname; e != a {
+		fmt.Printf("custFixAppEc2China: ignoring customization, expected %s, got %s\n", e, a)
 		return
 	}
 

--- a/aws/endpoints/decode_test.go
+++ b/aws/endpoints/decode_test.go
@@ -222,3 +222,56 @@ func TestCustFixAppAutoscalingUsGov(t *testing.T) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 }
+
+func TestCustFixEc2China(t *testing.T) {
+	const doc = `
+{
+  "version": 3,
+  "partitions": [{
+    "defaults" : {
+      "hostname" : "{service}.{region}.{dnsSuffix}",
+      "protocols" : [ "https" ],
+      "signatureVersions" : [ "v4" ]
+    },
+    "dnsSuffix" : "amazonaws.com.cn",
+    "partition" : "aws-cn",
+    "partitionName" : "AWS China",
+    "regionRegex" : "^cn\\-\\w+\\-\\d+$",
+    "regions" : {
+      "cn-north-1" : {
+        "description" : "China (Beijing)"
+      },
+      "cn-northwest-1" : {
+        "description" : "China (Ningxia)"
+      }
+    },
+    "services" : {
+      "ec2" : {
+        "defaults" : {
+          "protocols" : [ "http", "https" ]
+        },
+        "endpoints" : {
+          "cn-north-1" : { },
+          "cn-northwest-1" : { }
+        }
+      }
+	}
+  }]
+}`
+
+	resolver, err := DecodeModel(strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	endpoint, err := resolver.EndpointFor(
+		"ec2", "cn-northwest-1",
+	)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if e, a := `https://ec2.cn-northwest-1.amazonaws.com.cn`, endpoint.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}


### PR DESCRIPTION
Fix problems like [#2079](https://github.com/aws/aws-sdk-go/issues/2079), [#1957](https://github.com/aws/aws-sdk-go/issues/1957), but the corrected endpoint is `ec2.{region}.amazonaws.com`

![image](https://user-images.githubusercontent.com/8620373/100568609-9fdfd980-3306-11eb-8006-20837cdec95b.png)
