### PR TITLE
Add xmlutil fuzzer

### DIFF
--- a/private/protocol/xml/xmlutil/fuzz.go
+++ b/private/protocol/xml/xmlutil/fuzz.go
@@ -1,0 +1,47 @@
+// +build gofuzz
+
+package xmlutil
+
+import (
+	"bytes"
+	"encoding/xml"
+)
+
+type mockOutput struct {
+	_       struct{}          `type:"structure"`
+	String  *string           `type:"string"`
+	Integer *int64            `type:"integer"`
+	Nested  *mockNestedStruct `type:"structure"`
+	List    []*mockListElem   `locationName:"List" locationNameList:"Elem" type:"list"`
+	Closed  *mockClosedTags   `type:"structure"`
+}
+type mockNestedStruct struct {
+	_            struct{} `type:"structure"`
+	NestedString *string  `type:"string"`
+	NestedInt    *int64   `type:"integer"`
+}
+type mockClosedTags struct {
+	_    struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+	Attr *string  `locationName:"xsi:attrval" type:"string" xmlAttribute:"true"`
+}
+type mockListElem struct {
+	_          struct{}            `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+	String     *string             `type:"string"`
+	NestedElem *mockNestedListElem `type:"structure"`
+}
+type mockNestedListElem struct {
+	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+
+	String *string `type:"string"`
+	Type   *string `locationName:"xsi:type" type:"string" xmlAttribute:"true"`
+}
+
+func Fuzz(data []byte) int {
+	actual := mockOutput{}
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	err := UnmarshalXML(&actual, decoder, "")
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer for the xmlutil package.

I have worked on setting aws-sdk-go up on OSS-fuzz as well and can confirm that the fuzzer runs on their infrastructure. I will be happy to complete the integration with OSS-fuzz which will allow this fuzzer and all future fuzzers for aws-sdk-go to be run continuously. It will help with finding harder-to-find bugs which has been the case in other open source libraries inluding Kubernetes. If a bug is found through OSS-fuzz, an email with a bug report is sent to the maintainers on the mailing list with a link to a detailed bug report. The service is free and is offered with an implied expectation that bugs are fixed so that the resources spent on fuzzing aws-sdk-go are put to good use.