### PR TITLE
codegen: Ensure event stream events are in sorted order

### DIFF
--- a/private/model/api/eventstream.go
+++ b/private/model/api/eventstream.go
@@ -217,7 +217,10 @@ func (es *EventStreams) GetStream(topShape *Shape, streamShape *Shape) *EventStr
 	}
 
 	if topShape.API.Metadata.Protocol == "json" {
-		topShape.EventFor = append(topShape.EventFor, stream)
+		if topShape.EventFor == nil {
+			topShape.EventFor = map[string]*EventStream{}
+		}
+		topShape.EventFor[stream.Name] = stream
 	}
 
 	return stream
@@ -276,7 +279,10 @@ func setupEventStream(s *Shape) *EventStream {
 
 		updateEventPayloadRef(eventRef.Shape)
 
-		eventRef.Shape.EventFor = append(eventRef.Shape.EventFor, eventStream)
+		if eventRef.Shape.EventFor == nil {
+			eventRef.Shape.EventFor = map[string]*EventStream{}
+		}
+		eventRef.Shape.EventFor[eventStream.Name] = eventStream
 
 		// Exceptions and events are two different lists to allow the SDK
 		// to easily generate code with the two handled differently.

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -97,7 +97,7 @@ type Shape struct {
 
 	OutputEventStreamAPI *EventStreamAPI
 	EventStream          *EventStream
-	EventFor             []*EventStream `json:"-"`
+	EventFor             map[string]*EventStream `json:"-"`
 
 	IsInputEventStream  bool `json:"-"`
 	IsOutputEventStream bool `json:"-"`


### PR DESCRIPTION
Updates the SDK's code generation for event stream member event for
methods to be sorted order. Ensures load order doesn't impact code
generation output.

Fixes https://github.com/aws/aws-sdk-go/issues/3664
