### PR TITLE
Add S3 Bucket Not Found Status for controlling bucket status

### DIFF
--- a/service/s3/errors.go
+++ b/service/s3/errors.go
@@ -33,6 +33,12 @@ const (
 	// The specified bucket does not exist.
 	ErrCodeNoSuchBucket = "NoSuchBucket"
 
+	// ErrCodeBucketNotFound for service response error code
+	// "NotFound".
+	//
+	// The specified bucket does not exist
+	ErrCodeBucketNotFound = "NotFound"
+
 	// ErrCodeNoSuchKey for service response error code
 	// "NoSuchKey".
 	//


### PR DESCRIPTION
we get 'NotFound' response when bucket does not exists. We need to add Err Code for NotFound

