### PR TITLE
make an empty list a valid return value for ValuesAtPath()

### DIFF
--- a/aws/awsutil/path_value.go
+++ b/aws/awsutil/path_value.go
@@ -171,7 +171,7 @@ func ValuesAtPath(i interface{}, path string) ([]interface{}, error) {
 	if v.Kind() == reflect.Map && v.Len() == 0 {
 		return nil, nil
 	}
-	if v.Kind() == reflect.Slice {
+	if v.Kind() == reflect.Slice && v.Len() != 0 {
 		out := make([]interface{}, v.Len())
 		for i := 0; i < v.Len(); i++ {
 			out[i] = v.Index(i).Interface()

--- a/aws/awsutil/path_value_test.go
+++ b/aws/awsutil/path_value_test.go
@@ -61,7 +61,7 @@ func TestValueAtPathSuccess(t *testing.T) {
 }
 
 func TestValueAtPathFailure(t *testing.T) {
-	var nilStruct []Struct
+	var nilListOfStruct []Struct
 	var testCases = []struct {
 		expect      []interface{}
 		errContains string
@@ -76,7 +76,7 @@ func TestValueAtPathFailure(t *testing.T) {
 		{nil, "", data, "B.B.C.Z"},
 		{nil, "", data, "z[-1].C"},
 		{nil, "", nil, "A.B.C"},
-		{[]interface{}{nilStruct}, "", Struct{}, "A"},
+		{[]interface{}{nilListOfStruct}, "", Struct{}, "A"},
 		{nil, "", data, "A[0].B.C"},
 		{nil, "", data, "D"},
 	}

--- a/aws/awsutil/path_value_test.go
+++ b/aws/awsutil/path_value_test.go
@@ -62,7 +62,6 @@ func TestValueAtPathSuccess(t *testing.T) {
 
 func TestValueAtPathFailure(t *testing.T) {
 	var nilStruct []Struct
-	nilStruct = nil
 	var testCases = []struct {
 		expect      []interface{}
 		errContains string

--- a/aws/awsutil/path_value_test.go
+++ b/aws/awsutil/path_value_test.go
@@ -1,7 +1,6 @@
 package awsutil_test
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 

--- a/aws/awsutil/path_value_test.go
+++ b/aws/awsutil/path_value_test.go
@@ -1,6 +1,7 @@
 package awsutil_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -47,6 +48,7 @@ func TestValueAtPathSuccess(t *testing.T) {
 			Struct{A: []Struct{{C: "1"}, {C: "1"}, {C: "1"}, {C: "1"}, {C: "1"}}},
 			Struct{A: []Struct{{C: "2"}, {C: "2"}, {C: "2"}, {C: "2"}, {C: "2"}}},
 		}, data2, "A"},
+		{[]interface{}{[]Struct{}}, Struct{A: []Struct{}}, "A"},
 	}
 	for i, c := range testCases {
 		v, err := awsutil.ValuesAtPath(c.data, c.path)
@@ -60,6 +62,8 @@ func TestValueAtPathSuccess(t *testing.T) {
 }
 
 func TestValueAtPathFailure(t *testing.T) {
+	var nilStruct []Struct
+	nilStruct = nil
 	var testCases = []struct {
 		expect      []interface{}
 		errContains string
@@ -74,7 +78,7 @@ func TestValueAtPathFailure(t *testing.T) {
 		{nil, "", data, "B.B.C.Z"},
 		{nil, "", data, "z[-1].C"},
 		{nil, "", nil, "A.B.C"},
-		{[]interface{}{}, "", Struct{}, "A"},
+		{[]interface{}{nilStruct}, "", Struct{}, "A"},
 		{nil, "", data, "A[0].B.C"},
 		{nil, "", data, "D"},
 	}


### PR DESCRIPTION
When using the `request.Waiter` [functionality to wait for a desired outcome](https://github.com/aws/aws-sdk-go/blob/master/aws/request/waiter.go), you currently cannot wait for a value to be an empty list. Example:

```
request.WaiterAcceptor{
		Matcher:  request.PathAllWaiterMatch,
		Argument: "Nodegroups",
		Expected: []*string{},
		State:    request.FailureWaiterState,
}
```
here I am defining an Acceptor that waits until the value returned from `ListNodegroupsOutput.Nodegroups` is an empty list
```
type ListNodegroupsOutput struct {
	_ struct{} `type:"structure"`

	// The nextToken value to include in a future ListNodegroups request. When the
	// results of a ListNodegroups request exceed maxResults, you can use this value
	// to retrieve the next page of results. This value is null when there are no
	// more results to return.
	NextToken *string `locationName:"nextToken" type:"string"`

	// A list of all of the node groups associated with the specified cluster.
	Nodegroups []*string `locationName:"nodegroups" type:"list"`
}
```

Currently this does not work, because the [current implementation](https://github.com/aws/aws-sdk-go/blob/fa80f22d2a4aa9b10696dd09960b402b7953dc4c/aws/awsutil/path_value.go#L174-L180) will instead of returning `[]interface{}{[]*string{}}` instead returns `[]interface{}{}`:
```
	if v.Kind() == reflect.Slice {
		out := make([]interface{}, v.Len())
		for i := 0; i < v.Len(); i++ {
			out[i] = v.Index(i).Interface()
		}
		return out, nil
	}
```

This PR changes it so that returning an empty list allowed.
