### PR TITLE
Revert "Pass context to endpoint discovery requests"

### DIFF
--- a/private/model/api/codegentest/service/awsendpointdiscoverytest/api.go
+++ b/private/model/api/codegentest/service/awsendpointdiscoverytest/api.go
@@ -97,7 +97,7 @@ func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 		Operation: d.Params["op"],
 	}
 
-	resp, err := d.Client.DescribeEndpointsWithContext(d.req.Context(), input)
+	resp, err := d.Client.DescribeEndpoints(input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -481,7 +481,7 @@ func (d *discoverer{{ .ExportedName }}) Discover() (crr.Endpoint, error) {
 		{{ end -}}
 	}
 
-	resp, err := d.Client.{{ .API.EndpointDiscoveryOp.Name }}WithContext(d.req.Context(), input)
+	resp, err := d.Client.{{ .API.EndpointDiscoveryOp.Name }}(input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -1801,7 +1801,7 @@ type discovererDescribeEndpoints struct {
 func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 	input := &DescribeEndpointsInput{}
 
-	resp, err := d.Client.DescribeEndpointsWithContext(d.req.Context(), input)
+	resp, err := d.Client.DescribeEndpoints(input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}

--- a/service/timestreamquery/api.go
+++ b/service/timestreamquery/api.go
@@ -245,7 +245,7 @@ type discovererDescribeEndpoints struct {
 func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 	input := &DescribeEndpointsInput{}
 
-	resp, err := d.Client.DescribeEndpointsWithContext(d.req.Context(), input)
+	resp, err := d.Client.DescribeEndpoints(input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}

--- a/service/timestreamwrite/api.go
+++ b/service/timestreamwrite/api.go
@@ -768,7 +768,7 @@ type discovererDescribeEndpoints struct {
 func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 	input := &DescribeEndpointsInput{}
 
-	resp, err := d.Client.DescribeEndpointsWithContext(d.req.Context(), input)
+	resp, err := d.Client.DescribeEndpoints(input)
 	if err != nil {
 		return crr.Endpoint{}, err
 	}


### PR DESCRIPTION
Reverts aws/aws-sdk-go#3653

Upon additional investigation we determined that there might be some unattended behaviors with regards to requests being terminated by a context when attempting to discover an endpoint. Since endpoint discovery may happen out of band in a separate goroutine, essentially not blocking the original operation, it's lifetime shouldn't always be coupled to the same context timeout. There is likely a larger design change that would have to occur to make this possible.