### PR TITLE
Add fips-us-gov-east-1 for s3

### DIFF
--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -9124,6 +9124,12 @@ var awsusgovPartition = partition{
 				DualStackHostname: "{service}.dualstack.{region}.{dnsSuffix}",
 			},
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "s3-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
 				"fips-us-gov-west-1": endpoint{
 					Hostname: "s3-fips.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{


### PR DESCRIPTION
Per documentation here:

https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html

I believe this endpoint configuration is missing.