### PR TITLE
Add missing fields for config test.

### DIFF
--- a/aws/config_test.go
+++ b/aws/config_test.go
@@ -49,17 +49,22 @@ func TestCopyReturnsNewInstance(t *testing.T) {
 var mergeTestZeroValueConfig = Config{}
 
 var mergeTestConfig = Config{
-	Credentials:             testCredentials,
-	Endpoint:                String("MergeTestEndpoint"),
-	Region:                  String("MERGE_TEST_AWS_REGION"),
-	DisableSSL:              Bool(true),
-	HTTPClient:              http.DefaultClient,
-	LogLevel:                LogLevel(LogDebug),
-	Logger:                  NewDefaultLogger(),
-	MaxRetries:              Int(10),
-	DisableParamValidation:  Bool(true),
-	DisableComputeChecksums: Bool(true),
-	S3ForcePathStyle:        Bool(true),
+	Credentials:                    testCredentials,
+	Endpoint:                       String("MergeTestEndpoint"),
+	Region:                         String("MERGE_TEST_AWS_REGION"),
+	DisableSSL:                     Bool(true),
+	HTTPClient:                     http.DefaultClient,
+	LogLevel:                       LogLevel(LogDebug),
+	Logger:                         NewDefaultLogger(),
+	MaxRetries:                     Int(10),
+	DisableParamValidation:         Bool(true),
+	DisableComputeChecksums:        Bool(true),
+	DisableEndpointHostPrefix:      Bool(true),
+	EnableEndpointDiscovery:        Bool(true),
+	EnforceShouldRetryCheck:        Bool(true),
+	DisableRestProtocolURICleaning: Bool(true),
+	S3ForcePathStyle:               Bool(true),
+	LowerCaseHeaderMaps:            Bool(true),
 }
 
 var mergeTests = []struct {


### PR DESCRIPTION
Actualy, I wanna fix the `LowerCaseHeaderMaps` issue, its' an important config for the users who are using Metadata, related to #445. 

The `unmarshalHeaderMap` method always returns the canonical header key form, but before this PR #3671, the `LowerCaseHeaderMaps` config didn't work, so I tried to debug it and I found there's a bug in`mergeInConfig` method, now it has been fixed, so just add some tests.
