### PR TITLE
AWS Single Sign-On (SSO) Provider Support

### DIFF
--- a/aws/credentials/ssocreds/doc.go
+++ b/aws/credentials/ssocreds/doc.go
@@ -1,0 +1,60 @@
+// Package ssocreds provides a credential provider for retrieving temporary AWS credentials using an SSO access token.
+//
+// IMPORTANT: The provider in this package does not initiate or perform the AWS SSO login flow. The SDK provider
+// expects that you have already performed the SSO login flow using AWS CLI using the "aws sso login" command, or by
+// some other mechanism. The provider must find a valid non-expired access token for the AWS SSO user portal URL in
+// ~/.aws/sso/cache. If a cached token is not found, it is expired, or the file is malformed an error will be returned.
+//
+// Loading AWS SSO credentials with the AWS shared configuration file
+//
+// You can use configure AWS SSO credentials from the AWS shared configuration file by
+// providing the specifying the required keys in the profile:
+//
+//  sso_account_id
+//  sso_region
+//  sso_role_name
+//  sso_start_url
+//
+// For example, the following defines a profile "devsso" and specifies the AWS SSO parameters that defines the target
+// account, role, sign-on portal, and the region where the user portal is located. Note: all SSO arguments must be
+// provided, or an error will be returned.
+//
+//  [profile devsso]
+//  sso_start_url = https://my-sso-portal.awsapps.com/start
+//  sso_role_name = SSOReadOnlyRole
+//  sso_region = us-east-1
+//  sso_account_id = 123456789012
+//
+// Using the config module, you can load the AWS SDK shared configuration, and specify that this profile be used to
+// retrieve credentials. For example:
+//
+//  sess, err := session.NewSessionWithOptions(session.Options{
+//      SharedConfigState: session.SharedConfigEnable,
+//      Profile:           "devsso",
+//  })
+//  if err != nil {
+//      return err
+//  }
+//
+// Programmatically loading AWS SSO credentials directly
+//
+// You can programmatically construct the AWS SSO Provider in your application, and provide the necessary information
+// to load and retrieve temporary credentials using an access token from ~/.aws/sso/cache.
+//
+//  svc := sso.New(sess, &aws.Config{
+//      Region: aws.String("us-west-2"), // Client Region must correspond to the AWS SSO user portal region
+//  })
+//
+//  provider := ssocreds.NewCredentialsWithClient(svc, "123456789012", "SSOReadOnlyRole", "https://my-sso-portal.awsapps.com/start")
+//
+//  credentials, err := provider.Get()
+//  if err != nil {
+//      return err
+//  }
+//
+// Additional Resources
+//
+// Configuring the AWS CLI to use AWS Single Sign-On: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html
+//
+// AWS Single Sign-On User Guide: https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html
+package ssocreds

--- a/aws/credentials/ssocreds/os.go
+++ b/aws/credentials/ssocreds/os.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package ssocreds
+
+import "os"
+
+func getHomeDirectory() string {
+	return os.Getenv("HOME")
+}

--- a/aws/credentials/ssocreds/os_windows.go
+++ b/aws/credentials/ssocreds/os_windows.go
@@ -1,0 +1,7 @@
+package ssocreds
+
+import "os"
+
+func getHomeDirectory() string {
+	return os.Getenv("USERPROFILE")
+}

--- a/aws/credentials/ssocreds/provider.go
+++ b/aws/credentials/ssocreds/provider.go
@@ -1,0 +1,180 @@
+package ssocreds
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/sso"
+	"github.com/aws/aws-sdk-go/service/sso/ssoiface"
+)
+
+// ErrCodeSSOProviderInvalidToken is the code type that is returned if loaded token has expired or is otherwise invalid.
+// To refresh the SSO session run aws sso login with the corresponding profile.
+const ErrCodeSSOProviderInvalidToken = "SSOProviderInvalidToken"
+
+const invalidTokenMessage = "the SSO session has expired or is invalid"
+
+func init() {
+	nowTime = time.Now
+	defaultCacheLocation = defaultCacheLocationImpl
+}
+
+var nowTime func() time.Time
+
+// ProviderName is the name of the provider used to specify the source of credentials.
+const ProviderName = "SSOProvider"
+
+var defaultCacheLocation func() string
+
+func defaultCacheLocationImpl() string {
+	return filepath.Join(getHomeDirectory(), ".aws", "sso", "cache")
+}
+
+// Provider is an AWS credential provider that retrieves temporary AWS credentials by exchanging an SSO login token.
+type Provider struct {
+	credentials.Expiry
+
+	// The Client which is configured for the AWS Region where the AWS SSO user portal is located.
+	Client ssoiface.SSOAPI
+
+	// The AWS account that is assigned to the user.
+	AccountID string
+
+	// The role name that is assigned to the user.
+	RoleName string
+
+	// The URL that points to the organization's AWS Single Sign-On (AWS SSO) user portal.
+	StartURL string
+}
+
+// NewCredentials returns a new AWS Single Sign-On (AWS SSO) credential provider. The ConfigProvider is expected to be configured
+// for the AWS Region where the AWS SSO user portal is located.
+func NewCredentials(configProvider client.ConfigProvider, accountID, roleName, startURL string, optFns ...func(provider *Provider)) *credentials.Credentials {
+	return NewCredentialsWithClient(sso.New(configProvider), accountID, roleName, startURL, optFns...)
+}
+
+// NewCredentialsWithClient returns a new AWS Single Sign-On (AWS SSO) credential provider. The provided client is expected to be configured
+// for the AWS Region where the AWS SSO user portal is located.
+func NewCredentialsWithClient(client ssoiface.SSOAPI, accountID, roleName, startURL string, optFns ...func(provider *Provider)) *credentials.Credentials {
+	p := &Provider{
+		Client:    client,
+		AccountID: accountID,
+		RoleName:  roleName,
+		StartURL:  startURL,
+	}
+
+	for _, fn := range optFns {
+		fn(p)
+	}
+
+	return credentials.NewCredentials(p)
+}
+
+// Retrieve retrieves temporary AWS credentials from the configured Amazon Single Sign-On (AWS SSO) user portal
+// by exchanging the accessToken present in ~/.aws/sso/cache.
+func (p *Provider) Retrieve() (credentials.Value, error) {
+	return p.RetrieveWithContext(aws.BackgroundContext())
+}
+
+// RetrieveWithContext retrieves temporary AWS credentials from the configured Amazon Single Sign-On (AWS SSO) user portal
+// by exchanging the accessToken present in ~/.aws/sso/cache.
+func (p *Provider) RetrieveWithContext(ctx credentials.Context) (credentials.Value, error) {
+	tokenFile, err := loadTokenFile(p.StartURL)
+	if err != nil {
+		return credentials.Value{}, err
+	}
+
+	output, err := p.Client.GetRoleCredentialsWithContext(ctx, &sso.GetRoleCredentialsInput{
+		AccessToken: &tokenFile.AccessToken,
+		AccountId:   &p.AccountID,
+		RoleName:    &p.RoleName,
+	})
+	if err != nil {
+		return credentials.Value{}, err
+	}
+
+	expireTime := time.Unix(0, aws.Int64Value(output.RoleCredentials.Expiration)*int64(time.Millisecond)).UTC()
+	p.SetExpiration(expireTime, 0)
+
+	return credentials.Value{
+		AccessKeyID:     aws.StringValue(output.RoleCredentials.AccessKeyId),
+		SecretAccessKey: aws.StringValue(output.RoleCredentials.SecretAccessKey),
+		SessionToken:    aws.StringValue(output.RoleCredentials.SessionToken),
+		ProviderName:    ProviderName,
+	}, nil
+}
+
+func getCacheFileName(url string) (string, error) {
+	hash := sha1.New()
+	_, err := hash.Write([]byte(url))
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(hex.EncodeToString(hash.Sum(nil))) + ".json", nil
+}
+
+type rfc3339 time.Time
+
+func (r *rfc3339) UnmarshalJSON(bytes []byte) error {
+	var value string
+
+	if err := json.Unmarshal(bytes, &value); err != nil {
+		return err
+	}
+
+	parse, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return fmt.Errorf("expected RFC3339 timestamp: %v", err)
+	}
+
+	*r = rfc3339(parse)
+
+	return nil
+}
+
+type token struct {
+	AccessToken string  `json:"accessToken"`
+	ExpiresAt   rfc3339 `json:"expiresAt"`
+	Region      string  `json:"region,omitempty"`
+	StartURL    string  `json:"startUrl,omitempty"`
+}
+
+func (t token) Expired() bool {
+	return nowTime().Round(0).After(time.Time(t.ExpiresAt))
+}
+
+func loadTokenFile(startURL string) (t token, err error) {
+	key, err := getCacheFileName(startURL)
+	if err != nil {
+		return token{}, awserr.New(ErrCodeSSOProviderInvalidToken, invalidTokenMessage, err)
+	}
+
+	fileBytes, err := ioutil.ReadFile(filepath.Join(defaultCacheLocation(), key))
+	if err != nil {
+		return token{}, awserr.New(ErrCodeSSOProviderInvalidToken, invalidTokenMessage, err)
+	}
+
+	if err := json.Unmarshal(fileBytes, &t); err != nil {
+		return token{}, awserr.New(ErrCodeSSOProviderInvalidToken, invalidTokenMessage, err)
+	}
+
+	if len(t.AccessToken) == 0 {
+		return token{}, awserr.New(ErrCodeSSOProviderInvalidToken, invalidTokenMessage, nil)
+	}
+
+	if t.Expired() {
+		return token{}, awserr.New(ErrCodeSSOProviderInvalidToken, invalidTokenMessage, nil)
+	}
+
+	return t, nil
+}

--- a/aws/credentials/ssocreds/provider_test.go
+++ b/aws/credentials/ssocreds/provider_test.go
@@ -1,0 +1,184 @@
+// +build go1.9
+
+package ssocreds
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/sso"
+	"github.com/aws/aws-sdk-go/service/sso/ssoiface"
+)
+
+type mockClient struct {
+	ssoiface.SSOAPI
+
+	t *testing.T
+
+	Output *sso.GetRoleCredentialsOutput
+	Err    error
+
+	ExpectedAccountID    string
+	ExpectedAccessToken  string
+	ExpectedRoleName     string
+	ExpectedClientRegion string
+
+	Response func(mockClient) (*sso.GetRoleCredentialsOutput, error)
+}
+
+func (m mockClient) GetRoleCredentialsWithContext(ctx aws.Context, params *sso.GetRoleCredentialsInput, _ ...request.Option) (*sso.GetRoleCredentialsOutput, error) {
+	m.t.Helper()
+
+	if len(m.ExpectedAccountID) > 0 {
+		if e, a := m.ExpectedAccountID, aws.StringValue(params.AccountId); e != a {
+			m.t.Errorf("expect %v, got %v", e, a)
+		}
+	}
+
+	if len(m.ExpectedAccessToken) > 0 {
+		if e, a := m.ExpectedAccessToken, aws.StringValue(params.AccessToken); e != a {
+			m.t.Errorf("expect %v, got %v", e, a)
+		}
+	}
+
+	if len(m.ExpectedRoleName) > 0 {
+		if e, a := m.ExpectedRoleName, aws.StringValue(params.RoleName); e != a {
+			m.t.Errorf("expect %v, got %v", e, a)
+		}
+	}
+
+	if m.Response == nil {
+		return &sso.GetRoleCredentialsOutput{}, nil
+	}
+
+	return m.Response(m)
+}
+
+func swapCacheLocation(dir string) func() {
+	original := defaultCacheLocation
+	defaultCacheLocation = func() string {
+		return dir
+	}
+	return func() {
+		defaultCacheLocation = original
+	}
+}
+
+func swapNowTime(referenceTime time.Time) func() {
+	original := nowTime
+	nowTime = func() time.Time {
+		return referenceTime
+	}
+	return func() {
+		nowTime = original
+	}
+}
+
+func TestProvider(t *testing.T) {
+	restoreCache := swapCacheLocation("testdata")
+	defer restoreCache()
+
+	restoreTime := swapNowTime(time.Date(2021, 01, 19, 19, 50, 0, 0, time.UTC))
+	defer restoreTime()
+
+	cases := map[string]struct {
+		Client    mockClient
+		AccountID string
+		Region    string
+		RoleName  string
+		StartURL  string
+
+		ExpectedErr         bool
+		ExpectedCredentials credentials.Value
+		ExpectedExpire      time.Time
+	}{
+		"missing required parameter values": {
+			StartURL:    "https://invalid-required",
+			ExpectedErr: true,
+		},
+		"valid required parameter values": {
+			Client: mockClient{
+				ExpectedAccountID:    "012345678901",
+				ExpectedRoleName:     "TestRole",
+				ExpectedClientRegion: "us-west-2",
+				ExpectedAccessToken:  "dGhpcyBpcyBub3QgYSByZWFsIHZhbHVl",
+				Response: func(mock mockClient) (*sso.GetRoleCredentialsOutput, error) {
+					return &sso.GetRoleCredentialsOutput{
+						RoleCredentials: &sso.RoleCredentials{
+							AccessKeyId:     aws.String("AccessKey"),
+							SecretAccessKey: aws.String("SecretKey"),
+							SessionToken:    aws.String("SessionToken"),
+							Expiration:      aws.Int64(1611177743123),
+						},
+					}, nil
+				},
+			},
+			AccountID: "012345678901",
+			Region:    "us-west-2",
+			RoleName:  "TestRole",
+			StartURL:  "https://valid-required-only",
+			ExpectedCredentials: credentials.Value{
+				AccessKeyID:     "AccessKey",
+				SecretAccessKey: "SecretKey",
+				SessionToken:    "SessionToken",
+				ProviderName:    ProviderName,
+			},
+			ExpectedExpire: time.Date(2021, 01, 20, 21, 22, 23, 0.123e9, time.UTC),
+		},
+		"expired access token": {
+			StartURL:    "https://expired",
+			ExpectedErr: true,
+		},
+		"api error": {
+			Client: mockClient{
+				ExpectedAccountID:    "012345678901",
+				ExpectedRoleName:     "TestRole",
+				ExpectedClientRegion: "us-west-2",
+				ExpectedAccessToken:  "dGhpcyBpcyBub3QgYSByZWFsIHZhbHVl",
+				Response: func(mock mockClient) (*sso.GetRoleCredentialsOutput, error) {
+					return nil, fmt.Errorf("api error")
+				},
+			},
+			AccountID:   "012345678901",
+			Region:      "us-west-2",
+			RoleName:    "TestRole",
+			StartURL:    "https://valid-required-only",
+			ExpectedErr: true,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			tt.Client.t = t
+
+			provider := &Provider{
+				Client:    tt.Client,
+				AccountID: tt.AccountID,
+				RoleName:  tt.RoleName,
+				StartURL:  tt.StartURL,
+			}
+
+			provider.Expiry.CurrentTime = nowTime
+
+			credentials, err := provider.Retrieve()
+			if (err != nil) != tt.ExpectedErr {
+				t.Errorf("expect error: %v", tt.ExpectedErr)
+			}
+
+			if e, a := tt.ExpectedCredentials, credentials; !reflect.DeepEqual(e, a) {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+
+			if !tt.ExpectedExpire.IsZero() {
+				if e, a := tt.ExpectedExpire, provider.ExpiresAt(); !e.Equal(a) {
+					t.Errorf("expect %v, got %v", e, a)
+				}
+			}
+		})
+	}
+}

--- a/aws/credentials/ssocreds/testdata/00126f0eb29dc1310529dcc8fc178693e1493135.json
+++ b/aws/credentials/ssocreds/testdata/00126f0eb29dc1310529dcc8fc178693e1493135.json
@@ -1,0 +1,4 @@
+{
+  "accessToken": "dGhpcyBpcyBub3QgYSByZWFsIHZhbHVl",
+  "expiresAt": "2021-01-19T23:00:00Z"
+}

--- a/aws/credentials/ssocreds/testdata/b5f90cb535abf87a12eb4c57db2b1e837e229ea0.json
+++ b/aws/credentials/ssocreds/testdata/b5f90cb535abf87a12eb4c57db2b1e837e229ea0.json
@@ -1,0 +1,4 @@
+{
+  "accessToken": "dGhpcyBpcyBub3QgYSByZWFsIHZhbHVl",
+  "expiresAt": "2021-01-19T18:00:00Z"
+}

--- a/aws/credentials/ssocreds/testdata/f7f7ff326478d8c33d47eeb3408cf1c783cb611e.json
+++ b/aws/credentials/ssocreds/testdata/f7f7ff326478d8c33d47eeb3408cf1c783cb611e.json
@@ -1,0 +1,6 @@
+{
+  "accessToken": "",
+  "expiresAt": "",
+  "region": "",
+  "startUrl": ""
+}

--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/processcreds"
+	"github.com/aws/aws-sdk-go/aws/credentials/ssocreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -100,6 +101,9 @@ func resolveCredsFromProfile(cfg *aws.Config,
 			sharedCfg.Creds,
 		)
 
+	case sharedCfg.hasSSOConfiguration():
+		creds = resolveSSOCredentials(cfg, sharedCfg, handlers)
+
 	case len(sharedCfg.CredentialProcess) != 0:
 		// Get credentials from CredentialProcess
 		creds = processcreds.NewCredentials(sharedCfg.CredentialProcess)
@@ -149,6 +153,21 @@ func resolveCredsFromProfile(cfg *aws.Config,
 	}
 
 	return creds, nil
+}
+
+func resolveSSOCredentials(cfg *aws.Config, sharedCfg sharedConfig, handlers request.Handlers) *credentials.Credentials {
+	cfgCopy := cfg.Copy()
+	cfgCopy.Region = &sharedCfg.SSORegion
+
+	return ssocreds.NewCredentials(
+		&Session{
+			Config:   cfgCopy,
+			Handlers: handlers.Copy(),
+		},
+		sharedCfg.SSOAccountID,
+		sharedCfg.SSORoleName,
+		sharedCfg.SSOStartURL,
+	)
 }
 
 // valid credential source values

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -36,7 +36,7 @@ const (
 
 // ErrSharedConfigSourceCollision will be returned if a section contains both
 // source_profile and credential_source
-var ErrSharedConfigSourceCollision = awserr.New(ErrCodeSharedConfig, "only source profile or credential source can be specified, not both", nil)
+var ErrSharedConfigSourceCollision = awserr.New(ErrCodeSharedConfig, "only one credential type may be specified per profile: source profile, credential source, credential process, web identity token, or sso", nil)
 
 // ErrSharedConfigECSContainerEnvVarEmpty will be returned if the environment
 // variables are empty and Environment was set as the credential source

--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -24,6 +25,12 @@ const (
 	mfaSerialKey           = `mfa_serial`        // optional
 	roleSessionNameKey     = `role_session_name` // optional
 	roleDurationSecondsKey = "duration_seconds"  // optional
+
+	// AWS Single Sign-On (AWS SSO) group
+	ssoAccountIDKey = "sso_account_id"
+	ssoRegionKey    = "sso_region"
+	ssoRoleNameKey  = "sso_role_name"
+	ssoStartURL     = "sso_start_url"
 
 	// CSM options
 	csmEnabledKey  = `csm_enabled`
@@ -77,6 +84,11 @@ type sharedConfig struct {
 	CredentialSource     string
 	CredentialProcess    string
 	WebIdentityTokenFile string
+
+	SSOAccountID string
+	SSORegion    string
+	SSORoleName  string
+	SSOStartURL  string
 
 	RoleARN            string
 	RoleSessionName    string
@@ -217,9 +229,9 @@ func (cfg *sharedConfig) setFromIniFiles(profiles map[string]struct{}, profile s
 		cfg.clearAssumeRoleOptions()
 	} else {
 		// First time a profile has been seen, It must either be a assume role
-		// or credentials. Assert if the credential type requires a role ARN,
-		// the ARN is also set.
-		if err := cfg.validateCredentialsRequireARN(profile); err != nil {
+		// credentials, or SSO. Assert if the credential type requires a role ARN,
+		// the ARN is also set, or validate that the SSO configuration is complete.
+		if err := cfg.validateCredentialsConfig(profile); err != nil {
 			return err
 		}
 	}
@@ -312,6 +324,12 @@ func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile, e
 			}
 			cfg.S3UsEast1RegionalEndpoint = sre
 		}
+
+		// AWS Single Sign-On (AWS SSO)
+		updateString(&cfg.SSOAccountID, section, ssoAccountIDKey)
+		updateString(&cfg.SSORegion, section, ssoRegionKey)
+		updateString(&cfg.SSORoleName, section, ssoRoleNameKey)
+		updateString(&cfg.SSOStartURL, section, ssoStartURL)
 	}
 
 	updateString(&cfg.CredentialProcess, section, credentialProcessKey)
@@ -338,6 +356,18 @@ func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile, e
 	updateString(&cfg.CSMClientID, section, csmClientIDKey)
 
 	updateBool(&cfg.S3UseARNRegion, section, s3UseARNRegionKey)
+
+	return nil
+}
+
+func (cfg *sharedConfig) validateCredentialsConfig(profile string) error {
+	if err := cfg.validateCredentialsRequireARN(profile); err != nil {
+		return err
+	}
+
+	if err := cfg.validateSSOConfiguration(profile); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -371,8 +401,39 @@ func (cfg *sharedConfig) validateCredentialType() error {
 		len(cfg.CredentialSource) != 0,
 		len(cfg.CredentialProcess) != 0,
 		len(cfg.WebIdentityTokenFile) != 0,
+		cfg.hasSSOConfiguration(),
 	) {
 		return ErrSharedConfigSourceCollision
+	}
+
+	return nil
+}
+
+func (cfg *sharedConfig) validateSSOConfiguration(profile string) error {
+	if !cfg.hasSSOConfiguration() {
+		return nil
+	}
+
+	var missing []string
+	if len(cfg.SSOAccountID) == 0 {
+		missing = append(missing, ssoAccountIDKey)
+	}
+
+	if len(cfg.SSORegion) == 0 {
+		missing = append(missing, ssoRegionKey)
+	}
+
+	if len(cfg.SSORoleName) == 0 {
+		missing = append(missing, ssoRoleNameKey)
+	}
+
+	if len(cfg.SSOStartURL) == 0 {
+		missing = append(missing, ssoStartURL)
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("profile %q is configured to use SSO but is missing required configuration: %s",
+			profile, strings.Join(missing, ", "))
 	}
 
 	return nil
@@ -384,6 +445,7 @@ func (cfg *sharedConfig) hasCredentials() bool {
 	case len(cfg.CredentialSource) != 0:
 	case len(cfg.CredentialProcess) != 0:
 	case len(cfg.WebIdentityTokenFile) != 0:
+	case cfg.hasSSOConfiguration():
 	case cfg.Creds.HasKeys():
 	default:
 		return false
@@ -405,6 +467,18 @@ func (cfg *sharedConfig) clearAssumeRoleOptions() {
 	cfg.MFASerial = ""
 	cfg.RoleSessionName = ""
 	cfg.SourceProfileName = ""
+}
+
+func (cfg *sharedConfig) hasSSOConfiguration() bool {
+	switch {
+	case len(cfg.SSOAccountID) != 0:
+	case len(cfg.SSORegion) != 0:
+	case len(cfg.SSORoleName) != 0:
+	case len(cfg.SSOStartURL) != 0:
+	default:
+		return false
+	}
+	return true
 }
 
 func oneOrNone(bs ...bool) bool {

--- a/aws/session/shared_config_test.go
+++ b/aws/session/shared_config_test.go
@@ -192,6 +192,56 @@ func TestLoadSharedConfig(t *testing.T) {
 				S3UsEast1RegionalEndpoint: endpoints.RegionalS3UsEast1Endpoint,
 			},
 		},
+		{
+			Filenames: []string{testConfigFilename},
+			Profile:   "sso_creds",
+			Expected: sharedConfig{
+				SSOAccountID: "012345678901",
+				SSORegion:    "us-west-2",
+				SSORoleName:  "TestRole",
+				SSOStartURL:  "https://127.0.0.1/start",
+			},
+		},
+		{
+			Filenames: []string{testConfigFilename},
+			Profile:   "source_sso_creds",
+			Expected: sharedConfig{
+				RoleARN:           "source_sso_creds_arn",
+				SourceProfileName: "sso_creds",
+				SourceProfile: &sharedConfig{
+					SSOAccountID: "012345678901",
+					SSORegion:    "us-west-2",
+					SSORoleName:  "TestRole",
+					SSOStartURL:  "https://127.0.0.1/start",
+				},
+			},
+		},
+		{
+			Filenames: []string{testConfigFilename},
+			Profile:   "invalid_sso_creds",
+			Err:       fmt.Errorf("profile \"invalid_sso_creds\" is configured to use SSO but is missing required configuration: sso_region, sso_role_name, sso_start_url"),
+		},
+		{
+			Filenames: []string{testConfigFilename},
+			Profile:   "sso_and_static",
+			Expected: sharedConfig{
+				Creds: credentials.Value{
+					AccessKeyID:     "sso_and_static_akid",
+					SecretAccessKey: "sso_and_static_secret",
+					SessionToken:    "sso_and_static_token",
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+				},
+				SSOAccountID: "012345678901",
+				SSORegion:    "us-west-2",
+				SSORoleName:  "TestRole",
+				SSOStartURL:  "https://THIS_SHOULD_NOT_BE_IN_TESTDATA_CACHE/start",
+			},
+		},
+		{
+			Filenames: []string{testConfigFilename},
+			Profile:   "source_sso_and_assume",
+			Err:       fmt.Errorf("only one credential type may be specified per profile"),
+		},
 	}
 
 	for i, c := range cases {

--- a/aws/session/testdata/credential_source_config
+++ b/aws/session/testdata/credential_source_config
@@ -30,4 +30,25 @@ credential_process = cat ./testdata/test_json.json
 role_arn = assume_role_w_creds_proc_source_prof
 source_profile = cred_proc_no_arn_set
 
+[profile sso_creds]
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://127.0.0.1/start
 
+[profile source_sso_creds]
+role_arn = source_sso_creds_arn
+source_profile = sso_creds
+
+[profile assume_sso_and_static]
+role_arn = assume_sso_and_static_arn
+source_profile = sso_and_static
+
+[profile sso_and_static]
+aws_access_key_id = sso_and_static_akid
+aws_secret_access_key = sso_and_static_secret
+aws_session_token = sso_and_static_token
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://THIS_SHOULD_NOT_BE_IN_TESTDATA_CACHE/start

--- a/aws/session/testdata/shared_config
+++ b/aws/session/testdata/shared_config
@@ -106,3 +106,37 @@ s3_us_east_1_regional_endpoint = regional
 
 [valid_arn_region]
 s3_use_arn_region=true
+
+[profile sso_creds]
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://127.0.0.1/start
+
+[profile source_sso_creds]
+role_arn = source_sso_creds_arn
+source_profile = sso_creds
+
+[profile invalid_sso_creds]
+sso_account_id = 012345678901
+
+[profile sso_and_static]
+aws_access_key_id = sso_and_static_akid
+aws_secret_access_key = sso_and_static_secret
+aws_session_token = sso_and_static_token
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://THIS_SHOULD_NOT_BE_IN_TESTDATA_CACHE/start
+
+[profile sso_and_assume]
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://127.0.0.1/start
+role_arn = sso_with_assume_role_arn
+source_profile = multiple_assume_role_with_credential_source
+
+[profile source_sso_and_assume]
+role_arn = source_sso_and_assume_arn
+source_profile = sso_and_assume


### PR DESCRIPTION
Adds support for the AWS Single Sign-On (SSO) service by supporting the ability to utilize tokens cached in ~/.aws/sso/cache.

Adds support for the AWS SSO provider in the default credential loading chain.