### PR TITLE
service/lexmodelsv2: Add fix to send expected Content-Type header

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/lexmodelsv2`: Add fix to send expected Content-Type header
+    * Fixes the Amazon Lex Model Builder V2 API client to send the expected Content-Type of application/x-amz-json-1.1.

--- a/service/lexmodelsv2/cust_integ_test.go
+++ b/service/lexmodelsv2/cust_integ_test.go
@@ -1,0 +1,20 @@
+// +build integration
+
+package lexmodelsv2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/awstesting/integration"
+)
+
+func TestInteg_ListBots(t *testing.T) {
+	sess := integration.SessionWithDefaultRegion("us-west-2")
+
+	client := New(sess)
+
+	_, err := client.ListBots(&ListBotsInput{})
+	if err != nil {
+		t.Fatalf("expect API call, got %v", err)
+	}
+}

--- a/service/lexmodelsv2/customizations.go
+++ b/service/lexmodelsv2/customizations.go
@@ -1,0 +1,18 @@
+package lexmodelsv2
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func init() {
+	initClient = func(c *client.Client) {
+		c.Handlers.Build.PushBack(func(r *request.Request) {
+			if strings.EqualFold(r.HTTPRequest.Header.Get("Content-Type"), "application/json") {
+				r.HTTPRequest.Header.Set("Content-Type", "application/x-amz-json-1.1")
+			}
+		})
+	}
+}

--- a/service/lexmodelsv2/customizations_test.go
+++ b/service/lexmodelsv2/customizations_test.go
@@ -1,0 +1,37 @@
+package lexmodelsv2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+)
+
+func TestClientContentType(t *testing.T) {
+	sess := unit.Session.Copy()
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			contentType := r.Header.Get("Content-Type")
+			if e, a := contentType, "application/x-amz-json-1.1"; !strings.EqualFold(e, a) {
+				t.Errorf("expect %v content-type, got %v", e, a)
+			}
+		},
+	))
+	defer server.Close()
+
+	client := New(sess, &aws.Config{Endpoint: &server.URL})
+	_, err := client.ListBotsWithContext(context.Background(),
+		&ListBotsInput{},
+		func(r *request.Request) {
+		},
+	)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes the Amazon Lex Model Builder V2 API client to send the expected Content-Type of application/x-amz-json-1.1.