### PR TITLE
s3: adds support for s3 vpc interface endpoints

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `service/s3`: Amazon S3 now supports AWS PrivateLink, providing direct access to S3 via a private endpoint within your virtual private network.
 
 ### SDK Bugs
 * `aws/session`: Fixed a bug that prevented credentials from being sourced from the environment if the loaded shared config profile contained partial SSO configuration. ([#3769](https://github.com/aws/aws-sdk-go/pull/3769))

--- a/example/service/s3/usingPrivateLink/README.md
+++ b/example/service/s3/usingPrivateLink/README.md
@@ -1,0 +1,33 @@
+# Example
+
+This example demonstrates how you can use the AWS SDK for Go's Amazon S3 client 
+to use AWS PrivateLink for Amazon S3.
+
+# Usage
+
+To access S3 bucket data using the s3 interface endpoints, prefix the vpc 
+endpoint with `bucket`. For eg, use endpoint url as `https://bucket.vpce-0xxxxxxx-xxx8xxg.s3.us-west-2.vpce.amazonaws.com` 
+to access S3 bucket data via the associated vpc endpoint. The SDK may mutate 
+this endpoint as per the input provided to work with ARNs. 
+
+To access S3 access point data using the s3 interface endpoints, prefix the vpc 
+endpoint with `accesspoint`. For eg, use endpoint url as `https://accesspoint.vpce-0xxxxxxx-xxxx8xxg.s3.us-west-2.vpce.amazonaws.com` 
+to access S3 access point data via the associated vpc endpoint. The SDK may 
+mutate this endpoint as per the input provided to work with ARNs.
+
+To work with S3 control using the s3 interface endpoints, prefix the vpc endpoint 
+with `control`. For eg, use endpoint url as `https://control.vpce-0xxxxxxx-xxx8xxg.s3.us-west-2.vpce.amazonaws.com` 
+to use S3 Control operations with the associated vpc endpoint. The SDK may mutate 
+this endpoint as per the input provided to work with ARNs.
+
+The example will create s3 client's that use appropriate vpc endpoint url. The example 
+will then create a bucket of the name provided in code. Replace the value of 
+the `accountID` const with the account ID for your AWS account. The 
+`vpcBucketEndpointUrl`, `vpcAccesspointEndpoint`, `vpcControlEndpoint`, `bucket`, 
+`keyName`, and `accessPoint` const variables need to be updated to match the name 
+of the appropriate vpc endpoint, Bucket, Object Key, and Access Point that will be 
+created by the example.
+
+```sh
+AWS_REGION=<region> go run -tags example usingPrivateLink.go
+```

--- a/example/service/s3/usingPrivateLink/usingPrivateLink.go
+++ b/example/service/s3/usingPrivateLink/usingPrivateLink.go
@@ -1,0 +1,105 @@
+// +build example
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3control"
+)
+
+const (
+	bucketName  = "myBucketName"
+	keyName     = "myKeyName"
+	accountID   = "123456789012"
+	accessPoint = "accesspointname"
+
+	// vpcBucketEndpoint will be used by the SDK to resolve an endpoint, when making a call to
+	// access `bucket` data using s3 interface endpoint. This endpoint may be mutated by the SDK,
+	// as per the input provided to work with ARNs.
+	vpcBucketEndpoint = "https://bucket.vpce-0xxxxxxx-xxx8xxg.s3.us-west-2.vpce.amazonaws.com"
+
+	// vpcAccesspointEndpoint will be used by the SDK to resolve an endpoint, when making a call to
+	// access `access-point` data using s3 interface endpoint. This endpoint may be mutated by the SDK,
+	// as per the input provided to work with ARNs.
+	vpcAccesspointEndpoint = "https://accesspoint.vpce-0xxxxxxx-xxx8xxg.s3.us-west-2.vpce.amazonaws.com"
+
+	// vpcControlEndpoint will be used by the SDK to resolve an endpoint, when making a call to
+	// access `control` data using s3 interface endpoint. This endpoint may be mutated by the SDK,
+	// as per the input provided to work with ARNs.
+	vpcControlEndpoint = "https://control.vpce-0xxxxxxx-xxx8xxg.s3.us-west-2.vpce.amazonaws.com"
+)
+
+func main() {
+	sess := session.Must(session.NewSession())
+
+	s3BucketSvc := s3.New(sess, &aws.Config{
+		Endpoint: aws.String(vpcBucketEndpoint),
+	})
+
+	s3AccesspointSvc := s3.New(sess, &aws.Config{
+		Endpoint: aws.String(vpcAccesspointEndpoint),
+	})
+
+	s3ControlSvc := s3control.New(sess, &aws.Config{
+		Endpoint: aws.String(vpcControlEndpoint),
+	})
+
+	// Create an S3 Bucket
+	fmt.Println("create s3 bucket")
+	_, err := s3BucketSvc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to create bucket: %v", err))
+	}
+
+	// Wait for S3 Bucket to Exist
+	fmt.Println("wait for s3 bucket to exist")
+	err = s3BucketSvc.WaitUntilBucketExists(&s3.HeadBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		panic(fmt.Sprintf("bucket failed to materialize: %v", err))
+	}
+
+	// Create an Access Point referring to the bucket
+	fmt.Println("create an access point")
+	_, err = s3ControlSvc.CreateAccessPoint(&s3control.CreateAccessPointInput{
+		AccountId: aws.String(accountID),
+		Bucket:    aws.String(bucketName),
+		Name:      aws.String(accessPoint),
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to create access point: %v", err))
+	}
+
+	// Use the SDK's ARN builder to create an ARN for the Access Point.
+	apARN := arn.ARN{
+		Partition: "aws",
+		Service:   "s3",
+		Region:    aws.StringValue(sess.Config.Region),
+		AccountID: accountID,
+		Resource:  "accesspoint/" + accessPoint,
+	}
+
+	// And Use Access Point ARN where bucket parameters are accepted
+	fmt.Println("get object using access point")
+	getObjectOutput, err := s3AccesspointSvc.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(apARN.String()),
+		Key:    aws.String("somekey"),
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed get object request: %v", err))
+	}
+
+	_, err = ioutil.ReadAll(getObjectOutput.Body)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read object body: %v", err))
+	}
+}

--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -94,6 +94,10 @@ func supressSmokeTest(a *API) error {
 
 // Customizes the API generation to replace values specific to S3.
 func s3Customizations(a *API) error {
+
+	// back-fill signing name as 's3'
+	a.Metadata.SigningName = "s3"
+
 	var strExpires *Shape
 
 	var keepContentMD5Ref = map[string]struct{}{

--- a/service/s3/endpoint.go
+++ b/service/s3/endpoint.go
@@ -98,7 +98,7 @@ func endpointHandler(req *request.Request) {
 		Request:  req,
 	}
 
-	if resReq.IsCrossPartition() {
+	if len(resReq.Request.ClientInfo.PartitionID) != 0 && resReq.IsCrossPartition() {
 		req.Error = s3shared.NewClientPartitionMismatchError(resource,
 			req.ClientInfo.PartitionID, aws.StringValue(req.Config.Region), nil)
 		return
@@ -107,11 +107,6 @@ func endpointHandler(req *request.Request) {
 	if !resReq.AllowCrossRegion() && resReq.IsCrossRegion() {
 		req.Error = s3shared.NewClientRegionMismatchError(resource,
 			req.ClientInfo.PartitionID, aws.StringValue(req.Config.Region), nil)
-		return
-	}
-
-	if resReq.HasCustomEndpoint() {
-		req.Error = s3shared.NewInvalidARNWithCustomEndpointError(resource, nil)
 		return
 	}
 
@@ -155,8 +150,7 @@ func updateRequestAccessPointEndpoint(req *request.Request, accessPoint arn.Acce
 			req.ClientInfo.PartitionID, aws.StringValue(req.Config.Region), nil)
 	}
 
-	// Ignore the disable host prefix for access points since custom endpoints
-	// are not supported.
+	// Ignore the disable host prefix for access points
 	req.Config.DisableEndpointHostPrefix = aws.Bool(false)
 
 	if err := accessPointEndpointBuilder(accessPoint).build(req); err != nil {
@@ -181,8 +175,7 @@ func updateRequestOutpostAccessPointEndpoint(req *request.Request, accessPoint a
 			req.ClientInfo.PartitionID, aws.StringValue(req.Config.Region), nil)
 	}
 
-	// Ignore the disable host prefix for access points since custom endpoints
-	// are not supported.
+	// Ignore the disable host prefix for access points
 	req.Config.DisableEndpointHostPrefix = aws.Bool(false)
 
 	if err := outpostAccessPointEndpointBuilder(accessPoint).build(req); err != nil {

--- a/service/s3/service.go
+++ b/service/s3/service.go
@@ -48,6 +48,9 @@ const (
 //     svc := s3.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *S3 {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
+		c.SigningName = "s3"
+	}
 	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 

--- a/service/s3control/endpoint_builder.go
+++ b/service/s3control/endpoint_builder.go
@@ -20,6 +20,11 @@ const (
 	outpostPrefixLabel = "outpost"
 )
 
+// hasCustomEndpoint returns true if endpoint is a custom endpoint
+func hasCustomEndpoint(r *request.Request) bool {
+	return len(aws.StringValue(r.Config.Endpoint)) > 0
+}
+
 // outpostAccessPointEndpointBuilder represents the endpoint builder for outpost access point arn.
 type outpostAccessPointEndpointBuilder arn.OutpostAccessPointARN
 
@@ -51,14 +56,17 @@ func (o outpostAccessPointEndpointBuilder) build(req *request.Request) error {
 			req.ClientInfo.PartitionID, resolveRegion, err)
 	}
 
-	if err = updateRequestEndpoint(req, endpoint.URL); err != nil {
-		return err
-	}
+	endpoint.URL = endpoints.AddScheme(endpoint.URL, aws.BoolValue(req.Config.DisableSSL))
 
-	// add url host as s3-outposts
-	cfgHost := req.HTTPRequest.URL.Host
-	if strings.HasPrefix(cfgHost, endpointsID) {
-		req.HTTPRequest.URL.Host = resolveService + cfgHost[len(endpointsID):]
+	if !hasCustomEndpoint(req) {
+		if err = updateRequestEndpoint(req, endpoint.URL); err != nil {
+			return err
+		}
+		// add url host as s3-outposts
+		cfgHost := req.HTTPRequest.URL.Host
+		if strings.HasPrefix(cfgHost, endpointsID) {
+			req.HTTPRequest.URL.Host = resolveService + cfgHost[len(endpointsID):]
+		}
 	}
 
 	// set the signing region, name to resolved names from ARN
@@ -105,14 +113,18 @@ func (o outpostBucketResourceEndpointBuilder) build(req *request.Request) error 
 			req.ClientInfo.PartitionID, cfgRegion, err)
 	}
 
-	if err = updateRequestEndpoint(req, endpoint.URL); err != nil {
-		return err
-	}
+	endpoint.URL = endpoints.AddScheme(endpoint.URL, aws.BoolValue(req.Config.DisableSSL))
 
-	// add url host as s3-outposts
-	cfgHost := req.HTTPRequest.URL.Host
-	if strings.HasPrefix(cfgHost, endpointsID) {
-		req.HTTPRequest.URL.Host = resolveService + cfgHost[len(endpointsID):]
+	if !hasCustomEndpoint(req) {
+		if err = updateRequestEndpoint(req, endpoint.URL); err != nil {
+			return err
+		}
+
+		// add url host as s3-outposts
+		cfgHost := req.HTTPRequest.URL.Host
+		if strings.HasPrefix(cfgHost, endpointsID) {
+			req.HTTPRequest.URL.Host = resolveService + cfgHost[len(endpointsID):]
+		}
 	}
 
 	// signer redirection
@@ -134,8 +146,6 @@ func resolveRegionalEndpoint(r *request.Request, region string, endpointsID stri
 }
 
 func updateRequestEndpoint(r *request.Request, endpoint string) (err error) {
-	endpoint = endpoints.AddScheme(endpoint, aws.BoolValue(r.Config.DisableSSL))
-
 	r.HTTPRequest.URL, err = url.Parse(endpoint + r.Operation.HTTPPath)
 	if err != nil {
 		return awserr.New(request.ErrCodeSerialization,

--- a/service/s3control/endpoint_test.go
+++ b/service/s3control/endpoint_test.go
@@ -337,7 +337,7 @@ func runValidations(t *testing.T, cases map[string]testParams) {
 					t.Errorf("expected %v, got %v", e, a)
 				}
 
-				if e, a := c.expectedSigningName, r.ClientInfo.SigningName; c.config.Endpoint == nil && e != a {
+				if e, a := c.expectedSigningName, r.ClientInfo.SigningName; e != a {
 					t.Errorf("expected %v, got %v", e, a)
 				}
 				if e, a := c.expectedSigningRegion, r.ClientInfo.SigningRegion; e != a {
@@ -373,18 +373,20 @@ func runValidations(t *testing.T, cases map[string]testParams) {
 	}
 }
 
+type testParamsWithRequestFn struct {
+	bucket                     string
+	outpostID                  string
+	config                     *aws.Config
+	requestFn                  func(c *S3Control) *request.Request
+	expectedEndpoint           string
+	expectedSigningName        string
+	expectedSigningRegion      string
+	expectedHeaderForOutpostID string
+	expectedErr                string
+}
+
 func TestCustomEndpoint_SpecialOperations(t *testing.T) {
-	cases := map[string]struct {
-		bucket                     string
-		outpostID                  string
-		config                     *aws.Config
-		requestFn                  func(c *S3Control) *request.Request
-		expectedEndpoint           string
-		expectedSigningName        string
-		expectedSigningRegion      string
-		expectedHeaderForOutpostID string
-		expectedErr                string
-	}{
+	cases := map[string]testParamsWithRequestFn{
 		"CreateBucketOperation": {
 			bucket:    "mockBucket",
 			outpostID: "op-01234567890123456",
@@ -456,54 +458,201 @@ func TestCustomEndpoint_SpecialOperations(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			sess := unit.Session.Copy(c.config)
-			svc := New(sess)
-			req := c.requestFn(svc)
-			req.Handlers.Send.Clear()
-			req.Handlers.Send.PushBack(func(r *request.Request) {
-				defer func() {
-					r.HTTPResponse = &http.Response{
-						StatusCode:    200,
-						ContentLength: 0,
-						Body:          ioutil.NopCloser(bytes.NewReader(nil)),
-					}
-				}()
-				if len(c.expectedErr) != 0 {
-					return
-				}
-
-				endpoint := fmt.Sprintf("%s://%s", r.HTTPRequest.URL.Scheme, r.HTTPRequest.URL.Host)
-				if e, a := c.expectedEndpoint, endpoint; e != a {
-					t.Errorf("expected %v, got %v", e, a)
-				}
-
-				if e, a := c.expectedSigningName, r.ClientInfo.SigningName; c.config.Endpoint == nil && e != a {
-					t.Errorf("expected %v, got %v", e, a)
-				}
-				if e, a := c.expectedSigningRegion, r.ClientInfo.SigningRegion; e != a {
-					t.Errorf("expected %v, got %v", e, a)
-				}
-
-				if e, a := c.expectedHeaderForOutpostID, r.HTTPRequest.Header.Get("x-amz-outpost-id"); e != a {
-					if len(e) == 0 {
-						t.Errorf("expected no outpost id header set, got %v", a)
-					} else if len(a) == 0 {
-						t.Errorf("expected outpost id header set as %v, got none", e)
-					} else {
-						t.Errorf("expected %v as Outpost id header value, got %v", e, a)
-					}
-				}
-			})
-
-			err := req.Send()
-			if len(c.expectedErr) == 0 && err != nil {
-				t.Errorf("expected no error but got: %v", err)
-			} else if len(c.expectedErr) != 0 && err == nil {
-				t.Errorf("expected err %q, but got nil", c.expectedErr)
-			} else if len(c.expectedErr) != 0 && err != nil && !strings.Contains(err.Error(), c.expectedErr) {
-				t.Errorf("expected %v, got %v", c.expectedErr, err.Error())
-			}
+			runValidationsWithRequestFn(t, c)
 		})
+	}
+}
+
+func TestCustomEndpointURL(t *testing.T) {
+	account := "123456789012"
+	cases := map[string]testParamsWithRequestFn{
+		"standard GetAccesspoint with custom endpoint url": {
+			config: &aws.Config{
+				Endpoint: aws.String("beta.example.com"),
+				Region:   aws.String("us-west-2"),
+			},
+			requestFn: func(c *S3Control) *request.Request {
+				req, _ := c.GetAccessPointRequest(&GetAccessPointInput{
+					AccountId: aws.String(account),
+					Name:      aws.String("apname"),
+				})
+				return req
+			},
+			expectedEndpoint:      "https://123456789012.beta.example.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "us-west-2",
+		},
+		"Outpost Accesspoint ARN with GetAccesspoint and custom endpoint url": {
+			config: &aws.Config{
+				Endpoint: aws.String("beta.example.com"),
+				Region:   aws.String("us-west-2"),
+			},
+			requestFn: func(c *S3Control) *request.Request {
+				req, _ := c.GetAccessPointRequest(&GetAccessPointInput{
+					AccountId: aws.String(account),
+					Name:      aws.String("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint"),
+				})
+				return req
+			},
+			expectedEndpoint:           "https://beta.example.com",
+			expectedSigningName:        "s3-outposts",
+			expectedSigningRegion:      "us-west-2",
+			expectedHeaderForOutpostID: "op-01234567890123456",
+		},
+		"standard CreateBucket with custom endpoint url": {
+			config: &aws.Config{
+				Endpoint: aws.String("beta.example.com"),
+				Region:   aws.String("us-west-2"),
+			},
+			requestFn: func(c *S3Control) *request.Request {
+				req, _ := c.CreateBucketRequest(&CreateBucketInput{
+					Bucket:    aws.String("bucketname"),
+					OutpostId: aws.String("op-123"),
+				})
+				return req
+			},
+			expectedEndpoint:           "https://beta.example.com",
+			expectedSigningName:        "s3-outposts",
+			expectedSigningRegion:      "us-west-2",
+			expectedHeaderForOutpostID: "op-123",
+		},
+		"Outpost Accesspoint for GetBucket with custom endpoint url": {
+			config: &aws.Config{
+				Endpoint: aws.String("beta.example.com"),
+				Region:   aws.String("us-west-2"),
+			},
+			requestFn: func(c *S3Control) *request.Request {
+				req, _ := c.GetBucketRequest(&GetBucketInput{
+					Bucket: aws.String("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:bucket:mybucket"),
+				})
+				return req
+			},
+			expectedEndpoint:           "https://beta.example.com",
+			expectedSigningName:        "s3-outposts",
+			expectedSigningRegion:      "us-west-2",
+			expectedHeaderForOutpostID: "op-01234567890123456",
+		},
+		"GetAccesspoint with dualstack and custom endpoint url": {
+			config: &aws.Config{
+				Endpoint:     aws.String("beta.example.com"),
+				Region:       aws.String("us-west-2"),
+				UseDualStack: aws.Bool(true),
+			},
+			requestFn: func(c *S3Control) *request.Request {
+				req, _ := c.GetAccessPointRequest(&GetAccessPointInput{
+					AccountId: aws.String(account),
+					Name:      aws.String("apname"),
+				})
+				return req
+			},
+			expectedEndpoint:      "https://123456789012.beta.example.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "us-west-2",
+		},
+		"GetAccesspoint with Outposts accesspoint ARN and dualstack": {
+			config: &aws.Config{
+				Endpoint:     aws.String("beta.example.com"),
+				UseDualStack: aws.Bool(true),
+				Region:       aws.String("us-west-2"),
+			},
+			requestFn: func(c *S3Control) *request.Request {
+				req, _ := c.GetAccessPointRequest(&GetAccessPointInput{
+					AccountId: aws.String(account),
+					Name:      aws.String("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint"),
+				})
+				return req
+			},
+			expectedErr: "client configured for S3 Dual-stack but is not supported with resource ARN",
+		},
+		"standard CreateBucket with dualstack": {
+			config: &aws.Config{
+				Endpoint:     aws.String("beta.example.com"),
+				UseDualStack: aws.Bool(true),
+				Region:       aws.String("us-west-2"),
+			},
+			requestFn: func(c *S3Control) *request.Request {
+				req, _ := c.CreateBucketRequest(&CreateBucketInput{
+					Bucket:    aws.String("bucketname"),
+					OutpostId: aws.String("op-1234567890123456"),
+				})
+				return req
+			},
+			expectedEndpoint:           "https://beta.example.com",
+			expectedSigningName:        "s3-outposts",
+			expectedSigningRegion:      "us-west-2",
+			expectedHeaderForOutpostID: "op-1234567890123456",
+		},
+		"GetBucket with Outpost bucket ARN": {
+			config: &aws.Config{
+				Endpoint:     aws.String("beta.example.com"),
+				Region:       aws.String("us-west-2"),
+				UseDualStack: aws.Bool(true),
+			},
+			requestFn: func(c *S3Control) *request.Request {
+				req, _ := c.GetBucketRequest(&GetBucketInput{
+					Bucket: aws.String("arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:bucket:mybucket"),
+				})
+				return req
+			},
+			expectedErr: "client configured for S3 Dual-stack but is not supported with resource ARN",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			runValidationsWithRequestFn(t, c)
+		})
+	}
+}
+
+func runValidationsWithRequestFn(t *testing.T, c testParamsWithRequestFn) {
+	sess := unit.Session.Copy(c.config)
+	svc := New(sess)
+
+	req := c.requestFn(svc)
+	req.Handlers.Send.Clear()
+	req.Handlers.Send.PushBack(func(r *request.Request) {
+		defer func() {
+			r.HTTPResponse = &http.Response{
+				StatusCode:    200,
+				ContentLength: 0,
+				Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+			}
+		}()
+		if len(c.expectedErr) != 0 {
+			return
+		}
+
+		endpoint := fmt.Sprintf("%s://%s", r.HTTPRequest.URL.Scheme, r.HTTPRequest.URL.Host)
+		if e, a := c.expectedEndpoint, endpoint; e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+
+		if e, a := c.expectedSigningName, r.ClientInfo.SigningName; e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+		if e, a := c.expectedSigningRegion, r.ClientInfo.SigningRegion; e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+
+		if e, a := c.expectedHeaderForOutpostID, r.HTTPRequest.Header.Get("x-amz-outpost-id"); e != a {
+			if len(e) == 0 {
+				t.Errorf("expected no outpost id header set, got %v", a)
+			} else if len(a) == 0 {
+				t.Errorf("expected outpost id header set as %v, got none", e)
+			} else {
+				t.Errorf("expected %v as Outpost id header value, got %v", e, a)
+			}
+		}
+	})
+
+	err := req.Send()
+	if len(c.expectedErr) == 0 && err != nil {
+		t.Errorf("expected no error but got: %v", err)
+	} else if len(c.expectedErr) != 0 && err == nil {
+		t.Errorf("expected err %q, but got nil", c.expectedErr)
+	} else if len(c.expectedErr) != 0 && err != nil && !strings.Contains(err.Error(), c.expectedErr) {
+		t.Errorf("expected %v, got %v", c.expectedErr, err.Error())
 	}
 }
 


### PR DESCRIPTION
`service/s3`: Adds support for S3 vpc interface endpoint.
`service/s3control`: Adds support for S3control vpc interface endpoint.


