### PR TITLE
aws/client: Fix logging to allow it to be enabled per operation

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/client`: Fix logging to allow it to be enabled per operation
+  * Allow logging of operation and request to be enabled per operation, not only per client or session.

--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -88,10 +88,6 @@ func (c *Client) NewRequest(operation *request.Operation, params interface{}, da
 // AddDebugHandlers injects debug logging handlers into the service to log request
 // debug information.
 func (c *Client) AddDebugHandlers() {
-	if !c.Config.LogLevel.AtLeast(aws.LogDebug) {
-		return
-	}
-
 	c.Handlers.Send.PushFrontNamed(LogHTTPRequestHandler)
 	c.Handlers.Send.PushBackNamed(LogHTTPResponseHandler)
 }

--- a/aws/client/client_test.go
+++ b/aws/client/client_test.go
@@ -47,11 +47,13 @@ func TestNewClient_CopyHandlers(t *testing.T) {
 	if e, a := 2, handlers.Send.Len(); e != a {
 		t.Errorf("expect %d original handlers, got %d", e, a)
 	}
-	if e, a := 3, c.Handlers.Send.Len(); e != a {
+	if e, a := 5, c.Handlers.Send.Len(); e != a {
 		t.Errorf("expect %d client handlers, got %d", e, a)
 	}
 
-	handlers.Send.Run(nil)
+	req := c.NewRequest(&request.Operation{}, struct{}{}, struct{}{})
+
+	handlers.Send.Run(req)
 	if !*firstCalled {
 		t.Errorf("expect first handler to of been called")
 	}
@@ -64,7 +66,7 @@ func TestNewClient_CopyHandlers(t *testing.T) {
 		t.Errorf("expect client handler to not of been called, but was")
 	}
 
-	c.Handlers.Send.Run(nil)
+	c.Handlers.Send.Run(req)
 	if !*firstCalled {
 		t.Errorf("expect client's first handler to of been called")
 	}

--- a/aws/client/logger.go
+++ b/aws/client/logger.go
@@ -53,6 +53,10 @@ var LogHTTPRequestHandler = request.NamedHandler{
 }
 
 func logRequest(r *request.Request) {
+	if !r.Config.LogLevel.AtLeast(aws.LogDebug) {
+		return
+	}
+
 	logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
 	bodySeekable := aws.IsReaderSeekable(r.Body)
 
@@ -120,6 +124,10 @@ var LogHTTPResponseHandler = request.NamedHandler{
 }
 
 func logResponse(r *request.Request) {
+	if !r.Config.LogLevel.AtLeast(aws.LogDebug) {
+		return
+	}
+
 	lw := &logWriter{r.Config.Logger, bytes.NewBuffer(nil)}
 
 	if r.HTTPResponse == nil {

--- a/aws/client/logger_test.go
+++ b/aws/client/logger_test.go
@@ -134,6 +134,7 @@ func TestLogResponse(t *testing.T) {
 		ExpectBody []byte
 		ReadBody   bool
 		LogLevel   aws.LogLevelType
+		ExpectLog  bool
 	}{
 		{
 			Body:       bytes.NewBuffer([]byte("body content")),
@@ -142,11 +143,13 @@ func TestLogResponse(t *testing.T) {
 		{
 			Body:       bytes.NewBuffer([]byte("body content")),
 			LogLevel:   aws.LogDebug,
+			ExpectLog:  true,
 			ExpectBody: []byte("body content"),
 		},
 		{
 			Body:       bytes.NewBuffer([]byte("body content")),
 			LogLevel:   aws.LogDebugWithHTTPBody,
+			ExpectLog:  true,
 			ReadBody:   true,
 			ExpectBody: []byte("body content"),
 		},
@@ -190,8 +193,10 @@ func TestLogResponse(t *testing.T) {
 			}
 		}
 
-		if logW.Len() == 0 {
+		if c.ExpectLog && logW.Len() == 0 {
 			t.Errorf("%d, expect HTTP Response headers to be logged", i)
+		} else if !c.ExpectLog && logW.Len() != 0 {
+			t.Errorf("%d, expect no log, got,\n%v", i, logW.String())
 		}
 
 		b, err := ioutil.ReadAll(req.HTTPResponse.Body)


### PR DESCRIPTION
Allow logging of operation and request to be enabled per operation, not only per client or session.

```go
	client := dynamodb.New(sess)

	var w bytes.Buffer
	resp, err := client.DescribeTableWithContext(context.TODO(), params,
		func(r *request.Request) {
			r.Config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
			r.Config.Logger = aws.LoggerFunc(func(args ...interface{}) {
				fmt.Fprintln(&w, args...)
			})
		})
	if someCondition {
		log.Printf("Condition met\n%s", w.String())
	}
```