### PR TITLE
 private/protocol: Fix protocol unit test for Go 1.16.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ go:
     - 1.13.x
     - 1.14.x
     - 1.15.x
+    - 1.16.x
     - tip
 
 matrix:
@@ -39,6 +40,8 @@ matrix:
         - os: windows
           go: 1.15.x
         - os: windows
+          go: 1.16.x
+        - os: windows
           go: tip
 
 before_install:
@@ -46,7 +49,8 @@ before_install:
 
 script:
   - if [ -z $(go env GOMOD) ]; then
-      if [ "$TRAVIS_GO_VERSION" == "1.13.x" ] ||
+      if [ "$TRAVIS_GO_VERSION" == "1.14.x" ] ||
+          [ "$TRAVIS_GO_VERSION" == "1.13.x" ] ||
           [ "$TRAVIS_GO_VERSION" == "1.12.x" ] ||
           [ "$TRAVIS_GO_VERSION" == "1.11.x" ] ||
           [ "$TRAVIS_GO_VERSION" == "1.10.x" ]; then
@@ -55,8 +59,8 @@ script:
       make get-deps;
     fi;
     if [ "$TRAVIS_GO_VERSION" == "tip" ] ||
-        [ "$TRAVIS_GO_VERSION" == "1.15.x" ] ||
-        [ "$TRAVIS_GO_VERSION" == "1.14.x" ]; then
+        [ "$TRAVIS_GO_VERSION" == "1.16.x" ] ||
+        [ "$TRAVIS_GO_VERSION" == "1.15.x" ]; then
 
       if [ "$TRAVIS_OS_NAME" = "windows" ]; then
         make unit-no-verify;

--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,13 @@ sandbox-go1.15: sandbox-build-go1.15
 sandbox-test-go1.15: sandbox-build-go1.15
 	docker run -t aws-sdk-go-1.15
 
+sandbox-build-go1.16:
+	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.16 -t "aws-sdk-go-1.16" .
+sandbox-go1.16: sandbox-build-go1.16
+	docker run -i -t aws-sdk-go-1.16 bash
+sandbox-test-go1.16: sandbox-build-go1.16
+	docker run -t aws-sdk-go-1.16
+
 sandbox-build-gotip:
 	@echo "Run make update-aws-golang-tip, if this test fails because missing aws-golang:tip container"
 	docker build -f ./awstesting/sandbox/Dockerfile.test.gotip -t "aws-sdk-go-tip" .

--- a/aws/credentials/credentials_bench_test.go
+++ b/aws/credentials/credentials_bench_test.go
@@ -25,7 +25,7 @@ func BenchmarkCredentials_Get(b *testing.B) {
 					for j := 0; j < b.N; j++ {
 						v, err := creds.Get()
 						if err != nil {
-							b.Fatalf("expect no error %v, %v", v, err)
+							b.Errorf("expect no error %v, %v", v, err)
 						}
 					}
 					wg.Done()
@@ -55,7 +55,7 @@ func BenchmarkCredentials_Get_Expire(b *testing.B) {
 						for j := 0; j < b.N; j++ {
 							v, err := creds.Get()
 							if err != nil {
-								b.Fatalf("expect no error %v, %v", v, err)
+								b.Errorf("expect no error %v, %v", v, err)
 							}
 							// periodically expire creds to cause rwlock
 							if id == 0 && j%expRate == 0 {

--- a/awstesting/assert.go
+++ b/awstesting/assert.go
@@ -1,9 +1,7 @@
 package awstesting
 
 import (
-	"bytes"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -12,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil"
+	"github.com/aws/aws-sdk-go/internal/smithytesting"
 )
 
 // Match is a testing helper to test for testing error by comparing expected
@@ -114,26 +112,14 @@ func AssertJSON(t *testing.T, expect, actual string, msgAndArgs ...interface{}) 
 	return equal(t, expectVal, actualVal, msgAndArgs...)
 }
 
-// AssertXML verifies that the expect xml string matches the actual.
-// Elements in actual must match the order they appear in expect to match equally
+// AssertXML verifies that the expect XML string matches the actual.
 func AssertXML(t *testing.T, expect, actual string, msgAndArgs ...interface{}) bool {
-	buffer := bytes.NewReader([]byte(expect))
-	decoder := xml.NewDecoder(buffer)
-
-	expectVal, err := xmlutil.XMLToStruct(decoder, nil)
-	if err != nil {
-		t.Fatalf("failed to umarshal xml to struct: %v", err)
+	if err := smithytesting.XMLEqual([]byte(expect), []byte(actual)); err != nil {
+		t.Error("expect XML match", err, messageFromMsgAndArgs(msgAndArgs))
+		return false
 	}
 
-	buffer = bytes.NewReader([]byte(actual))
-	decoder = xml.NewDecoder(buffer)
-
-	actualVal, err := xmlutil.XMLToStruct(decoder, nil)
-	if err != nil {
-		t.Fatalf("failed to umarshal xml to struct: %v", err)
-	}
-
-	return equal(t, expectVal, actualVal, msgAndArgs...)
+	return true
 }
 
 // DidPanic returns if the function paniced and returns true if the function paniced.

--- a/awstesting/sandbox/Dockerfile.test.go1.16
+++ b/awstesting/sandbox/Dockerfile.test.go1.16
@@ -1,0 +1,12 @@
+FROM golang:1.16
+
+ENV GOPROXY=direct
+
+ADD . /go/src/github.com/aws/aws-sdk-go
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		vim \
+	&& rm -rf /var/list/apt/lists/*
+
+WORKDIR /go/src/github.com/aws/aws-sdk-go
+CMD ["make", "get-deps-verify", "unit"]

--- a/internal/smithytesting/document.go
+++ b/internal/smithytesting/document.go
@@ -8,9 +8,10 @@ import (
 	"github.com/aws/aws-sdk-go/internal/smithytesting/xml"
 )
 
-// XMLEqual asserts two xml documents by sorting the XML and comparing the strings
-// It returns an error in case of mismatch or in case of malformed xml found while sorting.
-// In case of mismatched XML, the error string will contain the diff between the two XMLs.
+// XMLEqual asserts two XML documents by sorting the XML and comparing the
+// strings It returns an error in case of mismatch or in case of malformed XML
+// found while sorting.  In case of mismatched XML, the error string will
+// contain the diff between the two XML documents.
 func XMLEqual(expectBytes, actualBytes []byte) error {
 	actualString, err := xml.SortXML(bytes.NewBuffer(actualBytes), true)
 	if err != nil {
@@ -23,7 +24,8 @@ func XMLEqual(expectBytes, actualBytes []byte) error {
 	}
 
 	if !reflect.DeepEqual(expectString, actualString) {
-		return fmt.Errorf("XML mismatch\nexpect: %+v\nactual: %+v\n", expectString, actualString)
+		return fmt.Errorf("unexpected XML mismatch\nexpect: %+v\nactual: %+v",
+			expectString, actualString)
 	}
 
 	return nil

--- a/internal/smithytesting/document.go
+++ b/internal/smithytesting/document.go
@@ -1,0 +1,30 @@
+package smithytesting
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+
+	"github.com/aws/aws-sdk-go/internal/smithytesting/xml"
+)
+
+// XMLEqual asserts two xml documents by sorting the XML and comparing the strings
+// It returns an error in case of mismatch or in case of malformed xml found while sorting.
+// In case of mismatched XML, the error string will contain the diff between the two XMLs.
+func XMLEqual(expectBytes, actualBytes []byte) error {
+	actualString, err := xml.SortXML(bytes.NewBuffer(actualBytes), true)
+	if err != nil {
+		return err
+	}
+
+	expectString, err := xml.SortXML(bytes.NewBuffer(expectBytes), true)
+	if err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(expectString, actualString) {
+		return fmt.Errorf("XML mismatch\nexpect: %+v\nactual: %+v\n", expectString, actualString)
+	}
+
+	return nil
+}

--- a/internal/smithytesting/document_test.go
+++ b/internal/smithytesting/document_test.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package smithytesting
 
 import (

--- a/internal/smithytesting/document_test.go
+++ b/internal/smithytesting/document_test.go
@@ -1,0 +1,155 @@
+package smithytesting
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEqualXMLUtil(t *testing.T) {
+	cases := map[string]struct {
+		expectedXML string
+		actualXML   string
+		expectErr   string
+	}{
+		"empty": {
+			expectedXML: ``,
+			actualXML:   ``,
+		},
+		"emptyWithDiff": {
+			expectedXML: ``,
+			actualXML:   `<Root></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"simpleXML": {
+			expectedXML: `<Root></Root>`,
+			actualXML:   `<Root></Root>`,
+		},
+		"simpleXMLWithDiff": {
+			expectedXML: `<Root></Root>`,
+			actualXML:   `<Root>abc</Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"nestedXML": {
+			expectedXML: `<Root><abc>123</abc><cde>xyz</cde></Root>`,
+			actualXML:   `<Root><abc>123</abc><cde>xyz</cde></Root>`,
+		},
+		"nestedXMLWithExpectedDiff": {
+			expectedXML: `<Root><abc>123</abc><cde>xyz</cde><pqr>234</pqr></Root>`,
+			actualXML:   `<Root><abc>123</abc><cde>xyz</cde></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"nestedXMLWithActualDiff": {
+			expectedXML: `<Root><abc>123</abc><cde>xyz</cde></Root>`,
+			actualXML:   `<Root><abc>123</abc><cde>xyz</cde><pqr>234</pqr></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"Array": {
+			expectedXML: `<Root><list><member><nested>xyz</nested></member><member><nested>abc</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>abc</nested></member></list></Root>`,
+		},
+		"ArrayWithSecondDiff": {
+			expectedXML: `<Root><list><member><nested>xyz</nested></member><member><nested>123</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>345</nested></member></list></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"ArrayWithFirstDiff": {
+			expectedXML: `<Root><list><member><nested>abc</nested></member><member><nested>345</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>345</nested></member></list></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"ArrayWithMixedDiff": {
+			expectedXML: `<Root><list><member><nested>345</nested></member><member><nested>xyz</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>345</nested></member></list></Root>`,
+		},
+		"ArrayWithRepetitiveMembers": {
+			expectedXML: `<Root><list><member><nested>xyz</nested></member><member><nested>xyz</nested></member></list></Root>`,
+			actualXML:   `<Root><list><member><nested>xyz</nested></member><member><nested>xyz</nested></member></list></Root>`,
+		},
+		"Map": {
+			expectedXML: `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+		},
+		"MapWithFirstDiff": {
+			expectedXML: `<Root><map><entry><key>bcf</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"MapWithSecondDiff": {
+			expectedXML: `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>abc</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"MapWithMixedDiff": {
+			expectedXML: `<Root><map><entry><key>cde</key><value>356</value></entry><entry><key>abc</key><value>123</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+		},
+		"MismatchCheckforKeyValue": {
+			expectedXML: `<Root><map><entry><key>cde</key><value>abc</value></entry><entry><key>abc</key><value>356</value></entry></map></Root>`,
+			actualXML:   `<Root><map><entry><key>abc</key><value>123</value></entry><entry><key>cde</key><value>356</value></entry></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"MixMapAndListNestedXML": {
+			expectedXML: `<Root><list>mem1</list><list>mem2</list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			actualXML:   `<Root><list>mem1</list><list>mem2</list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+		},
+		"MixMapAndListNestedXMLWithDiff": {
+			expectedXML: `<Root><list>mem1</list><list>mem2</list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			actualXML:   `<Root><list>mem1</list><list>mem2</list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><beta><x>gamma</x></beta></nested></v></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"xmlWithNamespaceAndAttr": {
+			expectedXML: `<Root xmlns:ab="https://example.com" attr="apple">value</Root>`,
+			actualXML:   `<Root xmlns:ab="https://example.com" attr="apple">value</Root>`,
+		},
+		"xmlUnorderedAttributes": {
+			expectedXML: `<Root atr="banana" attrNew="apple">v</Root>`,
+			actualXML:   `<Root attrNew="apple" atr="banana">v</Root>`,
+		},
+		"xmlAttributesWithDiff": {
+			expectedXML: `<Root atr="someAtr" attrNew="apple">v</Root>`,
+			actualXML:   `<Root attrNew="apple" atr="banana">v</Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"xmlUnorderedNamespaces": {
+			expectedXML: `<Root xmlns:ab="https://example.com" xmlns:baz="https://example2.com">v</Root>`,
+			actualXML:   `<Root xmlns:baz="https://example2.com" xmlns:ab="https://example.com">v</Root>`,
+		},
+		"xmlNamespaceWithDiff": {
+			expectedXML: `<Root xmlns:ab="https://example-diff.com" xmlns:baz="https://example2.com">v</Root>`,
+			actualXML:   `<Root xmlns:baz="https://example2.com" xmlns:ab="https://example.com">v</Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"NestedWithNamespaceAndAttributes": {
+			expectedXML: `<Root xmlns:ab="https://example.com" xmlns:un="https://example2.com" attr="test" attr2="test2"><ab:list>mem1</ab:list><ab:list>mem2</ab:list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			actualXML:   `<Root xmlns:ab="https://example.com" xmlns:un="https://example2.com" attr="test" attr2="test2"><ab:list>mem1</ab:list><ab:list>mem2</ab:list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+		},
+		"NestedWithNamespaceAndAttributesWithDiff": {
+			expectedXML: `<Root xmlns:ab="https://example.com" xmlns:un="https://example2.com" attr="test" attr2="test2"><list>mem2</list><ab:list>mem2</ab:list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			actualXML:   `<Root xmlns:ab="https://example.com" xmlns:un="https://example2.com" attr="test" attr2="test2"><list>mem1</list><ab:list>mem2</ab:list><map><k>abc</k><v><nested><enorm>abc</enorm></nested></v><k>xyz</k><v><nested><alpha><x>gamma</x></alpha></nested></v></map></Root>`,
+			expectErr:   "XML mismatch",
+		},
+		"MalformedXML": {
+			expectedXML: `<Root><fmap><key>a</key><key2>a2</key2><value>v</value></fmap><fmap><key>b</key><key2>b2</key2><value>w</value></fmap></Root>`,
+			actualXML:   `<Root><fmap><key>a</key><key2>a2</key2><value>v</value></fmap><fmap><key>b</key><key2>b2</key2><value>w</value></fmap></Root>`,
+			expectErr:   "malformed xml",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := []byte(c.actualXML)
+			expected := []byte(c.expectedXML)
+
+			err := XMLEqual(actual, expected)
+			if err != nil {
+				if len(c.expectErr) == 0 {
+					t.Fatalf("expected no error while parsing xml, got %v", err)
+				} else if !strings.Contains(err.Error(), c.expectErr) {
+					t.Fatalf("expected expected XML err to contain %s, got %s", c.expectErr, err.Error())
+				}
+			} else if len(c.expectErr) != 0 {
+				t.Fatalf("expected error %s, got none", c.expectErr)
+			}
+		})
+	}
+}

--- a/internal/smithytesting/xml/doc.go
+++ b/internal/smithytesting/xml/doc.go
@@ -1,0 +1,6 @@
+// package xml is xml testing package that supports xml comparison utility.
+// The package consists of XMLToStruct and StructToXML utils that help sort xml elements
+// as per their nesting level. XMLToStruct function converts an xml document into a sorted
+// tree node structure, while StructToXML converts the sorted xml nodes into a sorted xml document.
+// SortXML function should be used to sort an xml document. It can be configured to ignore indentation
+package xml

--- a/internal/smithytesting/xml/doc.go
+++ b/internal/smithytesting/xml/doc.go
@@ -1,6 +1,7 @@
-// package xml is xml testing package that supports xml comparison utility.
-// The package consists of XMLToStruct and StructToXML utils that help sort xml elements
-// as per their nesting level. XMLToStruct function converts an xml document into a sorted
-// tree node structure, while StructToXML converts the sorted xml nodes into a sorted xml document.
-// SortXML function should be used to sort an xml document. It can be configured to ignore indentation
+// Package xml is XML testing package that supports XML comparison utility.
+// The package consists of ToStruct and StructToXML utils that help sort XML
+// elements as per their nesting level. ToStruct function converts an XML
+// document into a sorted tree node structure, while StructToXML converts the
+// sorted XML nodes into a sorted XML document.  SortXML function should be
+// used to sort an XML document. It can be configured to ignore indentation
 package xml

--- a/internal/smithytesting/xml/sort.go
+++ b/internal/smithytesting/xml/sort.go
@@ -1,0 +1,48 @@
+package xml
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"strings"
+)
+
+type xmlAttrSlice []xml.Attr
+
+func (x xmlAttrSlice) Len() int {
+	return len(x)
+}
+
+func (x xmlAttrSlice) Less(i, j int) bool {
+	spaceI, spaceJ := x[i].Name.Space, x[j].Name.Space
+	localI, localJ := x[i].Name.Local, x[j].Name.Local
+	valueI, valueJ := x[i].Value, x[j].Value
+
+	spaceCmp := strings.Compare(spaceI, spaceJ)
+	localCmp := strings.Compare(localI, localJ)
+	valueCmp := strings.Compare(valueI, valueJ)
+
+	if spaceCmp == -1 || (spaceCmp == 0 && (localCmp == -1 || (localCmp == 0 && valueCmp == -1))) {
+		return true
+	}
+
+	return false
+}
+
+func (x xmlAttrSlice) Swap(i, j int) {
+	x[i], x[j] = x[j], x[i]
+}
+
+// SortXML sorts the reader's XML elements
+func SortXML(r io.Reader, ignoreIndentation bool) (string, error) {
+	var buf bytes.Buffer
+	d := xml.NewDecoder(r)
+	root, err := XMLToStruct(d, nil, ignoreIndentation)
+	if err != nil {
+		return buf.String(), err
+	}
+
+	e := xml.NewEncoder(&buf)
+	err = StructToXML(e, root, true)
+	return buf.String(), err
+}

--- a/internal/smithytesting/xml/sort.go
+++ b/internal/smithytesting/xml/sort.go
@@ -37,7 +37,7 @@ func (x xmlAttrSlice) Swap(i, j int) {
 func SortXML(r io.Reader, ignoreIndentation bool) (string, error) {
 	var buf bytes.Buffer
 	d := xml.NewDecoder(r)
-	root, err := XMLToStruct(d, nil, ignoreIndentation)
+	root, err := ToStruct(d, nil, ignoreIndentation)
 	if err != nil {
 		return buf.String(), err
 	}

--- a/internal/smithytesting/xml/sort_test.go
+++ b/internal/smithytesting/xml/sort_test.go
@@ -1,0 +1,20 @@
+package xml
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestSortXML(t *testing.T) {
+	xmlInput := bytes.NewReader([]byte(`<Root><cde>xyz</cde><abc>123</abc><xyz><item>1</item></xyz></Root>`))
+	sortedXML, err := SortXML(xmlInput, false)
+	expectedsortedXML := `<Root><abc>123</abc><cde>xyz</cde><xyz><item>1</item></xyz></Root>`
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(sortedXML, expectedsortedXML) {
+		t.Errorf("expect match\nexpect: %+v\nactual: %+v\n", expectedsortedXML, sortedXML)
+	}
+}

--- a/internal/smithytesting/xml/xmlToStruct.go
+++ b/internal/smithytesting/xml/xmlToStruct.go
@@ -1,0 +1,339 @@
+package xml
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// A XMLNode contains the values to be encoded or decoded.
+type XMLNode struct {
+	Name     xml.Name              `json:",omitempty"`
+	Children map[string][]*XMLNode `json:",omitempty"`
+	Text     string                `json:",omitempty"`
+	Attr     []xml.Attr            `json:",omitempty"`
+
+	namespaces map[string]string
+	parent     *XMLNode
+}
+
+// NewXMLElement returns a pointer to a new XMLNode initialized to default values.
+func NewXMLElement(name xml.Name) *XMLNode {
+	return &XMLNode{
+		Name:     name,
+		Children: map[string][]*XMLNode{},
+		Attr:     []xml.Attr{},
+	}
+}
+
+// AddChild adds child to the XMLNode.
+func (n *XMLNode) AddChild(child *XMLNode) {
+	child.parent = n
+	if _, ok := n.Children[child.Name.Local]; !ok {
+		// flattened will have multiple children with same tag name
+		n.Children[child.Name.Local] = []*XMLNode{}
+	}
+	n.Children[child.Name.Local] = append(n.Children[child.Name.Local], child)
+}
+
+// XMLToStruct converts a xml.Decoder stream to XMLNode with nested values.
+func XMLToStruct(d *xml.Decoder, s *xml.StartElement, ignoreIndentation bool) (*XMLNode, error) {
+	out := &XMLNode{}
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return out, err
+			}
+		}
+
+		if tok == nil {
+			break
+		}
+
+		switch typed := tok.(type) {
+		case xml.CharData:
+			text := string(typed.Copy())
+			if ignoreIndentation {
+				text = strings.TrimSpace(text)
+			}
+			if len(text) != 0 {
+				out.Text = text
+			}
+		case xml.StartElement:
+			el := typed.Copy()
+			out.Attr = el.Attr
+			if out.Children == nil {
+				out.Children = map[string][]*XMLNode{}
+			}
+
+			name := typed.Name.Local
+			slice := out.Children[name]
+			if slice == nil {
+				slice = []*XMLNode{}
+			}
+			node, e := XMLToStruct(d, &el, ignoreIndentation)
+			out.findNamespaces()
+			if e != nil {
+				return out, e
+			}
+
+			node.Name = typed.Name
+			node.findNamespaces()
+
+			// Add attributes onto the node
+			node.Attr = el.Attr
+
+			tempOut := *out
+			// Save into a temp variable, simply because out gets squashed during
+			// loop iterations
+			node.parent = &tempOut
+			slice = append(slice, node)
+			out.Children[name] = slice
+		case xml.EndElement:
+			if s != nil && s.Name.Local == typed.Name.Local { // matching end token
+				return out, nil
+			}
+			out = &XMLNode{}
+		}
+	}
+	return out, nil
+}
+
+func (n *XMLNode) findNamespaces() {
+	ns := map[string]string{}
+	for _, a := range n.Attr {
+		if a.Name.Space == "xmlns" {
+			ns[a.Value] = a.Name.Local
+		}
+	}
+
+	n.namespaces = ns
+}
+
+func (n *XMLNode) findElem(name string) (string, bool) {
+	for node := n; node != nil; node = node.parent {
+		for _, a := range node.Attr {
+			namespace := a.Name.Space
+			if v, ok := node.namespaces[namespace]; ok {
+				namespace = v
+			}
+			if name == fmt.Sprintf("%s:%s", namespace, a.Name.Local) {
+				return a.Value, true
+			}
+		}
+	}
+	return "", false
+}
+
+// StructToXML writes an XMLNode to a xml.Encoder as tokens.
+func StructToXML(e *xml.Encoder, node *XMLNode, sorted bool) error {
+	var err error
+	// Sort Attributes
+	attrs := node.Attr
+	if sorted {
+		sortedAttrs := make([]xml.Attr, len(attrs))
+		for _, k := range node.Attr {
+			sortedAttrs = append(sortedAttrs, k)
+		}
+		sort.Sort(xmlAttrSlice(sortedAttrs))
+		attrs = sortedAttrs
+	}
+
+	st := xml.StartElement{Name: node.Name, Attr: attrs}
+	e.EncodeToken(st)
+	// return fmt.Errorf("encoder string : %s, %s, %s", node.Name.Local, node.Name.Space, st.Attr)
+
+	if node.Text != "" {
+		e.EncodeToken(xml.CharData([]byte(node.Text)))
+	} else if sorted {
+		sortedNames := []string{}
+		for k := range node.Children {
+			sortedNames = append(sortedNames, k)
+		}
+		sort.Strings(sortedNames)
+
+		for _, k := range sortedNames {
+			// we should sort the []*xml.Node for each key if len >1
+			flattenedNodes := node.Children[k]
+			// Meaning this has multiple nodes
+			if len(flattenedNodes) > 1 {
+				// sort flattened nodes
+				flattenedNodes, err = sortFlattenedNodes(flattenedNodes)
+				if err != nil {
+					return err
+				}
+			}
+
+			for _, v := range flattenedNodes {
+				err = StructToXML(e, v, sorted)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		for _, c := range node.Children {
+			for _, v := range c {
+				err = StructToXML(e, v, sorted)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	e.EncodeToken(xml.EndElement{Name: node.Name})
+	return e.Flush()
+}
+
+// sortFlattenedNodes sorts nodes with nodes having same element tag
+// but overall different values. The function will return list of pointer to
+// XMLNode and an error.
+//
+// Overall sort order is followed is:
+// Nodes with concrete value (no nested node as value) are given precedence
+// and are added to list after sorting them
+//
+// Next nested nodes within a flattened list are given precedence.
+//
+// Next nodes within a flattened map are sorted based on either key or value
+// which ever has lower value and then added to the global sorted list.
+// If value was initially chosen, but has nested nodes; key will be chosen as comparable
+// as it is unique and will always have concrete data ie. string.
+func sortFlattenedNodes(nodes []*XMLNode) ([]*XMLNode, error) {
+	var sortedNodes []*XMLNode
+
+	// concreteNodeMap stores concrete value associated with a list of nodes
+	// This is possible in case multiple members of a flatList has same values.
+	concreteNodeMap := make(map[string][]*XMLNode, 0)
+
+	// flatListNodeMap stores flat list or wrapped list members associated with a list of nodes
+	// This will have only flattened list with members that are Nodes and not concrete values.
+	flatListNodeMap := make(map[string][]*XMLNode, 0)
+
+	// flatMapNodeMap stores flat map or map entry members associated with a list of nodes
+	// This will have only flattened map concrete value members. It is possible to limit this
+	// to concrete value as map key is expected to be concrete.
+	flatMapNodeMap := make(map[string][]*XMLNode, 0)
+
+	// nodes with concrete value are prioritized and appended based on sorting order
+	sortedNodesWithConcreteValue := []string{}
+
+	// list with nested nodes are second in priority and appended based on sorting order
+	sortedNodesWithListValue := []string{}
+
+	// map are last in priority and appended based on sorting order
+	sortedNodesWithMapValue := []string{}
+
+	for _, node := range nodes {
+		// node has no children element, then we consider it as having concrete value
+		if len(node.Children) == 0 {
+			sortedNodesWithConcreteValue = append(sortedNodesWithConcreteValue, node.Text)
+			if v, ok := concreteNodeMap[node.Text]; ok {
+				concreteNodeMap[node.Text] = append(v, node)
+			} else {
+				concreteNodeMap[node.Text] = []*XMLNode{node}
+			}
+		}
+
+		// if node has a single child, then it is a flattened list node
+		if len(node.Children) == 1 {
+			for _, nestedNodes := range node.Children {
+				nestedNodeName := nestedNodes[0].Name.Local
+
+				// append to sorted node name for list value
+				sortedNodesWithListValue = append(sortedNodesWithListValue, nestedNodeName)
+
+				if v, ok := flatListNodeMap[nestedNodeName]; ok {
+					flatListNodeMap[nestedNodeName] = append(v, nestedNodes[0])
+				} else {
+					flatListNodeMap[nestedNodeName] = []*XMLNode{nestedNodes[0]}
+				}
+			}
+		}
+
+		// if node has two children, then it is a flattened map node
+		if len(node.Children) == 2 {
+			nestedPair := []*XMLNode{}
+			for _, k := range node.Children {
+				nestedPair = append(nestedPair, k[0])
+			}
+
+			comparableValues := []string{nestedPair[0].Name.Local, nestedPair[1].Name.Local}
+			sort.Strings(comparableValues)
+
+			comparableValue := comparableValues[0]
+			for _, nestedNode := range nestedPair {
+				if comparableValue == nestedNode.Name.Local && len(nestedNode.Children) != 0 {
+					// if value was selected and is nested node, skip it and use key instead
+					comparableValue = comparableValues[1]
+					continue
+				}
+
+				// now we are certain there is no nested node
+				if comparableValue == nestedNode.Name.Local {
+					// get chardata for comparison
+					comparableValue = nestedNode.Text
+					sortedNodesWithMapValue = append(sortedNodesWithMapValue, comparableValue)
+
+					if v, ok := flatMapNodeMap[comparableValue]; ok {
+						flatMapNodeMap[comparableValue] = append(v, node)
+					} else {
+						flatMapNodeMap[comparableValue] = []*XMLNode{node}
+					}
+					break
+				}
+			}
+		}
+
+		// we don't support multiple same name nodes in an xml doc except for in flattened maps, list.
+		if len(node.Children) > 2 {
+			return nodes, fmt.Errorf("malformed xml: multiple nodes with same key name exist, " +
+				"but are not associated with flattened maps (2 children) or list (0 or 1 child)")
+		}
+	}
+
+	// sort concrete value node name list and append corresponding nodes
+	// to sortedNodes
+	sort.Strings(sortedNodesWithConcreteValue)
+	for _, name := range sortedNodesWithConcreteValue {
+		for _, node := range concreteNodeMap[name] {
+			sortedNodes = append(sortedNodes, node)
+		}
+	}
+
+	// sort nested nodes with a list and append corresponding nodes
+	// to sortedNodes
+	sort.Strings(sortedNodesWithListValue)
+	for _, name := range sortedNodesWithListValue {
+		// if two nested nodes have same name, then sort them separately.
+		if len(flatListNodeMap[name]) > 1 {
+			// return nodes, fmt.Errorf("flat list node name are %s %v", flatListNodeMap[name][0].Name.Local, len(flatListNodeMap[name]))
+			nestedFlattenedList, err := sortFlattenedNodes(flatListNodeMap[name])
+			if err != nil {
+				return nodes, err
+			}
+			// append the identical but sorted nodes
+			for _, nestedNode := range nestedFlattenedList {
+				sortedNodes = append(sortedNodes, nestedNode)
+			}
+		} else {
+			// append the sorted nodes
+			sortedNodes = append(sortedNodes, flatListNodeMap[name][0])
+		}
+	}
+
+	// sorted nodes with a map and append corresponding nodes to sortedNodes
+	sort.Strings(sortedNodesWithMapValue)
+	for _, name := range sortedNodesWithMapValue {
+		sortedNodes = append(sortedNodes, flatMapNodeMap[name][0])
+	}
+
+	return sortedNodes, nil
+}

--- a/private/model/cli/gen-protocol-tests/main.go
+++ b/private/model/cli/gen-protocol-tests/main.go
@@ -198,12 +198,7 @@ func (t tplInputTestCaseData) BodyAssertions() string {
 	protocol := t.TestCase.TestSuite.API.Metadata.Protocol
 
 	// Extract the body bytes
-	switch protocol {
-	case "rest-xml":
-		fmt.Fprintln(code, "body := util.SortXML(r.Body)")
-	default:
-		fmt.Fprintln(code, "body, _ := ioutil.ReadAll(r.Body)")
-	}
+	fmt.Fprintln(code, "body, _ := ioutil.ReadAll(r.Body)")
 
 	// Generate the body verification code
 	expectedBody := util.Trim(t.TestCase.InputTest.Body)
@@ -213,7 +208,7 @@ func (t tplInputTestCaseData) BodyAssertions() string {
 			expectedBody)
 	case "rest-xml":
 		if strings.HasPrefix(expectedBody, "<") {
-			fmt.Fprintf(code, "awstesting.AssertXML(t, `%s`, util.Trim(body))",
+			fmt.Fprintf(code, "awstesting.AssertXML(t, `%s`, util.Trim(string(body)))",
 				expectedBody)
 		} else {
 			code.WriteString(fmtAssertEqual(fmt.Sprintf("%q", expectedBody), "util.Trim(string(body))"))
@@ -294,7 +289,7 @@ func (i *testCase) TestCase(idx int) string {
 			m, _ := url.ParseQuery(i.InputTest.Body)
 			i.InputTest.Body = m.Encode()
 		case "rest-xml":
-			i.InputTest.Body = util.SortXML(bytes.NewReader([]byte(i.InputTest.Body)))
+			// Nothing to do
 		case "json", "rest-json":
 			// Nothing to do
 		}

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -6058,8 +6058,8 @@ func TestInputService1ProtocolTestBasicXMLSerializationCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">bar</Description><Name xmlns="https://foo/">foo</Name></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Name>foo</Name><Description>bar</Description></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6087,8 +6087,8 @@ func TestInputService1ProtocolTestBasicXMLSerializationCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">bar</Description><Name xmlns="https://foo/">foo</Name></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Name>foo</Name><Description>bar</Description></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6137,8 +6137,8 @@ func TestInputService2ProtocolTestSerializeOtherScalarTypesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><First xmlns="https://foo/">true</First><Fourth xmlns="https://foo/">3</Fourth><Second xmlns="https://foo/">false</Second><Third xmlns="https://foo/">1.2</Third></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><First>true</First><Second>false</Second><Third>1.2</Third><Fourth>3</Fourth></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6169,8 +6169,8 @@ func TestInputService3ProtocolTestNestedStructuresCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">baz</Description><SubStructure xmlns="https://foo/"><Bar xmlns="https://foo/">b</Bar><Foo xmlns="https://foo/">a</Foo></SubStructure></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><SubStructure><Foo>a</Foo><Bar>b</Bar></SubStructure><Description>baz</Description></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6200,8 +6200,8 @@ func TestInputService3ProtocolTestNestedStructuresCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">baz</Description><SubStructure xmlns="https://foo/"><Foo xmlns="https://foo/">a</Foo></SubStructure></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><SubStructure><Foo>a</Foo></SubStructure><Description>baz</Description></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6229,8 +6229,8 @@ func TestInputService4ProtocolTestNestedStructuresCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">baz</Description><SubStructure xmlns="https://foo/"></SubStructure></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><SubStructure /><Description>baz</Description></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6261,8 +6261,8 @@ func TestInputService5ProtocolTestNonFlattenedListsCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><ListParam xmlns="https://foo/"><member xmlns="https://foo/">one</member><member xmlns="https://foo/">two</member><member xmlns="https://foo/">three</member></ListParam></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><ListParam><member>one</member><member>two</member><member>three</member></ListParam></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6293,8 +6293,8 @@ func TestInputService6ProtocolTestNonFlattenedListsWithLocationNameCase1(t *test
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><AlternateName xmlns="https://foo/"><NotMember xmlns="https://foo/">one</NotMember><NotMember xmlns="https://foo/">two</NotMember><NotMember xmlns="https://foo/">three</NotMember></AlternateName></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><AlternateName><NotMember>one</NotMember><NotMember>two</NotMember><NotMember>three</NotMember></AlternateName></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6325,8 +6325,8 @@ func TestInputService7ProtocolTestFlattenedListsCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><ListParam xmlns="https://foo/">one</ListParam><ListParam xmlns="https://foo/">two</ListParam><ListParam xmlns="https://foo/">three</ListParam></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><ListParam>one</ListParam><ListParam>two</ListParam><ListParam>three</ListParam></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6357,8 +6357,8 @@ func TestInputService8ProtocolTestFlattenedListsWithLocationNameCase1(t *testing
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><item xmlns="https://foo/">one</item><item xmlns="https://foo/">two</item><item xmlns="https://foo/">three</item></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><item>one</item><item>two</item><item>three</item></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6395,8 +6395,8 @@ func TestInputService9ProtocolTestListOfStructuresCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><item xmlns="https://foo/"><value xmlns="https://foo/">one</value></item><item xmlns="https://foo/"><value xmlns="https://foo/">two</value></item><item xmlns="https://foo/"><value xmlns="https://foo/">three</value></item></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><item><value>one</value></item><item><value>two</value></item><item><value>three</value></item></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6425,8 +6425,8 @@ func TestInputService10ProtocolTestBlobShapesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><StructureParam xmlns="https://foo/"><b xmlns="https://foo/">Zm9v</b></StructureParam></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><StructureParam><b>Zm9v</b></StructureParam></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone", r.URL.String())
@@ -6461,8 +6461,8 @@ func TestInputService11ProtocolTestTimestampShapesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<TimestampStructure xmlns="https://foo/"><TimeArg xmlns="https://foo/">2015-01-25T08:00:00Z</TimeArg><TimeCustom xmlns="https://foo/">Sun, 25 Jan 2015 08:00:00 GMT</TimeCustom><TimeFormat xmlns="https://foo/">Sun, 25 Jan 2015 08:00:00 GMT</TimeFormat></TimestampStructure>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<TimestampStructure xmlns="https://foo/"><TimeArg>2015-01-25T08:00:00Z</TimeArg><TimeCustom>Sun, 25 Jan 2015 08:00:00 GMT</TimeCustom><TimeFormat>Sun, 25 Jan 2015 08:00:00 GMT</TimeFormat></TimestampStructure>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/2014-01-01/hostedzone?TimeQuery=2015-01-25T08%3A00%3A00Z&TimeCustomQuery=1422172800&TimeFormatQuery=1422172800", r.URL.String())
@@ -6650,7 +6650,7 @@ func TestInputService17ProtocolTestStringPayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
+	body, _ := ioutil.ReadAll(r.Body)
 	if e, a := "bar", util.Trim(string(body)); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -6680,7 +6680,7 @@ func TestInputService18ProtocolTestBlobPayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
+	body, _ := ioutil.ReadAll(r.Body)
 	if e, a := "bar", util.Trim(string(body)); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -6731,8 +6731,8 @@ func TestInputService19ProtocolTestStructurePayloadCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -6778,8 +6778,8 @@ func TestInputService19ProtocolTestStructurePayloadCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<foo></foo>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<foo />`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -6830,8 +6830,8 @@ func TestInputService20ProtocolTestXMLAttributeCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<Grant xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:type="CanonicalUser" xmlns:_xmlns="xmlns" _xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Grantee><EmailAddress>foo@example.com</EmailAddress></Grantee></Grant>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><EmailAddress>foo@example.com</EmailAddress></Grantee></Grant>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -6922,8 +6922,8 @@ func TestInputService23ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><NoRecurse>foo</NoRecurse></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -6954,8 +6954,8 @@ func TestInputService23ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveStruct><NoRecurse>foo</NoRecurse></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -6990,8 +6990,8 @@ func TestInputService23ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></RecursiveStruct></RecursiveStruct></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveStruct><RecursiveStruct><RecursiveStruct><NoRecurse>foo</NoRecurse></RecursiveStruct></RecursiveStruct></RecursiveStruct></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -7027,8 +7027,8 @@ func TestInputService23ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveList><member><NoRecurse>foo</NoRecurse></member><member><NoRecurse>bar</NoRecurse></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -7066,8 +7066,8 @@ func TestInputService23ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveList xmlns="https://foo/"><member xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></member><member xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></RecursiveStruct></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveList><member><NoRecurse>foo</NoRecurse></member><member><RecursiveStruct><NoRecurse>bar</NoRecurse></RecursiveStruct></member></RecursiveList></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -7103,8 +7103,8 @@ func TestInputService23ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct xmlns="https://foo/"><RecursiveMap xmlns="https://foo/"><entry xmlns="https://foo/"><key xmlns="https://foo/">bar</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">bar</NoRecurse></value></entry><entry xmlns="https://foo/"><key xmlns="https://foo/">foo</key><value xmlns="https://foo/"><NoRecurse xmlns="https://foo/">foo</NoRecurse></value></entry></RecursiveMap></RecursiveStruct></OperationRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<OperationRequest xmlns="https://foo/"><RecursiveStruct><RecursiveMap><entry><key>bar</key><value><NoRecurse>bar</NoRecurse></value></entry><entry><key>foo</key><value><NoRecurse>foo</NoRecurse></value></entry></RecursiveMap></RecursiveStruct></OperationRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -7131,8 +7131,8 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<InputShape><Token>abc123</Token></InputShape>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<InputShape><Token>abc123</Token></InputShape>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -7157,8 +7157,8 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -7197,8 +7197,8 @@ func TestInputService25ProtocolTestEnumCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<InputShape><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member></member><member>bar</member></ListEnums></InputShape>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<InputShape><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member></member><member>bar</member></ListEnums></InputShape>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/Enum/bar?ListEnums=0&ListEnums=&ListEnums=1", r.URL.String())
@@ -7249,8 +7249,8 @@ func TestInputService26ProtocolTestEndpointHostTraitCase1(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<StaticOpRequest><Name>myname</Name></StaticOpRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<StaticOpRequest><Name>myname</Name></StaticOpRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://data-service.region.amazonaws.com/path", r.URL.String())
@@ -7277,8 +7277,8 @@ func TestInputService26ProtocolTestEndpointHostTraitCase2(t *testing.T) {
 	if r.Body == nil {
 		t.Errorf("expect body not to be nil")
 	}
-	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<MemberRefOpRequest><Name>myname</Name></MemberRefOpRequest>`, util.Trim(body))
+	body, _ := ioutil.ReadAll(r.Body)
+	awstesting.AssertXML(t, `<MemberRefOpRequest><Name>myname</Name></MemberRefOpRequest>`, util.Trim(string(body)))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://foo-myname.service.region.amazonaws.com/path", r.URL.String())

--- a/private/util/util.go
+++ b/private/util/util.go
@@ -42,6 +42,8 @@ func Capitalize(s string) string {
 }
 
 // SortXML sorts the reader's XML elements
+//
+// Deprecated: incorrectly handles XML namespaces, should not be used.
 func SortXML(r io.Reader) string {
 	var buf bytes.Buffer
 	d := xml.NewDecoder(r)

--- a/service/kinesis/cust_integ_eventstream_test.go
+++ b/service/kinesis/cust_integ_eventstream_test.go
@@ -52,7 +52,7 @@ func TestInteg_SubscribeToShard(t *testing.T) {
 
 			sub, err := svc.SubscribeToShardWithContext(ctx, params)
 			if err != nil {
-				t.Fatalf("expect no error, %v, %v", err, *s.ShardId)
+				t.Errorf("expect no error, %v, %v", err, *s.ShardId)
 			}
 			defer sub.EventStream.Close()
 
@@ -66,7 +66,7 @@ func TestInteg_SubscribeToShard(t *testing.T) {
 						atomic.AddInt32(&goodCount, 1)
 						for _, r := range e.Records {
 							if len(r.Data) == 0 {
-								t.Fatalf("expect data in record, got none")
+								t.Errorf("expect data in record, got none")
 							}
 						}
 					}
@@ -79,7 +79,7 @@ func TestInteg_SubscribeToShard(t *testing.T) {
 			}
 
 			if err := sub.EventStream.Err(); err != nil {
-				t.Fatalf("expect no error, %v, %v", err, *s.ShardId)
+				t.Errorf("expect no error, %v, %v", err, *s.ShardId)
 			}
 		}(i, shard)
 	}


### PR DESCRIPTION
Fixes the SDK's handling of XML protocol tests to correctly compare two
XML document strings without mangling the XML namespace.

Fixes #3731

Fixes unit and vet for Go 1.16