### PR TITLE
Rename master branch to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,4 +74,4 @@ script:
 
 branches:
   only:
-    - master
+    - main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Jump To:
 
 *Before you send us a pull request, please be sure that:*
 
-1. You're working from the latest source on the master branch.
+1. You're working from the latest source on the main branch.
 2. You check existing open, and recently closed, pull requests to be sure 
    that someone else hasn't already addressed the problem.
 3. You create an issue before working on a contribution that will take a 
@@ -26,7 +26,7 @@ Jump To:
 *Creating a Pull Request*
 
 1. Fork the repository.
-2. In your fork, make your change in a branch that's based on this repo's master branch.
+2. In your fork, make your change in a branch that's based on this repo's main branch.
 3. Commit the change to your fork, using a clear and descriptive commit message.
 4. Create a pull request, answering any questions in the pull request form.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS SDK for Go
 
-[![API Reference](https://img.shields.io/badge/api-reference-blue.svg)](https://docs.aws.amazon.com/sdk-for-go/api) [![Join the chat at https://gitter.im/aws/aws-sdk-go](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aws/aws-sdk-go?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://api.travis-ci.com/aws/aws-sdk-go.svg?branch=master)](https://travis-ci.com/aws/aws-sdk-go) [![Apache V2 License](https://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/aws/aws-sdk-go/blob/master/LICENSE.txt)
+[![API Reference](https://img.shields.io/badge/api-reference-blue.svg)](https://docs.aws.amazon.com/sdk-for-go/api) [![Join the chat at https://gitter.im/aws/aws-sdk-go](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aws/aws-sdk-go?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://api.travis-ci.com/aws/aws-sdk-go.svg?branch=main)](https://travis-ci.com/aws/aws-sdk-go) [![Apache V2 License](https://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/aws/aws-sdk-go/blob/main/LICENSE.txt)
 
 aws-sdk-go is the official AWS SDK for the Go programming language.
 
@@ -511,7 +511,7 @@ great for getting started with a service, or when looking for more
 information about a service. While this document is not required for coding, 
 services may supply helpful samples to look out for.
 
-[SDK Examples](https://github.com/aws/aws-sdk-go/tree/master/example) -
+[SDK Examples](https://github.com/aws/aws-sdk-go/tree/main/example) -
 Included in the SDK's repo are several hand crafted examples using the SDK
 features and AWS services.
 

--- a/example/service/dynamodb/unitTest/README.md
+++ b/example/service/dynamodb/unitTest/README.md
@@ -30,7 +30,7 @@ getter.DynamoDB.GetItem(/* ... */)
 ## Querying in tests
 Construct a `fakeDynamoDB` and add the necessary methods for each of those
 structs (custom ones for `ItemGetter` and [whatever methods you're using for
-DynamoDB](https://github.com/aws/aws-sdk-go/blob/master/service/dynamodb/dynamodbiface/interface.go)),
+DynamoDB](https://github.com/aws/aws-sdk-go/blob/main/service/dynamodb/dynamodbiface/interface.go)),
 and you're good to go!
 
 ```go


### PR DESCRIPTION
* Updates Travis jobs to refer to `main` as the target branch name.
* Updates documentation links to refer to `main`.