### PR TITLE
service/lookoutmetrics: Fixes handling of API requests

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/lookoutmetrics`: Fixes handling of API requests.
+  * Fix SDK's serialization of request to include expected Content-Type header.
+

--- a/service/lookoutmetrics/cust_integ_test.go
+++ b/service/lookoutmetrics/cust_integ_test.go
@@ -1,0 +1,18 @@
+// +build go1.7,integration
+
+package lookoutmetrics
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/awstesting/integration"
+)
+
+func TestInteg_ListAnomalyDetectors(t *testing.T) {
+	sess := integration.SessionWithDefaultRegion("us-west-2")
+	client := New(sess)
+	_, err := client.ListAnomalyDetectors(&ListAnomalyDetectorsInput{})
+	if err != nil {
+		t.Fatalf("expect API call, got %v", err)
+	}
+}

--- a/service/lookoutmetrics/customizations.go
+++ b/service/lookoutmetrics/customizations.go
@@ -1,0 +1,18 @@
+package lookoutmetrics
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func init() {
+	initClient = func(c *client.Client) {
+		c.Handlers.Build.PushBack(func(r *request.Request) {
+			if strings.EqualFold(r.HTTPRequest.Header.Get("Content-Type"), "application/json") {
+				r.HTTPRequest.Header.Set("Content-Type", "application/x-amz-json-1.1")
+			}
+		})
+	}
+}

--- a/service/lookoutmetrics/customizations_test.go
+++ b/service/lookoutmetrics/customizations_test.go
@@ -1,0 +1,33 @@
+package lookoutmetrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+)
+
+func TestClientContentType(t *testing.T) {
+	sess := unit.Session.Copy()
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			contentType := r.Header.Get("Content-Type")
+			if e, a := contentType, "application/x-amz-json-1.1"; !strings.EqualFold(e, a) {
+				t.Errorf("expect %v content-type, got %v", e, a)
+			}
+		},
+	))
+	defer server.Close()
+
+	client := New(sess, &aws.Config{Endpoint: &server.URL})
+	_, err := client.ActivateAnomalyDetector(&ActivateAnomalyDetectorInput{
+		AnomalyDetectorArn: aws.String("foo"),
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+}

--- a/service/lookoutmetrics/customizations_test.go
+++ b/service/lookoutmetrics/customizations_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package lookoutmetrics
 
 import (


### PR DESCRIPTION
Fix SDK's serialization of request to include expected Content-Type header.