### PR TITLE
service/route53: Fix customization test being to specific

### DIFF
--- a/service/route53/customizations_test.go
+++ b/service/route53/customizations_test.go
@@ -16,7 +16,7 @@ func TestBuildCorrectURI(t *testing.T) {
 		Id: aws.String("/hostedzone/ABCDEFG"),
 	})
 
-	expectPath := strings.ReplaceAll(req.Operation.HTTPPath, "{Id}", "ABCDEFG")
+	expectPath := strings.Replace(req.Operation.HTTPPath, "{Id}", "ABCDEFG", -1)
 
 	req.HTTPRequest.URL.RawQuery = "abc=123"
 

--- a/service/route53/customizations_test.go
+++ b/service/route53/customizations_test.go
@@ -1,6 +1,7 @@
 package route53_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -9,13 +10,13 @@ import (
 )
 
 func TestBuildCorrectURI(t *testing.T) {
-	const expectPath = "/2013-04-01/hostedzone/ABCDEFG"
-
 	svc := route53.New(unit.Session)
 	svc.Handlers.Validate.Clear()
 	req, _ := svc.GetHostedZoneRequest(&route53.GetHostedZoneInput{
 		Id: aws.String("/hostedzone/ABCDEFG"),
 	})
+
+	expectPath := strings.ReplaceAll(req.Operation.HTTPPath, "{Id}", "ABCDEFG")
 
 	req.HTTPRequest.URL.RawQuery = "abc=123"
 


### PR DESCRIPTION
Fixes the API client's customization unit test to be less specific about
the expected URL. This change prevents unit test failures if unrelated
API model updates occur.