### PR TITLE
aws/session: Fix SSO unit test to cleanup tmp directory

### DIFF
--- a/aws/session/credentials_test.go
+++ b/aws/session/credentials_test.go
@@ -788,5 +788,6 @@ func ssoTestSetup() (func(), error) {
 	}
 
 	return func() {
+		os.RemoveAll(dir)
 	}, nil
 }


### PR DESCRIPTION
Fixes SSO unit test to cleanup temporary directory.