### PR TITLE
aws/session: Enable SSO provider to be mixed with other credential providers

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/session`: Enable SSO provider to be mixed with other credential providers ([#3905](https://github.com/aws/aws-sdk-go/pull/3905))
+  * Fixes [#3763](https://github.com/aws/aws-sdk-go/issues/3763)
 
 ### SDK Bugs

--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -101,13 +101,6 @@ func resolveCredsFromProfile(cfg *aws.Config,
 			sharedCfg.Creds,
 		)
 
-	case sharedCfg.hasSSOConfiguration():
-		creds, err = resolveSSOCredentials(cfg, sharedCfg, handlers)
-
-	case len(sharedCfg.CredentialProcess) != 0:
-		// Get credentials from CredentialProcess
-		creds = processcreds.NewCredentials(sharedCfg.CredentialProcess)
-
 	case len(sharedCfg.CredentialSource) != 0:
 		creds, err = resolveCredsFromSource(cfg, envCfg,
 			sharedCfg, handlers, sessOpts,
@@ -122,6 +115,13 @@ func resolveCredsFromProfile(cfg *aws.Config,
 			sharedCfg.RoleARN,
 			sharedCfg.RoleSessionName,
 		)
+
+	case sharedCfg.hasSSOConfiguration():
+		creds, err = resolveSSOCredentials(cfg, sharedCfg, handlers)
+
+	case len(sharedCfg.CredentialProcess) != 0:
+		// Get credentials from CredentialProcess
+		creds = processcreds.NewCredentials(sharedCfg.CredentialProcess)
 
 	default:
 		// Fallback to default credentials provider, include mock errors for

--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -401,7 +401,6 @@ func (cfg *sharedConfig) validateCredentialType() error {
 		len(cfg.CredentialSource) != 0,
 		len(cfg.CredentialProcess) != 0,
 		len(cfg.WebIdentityTokenFile) != 0,
-		cfg.hasSSOConfiguration(),
 	) {
 		return ErrSharedConfigSourceCollision
 	}
@@ -459,6 +458,10 @@ func (cfg *sharedConfig) clearCredentialOptions() {
 	cfg.CredentialProcess = ""
 	cfg.WebIdentityTokenFile = ""
 	cfg.Creds = credentials.Value{}
+	cfg.SSOAccountID = ""
+	cfg.SSORegion = ""
+	cfg.SSORoleName = ""
+	cfg.SSOStartURL = ""
 }
 
 func (cfg *sharedConfig) clearAssumeRoleOptions() {

--- a/aws/session/shared_config_test.go
+++ b/aws/session/shared_config_test.go
@@ -261,7 +261,38 @@ func TestLoadSharedConfig(t *testing.T) {
 		{
 			Filenames: []string{testConfigFilename},
 			Profile:   "source_sso_and_assume",
-			Err:       fmt.Errorf("only one credential type may be specified per profile"),
+			Expected: sharedConfig{
+				Profile:           "source_sso_and_assume",
+				RoleARN:           "source_sso_and_assume_arn",
+				SourceProfileName: "sso_and_assume",
+				SourceProfile: &sharedConfig{
+					Profile:           "sso_and_assume",
+					RoleARN:           "sso_with_assume_role_arn",
+					SourceProfileName: "multiple_assume_role_with_credential_source",
+					SourceProfile: &sharedConfig{
+						Profile:           "multiple_assume_role_with_credential_source",
+						RoleARN:           "multiple_assume_role_with_credential_source_role_arn",
+						SourceProfileName: "assume_role_with_credential_source",
+						SourceProfile: &sharedConfig{
+							Profile:          "assume_role_with_credential_source",
+							RoleARN:          "assume_role_with_credential_source_role_arn",
+							CredentialSource: credSourceEc2Metadata,
+						},
+					},
+				},
+			},
+		},
+		{
+			Filenames: []string{testConfigFilename},
+			Profile:   "sso_mixed_credproc",
+			Expected: sharedConfig{
+				Profile:           "sso_mixed_credproc",
+				SSOAccountID:      "012345678901",
+				SSORegion:         "us-west-2",
+				SSORoleName:       "TestRole",
+				SSOStartURL:       "https://127.0.0.1/start",
+				CredentialProcess: "/path/to/process",
+			},
 		},
 	}
 

--- a/aws/session/testdata/credential_source_config
+++ b/aws/session/testdata/credential_source_config
@@ -57,3 +57,17 @@ sso_start_url = https://THIS_SHOULD_NOT_BE_IN_TESTDATA_CACHE/start
 sso_account_id = 012345678901
 sso_role_name = TestRole
 
+[profile sso_mixed_credproc]
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://127.0.0.1/start
+credential_process = cat ./testdata/test_json.json
+
+[profile sso_mixed_webident]
+web_identity_token_file = ./testdata/wit.txt
+role_arn = sso_mixed_webident_arn
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://127.0.0.1/start

--- a/aws/session/testdata/credential_source_config_for_windows
+++ b/aws/session/testdata/credential_source_config_for_windows
@@ -8,3 +8,18 @@ credential_process = type .\testdata\test_json.json
 [chained_cred_proc]
 role_arn = assume_role_w_creds_proc_source_prof
 source_profile = cred_proc_no_arn_set
+
+[profile sso_mixed_credproc]
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://127.0.0.1/start
+credential_process = type .\testdata\test_json.json
+
+[profile sso_mixed_webident]
+web_identity_token_file = .\testdata\wit.txt
+role_arn = sso_mixed_webident_arn
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://127.0.0.1/start

--- a/aws/session/testdata/shared_config
+++ b/aws/session/testdata/shared_config
@@ -140,3 +140,10 @@ source_profile = multiple_assume_role_with_credential_source
 [profile source_sso_and_assume]
 role_arn = source_sso_and_assume_arn
 source_profile = sso_and_assume
+
+[profile sso_mixed_credproc]
+sso_account_id = 012345678901
+sso_region = us-west-2
+sso_role_name = TestRole
+sso_start_url = https://127.0.0.1/start
+credential_process = /path/to/process

--- a/aws/session/testdata/wit.txt
+++ b/aws/session/testdata/wit.txt
@@ -1,0 +1,1 @@
+YXdzIHNkayBmb3IgZ28gd2ViIGlkZW50aXR5IHRva2Vu


### PR DESCRIPTION
Enables SSO credential provider configuration to be mixed with other credential providers. 

Fixes: #3763