### PR TITLE
Add GitHub actions instead of Travis for Go CI tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,118 @@
+name: Go Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  full-test:
+    name: Full SDK and tools test
+    # Tests for activily maintained Go versions.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version:
+          - 1.15.x
+          - 1.16.x
+    steps:
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Test
+      shell: bash
+      run: |
+        if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          make unit-no-verify
+        else
+          make get-deps-verify ci-test
+        fi
+
+  deprecated-go-module-tests:
+    needs: full-test
+    name: Deprecated Go versions with module support
+    # Tests for deprecated Go versions with module support
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version:
+          - 1.12.x
+          - 1.13.x
+          - 1.14.x
+    steps:
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Test
+      shell: bash
+      run: make unit-old-go-race-cover
+
+  deprecated-pre-go-module-tests:
+    needs: full-test
+    name: Deprecated Go versions without module support
+    # Tests for deprecated Go versions without module support
+    #
+    # setup-go doesn't play well with old Go versions that need GOPATH
+    # * https://github.com/actions/setup-go/issues/14
+    # * https://github.com/actions/setup-go/issues/12
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        go-version:
+          - 1.5.x
+          - 1.6.x
+          - 1.7.x
+          - 1.8.x
+          - 1.9.x
+          - 1.10.x
+          - 1.11.x
+          - 1.12.x
+        exclude:
+          - os: macos-latest
+            go-version: 1.5.x
+          - os: macos-latest
+            go-version: 1.6.x
+        include:
+          - os: windows-latest
+            go-version: 1.12.x
+    steps:
+    - name: Setup Go env
+      shell: bash
+      run: |
+        echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
+        echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
+
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        path: go/src/github.com/aws/aws-sdk-go
+
+    - name: Test
+      shell: bash
+      working-directory: go/src/github.com/aws/aws-sdk-go
+      run: make get-deps unit-old-go-race-cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,70 +1,26 @@
 language: go
-
 sudo: required
-
-os:
-    - linux
-    - osx
-go:
-    - 1.5.x
-    - 1.6.x
-    - 1.7.x
-    - 1.8.x
-    - 1.9.x
-    - 1.10.x
-    - 1.11.x
-    - 1.12.x
-    - 1.13.x
-    - 1.14.x
-    - 1.15.x
-    - 1.16.x
-    - tip
-
-matrix:
-    allow_failures:
-        - go: tip
-    exclude:
-          # OSX 1.6.4 is not present in travis.
-          # https://github.com/travis-ci/travis-ci/issues/10309
-        - go: 1.6.x
-          os: osx
-        - go: 1.5.x
-          os: osx
-    include:
-        - os: windows
-          go: 1.12.x
-        - os: windows
-          go: 1.13.x
-        - os: windows
-          go: 1.14.x
-        - os: windows
-          go: 1.15.x
-        - os: windows
-          go: 1.16.x
-        - os: windows
-          go: tip
-
-before_install:
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install make; fi
-
-script:
-  - if [ -z $(go env GOMOD) ]; then
-      make get-deps;
-    fi;
-    if [ "$TRAVIS_GO_VERSION" == "tip" ] ||
-        [ "$TRAVIS_GO_VERSION" == "1.16.x" ] ||
-        [ "$TRAVIS_GO_VERSION" == "1.15.x" ]; then
-
-      if [ "$TRAVIS_OS_NAME" = "windows" ]; then
-        make unit-no-verify;
-      else
-        make get-deps-verify;
-        make ci-test;
-      fi
-    else
-      make unit-old-go-race-cover;
-    fi
+dist: bionic
 
 branches:
   only:
     - main
+
+os:
+    - linux
+    - osx
+    # Travis doesn't work with windows and Go tip
+    #- windows
+
+go:
+    - tip
+
+allow_failures:
+    - go: tip
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install make; fi
+  - (cd /tmp/; go get golang.org/x/lint/golint)
+
+script: make get-deps-verify ci-test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,16 @@ branches:
     - main
 
 os:
-    - linux
-    - osx
-    # Travis doesn't work with windows and Go tip
-    #- windows
+  - linux
+  - osx
+  # Travis doesn't work with windows and Go tip
+  #- windows
 
 go:
-    - tip
+  - tip
 
-allow_failures:
+matrix:
+  allow_failures:
     - go: tip
 
 before_install:


### PR DESCRIPTION
Updates the SDK's CI to use GitHub actions intead of Travis for most CI tasks. Travis is still used for Go tip.