### PR TITLE
service/s3: Add option to disable SHA256 computation on S3 PutObject

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -161,6 +161,10 @@ type Config struct {
 	// on GetObject API calls.
 	S3DisableContentMD5Validation *bool
 
+	// Set this to `true` to disable the S3 service client from automatically
+	// adding the Content-Sha256 to S3 Object Put and Upload API calls.
+	S3DisableContentSHA256Computation *bool
+
 	// Set this to `true` to have the S3 service client to use the region specified
 	// in the ARN, when an ARN is provided as an argument to a bucket parameter.
 	S3UseARNRegion *bool

--- a/service/s3/body_hash.go
+++ b/service/s3/body_hash.go
@@ -48,7 +48,7 @@ func computeBodyHashes(r *request.Request) {
 		hashers = append(hashers, md5Hash)
 	}
 
-	if v := r.HTTPRequest.Header.Get(contentSha256Header); len(v) == 0 {
+	if v := r.HTTPRequest.Header.Get(contentSha256Header); len(v) == 0 && !aws.BoolValue(r.Config.S3DisableContentSHA256Computation) {
 		sha256Hash = sha256.New()
 		hashers = append(hashers, sha256Hash)
 	}

--- a/service/s3/body_hash_test.go
+++ b/service/s3/body_hash_test.go
@@ -25,16 +25,17 @@ func (errorReader) Seek(int64, int) (int64, error) {
 	return 0, nil
 }
 
-func TestComputeBodyHases(t *testing.T) {
+func TestComputeBodyHashes(t *testing.T) {
 	bodyContent := []byte("bodyContent goes here")
 
 	cases := []struct {
-		Req               *request.Request
-		ExpectMD5         string
-		ExpectSHA256      string
-		Error             string
-		DisableContentMD5 bool
-		Presigned         bool
+		Req                  *request.Request
+		ExpectMD5            string
+		ExpectSHA256         string
+		Error                string
+		DisableContentMD5    bool
+		DisableContentSHA256 bool
+		Presigned            bool
 	}{
 		{
 			Req: &request.Request{
@@ -136,6 +137,18 @@ func TestComputeBodyHases(t *testing.T) {
 			DisableContentMD5: true,
 		},
 		{
+			// Disabled ContentSHA256 computation
+			Req: &request.Request{
+				HTTPRequest: &http.Request{
+					Header: http.Header{},
+				},
+				Body: bytes.NewReader(bodyContent),
+			},
+			ExpectMD5:            "CqD6NNPvoNOBT/5pkjtzOw==",
+			ExpectSHA256:         "",
+			DisableContentSHA256: true,
+		},
+		{
 			// Disabled ContentMD5 validation
 			Req: &request.Request{
 				HTTPRequest: &http.Request{
@@ -151,6 +164,7 @@ func TestComputeBodyHases(t *testing.T) {
 
 	for i, c := range cases {
 		c.Req.Config.S3DisableContentMD5Validation = aws.Bool(c.DisableContentMD5)
+		c.Req.Config.S3DisableContentSHA256Computation = aws.Bool(c.DisableContentSHA256)
 
 		if c.Presigned {
 			c.Req.ExpireTime = 10 * time.Minute


### PR DESCRIPTION
It is potentially very expensive to compute the SHA256 hash for large blobs that we're uploading to S3. However we still want some form of integrity checking (`Content-Md5`).

This PR adds a new configuration option that allows us to disable the SHA256 computation whilst still keeping the default behavior of calculating the MD5 hash.