### PR TITLE
rename new shapes that are suffixed as Input/Output in shape name

### DIFF
--- a/private/model/api/legacy_io_suffix.go
+++ b/private/model/api/legacy_io_suffix.go
@@ -1,0 +1,247 @@
+// +build codegen
+
+package api
+
+// IoSuffix represents map of service to shape names that
+// are suffixed with `Input`, `Output` string and are not
+// Input or Output shapes used by any operation within
+// the service enclosure.
+type IoSuffix map[string]map[string]struct{}
+
+// LegacyIoSuffix returns if the shape names are legacy
+// names that contain "Input" and "Output" name as suffix.
+func (i IoSuffix) LegacyIOSuffix(a *API, shapeName string) bool {
+	names, ok := i[a.name]
+	if !ok {
+		return false
+	}
+
+	_, ok = names[shapeName]
+	return ok
+}
+
+// legacyIOSuffixed is the list of known shapes that have "Input" and "Output"
+// as suffix in shape name, but are not the actual input, output shape
+// for a corresponding service operation.
+var legacyIOSuffixed = IoSuffix{
+	"TranscribeService": {
+		"RedactionOutput": struct{}{},
+	},
+	"Textract": {"HumanLoopActivationOutput": struct{}{}},
+	"Synthetics": {
+		"CanaryRunConfigInput":  struct{}{},
+		"CanaryScheduleOutput":  struct{}{},
+		"VpcConfigInput":        struct{}{},
+		"VpcConfigOutput":       struct{}{},
+		"CanaryCodeOutput":      struct{}{},
+		"CanaryCodeInput":       struct{}{},
+		"CanaryRunConfigOutput": struct{}{},
+		"CanaryScheduleInput":   struct{}{},
+	},
+	"SWF": {"FunctionInput": struct{}{}},
+	"SFN": {
+		"InvalidOutput":         struct{}{},
+		"InvalidExecutionInput": struct{}{},
+		"SensitiveDataJobInput": struct{}{},
+	},
+	"SSM": {
+		"CommandPluginOutput":                 struct{}{},
+		"MaintenanceWindowStepFunctionsInput": struct{}{},
+		"InvocationTraceOutput":               struct{}{},
+	},
+	"SSMIncidents": {"RegionMapInput": struct{}{}},
+
+	"SMS": {
+		"AppValidationOutput":    struct{}{},
+		"ServerValidationOutput": struct{}{},
+		"ValidationOutput":       struct{}{},
+		"SSMOutput":              struct{}{},
+	},
+	"ServiceDiscovery": {"InvalidInput": struct{}{}},
+	"ServiceCatalog": {
+		"RecordOutput":               struct{}{},
+		"ProvisioningArtifactOutput": struct{}{},
+	},
+	"Schemas": {
+		"GetDiscoveredSchemaVersionItemInput":         struct{}{},
+		"__listOfGetDiscoveredSchemaVersionItemInput": struct{}{},
+	},
+
+	"SageMaker": {
+		"ProcessingOutput":             struct{}{},
+		"TaskInput":                    struct{}{},
+		"TransformOutput":              struct{}{},
+		"ModelBiasJobInput":            struct{}{},
+		"TransformInput":               struct{}{},
+		"LabelingJobOutput":            struct{}{},
+		"DataQualityJobInput":          struct{}{},
+		"MonitoringOutput":             struct{}{},
+		"MonitoringS3Output":           struct{}{},
+		"MonitoringInput":              struct{}{},
+		"ProcessingS3Output":           struct{}{},
+		"ModelQualityJobInput":         struct{}{},
+		"ProcessingInput":              struct{}{},
+		"ProcessingFeatureStoreOutput": struct{}{},
+		"ModelExplainabilityJobInput":  struct{}{},
+		"ProcessingS3Input":            struct{}{},
+		"MonitoringGroundTruthS3Input": struct{}{},
+		"EdgePresetDeploymentOutput":   struct{}{},
+		"EndpointInput":                struct{}{},
+	},
+
+	"AugmentedAIRuntime": {"HumanLoopOutput": struct{}{}, "HumanLoopInput": struct{}{}},
+
+	"S3": {
+		"ParquetInput": struct{}{},
+		"CSVOutput":    struct{}{},
+		"JSONOutput":   struct{}{},
+		"JSONInput":    struct{}{},
+		"CSVInput":     struct{}{},
+	},
+
+	"Route53Domains": {"InvalidInput": struct{}{}},
+	"Route53":        {"InvalidInput": struct{}{}},
+	"RoboMaker":      {"S3KeyOutput": struct{}{}},
+
+	"Rekognition": {
+		"StreamProcessorInput":      struct{}{},
+		"HumanLoopActivationOutput": struct{}{},
+		"StreamProcessorOutput":     struct{}{},
+	},
+
+	"Proton": {"TemplateVersionSourceInput": struct{}{}, "CompatibleEnvironmentTemplateInput": struct{}{}},
+
+	"Personalize": {
+		"BatchInferenceJobInput":  struct{}{},
+		"BatchInferenceJobOutput": struct{}{},
+		"DatasetExportJobOutput":  struct{}{},
+	},
+
+	"MWAA": {
+		"ModuleLoggingConfigurationInput": struct{}{},
+		"LoggingConfigurationInput":       struct{}{},
+		"UpdateNetworkConfigurationInput": struct{}{},
+	},
+
+	"MQ": {"LdapServerMetadataOutput": struct{}{}, "LdapServerMetadataInput": struct{}{}},
+
+	"MediaLive": {
+		"InputDeviceConfiguredInput": struct{}{},
+		"__listOfOutput":             struct{}{},
+		"Input":                      struct{}{},
+		"__listOfInput":              struct{}{},
+		"Output":                     struct{}{},
+		"InputDeviceActiveInput":     struct{}{},
+	},
+
+	"MediaConvert": {
+		"Input":          struct{}{},
+		"__listOfOutput": struct{}{},
+		"Output":         struct{}{},
+		"__listOfInput":  struct{}{},
+	},
+	"MediaConnect": {"Output": struct{}{}, "__listOfOutput": struct{}{}},
+
+	"Lambda": {
+		"LayerVersionContentOutput": struct{}{},
+		"LayerVersionContentInput":  struct{}{},
+	},
+
+	"KinesisAnalyticsV2": {
+		"KinesisStreamsInput":   struct{}{},
+		"KinesisFirehoseInput":  struct{}{},
+		"LambdaOutput":          struct{}{},
+		"Output":                struct{}{},
+		"KinesisFirehoseOutput": struct{}{},
+		"Input":                 struct{}{},
+		"KinesisStreamsOutput":  struct{}{},
+	},
+
+	"KinesisAnalytics": {
+		"Output":                struct{}{},
+		"KinesisFirehoseInput":  struct{}{},
+		"LambdaOutput":          struct{}{},
+		"KinesisFirehoseOutput": struct{}{},
+		"KinesisStreamsInput":   struct{}{},
+		"Input":                 struct{}{},
+		"KinesisStreamsOutput":  struct{}{},
+	},
+
+	"IoTEvents": {"Input": struct{}{}},
+	"IoT":       {"PutItemInput": struct{}{}},
+
+	"Honeycode": {"CellInput": struct{}{}, "RowDataInput": struct{}{}},
+
+	"Glue": {
+		"TableInput":               struct{}{},
+		"UserDefinedFunctionInput": struct{}{},
+		"DatabaseInput":            struct{}{},
+		"PartitionInput":           struct{}{},
+		"ConnectionInput":          struct{}{},
+	},
+
+	"Glacier": {
+		"CSVInput":                   struct{}{},
+		"CSVOutput":                  struct{}{},
+		"InventoryRetrievalJobInput": struct{}{},
+	},
+
+	"FIS": {
+		"CreateExperimentTemplateTargetInput":        struct{}{},
+		"CreateExperimentTemplateStopConditionInput": struct{}{},
+		"UpdateExperimentTemplateStopConditionInput": struct{}{},
+		"CreateExperimentTemplateActionInput":        struct{}{},
+		"UpdateExperimentTemplateTargetInput":        struct{}{},
+	},
+
+	"Firehose": {"DeliveryStreamEncryptionConfigurationInput": struct{}{}},
+
+	"CloudWatchEvents": {"TransformerInput": struct{}{}, "TargetInput": struct{}{}},
+
+	"EventBridge": {"TransformerInput": struct{}{}, "TargetInput": struct{}{}},
+
+	"ElasticsearchService": {
+		"AutoTuneOptionsOutput":        struct{}{},
+		"SAMLOptionsInput":             struct{}{},
+		"AdvancedSecurityOptionsInput": struct{}{},
+		"SAMLOptionsOutput":            struct{}{},
+		"AutoTuneOptionsInput":         struct{}{},
+	},
+
+	"ElasticTranscoder": {
+		"JobOutput":       struct{}{},
+		"CreateJobOutput": struct{}{},
+		"JobInput":        struct{}{},
+	},
+
+	"ElastiCache": {
+		"UserGroupIdListInput": struct{}{},
+		"PasswordListInput":    struct{}{},
+		"UserIdListInput":      struct{}{},
+	},
+
+	"ECRPublic":  {"RepositoryCatalogDataInput": struct{}{}},
+	"DeviceFarm": {"TestGridUrlExpiresInSecondsInput": struct{}{}},
+
+	"GlueDataBrew": {"Output": struct{}{}, "Input": struct{}{}, "OverwriteOutput": struct{}{}},
+
+	"CodePipeline": {"ActionExecutionInput": struct{}{}, "ActionExecutionOutput": struct{}{}},
+
+	"CodeBuild": {"ValueInput": struct{}{}, "KeyInput": struct{}{}},
+
+	"CloudFormation": {"Output": struct{}{}},
+
+	"Backup": {
+		"PlanInput":  struct{}{},
+		"RulesInput": struct{}{},
+		"RuleInput":  struct{}{},
+	},
+
+	"ApplicationInsights": {"StatesInput": struct{}{}},
+
+	"ApiGatewayV2": {
+		"TlsConfigInput":               struct{}{},
+		"MutualTlsAuthenticationInput": struct{}{},
+	},
+	"APIGateway": {"MutualTlsAuthenticationInput": struct{}{}},
+}

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -215,6 +215,7 @@ func (a *API) Setup() error {
 	}
 	a.renameExportable()
 	a.applyShapeNameAliases()
+	a.renameIOSuffixedShapeNames()
 	a.createInputOutputShapes()
 	a.writeInputOutputLocationName()
 	a.renameAPIPayloadShapes()

--- a/private/model/api/passes_test.go
+++ b/private/model/api/passes_test.go
@@ -300,20 +300,34 @@ func TestCreateInputOutputShapes(t *testing.T) {
 		"allRename": {
 			API: &API{Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:      "FirstOp",
 						InputRef:  ShapeRef{ShapeName: "FirstOpRequest"},
 						OutputRef: ShapeRef{ShapeName: "FirstOpResponse"},
 					},
-					"SecondOp": {Name: "SecondOp",
+					"SecondOp": {
+						Name:      "SecondOp",
 						InputRef:  ShapeRef{ShapeName: "SecondOpRequest"},
 						OutputRef: ShapeRef{ShapeName: "SecondOpResponse"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpRequest":   {ShapeName: "FirstOpRequest", Type: "structure"},
-					"FirstOpResponse":  {ShapeName: "FirstOpResponse", Type: "structure"},
-					"SecondOpRequest":  {ShapeName: "SecondOpRequest", Type: "structure"},
-					"SecondOpResponse": {ShapeName: "SecondOpResponse", Type: "structure"},
+					"FirstOpRequest": {
+						ShapeName: "FirstOpRequest",
+						Type:      "structure",
+					},
+					"FirstOpResponse": {
+						ShapeName: "FirstOpResponse",
+						Type:      "structure",
+					},
+					"SecondOpRequest": {
+						ShapeName: "SecondOpRequest",
+						Type:      "structure",
+					},
+					"SecondOpResponse": {
+						ShapeName: "SecondOpResponse",
+						Type:      "structure",
+					},
 				},
 			},
 			ExpectOps: map[string]OpExpect{
@@ -327,27 +341,43 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"FirstOpInput", "FirstOpOutput",
-				"SecondOpInput", "SecondOpOutput",
+				"FirstOpInput",
+				"FirstOpOutput",
+				"SecondOpInput",
+				"SecondOpOutput",
 			},
 		},
 		"noRename": {
 			API: &API{Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:      "FirstOp",
 						InputRef:  ShapeRef{ShapeName: "FirstOpInput"},
 						OutputRef: ShapeRef{ShapeName: "FirstOpOutput"},
 					},
-					"SecondOp": {Name: "SecondOp",
+					"SecondOp": {
+						Name:      "SecondOp",
 						InputRef:  ShapeRef{ShapeName: "SecondOpInput"},
 						OutputRef: ShapeRef{ShapeName: "SecondOpOutput"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpInput":   {ShapeName: "FirstOpInput", Type: "structure"},
-					"FirstOpOutput":  {ShapeName: "FirstOpOutput", Type: "structure"},
-					"SecondOpInput":  {ShapeName: "SecondOpInput", Type: "structure"},
-					"SecondOpOutput": {ShapeName: "SecondOpOutput", Type: "structure"},
+					"FirstOpInput": {
+						ShapeName: "FirstOpInput",
+						Type:      "structure",
+					},
+					"FirstOpOutput": {
+						ShapeName: "FirstOpOutput",
+						Type:      "structure",
+					},
+					"SecondOpInput": {
+						ShapeName: "SecondOpInput",
+						Type:      "structure",
+					},
+					"SecondOpOutput": {
+						ShapeName: "SecondOpOutput",
+						Type:      "structure",
+					},
 				},
 			},
 			ExpectOps: map[string]OpExpect{
@@ -361,39 +391,61 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"FirstOpInput", "FirstOpOutput",
-				"SecondOpInput", "SecondOpOutput",
+				"FirstOpInput",
+				"FirstOpOutput",
+				"SecondOpInput",
+				"SecondOpOutput",
 			},
 		},
 		"renameWithNested": {
 			API: &API{Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:      "FirstOp",
 						InputRef:  ShapeRef{ShapeName: "FirstOpWriteMe"},
 						OutputRef: ShapeRef{ShapeName: "FirstOpReadMe"},
 					},
-					"SecondOp": {Name: "SecondOp",
+					"SecondOp": {
+						Name:      "SecondOp",
 						InputRef:  ShapeRef{ShapeName: "SecondOpWriteMe"},
 						OutputRef: ShapeRef{ShapeName: "SecondOpReadMe"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpWriteMe": {ShapeName: "FirstOpWriteMe", Type: "structure",
+					"FirstOpWriteMe": {
+						ShapeName: "FirstOpWriteMe",
+						Type:      "structure",
 						MemberRefs: map[string]*ShapeRef{
 							"Foo": {ShapeName: "String"},
 						},
 					},
-					"FirstOpReadMe": {ShapeName: "FirstOpReadMe", Type: "structure",
+					"FirstOpReadMe": {
+						ShapeName: "FirstOpReadMe",
+						Type:      "structure",
 						MemberRefs: map[string]*ShapeRef{
 							"Bar":  {ShapeName: "Struct"},
 							"Once": {ShapeName: "Once"},
 						},
 					},
-					"SecondOpWriteMe": {ShapeName: "SecondOpWriteMe", Type: "structure"},
-					"SecondOpReadMe":  {ShapeName: "SecondOpReadMe", Type: "structure"},
-					"Once":            {ShapeName: "Once", Type: "string"},
-					"String":          {ShapeName: "String", Type: "string"},
-					"Struct": {ShapeName: "Struct", Type: "structure",
+					"SecondOpWriteMe": {
+						ShapeName: "SecondOpWriteMe",
+						Type:      "structure",
+					},
+					"SecondOpReadMe": {
+						ShapeName: "SecondOpReadMe",
+						Type:      "structure",
+					},
+					"Once": {
+						ShapeName: "Once",
+						Type:      "string",
+					},
+					"String": {
+						ShapeName: "String",
+						Type:      "string",
+					},
+					"Struct": {
+						ShapeName: "Struct",
+						Type:      "structure",
 						MemberRefs: map[string]*ShapeRef{
 							"Foo": {ShapeName: "String"},
 							"Bar": {ShapeName: "Struct"},
@@ -412,25 +464,34 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"FirstOpInput", "FirstOpOutput",
+				"FirstOpInput",
+				"FirstOpOutput",
 				"Once",
-				"SecondOpInput", "SecondOpOutput",
-				"String", "Struct",
+				"SecondOpInput",
+				"SecondOpOutput",
+				"String",
+				"Struct",
 			},
 		},
 		"aliasedInput": {
 			API: &API{Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:      "FirstOp",
 						InputRef:  ShapeRef{ShapeName: "FirstOpRequest"},
 						OutputRef: ShapeRef{ShapeName: "FirstOpResponse"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpRequest": {ShapeName: "FirstOpRequest", Type: "structure",
+					"FirstOpRequest": {
+						ShapeName:        "FirstOpRequest",
+						Type:             "structure",
 						AliasedShapeName: true,
 					},
-					"FirstOpResponse": {ShapeName: "FirstOpResponse", Type: "structure"},
+					"FirstOpResponse": {
+						ShapeName: "FirstOpResponse",
+						Type:      "structure",
+					},
 				},
 			},
 			ExpectOps: map[string]OpExpect{
@@ -440,20 +501,28 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"FirstOpOutput", "FirstOpRequest",
+				"FirstOpOutput",
+				"FirstOpRequest",
 			},
 		},
 		"aliasedOutput": {
-			API: &API{Metadata: meta,
+			API: &API{
+				Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:      "FirstOp",
 						InputRef:  ShapeRef{ShapeName: "FirstOpRequest"},
 						OutputRef: ShapeRef{ShapeName: "FirstOpResponse"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpRequest": {ShapeName: "FirstOpRequest", Type: "structure"},
-					"FirstOpResponse": {ShapeName: "FirstOpResponse", Type: "structure",
+					"FirstOpRequest": {
+						ShapeName: "FirstOpRequest",
+						Type:      "structure",
+					},
+					"FirstOpResponse": {
+						ShapeName:        "FirstOpResponse",
+						Type:             "structure",
 						AliasedShapeName: true,
 					},
 				},
@@ -469,22 +538,31 @@ func TestCreateInputOutputShapes(t *testing.T) {
 			},
 		},
 		"resusedShape": {
-			API: &API{Metadata: meta,
+			API: &API{
+				Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:      "FirstOp",
 						InputRef:  ShapeRef{ShapeName: "FirstOpRequest"},
 						OutputRef: ShapeRef{ShapeName: "ReusedShape"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpRequest": {ShapeName: "FirstOpRequest", Type: "structure",
+					"FirstOpRequest": {
+						ShapeName: "FirstOpRequest",
+						Type:      "structure",
 						MemberRefs: map[string]*ShapeRef{
 							"Foo": {ShapeName: "ReusedShape"},
 							"ooF": {ShapeName: "ReusedShapeList"},
 						},
 					},
-					"ReusedShape": {ShapeName: "ReusedShape", Type: "structure"},
-					"ReusedShapeList": {ShapeName: "ReusedShapeList", Type: "list",
+					"ReusedShape": {
+						ShapeName: "ReusedShape",
+						Type:      "structure",
+					},
+					"ReusedShapeList": {
+						ShapeName: "ReusedShapeList",
+						Type:      "list",
 						MemberRef: ShapeRef{ShapeName: "ReusedShape"},
 					},
 				},
@@ -496,29 +574,39 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"FirstOpInput", "FirstOpOutput",
-				"ReusedShape", "ReusedShapeList",
+				"FirstOpInput",
+				"FirstOpOutput",
+				"ReusedShape",
+				"ReusedShapeList",
 			},
 		},
 		"aliasedResusedShape": {
-			API: &API{Metadata: meta,
+			API: &API{
+				Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:      "FirstOp",
 						InputRef:  ShapeRef{ShapeName: "FirstOpRequest"},
 						OutputRef: ShapeRef{ShapeName: "ReusedShape"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpRequest": {ShapeName: "FirstOpRequest", Type: "structure",
+					"FirstOpRequest": {
+						ShapeName: "FirstOpRequest",
+						Type:      "structure",
 						MemberRefs: map[string]*ShapeRef{
 							"Foo": {ShapeName: "ReusedShape"},
 							"ooF": {ShapeName: "ReusedShapeList"},
 						},
 					},
-					"ReusedShape": {ShapeName: "ReusedShape", Type: "structure",
+					"ReusedShape": {
+						ShapeName:        "ReusedShape",
+						Type:             "structure",
 						AliasedShapeName: true,
 					},
-					"ReusedShapeList": {ShapeName: "ReusedShapeList", Type: "list",
+					"ReusedShapeList": {
+						ShapeName: "ReusedShapeList",
+						Type:      "list",
 						MemberRef: ShapeRef{ShapeName: "ReusedShape"},
 					},
 				},
@@ -531,18 +619,23 @@ func TestCreateInputOutputShapes(t *testing.T) {
 			},
 			ExpectShapes: []string{
 				"FirstOpInput",
-				"ReusedShape", "ReusedShapeList",
+				"ReusedShape",
+				"ReusedShapeList",
 			},
 		},
 		"unsetInput": {
 			API: &API{Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:      "FirstOp",
 						OutputRef: ShapeRef{ShapeName: "FirstOpResponse"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpResponse": {ShapeName: "FirstOpResponse", Type: "structure"},
+					"FirstOpResponse": {
+						ShapeName: "FirstOpResponse",
+						Type:      "structure",
+					},
 				},
 			},
 			ExpectOps: map[string]OpExpect{
@@ -552,18 +645,23 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"FirstOpInput", "FirstOpOutput",
+				"FirstOpInput",
+				"FirstOpOutput",
 			},
 		},
 		"unsetOutput": {
 			API: &API{Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:     "FirstOp",
 						InputRef: ShapeRef{ShapeName: "FirstOpRequest"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpRequest": {ShapeName: "FirstOpRequest", Type: "structure"},
+					"FirstOpRequest": {
+						ShapeName: "FirstOpRequest",
+						Type:      "structure",
+					},
 				},
 			},
 			ExpectOps: map[string]OpExpect{
@@ -573,7 +671,8 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"FirstOpInput", "FirstOpOutput",
+				"FirstOpInput",
+				"FirstOpOutput",
 			},
 		},
 		"collidingShape": {
@@ -581,12 +680,15 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				name:     "APIClientName",
 				Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:     "FirstOp",
 						InputRef: ShapeRef{ShapeName: "FirstOpRequest"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpRequest": {ShapeName: "FirstOpRequest", Type: "structure",
+					"FirstOpRequest": {
+						ShapeName: "FirstOpRequest",
+						Type:      "structure",
 						MemberRefs: map[string]*ShapeRef{
 							"Foo": {ShapeName: "APIClientName"},
 							"ooF": {ShapeName: "APIClientNameList"},
@@ -608,8 +710,10 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"APIClientNameList", "APIClientName_",
-				"FirstOpInput", "FirstOpOutput",
+				"APIClientNameList",
+				"APIClientName_",
+				"FirstOpInput",
+				"FirstOpOutput",
 			},
 		},
 		"MemberShapesWithInputAsSuffix": {
@@ -617,12 +721,15 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				name:     "APIClientName",
 				Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:     "FirstOp",
 						InputRef: ShapeRef{ShapeName: "FirstOpRequest"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpRequest": {ShapeName: "FirstOpRequest", Type: "structure",
+					"FirstOpRequest": {
+						ShapeName: "FirstOpRequest",
+						Type:      "structure",
 						MemberRefs: map[string]*ShapeRef{
 							"Foo": {ShapeName: "APIClientName"},
 							"ooF": {ShapeName: "FirstOpInput"},
@@ -633,7 +740,9 @@ func TestCreateInputOutputShapes(t *testing.T) {
 					},
 					"FirstOpInput": {
 						ShapeName: "FirstOpInput", Type: "list",
-						MemberRef: ShapeRef{ShapeName: "APIClientName"},
+						MemberRef: ShapeRef{
+							ShapeName: "APIClientName",
+						},
 					},
 				},
 			},
@@ -644,8 +753,10 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"APIClientName_", "FirstOpInput",
-				"FirstOpInput_", "FirstOpOutput",
+				"APIClientName_",
+				"FirstOpInput",
+				"FirstOpInput_",
+				"FirstOpOutput",
 			},
 		},
 		"MemberShapesWithOutputAsSuffix": {
@@ -653,12 +764,15 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				name:     "APIClientName",
 				Metadata: meta,
 				Operations: map[string]*Operation{
-					"FirstOp": {Name: "FirstOp",
+					"FirstOp": {
+						Name:      "FirstOp",
 						OutputRef: ShapeRef{ShapeName: "FirstOpResponse"},
 					},
 				},
 				Shapes: map[string]*Shape{
-					"FirstOpResponse": {ShapeName: "FirstOpResponse", Type: "structure",
+					"FirstOpResponse": {
+						ShapeName: "FirstOpResponse",
+						Type:      "structure",
 						MemberRefs: map[string]*ShapeRef{
 							"Foo": {ShapeName: "APIClientName"},
 							"ooF": {ShapeName: "FirstOpOutput"},
@@ -680,8 +794,10 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				},
 			},
 			ExpectShapes: []string{
-				"APIClientName_", "FirstOpInput",
-				"FirstOpOutput", "FirstOpOutput_",
+				"APIClientName_",
+				"FirstOpInput",
+				"FirstOpOutput",
+				"FirstOpOutput_",
 			},
 		},
 	}

--- a/private/model/api/passes_test.go
+++ b/private/model/api/passes_test.go
@@ -612,6 +612,78 @@ func TestCreateInputOutputShapes(t *testing.T) {
 				"FirstOpInput", "FirstOpOutput",
 			},
 		},
+		"MemberShapesWithInputAsSuffix": {
+			API: &API{
+				name:     "APIClientName",
+				Metadata: meta,
+				Operations: map[string]*Operation{
+					"FirstOp": {Name: "FirstOp",
+						InputRef: ShapeRef{ShapeName: "FirstOpRequest"},
+					},
+				},
+				Shapes: map[string]*Shape{
+					"FirstOpRequest": {ShapeName: "FirstOpRequest", Type: "structure",
+						MemberRefs: map[string]*ShapeRef{
+							"Foo": {ShapeName: "APIClientName"},
+							"ooF": {ShapeName: "FirstOpInput"},
+						},
+					},
+					"APIClientName": {
+						ShapeName: "APIClientName", Type: "structure",
+					},
+					"FirstOpInput": {
+						ShapeName: "FirstOpInput", Type: "list",
+						MemberRef: ShapeRef{ShapeName: "APIClientName"},
+					},
+				},
+			},
+			ExpectOps: map[string]OpExpect{
+				"FirstOp": {
+					Input:  "FirstOpInput",
+					Output: "FirstOpOutput",
+				},
+			},
+			ExpectShapes: []string{
+				"APIClientName_", "FirstOpInput",
+				"FirstOpInput_", "FirstOpOutput",
+			},
+		},
+		"MemberShapesWithOutputAsSuffix": {
+			API: &API{
+				name:     "APIClientName",
+				Metadata: meta,
+				Operations: map[string]*Operation{
+					"FirstOp": {Name: "FirstOp",
+						OutputRef: ShapeRef{ShapeName: "FirstOpResponse"},
+					},
+				},
+				Shapes: map[string]*Shape{
+					"FirstOpResponse": {ShapeName: "FirstOpResponse", Type: "structure",
+						MemberRefs: map[string]*ShapeRef{
+							"Foo": {ShapeName: "APIClientName"},
+							"ooF": {ShapeName: "FirstOpOutput"},
+						},
+					},
+					"APIClientName": {
+						ShapeName: "APIClientName", Type: "structure",
+					},
+					"FirstOpOutput": {
+						ShapeName: "FirstOpOutput", Type: "list",
+						MemberRef: ShapeRef{ShapeName: "APIClientName"},
+					},
+				},
+			},
+			ExpectOps: map[string]OpExpect{
+				"FirstOp": {
+					Input:  "FirstOpInput",
+					Output: "FirstOpOutput",
+				},
+			},
+			ExpectShapes: []string{
+				"APIClientName_", "FirstOpInput",
+				"FirstOpOutput", "FirstOpOutput_",
+			},
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
Rename shapes that have `Input` or `Output` suffix in the shape name, but are not input or output shape for any operation. 

Shapes are renamed to add `_` at the end. 

To not break existing shape names, we maintain a legacy list. 

