### PR TITLE
Add missing expression attribute names to example

### DIFF
--- a/service/dynamodb/expression/examples_test.go
+++ b/service/dynamodb/expression/examples_test.go
@@ -37,6 +37,7 @@ func ExampleBuilder_WithProjection() {
 	// Use the built expression to populate the DynamoDB Query's API input
 	// parameters.
 	input := &dynamodb.QueryInput{
+		ExpressionAttributeNames:  expr.Names(),
 		ExpressionAttributeValues: expr.Values(),
 		KeyConditionExpression:    expr.KeyCondition(),
 		ProjectionExpression:      expr.Projection(),


### PR DESCRIPTION
Missing expression attribute names in example causes error: `An expression attribute value used in expression is not defined`