### PR TITLE
Replace crypto/sha256 with minio/sha256-simd

### DIFF
--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -56,9 +56,9 @@ package v4
 
 import (
 	"crypto/hmac"
-	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"github.com/minio/sha256-simd"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/aws/aws-sdk-go
 
 require (
 	github.com/jmespath/go-jmespath v0.4.0
+	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
+github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
+github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/private/signer/v2/v2.go
+++ b/private/signer/v2/v2.go
@@ -2,10 +2,10 @@ package v2
 
 import (
 	"crypto/hmac"
-	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/minio/sha256-simd"
 	"net/http"
 	"net/url"
 	"sort"

--- a/service/glacier/treehash.go
+++ b/service/glacier/treehash.go
@@ -1,7 +1,7 @@
 package glacier
 
 import (
-	"crypto/sha256"
+	"github.com/minio/sha256-simd"
 	"io"
 
 	"github.com/aws/aws-sdk-go/internal/sdkio"

--- a/service/glacier/treehash_test.go
+++ b/service/glacier/treehash_test.go
@@ -2,8 +2,8 @@ package glacier_test
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"fmt"
+	"github.com/minio/sha256-simd"
 	"io"
 
 	"github.com/aws/aws-sdk-go/service/glacier"

--- a/service/s3/body_hash.go
+++ b/service/s3/body_hash.go
@@ -3,10 +3,10 @@ package s3
 import (
 	"bytes"
 	"crypto/md5"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"github.com/minio/sha256-simd"
 	"hash"
 	"io"
 

--- a/service/s3/s3crypto/hash_io.go
+++ b/service/s3/s3crypto/hash_io.go
@@ -1,7 +1,7 @@
 package s3crypto
 
 import (
-	"crypto/sha256"
+	"github.com/minio/sha256-simd"
 	"hash"
 	"io"
 )


### PR DESCRIPTION
Recently I'm debugging latency issues for my software, and found calculating sha256 is one of the main sources of latency.

As I tested on my laptop(the CPU has "sha_ni" flag), writing 1000 times of 4M buffer to crypto/sha256 writer took 8.2s, while minio/sha256-simd took only 2s.

Disclaimer: I have no relationship with minio.