### PR TITLE
add smoke test for device-farm

### DIFF
--- a/models/apis/devicefarm/2015-06-23/smoke.json
+++ b/models/apis/devicefarm/2015-06-23/smoke.json
@@ -1,0 +1,18 @@
+{
+    "version": 1,
+    "defaultRegion": "us-west-2",
+    "testCases": [
+        {
+            "operationName": "ListDevices",
+            "input": {},
+            "errorExpectedFromService": false
+        },
+        {
+            "operationName": "GetDevice",
+            "input": {
+                "arn": "arn:aws:devicefarm:us-west-2::device:000000000000000000000000fake-arn"
+            },
+            "errorExpectedFromService": true
+        }
+    ]
+}

--- a/service/devicefarm/integ_test.go
+++ b/service/devicefarm/integ_test.go
@@ -21,7 +21,6 @@ var _ awserr.Error
 var _ request.Request
 
 func TestInteg_00_ListDevices(t *testing.T) {
-	t.Skipf("skipped to let release 07-13 succeed")
 	ctx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFn()
 
@@ -36,7 +35,6 @@ func TestInteg_00_ListDevices(t *testing.T) {
 	}
 }
 func TestInteg_01_GetDevice(t *testing.T) {
-	t.Skipf("skipped to let release 07-13 succeed")
 	ctx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFn()
 


### PR DESCRIPTION
Reverts https://github.com/aws/aws-sdk-go/pull/4004