### PR TITLE
example/aws/proxyWithTLSClientCert: Use `Transport.ForceAttemptHTTP2` to enable HTTP/2

### DIFF
--- a/example/aws/proxyWithTLSClientCert/main.go
+++ b/example/aws/proxyWithTLSClientCert/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"golang.org/x/net/http2"
 )
 
 // Example of creating an HTTP Client configured with a client TLS
@@ -50,10 +49,6 @@ func main() {
 	// Copy of net/http.DefaultTransport with TLS config loaded
 	tr := defaultHTTPTransport()
 	tr.TLSClientConfig = tlsCfg
-
-	// re-enable HTTP/2 because modifing TLS config will prevent auto support
-	// for HTTP/2.
-	http2.ConfigureTransport(tr)
 
 	// Configure the SDK's session with the HTTP client with TLS client
 	// certificate support enabled. This session will be used to create all
@@ -119,5 +114,6 @@ func defaultHTTPTransport() *http.Transport {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     true,
 	}
 }


### PR DESCRIPTION
This can remove `golang.org/x/net/http2` dependency.

This field was added at Go 1.13. This example file now required
Go 1.15+. So we can use this field safely.
Ref: https://golang.org/doc/go1.13#net/http