### PR TITLE
Default Retryer - removing unused and misleading variable 

### DIFF
--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -36,9 +36,6 @@ type DefaultRetryer struct {
 }
 
 const (
-	// DefaultRetryerMaxNumRetries sets maximum number of retries
-	DefaultRetryerMaxNumRetries = 3
-
 	// DefaultRetryerMinRetryDelay sets minimum retry delay
 	DefaultRetryerMinRetryDelay = 30 * time.Millisecond
 


### PR DESCRIPTION
For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
#4027  
The `DefaultRetryerMaxNumRetries` is not used because the `d.NumMaxRetries` defaults to 0 implicitly, making the variable useless and it's comment misleading:
