### PR TITLE
service/s3: Update unit test to clarify implemented behavior

### DIFF
--- a/service/s3/endpoint_test.go
+++ b/service/s3/endpoint_test.go
@@ -265,13 +265,21 @@ func TestEndpoint(t *testing.T) {
 			expectedSigningName:   "s3-outposts",
 			expectedSigningRegion: "us-gov-east-1",
 		},
-		"Outpost AccessPoint FIPS client region": {
-			bucket: "arn:aws-us-gov:s3-outposts:us-gov-east-1:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint",
+		"Outpost AccessPoint FIPS client region, resolved signing region does not match ARN region": {
+			bucket: "arn:aws-us-gov:s3-outposts:us-gov-unknown-1:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint",
 			config: &aws.Config{
 				EndpointResolver: endpoints.AwsUsGovPartition(),
-				Region:           aws.String("fips-us-gov-east-1"),
+				Region:           aws.String("fips-us-gov-unknown-1"),
 			},
 			expectedErr: "ConfigurationError: client region does not match provided ARN region",
+		},
+		"Outpost AccessPoint FIPS client region, resolved signing region does match ARN region": {
+			bucket: "arn:aws-us-gov:s3-outposts:us-gov-west-1:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint",
+			config: &aws.Config{
+				EndpointResolver: endpoints.AwsUsGovPartition(),
+				Region:           aws.String("fips-us-gov-west-1"),
+			},
+			expectedErr: "use of ARN is not supported when client or request is configured for FIPS",
 		},
 		"Outpost AccessPoint FIPS client region with matching ARN region": {
 			bucket: "arn:aws-us-gov:s3-outposts:us-gov-east-1:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint",


### PR DESCRIPTION
Updates Amazon S3 Output ARN unit test to more specifically describe the behavior that is being tested.

If the client's resolved endpoint's signing region does not match the Output ARN's region component the client will return the region not match error. If the client's resolved endpoint's signing region does match the Output ARN's region component, but the API client's configured region includes FIPS, the FIPS configured error will be returned.
