### PR TITLE
Fix DescribeAvailablePatches api

### DIFF
--- a/models/apis/ssm/2014-11-06/api-2.json
+++ b/models/apis/ssm/2014-11-06/api-2.json
@@ -8328,7 +8328,7 @@
       ]
     },
     "PatchDescription":{"type":"string"},
-    "PatchEpoch":{"type":"integer"},
+    "PatchEpoch":{"type":"string"},
     "PatchFailedCount":{"type":"integer"},
     "PatchFilter":{
       "type":"structure",

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -43403,7 +43403,7 @@ type Patch struct {
 
 	// The epoch of the patch. For example in pkg-example-EE-20180914-2.2.amzn1.noarch,
 	// the epoch value is 20180914-2. Applies to Linux-based instances only.
-	Epoch *int64 `type:"integer"`
+	Epoch *string `type:"string"`
 
 	// The ID of the patch. Applies to Windows patches only.
 	//
@@ -43515,7 +43515,7 @@ func (s *Patch) SetDescription(v string) *Patch {
 }
 
 // SetEpoch sets the Epoch field's value.
-func (s *Patch) SetEpoch(v int64) *Patch {
+func (s *Patch) SetEpoch(v string) *Patch {
 	s.Epoch = &v
 	return s
 }


### PR DESCRIPTION
Epoch is returned by api is string type not int64

https://github.com/aws/aws-sdk-go/issues/4042