### PR TITLE
Close http.Response.Body in S3 CopyObject, UploadPartCopy and CompleteMultipartUpload operations. 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/s3`: Close http.Response.Body in CopyObject, UploadPartCopy and CompleteMultipartUpload operations
+  * Fixes [#4037](https://github.com/aws/aws-sdk-go/issues/4037)

--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -40,7 +40,7 @@ func defaultInitRequestFn(r *request.Request) {
 		// Auto-populate LocationConstraint with current region
 		r.Handlers.Validate.PushFront(populateLocationConstraint)
 	case opCopyObject, opUploadPartCopy, opCompleteMultipartUpload:
-		r.Handlers.Unmarshal.PushFront(copyMultipartStatusOKUnmarhsalError)
+		r.Handlers.Unmarshal.PushFront(copyMultipartStatusOKUnmarshalError)
 		r.Handlers.Unmarshal.PushBackNamed(s3err.RequestFailureWrapperHandler())
 	case opPutObject, opUploadPart:
 		r.Handlers.Build.PushBack(computeBodyHashes)

--- a/service/s3/statusok_error.go
+++ b/service/s3/statusok_error.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/internal/sdkio"
 )
 
-func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
+func copyMultipartStatusOKUnmarshalError(r *request.Request) {
 	b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
@@ -21,6 +21,8 @@ func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
 		)
 		return
 	}
+	r.HTTPResponse.Body.Close()
+
 	body := bytes.NewReader(b)
 	r.HTTPResponse.Body = ioutil.NopCloser(body)
 	defer body.Seek(0, sdkio.SeekStart)

--- a/service/s3/statusok_error.go
+++ b/service/s3/statusok_error.go
@@ -13,15 +13,18 @@ import (
 
 func copyMultipartStatusOKUnmarshalError(r *request.Request) {
 	b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	r.HTTPResponse.Body.Close()
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New(request.ErrCodeSerialization, "unable to read response body", err),
 			r.HTTPResponse.StatusCode,
 			r.RequestID,
 		)
+		// Note, some middleware later in the stack like restxml.Unmarshal expect a valid, non-closed Body
+		// even in case of an error, so we replace it with an empty Reader.
+		r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(nil))
 		return
 	}
-	r.HTTPResponse.Body.Close()
 
 	body := bytes.NewReader(b)
 	r.HTTPResponse.Body = ioutil.NopCloser(body)

--- a/service/s3/statusok_error_test.go
+++ b/service/s3/statusok_error_test.go
@@ -236,7 +236,6 @@ func (f funcCloser) Close() error {
 	return f.closeFn()
 }
 
-
 func TestStatusOKPayloadHandling(t *testing.T) {
 	cases := map[string]struct {
 		Header   http.Header


### PR DESCRIPTION
Fixes #4037. See that issue for more details.

Note, in case of read error we don't close the body because later Unmarshal hooks expect it to not be closed (they close it themselves). There's an existing test guarding that behavior.

Close error is ignored as it has no side effects and there's nothing we can do about it.