### PR TITLE
Update stale_issue.yml to include pr message

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -16,7 +16,7 @@ jobs:
         # that category
         ancient-issue-message: We have noticed this issue has not received attention in 1 year. We will close this issue for now. If you think this is in error, please feel free to comment and reopen the issue.
         stale-issue-message: This issue has not received a response in 1 week. If you want to keep this issue open, please just leave a comment below and auto-close will be canceled.
-
+        stale-pr-message: Greetings! It looks like this PR hasn’t been active in longer than a week, add a comment or an upvote to prevent automatic closure, or if the issue is already closed, please feel free to open a new one.
         # These labels are required
         stale-issue-label: closing-soon
         exempt-issue-labels: no-autoclose


### PR DESCRIPTION
The stale issues yml had no message defined for stale pr's which meant that if "response-requested" was asssigned to a PR the aciton broke. 
Adding it fixes this.

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
