### PR TITLE
aws: Fix SDK's suppressing of sensitive API parameters being logged.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws`: Fix SDK's suppressing of sensitive API parameters being logged.
+  * The SDK did not correctly suppress sensitive API parameters via the `String` and `GoString` methods. Updates the SDK's behavior to suppress sensitive API parameters.

--- a/aws/awsutil/prettify.go
+++ b/aws/awsutil/prettify.go
@@ -50,9 +50,19 @@ func prettify(v reflect.Value, indent int, buf *bytes.Buffer) {
 
 		for i, n := range names {
 			val := v.FieldByName(n)
+			ft, ok := v.Type().FieldByName(n)
+			if !ok {
+				panic(fmt.Sprintf("expected to find field %v on type %v, but was not found", n, v.Type()))
+			}
+
 			buf.WriteString(strings.Repeat(" ", indent+2))
 			buf.WriteString(n + ": ")
-			prettify(val, indent+2, buf)
+
+			if tag := ft.Tag.Get("sensitive"); tag == "true" {
+				buf.WriteString("<sensitive>")
+			} else {
+				prettify(val, indent+2, buf)
+			}
 
 			if i < len(names)-1 {
 				buf.WriteString(",\n")

--- a/aws/awsutil/prettify_test.go
+++ b/aws/awsutil/prettify_test.go
@@ -1,0 +1,52 @@
+//go:build go1.7
+// +build go1.7
+
+package awsutil
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+type testPrettifyStruct struct {
+	Field1 string
+	Field2 *string
+	Field3 []byte `sensitive:"true"`
+	Value  []*string
+}
+
+func TestPrettify(t *testing.T) {
+	cases := map[string]struct {
+		Value  interface{}
+		Expect string
+	}{
+		"general": {
+			Value: testPrettifyStruct{
+				Field1: "abc123",
+				Field2: aws.String("abc123"),
+				Field3: []byte("don't show me"),
+				Value: []*string{
+					aws.String("first"),
+					aws.String("second"),
+				},
+			},
+			Expect: `{
+  Field1: "abc123",
+  Field2: "abc123",
+  Field3: <sensitive>,
+  Value: ["first","second"],
+
+}`,
+		},
+	}
+
+	for d, c := range cases {
+		t.Run(d, func(t *testing.T) {
+			actual := StringValue(c.Value)
+			if e, a := c.Expect, actual; e != a {
+				t.Errorf("expect:\n%v\nactual:\n%v\n", e, a)
+			}
+		})
+	}
+}

--- a/aws/awsutil/string_value.go
+++ b/aws/awsutil/string_value.go
@@ -8,6 +8,8 @@ import (
 )
 
 // StringValue returns the string representation of a value.
+//
+// Deprecated: Use Prettify instead.
 func StringValue(i interface{}) string {
 	var buf bytes.Buffer
 	stringValue(reflect.ValueOf(i), 0, &buf)


### PR DESCRIPTION
The SDK did not correctly suppress sensitive API parameters via the `String` and `GoString` methods. Updates the SDK's behavior to suppress sensitive API parameters.