### PR TITLE
service/dynamodb/dynamodbattribute: Fix string alias unmarshal

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/dynamodb/dynamodbattribute`: Fix string alias unmarshal.
+  * Fixes #3983 by correcting the unmarshaler's decoding of AttributeValue number (N) parameter into type that is a string alias.

--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -316,7 +316,7 @@ func (d *Decoder) decodeNumber(n *string, v reflect.Value, fieldTag tag) error {
 			v.Set(reflect.ValueOf(Number(*n)))
 			return nil
 		}
-		v.Set(reflect.ValueOf(*n))
+		v.SetString(*n)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		i, err := strconv.ParseInt(*n, 10, 64)
 		if err != nil {

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -684,3 +684,46 @@ func TestDecoderFieldByIndex(t *testing.T) {
 		t.Error("expected f to be an int with value equal to outer.Inner")
 	}
 }
+
+func TestDecodeAliasType(t *testing.T) {
+	type Str string
+	type Int int
+	type Uint uint
+	type TT struct {
+		A Str
+		B Int
+		C Uint
+		S Str
+	}
+
+	expect := TT{
+		A: "12345",
+		B: 12345,
+		C: 12345,
+		S: "string",
+	}
+	m := map[string]*dynamodb.AttributeValue{
+		"A": {
+			N: aws.String("12345"),
+		},
+		"B": {
+			N: aws.String("12345"),
+		},
+		"C": {
+			N: aws.String("12345"),
+		},
+		"S": {
+			S: aws.String("string"),
+		},
+	}
+
+	var actual TT
+	err := UnmarshalMap(m, &actual)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(expect, actual) {
+		t.Errorf("expect:\n%v\nactual:\n%v", expect, actual)
+	}
+}


### PR DESCRIPTION
Fixes #3983 by correcting the unmarshaler's decoding of AttributeValue N parameter into string aliased type.