### PR TITLE
private/protocol: Add support for parsing RFC 3339 timestamp without trailing Z

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `private/protocol`: Add support for parsing RFC 3339 timestamp without trailing Z
+  * Adds support for parsing RFC 3339 timestamp but without the `Z` character, nor UTC offset.
+  * Related to [aws/aws-sdk-go-v2#1387](https://github.com/aws/aws-sdk-go-v2/issues/1387)

--- a/private/protocol/timestamp.go
+++ b/private/protocol/timestamp.go
@@ -29,7 +29,8 @@ const (
 	RFC822OutputTimeFormat = "Mon, 02 Jan 2006 15:04:05 GMT"
 
 	// RFC3339 a subset of the ISO8601 timestamp format. e.g 2014-04-29T18:30:38Z
-	ISO8601TimeFormat = "2006-01-02T15:04:05.999999999Z"
+	ISO8601TimeFormat    = "2006-01-02T15:04:05.999999999Z"
+	iso8601TimeFormatNoZ = "2006-01-02T15:04:05.999999999"
 
 	// This format is used for output time with fractional second precision up to milliseconds
 	ISO8601OutputTimeFormat = "2006-01-02T15:04:05.999999999Z"
@@ -82,6 +83,7 @@ func ParseTime(formatName, value string) (time.Time, error) {
 	case ISO8601TimeFormatName: // Smithy DateTime format
 		return tryParse(value,
 			ISO8601TimeFormat,
+			iso8601TimeFormatNoZ,
 			time.RFC3339Nano,
 			time.RFC3339,
 		)

--- a/private/protocol/timestamp_test.go
+++ b/private/protocol/timestamp_test.go
@@ -86,6 +86,11 @@ func TestParseTime(t *testing.T) {
 			input:          "2000-01-02T20:34:56.123Z",
 			expectedOutput: time.Date(2000, time.January, 2, 20, 34, 56, .123e9, time.UTC),
 		},
+		"ISO8601Test milliseconds, no Z": {
+			formatName:     ISO8601TimeFormatName,
+			input:          "2000-01-02T20:34:56.123",
+			expectedOutput: time.Date(2000, time.January, 2, 20, 34, 56, .123e9, time.UTC),
+		},
 		"ISO8601Test nanoseconds": {
 			formatName:     ISO8601TimeFormatName,
 			input:          "2000-01-02T20:34:56.123456789Z",


### PR DESCRIPTION
Adds support for parsing RFC 3339 timestamp but without the `Z` character, nor UTC offset.

Related to https://github.com/aws/aws-sdk-go-v2/issues/1387