### PR TITLE
Add Document Type Safety Check

### DIFF
--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -1020,6 +1020,24 @@ func (a *API) addHeaderMapDocumentation() {
 	}
 }
 
+func (a *API) validateNoDocumentShapes() error {
+	var shapes []string
+	for name, shape := range a.Shapes {
+		if shape.Type != "structure" {
+			continue
+		}
+		if shape.Document {
+			shapes = append(shapes, name)
+		}
+	}
+
+	if len(shapes) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("model contains document shapes: %s", strings.Join(shapes, ", "))
+}
+
 func getDeprecatedMessage(msg string, name string) string {
 	if len(msg) == 0 {
 		return name + " has been deprecated"

--- a/private/model/api/api_test.go
+++ b/private/model/api/api_test.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -70,5 +71,25 @@ func TestAPI_StructName(t *testing.T) {
 				t.Errorf("expect %v structName, got %v", e, o)
 			}
 		})
+	}
+}
+
+func TestAPI_Setup_documentShapes(t *testing.T) {
+	api := API{
+		Shapes: map[string]*Shape{
+			"Document": {
+				Type:     "structure",
+				Document: true,
+			},
+		},
+	}
+
+	err := api.Setup()
+	if err == nil {
+		t.Fatalf("expect error, but got nil")
+	}
+	expect := "model contains document shapes"
+	if !strings.Contains(err.Error(), expect) {
+		t.Errorf("expect %s, got %v", expect, err)
 	}
 }

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -200,6 +200,9 @@ func (a *API) AttachString(str string) error {
 
 // Setup initializes the API.
 func (a *API) Setup() error {
+	if err := a.validateNoDocumentShapes(); err != nil {
+		return err
+	}
 	a.setServiceAliaseName()
 	a.setMetadataEndpointsKey()
 	a.writeShapeNames()

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -143,6 +143,9 @@ type Shape struct {
 
 	// Indicates the Shape is used as an operation output
 	UsedAsOutput bool
+
+	// Indicates a structure shape is a document type
+	Document bool `json:"document"`
 }
 
 // CanBeEmpty returns if the shape value can sent request as an empty value.


### PR DESCRIPTION
Adds explicit check to ensure document shapes aren't present in a model.