### PR TITLE
service/dynamodb/expression: Fixup NameBuilder example doc

### DIFF
--- a/service/dynamodb/expression/projection.go
+++ b/service/dynamodb/expression/projection.go
@@ -23,8 +23,9 @@ type ProjectionBuilder struct {
 //
 //     // Used in another Projection Expression
 //     anotherProjection := expression.AddNames(projection, expression.Name("baz"))
+//
 //     // Used to make an Builder
-//     builder := expression.NewBuilder().WithProjection(newProjection)
+//     builder := expression.NewBuilder().WithProjection(anotherProjection)
 //
 // Expression Equivalent:
 //


### PR DESCRIPTION
Fixes typo in NameBuilder.NamesList example documentation to use the correct variable name.
