### PR TITLE
Allow docs-2.json to reference shapes not present in API without failure

### DIFF
--- a/private/model/api/docstring.go
+++ b/private/model/api/docstring.go
@@ -50,8 +50,7 @@ func (d *apiDocumentation) setup(a *API) error {
 
 	for opName, doc := range d.Operations {
 		if _, ok := a.Operations[opName]; !ok {
-			return fmt.Errorf("%s, doc op %q not found in API op set",
-				a.name, opName)
+			continue
 		}
 		a.Operations[opName].Documentation = docstring(doc)
 	}

--- a/private/model/api/docstring_test.go
+++ b/private/model/api/docstring_test.go
@@ -80,3 +80,52 @@ func TestDocstring(t *testing.T) {
 		})
 	}
 }
+
+func TestApiDocumentation_missingShapes(t *testing.T) {
+	docs := apiDocumentation{
+		Service: "some service documentation",
+		Operations: map[string]string{
+			"OperationOne": "some operation documentation",
+			"OperationTwo": "some more operation documentation",
+		},
+		Shapes: map[string]shapeDocumentation{
+			"ShapeOne": {
+				Base: "some shape documentation",
+			},
+			"ShapeTwo": {
+				Base: "some more shape documentation",
+				Refs: map[string]string{
+					"ShapeOne$shapeTwo": "shape ref document",
+				},
+			},
+		},
+	}
+
+	api := API{
+		Operations: map[string]*Operation{
+			"OperationOne": {},
+		},
+		Shapes: map[string]*Shape{
+			"ShapeOne": {
+				Type:       "structure",
+				MemberRefs: map[string]*ShapeRef{},
+			},
+		},
+	}
+
+	if err := docs.setup(&api); err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if _, ok := api.Operations["OperationTwo"]; ok {
+		t.Errorf("expect operation shape to not be added from document model")
+	}
+
+	if _, ok := api.Shapes["ShapeTwo"]; ok {
+		t.Errorf("expect shape to not be added from document model")
+	}
+
+	if _, ok := api.Shapes["ShapeOne"].MemberRefs["shapeTwo"]; ok {
+		t.Errorf("expect shape to not be added from document model")
+	}
+}


### PR DESCRIPTION
Allow docs-2.json to reference shapes not present in API without failure.