### PR TITLE
Enables DynamoDB unmarshal `bool` attributes to `string`

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -253,6 +253,8 @@ func (d *Decoder) decodeBool(b *bool, v reflect.Value) error {
 	switch v.Kind() {
 	case reflect.Bool, reflect.Interface:
 		v.Set(reflect.ValueOf(*b).Convert(v.Type()))
+	case reflect.String:
+		v.Set(reflect.ValueOf(strconv.FormatBool(*b)))
 	default:
 		return &UnmarshalTypeError{Value: "bool", Type: v.Type()}
 	}

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -98,6 +98,11 @@ func TestUnmarshal(t *testing.T) {
 			expected: bool(true),
 		},
 		{
+			in:       &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			actual:   new(string),
+			expected: "true",
+		},
+		{
 			in: &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{
 				{S: aws.String("abc")}, {S: aws.String("123")},
 			}},


### PR DESCRIPTION
Hello all, today my team and I got some problems in our services because we're trying to unmarshal a DynamoDB item to a `map[string]string`, but unfortunately the actual implementation doesn't handle that scenario for `bool`.

When we use a `map[string]string` to unmarshal attributes that are `numbers` it's work correctly converting to `string`, it'll be so handy to have the same behavior with `bool`. This PR does exactly that, decode a `bool` to a `string`!

> P.S.: I don't need the raw types, just the values as strings.