### PR TITLE
 private/protocol/rest: Fix return error in location headers

### DIFF
--- a/private/protocol/rest/unmarshal.go
+++ b/private/protocol/rest/unmarshal.go
@@ -140,7 +140,7 @@ func unmarshalLocationElements(resp *http.Response, v reflect.Value, lowerCaseHe
 				prefix := field.Tag.Get("locationName")
 				err := unmarshalHeaderMap(m, resp.Header, prefix, lowerCaseHeaderMaps)
 				if err != nil {
-					awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
+					return awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #4120 by returning error from unmarshalHeaderMap method.