### PR TITLE
glue: Specify limit for GetTablesInput.MaxResults

### DIFF
--- a/models/apis/glue/2017-03-31/docs-2.json
+++ b/models/apis/glue/2017-03-31/docs-2.json
@@ -623,7 +623,7 @@
       "refs": {
         "GetDatabasesRequest$MaxResults": "<p>The maximum number of databases to return in one response.</p>",
         "GetTableVersionsRequest$MaxResults": "<p>The maximum number of table versions to return in one response.</p>",
-        "GetTablesRequest$MaxResults": "<p>The maximum number of tables to return in a single response.</p>",
+        "GetTablesRequest$MaxResults": "<p>The maximum number of tables to return in a single response. Truncated at 100.</p>",
         "GetUserDefinedFunctionsRequest$MaxResults": "<p>The maximum number of functions to return in one response.</p>"
       }
     },


### PR DESCRIPTION
Addresses issue #4203: [`GetTablesInput.MaxResults`](https://docs.aws.amazon.com/sdk-for-go/api/service/glue/#GetTablesInput) specifies maximum number of results to be returned in a GetTables call. This number is truncated downward to 100 if it is above, but this is not documented in the struct definition.