### PR TITLE
Fix typo in `NewSelectObjectContentEventStream` doc

### DIFF
--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -10535,7 +10535,7 @@ type SelectObjectContentEventStream struct {
 // (e.g. http.Response.Body), that will be closed when the stream Close method
 // is called.
 //
-//   es := NewSelectObjectContentEventStream(func(o *SelectObjectContentEventStream{
+//   es := NewSelectObjectContentEventStream(func(o *SelectObjectContentEventStream){
 //       es.Reader = myMockStreamReader
 //       es.StreamCloser = myMockStreamCloser
 //   })


### PR DESCRIPTION
A missing closing parenthesis is added to fix the syntax of the example call
provided in function documentation.
