### PR TITLE
#3711: MarshalMap error

### DIFF
--- a/service/dynamodb/dynamodbattribute/marshaler_test.go
+++ b/service/dynamodb/dynamodbattribute/marshaler_test.go
@@ -101,6 +101,11 @@ var marshallerMapTestInputs = []marshallerTestInput{
 		expected: map[string]*dynamodb.AttributeValue{},
 	},
 	{
+		input:    "some string",
+		expected: map[string]*dynamodb.AttributeValue{},
+		err:      &unsupportedMarshalTypeError{Type: reflect.TypeOf("")},
+	},
+	{
 		input:    map[string]interface{}{"string": "some string"},
 		expected: map[string]*dynamodb.AttributeValue{"string": {S: aws.String("some string")}},
 	},


### PR DESCRIPTION
Proposed resolution to #3711.

`nil` is still marshaled as an empty map, but other types will now return an error.

A slightly more complex variant would be to check that the input type is non-zero, so that e.g. a non-empty list would not cause an error. I'm not convinced that this would be helpful, though.