### PR TITLE
aws/config: Update Request Send to always ensure HTTPResponse is not nil

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/request`: Update Request Send to always ensure Request.HTTPResponse is populated.
+    * Fixes [#4211](https://github.com/aws/aws-sdk-go/issues/4211)

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -525,6 +526,14 @@ func (r *Request) GetBody() io.ReadSeeker {
 // Send will not close the request.Request's body.
 func (r *Request) Send() error {
 	defer func() {
+		// Ensure a non-nil HTTPResponse parameter is set to ensure handlers
+		// checking for HTTPResponse values, don't fail.
+		if r.HTTPResponse == nil {
+			r.HTTPResponse = &http.Response{
+				Header: http.Header{},
+				Body:   ioutil.NopCloser(&bytes.Buffer{}),
+			}
+		}
 		// Regardless of success or failure of the request trigger the Complete
 		// request handlers.
 		r.Handlers.Complete.Run(r)


### PR DESCRIPTION
Updates SDK Request.Send to always ensure HTTPResponse member is not
nil, and its Header and Body fields are not nil as well.

Fixes #4211