### PR TITLE
codegen: Fixup event stream (un)marshal event name to match model

### DIFF
--- a/private/model/api/codegentest/models/restjson/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/restjson/0000-00-00/api-2.json
@@ -67,13 +67,13 @@
       "type":"structure",
       "members":{
         "Headers":{"shape":"HeaderOnlyEvent"},
-        "ImplicitPayload":{"shape":"ImplicitPayloadEvent"},
+        "implicitPayload":{"shape":"ImplicitPayloadEvent"},
         "ExplicitPayload":{"shape":"ExplicitPayloadEvent"},
-        "PayloadOnly":{"shape":"PayloadOnlyEvent"},
+        "payloadOnly":{"shape":"PayloadOnlyEvent"},
         "PayloadOnlyBlob":{"shape":"PayloadOnlyBlobEvent"},
-        "PayloadOnlyString":{"shape":"PayloadOnlyStringEvent"},
+        "payloadOnlyString":{"shape":"PayloadOnlyStringEvent"},
         "Empty":{"shape":"EmptyEvent"},
-        "Exception":{"shape":"ExceptionEvent"},
+        "exception":{"shape":"ExceptionEvent"},
         "Exception2":{"shape":"ExceptionEvent2"}
       },
       "eventstream":true

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -933,15 +933,15 @@ func (u unmarshalerForEventStreamEvent) UnmarshalerForEventName(eventType string
 		return &ExplicitPayloadEvent{}, nil
 	case "Headers":
 		return &HeaderOnlyEvent{}, nil
-	case "ImplicitPayload":
+	case "implicitPayload":
 		return &ImplicitPayloadEvent{}, nil
-	case "PayloadOnly":
+	case "payloadOnly":
 		return &PayloadOnlyEvent{}, nil
 	case "PayloadOnlyBlob":
 		return &PayloadOnlyBlobEvent{}, nil
-	case "PayloadOnlyString":
+	case "payloadOnlyString":
 		return &PayloadOnlyStringEvent{}, nil
-	case "Exception":
+	case "exception":
 		return newErrorExceptionEvent(u.metadata).(eventstreamapi.Unmarshaler), nil
 	case "Exception2":
 		return newErrorExceptionEvent2(u.metadata).(eventstreamapi.Unmarshaler), nil

--- a/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
@@ -534,7 +534,7 @@ func mockGetEventStreamReadEvents() (
 				eventstreamtest.EventMessageTypeHeader,
 				{
 					Name:  eventstreamapi.EventTypeHeader,
-					Value: eventstream.StringValue("ImplicitPayload"),
+					Value: eventstream.StringValue("implicitPayload"),
 				},
 				{
 					Name:  "ByteVal",
@@ -548,7 +548,7 @@ func mockGetEventStreamReadEvents() (
 				eventstreamtest.EventMessageTypeHeader,
 				{
 					Name:  eventstreamapi.EventTypeHeader,
-					Value: eventstream.StringValue("PayloadOnly"),
+					Value: eventstream.StringValue("payloadOnly"),
 				},
 			},
 			Payload: eventstreamtest.MarshalEventPayload(payloadMarshaler, expectEvents[4]),
@@ -568,7 +568,7 @@ func mockGetEventStreamReadEvents() (
 				eventstreamtest.EventMessageTypeHeader,
 				{
 					Name:  eventstreamapi.EventTypeHeader,
-					Value: eventstream.StringValue("PayloadOnlyString"),
+					Value: eventstream.StringValue("payloadOnlyString"),
 				},
 			},
 			Payload: []byte(*expectEvents[6].(*PayloadOnlyStringEvent).StringPayload),
@@ -600,7 +600,7 @@ func TestGetEventStream_ReadException(t *testing.T) {
 				eventstreamtest.EventExceptionTypeHeader,
 				{
 					Name:  eventstreamapi.ExceptionTypeHeader,
-					Value: eventstream.StringValue("Exception"),
+					Value: eventstream.StringValue("exception"),
 				},
 			},
 			Payload: eventstreamtest.MarshalEventPayload(payloadMarshaler, expectEvents[0]),

--- a/private/model/api/eventstream.go
+++ b/private/model/api/eventstream.go
@@ -285,10 +285,15 @@ func setupEventStream(s *Shape) *EventStream {
 		}
 		eventRef.Shape.EventFor[eventStream.Name] = eventStream
 
+		eventName := eventRefName
+		if v := eventRef.LocationName; v != "" {
+			eventName = v
+		}
+
 		// Exceptions and events are two different lists to allow the SDK
 		// to easily generate code with the two handled differently.
 		event := &Event{
-			Name:  eventRefName,
+			Name:  eventName,
 			Shape: eventRef.Shape,
 			For:   eventStream,
 		}


### PR DESCRIPTION
Updates SDK's code generation for even stream event names to match the member's modeled name. Fixes the SDK not using the right case or name if the modeled name is not Go exportable name.