### PR TITLE
Fix lexv1 AlternativeIntentsSerializationError

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aws/aws-sdk-go
+module github.com/chrbsg/aws-sdk-go
 
 require (
 	github.com/jmespath/go-jmespath v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 )
 
 go 1.11
+
+replace github.com/aws/aws-sdk-go  => github.com/chrbsg/aws-sdk-go

--- a/models/apis/runtime.lex/2016-11-28/api-2.json
+++ b/models/apis/runtime.lex/2016-11-28/api-2.json
@@ -546,7 +546,7 @@
         },
         "alternativeIntents":{
           "shape":"String",
-          "jsonvalue":true,
+          "jsonvalue":false,
           "location":"header",
           "locationName":"x-amz-lex-alternative-intents"
         },

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -2396,7 +2396,11 @@ type PostContentOutput struct {
 	// Each alternative includes a score that indicates how confident Amazon Lex
 	// is that the intent matches the user's intent. The intents are sorted by the
 	// confidence score.
-	AlternativeIntents aws.JSONValue `location:"header" locationName:"x-amz-lex-alternative-intents" type:"jsonvalue"`
+	//
+	// The AlternativeIntents field is a base64 encoded JSON list.
+	// Before you can use the contents of the field, you must decode and
+	// unmarshal the contents.
+	AlternativeIntents *string `location:"header" locationName:"x-amz-lex-alternative-intents" type:"string"`
 
 	// The prompt (or statement) to convey to the user. This is based on the bot
 	// configuration and context. For example, if Amazon Lex did not understand
@@ -2616,8 +2620,8 @@ func (s *PostContentOutput) SetActiveContexts(v aws.JSONValue) *PostContentOutpu
 }
 
 // SetAlternativeIntents sets the AlternativeIntents field's value.
-func (s *PostContentOutput) SetAlternativeIntents(v aws.JSONValue) *PostContentOutput {
-	s.AlternativeIntents = v
+func (s *PostContentOutput) SetAlternativeIntents(v string) *PostContentOutput {
+	s.AlternativeIntents = &v
 	return s
 }
 

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -2389,7 +2389,7 @@ type PostContentOutput struct {
 	//
 	// You can use a context to control the intents that can follow up an intent,
 	// or to modify the operation of your application.
-	ActiveContexts aws.JSONValue `location:"header" locationName:"x-amz-lex-active-contexts" type:"jsonvalue"`
+//	ActiveContexts aws.JSONValue `location:"header" locationName:"x-amz-lex-active-contexts" type:"jsonvalue"`
 
 	// One to four alternative intents that may be applicable to the user's intent.
 	//
@@ -2614,10 +2614,10 @@ func (s PostContentOutput) GoString() string {
 }
 
 // SetActiveContexts sets the ActiveContexts field's value.
-func (s *PostContentOutput) SetActiveContexts(v aws.JSONValue) *PostContentOutput {
-	s.ActiveContexts = v
-	return s
-}
+//func (s *PostContentOutput) SetActiveContexts(v aws.JSONValue) *PostContentOutput {
+//	s.ActiveContexts = v
+//	return s
+//}
 
 // SetAlternativeIntents sets the AlternativeIntents field's value.
 func (s *PostContentOutput) SetAlternativeIntents(v string) *PostContentOutput {


### PR DESCRIPTION
Deserialisation of the `X-Amz-Lex-Alternative-Intents` header fails because it
is a JSON array, but `aws.JSONValue` is a `map[string]interface{}`. Fix this by
treating `X-Amz-Lex-Alternative-Intents` as a base64 encoded string, which will
not be decoded and unmarshalled by the SDK. The caller of the SDK must manually
base64 decode and JSON unmarshal the field, in order to use the contents.

bug #4258