### PR TITLE
codegen: Correct the generated event stream docstring

### DIFF
--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -131,7 +131,7 @@ type EmptyStreamEventStream struct {
 //
 // The Reader member must be set before reading events from the stream.
 //
-//   es := NewEmptyStreamEventStream(func(o *EmptyStreamEventStream{
+//   es := NewEmptyStreamEventStream(func(o *EmptyStreamEventStream){
 //       es.Reader = myMockStreamReader
 //   })
 func NewEmptyStreamEventStream(opts ...func(*EmptyStreamEventStream)) *EmptyStreamEventStream {
@@ -358,7 +358,7 @@ type GetEventStreamEventStream struct {
 //
 // The Reader member must be set before reading events from the stream.
 //
-//   es := NewGetEventStreamEventStream(func(o *GetEventStreamEventStream{
+//   es := NewGetEventStreamEventStream(func(o *GetEventStreamEventStream){
 //       es.Reader = myMockStreamReader
 //   })
 func NewGetEventStreamEventStream(opts ...func(*GetEventStreamEventStream)) *GetEventStreamEventStream {

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -131,7 +131,7 @@ type EmptyStreamEventStream struct {
 //
 // The Reader member must be set before reading events from the stream.
 //
-//   es := NewEmptyStreamEventStream(func(o *EmptyStreamEventStream{
+//   es := NewEmptyStreamEventStream(func(o *EmptyStreamEventStream){
 //       es.Reader = myMockStreamReader
 //   })
 func NewEmptyStreamEventStream(opts ...func(*EmptyStreamEventStream)) *EmptyStreamEventStream {
@@ -358,7 +358,7 @@ type GetEventStreamEventStream struct {
 //
 // The Reader member must be set before reading events from the stream.
 //
-//   es := NewGetEventStreamEventStream(func(o *GetEventStreamEventStream{
+//   es := NewGetEventStreamEventStream(func(o *GetEventStreamEventStream){
 //       es.Reader = myMockStreamReader
 //   })
 func NewGetEventStreamEventStream(opts ...func(*GetEventStreamEventStream)) *GetEventStreamEventStream {

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -134,7 +134,7 @@ type EmptyStreamEventStream struct {
 //
 // The Reader member must be set before reading events from the stream.
 //
-//   es := NewEmptyStreamEventStream(func(o *EmptyStreamEventStream{
+//   es := NewEmptyStreamEventStream(func(o *EmptyStreamEventStream){
 //       es.Reader = myMockStreamReader
 //   })
 func NewEmptyStreamEventStream(opts ...func(*EmptyStreamEventStream)) *EmptyStreamEventStream {
@@ -404,7 +404,7 @@ type GetEventStreamEventStream struct {
 //
 // The Reader member must be set before reading events from the stream.
 //
-//   es := NewGetEventStreamEventStream(func(o *GetEventStreamEventStream{
+//   es := NewGetEventStreamEventStream(func(o *GetEventStreamEventStream){
 //       es.Reader = myMockStreamReader
 //   })
 func NewGetEventStreamEventStream(opts ...func(*GetEventStreamEventStream)) *GetEventStreamEventStream {

--- a/private/model/api/eventstream_tmpl.go
+++ b/private/model/api/eventstream_tmpl.go
@@ -118,7 +118,7 @@ type {{ $esapi.Name }} struct {
 // is called.
 {{- end }}
 //
-//   es := New{{ $esapi.Name }}(func(o *{{ $esapi.Name}}{
+//   es := New{{ $esapi.Name }}(func(o *{{ $esapi.Name}}){
 {{- if $inputStream }}
 //       es.Writer = myMockStreamWriter
 {{- end }}

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -3320,7 +3320,7 @@ type SubscribeToShardEventStream struct {
 // (e.g. http.Response.Body), that will be closed when the stream Close method
 // is called.
 //
-//   es := NewSubscribeToShardEventStream(func(o *SubscribeToShardEventStream{
+//   es := NewSubscribeToShardEventStream(func(o *SubscribeToShardEventStream){
 //       es.Reader = myMockStreamReader
 //       es.StreamCloser = myMockStreamCloser
 //   })

--- a/service/lexruntimev2/api.go
+++ b/service/lexruntimev2/api.go
@@ -763,7 +763,7 @@ type StartConversationEventStream struct {
 //
 // The Reader member must be set before reading events from the stream.
 //
-//   es := NewStartConversationEventStream(func(o *StartConversationEventStream{
+//   es := NewStartConversationEventStream(func(o *StartConversationEventStream){
 //       es.Writer = myMockStreamWriter
 //       es.Reader = myMockStreamReader
 //   })

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -10535,7 +10535,7 @@ type SelectObjectContentEventStream struct {
 // (e.g. http.Response.Body), that will be closed when the stream Close method
 // is called.
 //
-//   es := NewSelectObjectContentEventStream(func(o *SelectObjectContentEventStream{
+//   es := NewSelectObjectContentEventStream(func(o *SelectObjectContentEventStream){
 //       es.Reader = myMockStreamReader
 //       es.StreamCloser = myMockStreamCloser
 //   })

--- a/service/transcribestreamingservice/api.go
+++ b/service/transcribestreamingservice/api.go
@@ -193,7 +193,7 @@ type StartMedicalStreamTranscriptionEventStream struct {
 //
 // The Reader member must be set before reading events from the stream.
 //
-//   es := NewStartMedicalStreamTranscriptionEventStream(func(o *StartMedicalStreamTranscriptionEventStream{
+//   es := NewStartMedicalStreamTranscriptionEventStream(func(o *StartMedicalStreamTranscriptionEventStream){
 //       es.Writer = myMockStreamWriter
 //       es.Reader = myMockStreamReader
 //   })
@@ -585,7 +585,7 @@ type StartStreamTranscriptionEventStream struct {
 //
 // The Reader member must be set before reading events from the stream.
 //
-//   es := NewStartStreamTranscriptionEventStream(func(o *StartStreamTranscriptionEventStream{
+//   es := NewStartStreamTranscriptionEventStream(func(o *StartStreamTranscriptionEventStream){
 //       es.Writer = myMockStreamWriter
 //       es.Reader = myMockStreamReader
 //   })


### PR DESCRIPTION
Fixes missing closing parentheses in event stream docstring found in https://github.com/aws/aws-sdk-go/pull/4251