### PR TITLE
Add capability to set timeout for ec2metadata's http client 

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -189,6 +189,11 @@ type Config struct {
 	//
 	EC2MetadataDisableTimeoutOverride *bool
 
+	// Set this to override duration of the EC2Metadata client
+	// This is helpful if you want to have different timout value between
+	// custom HTTP client and ec2metadata client
+	EC2MetadataTimeout *time.Duration
+
 	// Instructs the endpoint to be generated for a service client to
 	// be the dual stack endpoint. The dual stack endpoint will support
 	// both IPv4 and IPv6 addressing.
@@ -429,6 +434,13 @@ func (c *Config) WithEC2MetadataDisableTimeoutOverride(enable bool) *Config {
 	return c
 }
 
+// WithEC2MetadataTimeout sets a config EC2MetadataTimeout value
+// returning a Config pointer for chaining.
+func (c *Config) WithEC2MetadataTimeout(timeout time.Duration) *Config {
+	c.EC2MetadataTimeout = &timeout
+	return c
+}
+
 // WithSleepDelay overrides the function used to sleep while waiting for the
 // next retry. Defaults to time.Sleep.
 func (c *Config) WithSleepDelay(fn func(time.Duration)) *Config {
@@ -571,6 +583,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.EC2MetadataDisableTimeoutOverride != nil {
 		dst.EC2MetadataDisableTimeoutOverride = other.EC2MetadataDisableTimeoutOverride
+	}
+
+	if other.EC2MetadataTimeout != nil {
+		dst.EC2MetadataTimeout = other.EC2MetadataTimeout
 	}
 
 	if other.SleepDelay != nil {

--- a/aws/ec2metadata/service.go
+++ b/aws/ec2metadata/service.go
@@ -81,13 +81,18 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *EC2Metadata {
 // To disable this set Config.EC2MetadataDisableTimeoutOverride to false. Enabled by default.
 func NewClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion string, opts ...func(*client.Client)) *EC2Metadata {
 	if !aws.BoolValue(cfg.EC2MetadataDisableTimeoutOverride) && httpClientZero(cfg.HTTPClient) {
+		timeout := 1 * time.Second
+		if cfg.EC2MetadataTimeout != nil {
+			timeout = *cfg.EC2MetadataTimeout
+		}
+
 		// If the http client is unmodified and this feature is not disabled
 		// set custom timeouts for EC2Metadata requests.
 		cfg.HTTPClient = &http.Client{
 			// use a shorter timeout than default because the metadata
 			// service is local if it is running, and to fail faster
 			// if not running on an ec2 instance.
-			Timeout: 1 * time.Second,
+			Timeout: timeout,
 		}
 		// max number of retries on the client operation
 		cfg.MaxRetries = aws.Int(2)

--- a/aws/ec2metadata/service_test.go
+++ b/aws/ec2metadata/service_test.go
@@ -53,6 +53,15 @@ func TestClientNotOverrideDefaultHTTPClientTimeout(t *testing.T) {
 	}
 }
 
+func TestClientHTTPClientTimeout(t *testing.T) {
+	cfg := aws.NewConfig().WithEC2MetadataTimeout(time.Second * 5)
+	svc := ec2metadata.New(unit.Session, cfg)
+
+	if e, a := *cfg.EC2MetadataTimeout, *svc.Config.EC2MetadataTimeout; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
 func TestClientDisableOverrideDefaultHTTPClientTimeout(t *testing.T) {
 	svc := ec2metadata.New(unit.Session, aws.NewConfig().WithEC2MetadataDisableTimeoutOverride(true))
 


### PR DESCRIPTION
Currently if we use custom http client, it will take quite a long time for ec2metadata timeout #https://github.com/aws/aws-sdk-go/issues/2972. We could not able to use workaround for increasing hop as there is infra limit :) for that issue. 
This PR will allow us flexibility to have custom http client and custom timeout for ec2metadata at the same time. 

Using custom http client is important for us to make high throughput and low latency for our services. https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/custom-http.html