### PR TITLE
internal/ini: fix dropped test error

### DIFF
--- a/internal/ini/walker_test.go
+++ b/internal/ini/walker_test.go
@@ -15,6 +15,9 @@ import (
 func TestValidDataFiles(t *testing.T) {
 	const expectedFileSuffix = "_expected"
 	filepath.Walk("./testdata/valid", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if strings.HasSuffix(path, expectedFileSuffix) {
 			return nil
 		}


### PR DESCRIPTION
This fixes a dropped `err` variable in the tests for `internal/ini`.
