### PR TITLE
service/lexruntimev2: fix dropped test errors

### DIFF
--- a/service/lexruntimev2/eventstream_test.go
+++ b/service/lexruntimev2/eventstream_test.go
@@ -913,6 +913,9 @@ func TestStartConversation_Write(t *testing.T) {
 			BiDirectional: true,
 		},
 		true)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 	defer cleanupFn()
 
 	svc := New(sess)
@@ -1011,6 +1014,9 @@ func TestStartConversation_ReadWrite(t *testing.T) {
 			BiDirectional: true,
 		},
 		true)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 	defer cleanupFn()
 
 	svc := New(sess)


### PR DESCRIPTION
This fixes two dropped test errors in `service/lexruntimev2`.
