### PR TITLE
Revert "Disable regabi due to on-going stability issues (#4245)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ gen-codegen-test:
 
 gen-services:
 	@echo "Generating SDK clients"
-	env GOEXPERIMENT=noregabi go generate ./service
+	go generate ./service
 
 gen-protocol-test:
 	@echo "Generating SDK protocol tests"


### PR DESCRIPTION
This reverts commit 2a3e58928889934211e5c641d673ce1f9ed63a34.

Reverts REGABI disabling change since the issue was resolved in Go 1.17.6, and no longer impacts the SDK's code generation.