### PR TITLE
Added batch versioned delete iterator for versioned s3 buckets

### DIFF
--- a/service/s3/s3manager/batch.go
+++ b/service/s3/s3manager/batch.go
@@ -204,7 +204,7 @@ func (iter *DeleteListIterator) DeleteObject() BatchDeleteObject {
 //		},
 //		Paginator: request.Pagination{
 //			NewRequest: func() (*request.Request, error) {
-//				var inCpy *ListObjectsInput
+//				var inCpy *ListObjectVersionsInput
 //				if input != nil {
 //					tmp := *input
 //					inCpy = &tmp


### PR DESCRIPTION
Currently, DeleteListIterator does not support versioned buckets. I wanted to add a similar approach for batch deleting for versioned objects.  Could not find an existing issue about this. 
