### PR TITLE
corrected MessageId comment on `service/sqs/api.go`

### DIFF
--- a/models/apis/sqs/2012-11-05/docs-2.json
+++ b/models/apis/sqs/2012-11-05/docs-2.json
@@ -507,7 +507,7 @@
         "ListDeadLetterSourceQueuesRequest$QueueUrl": "<p>The URL of a dead-letter queue.</p> <p>Queue URLs and names are case-sensitive.</p>",
         "ListQueueTagsRequest$QueueUrl": "<p>The URL of the queue.</p>",
         "ListQueuesRequest$QueueNamePrefix": "<p>A string to use for filtering the list results. Only those queues whose name begins with the specified string are returned.</p> <p>Queue URLs and names are case-sensitive.</p>",
-        "Message$MessageId": "<p>A unique identifier for the message. A <code>MessageId</code>is considered unique across all Amazon Web Services accounts for an extended period of time.</p>",
+        "Message$MessageId": "<p>A unique identifier for the message. A <code>MessageId</code> is considered unique across all Amazon Web Services accounts for an extended period of time.</p>",
         "Message$ReceiptHandle": "<p>An identifier associated with the act of receiving the message. A new receipt handle is returned every time you receive a message. When deleting a message, you provide the last received receipt handle to delete the message.</p>",
         "Message$MD5OfBody": "<p>An MD5 digest of the non-URL-encoded message body string.</p>",
         "Message$Body": "<p>The message's contents (not URL-encoded).</p>",

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -3913,7 +3913,7 @@ type Message struct {
 	// in the Amazon SQS Developer Guide.
 	MessageAttributes map[string]*MessageAttributeValue `locationName:"MessageAttribute" locationNameKey:"Name" locationNameValue:"Value" type:"map" flattened:"true"`
 
-	// A unique identifier for the message. A MessageIdis considered unique across
+	// A unique identifier for the message. A MessageId is considered unique across
 	// all Amazon Web Services accounts for an extended period of time.
 	MessageId *string `type:"string"`
 


### PR DESCRIPTION
### Summary
This PR includes changes made to `service/sqs/api.go` to remove the typo in the `messageId` comment. This is a proposed solution to issue [4308](https://github.com/aws/aws-sdk-go/issues/4308).