### PR TITLE
Update transport_go1.17.go

### DIFF
--- a/private/protocol/eventstream/eventstreamapi/transport_go1.17.go
+++ b/private/protocol/eventstream/eventstreamapi/transport_go1.17.go
@@ -14,6 +14,6 @@ import "github.com/aws/aws-sdk-go/aws/request"
 // This is a no-op for Go 1.18 and above.
 func ApplyHTTPTransportFixes(r *request.Request) {
 	r.Handlers.Sign.PushBack(func(r *request.Request) {
-		r.HTTPRequest.Header.Set("Expect", "100-Continue")
+		r.HTTPRequest.Header.Set("Expect", "100-continue")
 	})
 }


### PR DESCRIPTION
Golang HTTP server strips off 'Expect' header in which case the server will just assume that its value is 100-continue. The different casings will break signature validation.  so better to just keep it in lower case.

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
