### PR TITLE
Update platform_handlers_go1.6.go

### DIFF
--- a/service/s3/platform_handlers_go1.6.go
+++ b/service/s3/platform_handlers_go1.6.go
@@ -25,5 +25,5 @@ func add100Continue(r *request.Request) {
 		return
 	}
 
-	r.HTTPRequest.Header.Set("Expect", "100-Continue")
+	r.HTTPRequest.Header.Set("Expect", "100-continue")
 }


### PR DESCRIPTION
Golang HTTP server strips off the 'Expect' header in which case the server will just assume that its value is 100-continue. The different casings will break signature validation. so better to just keep it in lower case.

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
