### PR TITLE
Golang HTTP server strips off 'Expect' header in which case the serve…

### DIFF
--- a/private/protocol/eventstream/eventstreamapi/transport_go1.17.go
+++ b/private/protocol/eventstream/eventstreamapi/transport_go1.17.go
@@ -8,12 +8,12 @@ import "github.com/aws/aws-sdk-go/aws/request"
 // ApplyHTTPTransportFixes applies fixes to the HTTP request for proper event
 // stream functionality. Go 1.15 through 1.17 HTTP client could hang forever
 // when an HTTP/2 connection failed with an non-200 status code and err. Using
-// Expect 100-Continue, allows the HTTP client to gracefully handle the non-200
+// Expect 100-continue, allows the HTTP client to gracefully handle the non-200
 // status code, and close the connection.
 //
 // This is a no-op for Go 1.18 and above.
 func ApplyHTTPTransportFixes(r *request.Request) {
 	r.Handlers.Sign.PushBack(func(r *request.Request) {
-		r.HTTPRequest.Header.Set("Expect", "100-Continue")
+		r.HTTPRequest.Header.Set("Expect", "100-continue")
 	})
 }

--- a/service/s3/platform_handlers_go1.6.go
+++ b/service/s3/platform_handlers_go1.6.go
@@ -25,5 +25,5 @@ func add100Continue(r *request.Request) {
 		return
 	}
 
-	r.HTTPRequest.Header.Set("Expect", "100-Continue")
+	r.HTTPRequest.Header.Set("Expect", "100-continue")
 }

--- a/service/s3/platform_handlers_go1.6_test.go
+++ b/service/s3/platform_handlers_go1.6_test.go
@@ -25,7 +25,7 @@ func TestAdd100Continue_Added(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
-	if e, a := "100-Continue", r.HTTPRequest.Header.Get("Expect"); e != a {
+	if e, a := "100-continue", r.HTTPRequest.Header.Get("Expect"); e != a {
 		t.Errorf("expected %s, but received %s", e, a)
 	}
 }


### PR DESCRIPTION
Golang HTTP server strips off 'Expect' header in which case the server will just assume that its value is 100-continue. The different casings will break signature validation. so better to just keep it in lower case.
