### PR TITLE
fix pass []any as any in variadic function

### DIFF
--- a/awstesting/assert.go
+++ b/awstesting/assert.go
@@ -25,12 +25,12 @@ func Match(t *testing.T, regex, expected string) {
 func AssertURL(t *testing.T, expect, actual string, msgAndArgs ...interface{}) bool {
 	expectURL, err := url.Parse(expect)
 	if err != nil {
-		t.Errorf(errMsg("unable to parse expected URL", err, msgAndArgs))
+		t.Errorf(errMsg("unable to parse expected URL", err, msgAndArgs...))
 		return false
 	}
 	actualURL, err := url.Parse(actual)
 	if err != nil {
-		t.Errorf(errMsg("unable to parse actual URL", err, msgAndArgs))
+		t.Errorf(errMsg("unable to parse actual URL", err, msgAndArgs...))
 		return false
 	}
 
@@ -47,12 +47,12 @@ var queryMapKey = regexp.MustCompile("(.*?)\\.[0-9]+\\.key")
 func AssertQuery(t *testing.T, expect, actual string, msgAndArgs ...interface{}) bool {
 	expectQ, err := url.ParseQuery(expect)
 	if err != nil {
-		t.Errorf(errMsg("unable to parse expected Query", err, msgAndArgs))
+		t.Errorf(errMsg("unable to parse expected Query", err, msgAndArgs...))
 		return false
 	}
 	actualQ, err := url.ParseQuery(actual)
 	if err != nil {
-		t.Errorf(errMsg("unable to parse actual Query", err, msgAndArgs))
+		t.Errorf(errMsg("unable to parse actual Query", err, msgAndArgs...))
 		return false
 	}
 

--- a/awstesting/assert_test.go
+++ b/awstesting/assert_test.go
@@ -35,11 +35,12 @@ func TestAssertURL(t *testing.T) {
 		{
 			e:       string([]byte{0}),
 			a:       string([]byte{0}),
-			asserts: true,
+			asserts: false,
 		},
 	}
 
 	for i, c := range cases {
+		mockT := &testing.T{}
 		if awstesting.AssertURL(t, c.e, c.a, "check in url query") != c.asserts {
 			t.Error("Assert JSON result was not expected.", i)
 		}

--- a/awstesting/assert_test.go
+++ b/awstesting/assert_test.go
@@ -27,6 +27,25 @@ func TestAssertJSON(t *testing.T) {
 	}
 }
 
+func TestAssertURL(t *testing.T) {
+	cases := []struct {
+		e, a    string
+		asserts bool
+	}{
+		{
+			e:       string([]byte{0}),
+			a:       string([]byte{0}),
+			asserts: true,
+		},
+	}
+
+	for i, c := range cases {
+		if awstesting.AssertURL(t, c.e, c.a, "check in url query") != c.asserts {
+			t.Error("Assert JSON result was not expected.", i)
+		}
+	}
+}
+
 func TestAssertXML(t *testing.T) {
 	cases := []struct {
 		e, a      string


### PR DESCRIPTION
i am writing a [linter](https://github.com/alingse/asasalint) to lint that pass []any as any in variadic function

and run github Actions for some top go packages, this package failed

see github actions lint result here https://github.com/alingse/asasalint/runs/7271305421?check_suite_focus=true
