### PR TITLE
service/pricing: Fix PriceList type to aws.JSONValue

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,7 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/pricing`: Fixes a bug that caused `GetProductsOutput.PriceList` to be generated incorrectly. ([#4486](https://github.com/aws/aws-sdk-go/pull/4486))
+  * The [v1.44.46](https://github.com/aws/aws-sdk-go/releases/tag/v1.44.46) release incorrectly resulted in the `PriceList` field's type changing from `[]aws.JSONValue` to `[]*string`.
+  * This release reverts this change, with the field now correctly updated to `[]aws.JSONValue`.
+  * Fixes [#4480](https://github.com/aws/aws-sdk-go/issues/4480)

--- a/private/model/api/legacy_jsonvalue.go
+++ b/private/model/api/legacy_jsonvalue.go
@@ -137,7 +137,7 @@ var legacyJSONValueShapes = map[string]map[string]legacyJSONValues{
 		},
 	},
 	"pricing": map[string]legacyJSONValues{
-		"PriceList": legacyJSONValues{
+		"PriceListJsonItems": legacyJSONValues{
 			Type:          "list",
 			ListMemberRef: true,
 		},

--- a/service/pricing/api.go
+++ b/service/pricing/api.go
@@ -1016,7 +1016,7 @@ type GetProductsOutput struct {
 
 	// The list of products that match your filters. The list contains both the
 	// product metadata and the price information.
-	PriceList []*string `type:"list"`
+	PriceList []aws.JSONValue `type:"list"`
 }
 
 // String returns the string representation.
@@ -1050,7 +1050,7 @@ func (s *GetProductsOutput) SetNextToken(v string) *GetProductsOutput {
 }
 
 // SetPriceList sets the PriceList field's value.
-func (s *GetProductsOutput) SetPriceList(v []*string) *GetProductsOutput {
+func (s *GetProductsOutput) SetPriceList(v []aws.JSONValue) *GetProductsOutput {
 	s.PriceList = v
 	return s
 }


### PR DESCRIPTION
* `service/pricing`: Fixes a bug that caused `GetProductsOutput.PriceList` to be generated incorrectly. ([#4486](https://github.com/aws/aws-sdk-go/pull/4486))
  * The [v1.44.46](https://github.com/aws/aws-sdk-go/releases/tag/v1.44.46) release incorrectly resulted in the `PriceList` field's type changing from `[]aws.JSONValue` to `[]*string`.
  * This release reverts this change, with the field now correctly updated to `[]aws.JSONValue`.
  * Fixes [#4480](https://github.com/aws/aws-sdk-go/issues/4480)