### PR TITLE
add String to dynamodbattribute.UnixTime

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
-* `service/dynamodb/dynamodbattribute: Add String method to UnixTime
+* `service/dynamodb/dynamodbattribute`: Add String method to UnixTime
   * Adds a `String` method to `UnixTime`, so that when structs with this field get logged it prints a human readable time.
 
 ### SDK Bugs

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `service/dynamodb/dynamodbattribute: Add String method to UnixTime
+  * Adds a `String` method to `UnixTime`, so that when structs with this field get logged it prints a human readable time.
 
 ### SDK Bugs

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -23,6 +23,11 @@ import (
 // January 1, 0001 UTC, and January 1, 0001 UTC.
 type UnixTime time.Time
 
+// String calls the underlying time.Time.String to return a human readable representation
+func (e UnixTime) String() string {
+	return time.Time(e).String()
+}
+
 // MarshalDynamoDBAttributeValue implements the Marshaler interface so that
 // the UnixTime can be marshaled from to a DynamoDB AttributeValue number
 // value encoded in the number of seconds since January 1, 1970 UTC.

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
+func TestString(t *testing.T) {
+	gotime := time.Date(2016, time.May, 03, 17, 06, 26, 0, time.UTC)
+	ddbtime := UnixTime(gotime)
+	if fmt.Sprint(gotime) != fmt.Sprint(ddbtime) {
+		t.Error("UnixTime.String not equal to time.Time.String")
+	}
+}
+
 func TestMarshalErrorTypes(t *testing.T) {
 	var _ awserr.Error = (*InvalidMarshalError)(nil)
 	var _ awserr.Error = (*unsupportedMarshalTypeError)(nil)


### PR DESCRIPTION
this change adds a String method to dynamodbattribute.UnixTime, so that when structs with this field get logged it prints a human readable time