### PR TITLE
codegen: Fix SDK codegen handling of poorly formatted API docs

### DIFF
--- a/private/model/api/docstring.go
+++ b/private/model/api/docstring.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"log"
 	"os"
 	"regexp"
 	"strings"
@@ -320,10 +321,14 @@ func (e *htmlTokenEncoder) Encode(token xhtml.Token) error {
 		h.handler.OnEndTagToken(token, handlerBlockClosing)
 
 		// Remove all but the root handler as the handler is no longer needed.
-		if handlerBlockClosing {
+		if handlerBlockClosing && len(e.handlers) != 0 {
 			e.handlers = e.handlers[:len(e.handlers)-1]
 		}
 		e.depth--
+		if e.depth < 0 {
+			log.Printf("ignoring unexpected closing tag, %v", token)
+			e.depth = 0
+		}
 
 	case xhtml.SelfClosingTagToken:
 		h.handler.OnSelfClosingTagToken(token)

--- a/private/model/api/docstring_test.go
+++ b/private/model/api/docstring_test.go
@@ -68,11 +68,14 @@ func TestDocstring(t *testing.T) {
 			In:     "<p> Deletes the replication configuration from the bucket. For information about replication configuration, see <a href=\" https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html\">Cross-Region Replication (CRR)</a> in the <i>Amazon S3 Developer Guide</i>. </p>",
 			Expect: "// Deletes the replication configuration from the bucket. For information about\n// replication configuration, see Cross-Region Replication (CRR) (https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html)\n// in the Amazon S3 Developer Guide.",
 		},
+		"unexpected closing tag": {
+			In:     "<p>Some cool text</p></p>",
+			Expect: "// Some cool text",
+		},
 	}
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Log("Input", c.In)
 			actual := docstring(c.In)
 			if e, a := c.Expect, actual; e != a {
 				t.Errorf("expect %q, got %q", e, a)


### PR DESCRIPTION
Fixes the SDKs code generation handling of unexpected closing HTML tags when processing API documentation.

This bug prevented the SDK to correctly generate `privatenetworks` API client published in the v1.44.74 release.
