### PR TITLE
fix-resolve-home-v1

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/session`: Modified config resolution strategy when `$HOME` or `%USERPROFILE%` environment variables are not set.
+  * When the environment variables are not set, the SDK will attempt to determine the home directory using `user.Current()`. 
 
 ### SDK Bugs

--- a/internal/shareddefaults/shared_config.go
+++ b/internal/shareddefaults/shared_config.go
@@ -1,6 +1,7 @@
 package shareddefaults
 
 import (
+	"os/user"
 	"path/filepath"
 )
 
@@ -29,5 +30,17 @@ func SharedConfigFilename() string {
 // UserHomeDir returns the home directory for the user the process is
 // running under.
 func UserHomeDir() string {
-	return userHomeDir()
+	var home string
+
+	home = userHomeDir()
+	if len(home) > 0 {
+		return home
+	}
+
+	currUser, _ := user.Current()
+	if currUser != nil {
+		home = currUser.HomeDir
+	}
+
+	return home
 }

--- a/internal/shareddefaults/shared_config.go
+++ b/internal/shareddefaults/shared_config.go
@@ -2,8 +2,8 @@ package shareddefaults
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
-	"runtime"
 )
 
 // SharedCredentialsFilename returns the SDK's default file path
@@ -31,10 +31,16 @@ func SharedConfigFilename() string {
 // UserHomeDir returns the home directory for the user the process is
 // running under.
 func UserHomeDir() string {
-	if runtime.GOOS == "windows" { // Windows
-		return os.Getenv("USERPROFILE")
+	home, _ := os.UserHomeDir()
+
+	if len(home) > 0 {
+		return home
 	}
 
-	// *nix
-	return os.Getenv("HOME")
+	currUser, _ := user.Current()
+	if currUser != nil {
+		home = currUser.HomeDir
+	}
+
+	return home
 }

--- a/internal/shareddefaults/shared_config.go
+++ b/internal/shareddefaults/shared_config.go
@@ -1,8 +1,6 @@
 package shareddefaults
 
 import (
-	"os"
-	"os/user"
 	"path/filepath"
 )
 
@@ -31,16 +29,5 @@ func SharedConfigFilename() string {
 // UserHomeDir returns the home directory for the user the process is
 // running under.
 func UserHomeDir() string {
-	home, _ := os.UserHomeDir()
-
-	if len(home) > 0 {
-		return home
-	}
-
-	currUser, _ := user.Current()
-	if currUser != nil {
-		home = currUser.HomeDir
-	}
-
-	return home
+	return userHomeDir()
 }

--- a/internal/shareddefaults/shared_config_resolve_home.go
+++ b/internal/shareddefaults/shared_config_resolve_home.go
@@ -1,0 +1,18 @@
+//go:build !go1.12
+// +build !go1.12
+
+package shareddefaults
+
+import (
+	"os"
+	"runtime"
+)
+
+func userHomeDir() string {
+	if runtime.GOOS == "windows" { // Windows
+		return os.Getenv("USERPROFILE")
+	}
+
+	// *nix
+	return os.Getenv("HOME")
+}

--- a/internal/shareddefaults/shared_config_resolve_home_go1.12.go
+++ b/internal/shareddefaults/shared_config_resolve_home_go1.12.go
@@ -5,20 +5,9 @@ package shareddefaults
 
 import (
 	"os"
-	"os/user"
 )
 
 func userHomeDir() string {
 	home, _ := os.UserHomeDir()
-
-	if len(home) > 0 {
-		return home
-	}
-
-	currUser, _ := user.Current()
-	if currUser != nil {
-		home = currUser.HomeDir
-	}
-
 	return home
 }

--- a/internal/shareddefaults/shared_config_resolve_home_go1.12.go
+++ b/internal/shareddefaults/shared_config_resolve_home_go1.12.go
@@ -1,0 +1,24 @@
+//go:build go1.12
+// +build go1.12
+
+package shareddefaults
+
+import (
+	"os"
+	"os/user"
+)
+
+func userHomeDir() string {
+	home, _ := os.UserHomeDir()
+
+	if len(home) > 0 {
+		return home
+	}
+
+	currUser, _ := user.Current()
+	if currUser != nil {
+		home = currUser.HomeDir
+	}
+
+	return home
+}


### PR DESCRIPTION
For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.


If there is an existing bug or feature this PR is answers please reference it here.
https://github.com/aws/aws-sdk-go/issues/4444

Added a fallback to resolve home using current user from "os/user".