### PR TITLE
private/protocol/query: Fix deserialize error code with spaces

### DIFF
--- a/private/protocol/ec2query/unmarshal.go
+++ b/private/protocol/ec2query/unmarshal.go
@@ -4,6 +4,7 @@ package ec2query
 
 import (
 	"encoding/xml"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -70,7 +71,7 @@ func UnmarshalError(r *request.Request) {
 	}
 
 	r.Error = awserr.NewRequestFailure(
-		awserr.New(respErr.Code, respErr.Message, nil),
+		awserr.New(strings.TrimSpace(respErr.Code), strings.TrimSpace(respErr.Message), nil),
 		r.HTTPResponse.StatusCode,
 		respErr.RequestID,
 	)

--- a/private/protocol/ec2query/unmarshal_error_test.go
+++ b/private/protocol/ec2query/unmarshal_error_test.go
@@ -40,6 +40,30 @@ func TestUnmarshalError(t *testing.T) {
 			Code: "codeAbc", Msg: "msg123",
 			Status: 400, ReqID: "reqID123",
 		},
+		"ErrorResponse with spaces": {
+			Request: &request.Request{
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header:     http.Header{},
+					Body: ioutil.NopCloser(strings.NewReader(
+						`<Response>
+							<Errors>
+								<Error>
+									<Code>
+									codeAbc
+									</Code>
+									<Message>
+									msg123
+									</Message>
+								</Error>
+							</Errors>
+							<RequestID>reqID123</RequestID>
+						</Response>`)),
+				},
+			},
+			Code: "codeAbc", Msg: "msg123",
+			Status: 400, ReqID: "reqID123",
+		},
 		"unknown tag": {
 			Request: &request.Request{
 				HTTPResponse: &http.Response{

--- a/private/protocol/query/unmarshal_error.go
+++ b/private/protocol/query/unmarshal_error.go
@@ -3,6 +3,7 @@ package query
 import (
 	"encoding/xml"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -62,7 +63,7 @@ func UnmarshalError(r *request.Request) {
 	}
 
 	r.Error = awserr.NewRequestFailure(
-		awserr.New(respErr.Code, respErr.Message, nil),
+		awserr.New(strings.TrimSpace(respErr.Code), strings.TrimSpace(respErr.Message), nil),
 		r.HTTPResponse.StatusCode,
 		reqID,
 	)

--- a/private/protocol/query/unmarshal_error_test.go
+++ b/private/protocol/query/unmarshal_error_test.go
@@ -37,6 +37,27 @@ func TestUnmarshalError(t *testing.T) {
 			Code: "codeAbc", Msg: "msg123",
 			Status: 400, ReqID: "reqID123",
 		},
+		"ErrorResponse with spaces": {
+			Request: &request.Request{
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header:     http.Header{},
+					Body: ioutil.NopCloser(strings.NewReader(
+						`<ErrorResponse>
+							<Error>
+								<Code>
+								codeAbc
+								</Code><Message>
+								msg123
+								</Message>
+							</Error>
+							<RequestId>reqID123</RequestId>
+						</ErrorResponse>`)),
+				},
+			},
+			Code: "codeAbc", Msg: "msg123",
+			Status: 400, ReqID: "reqID123",
+		},
 		"ServiceUnavailableException": {
 			Request: &request.Request{
 				HTTPResponse: &http.Response{


### PR DESCRIPTION
Fixes the ec2query and query protocol error deserializers to trim leading and trailing spaces from error code and message parameters. JSON based protocol's don't need this change, because the values are quoted.