### PR TITLE
fixed error handling

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* Added error handling for waiter's request.
+* Added a test to cover config error when region is missing.

--- a/aws/request/waiter.go
+++ b/aws/request/waiter.go
@@ -176,6 +176,9 @@ func (w Waiter) WaitWithContext(ctx aws.Context) error {
 		}
 		req.Handlers.Build.PushBack(MakeAddToUserAgentFreeFormHandler("Waiter"))
 		err = req.Send()
+		if err != nil {
+			return err
+		}
 
 		// See if any of the acceptors match the request's response, or error
 		for _, a := range w.Acceptors {


### PR DESCRIPTION
These changes are following this github Issue:
https://github.com/aws/aws-sdk-go/issues/4522

- Added a catch block to capture any exceptions that might arise from the Waiter's underlying API call.
- Added a test to cover that case.
- Documented changes in release notes under `CHANGELOG_PENDING.md` per GO SDK Runbook.