### PR TITLE
Fixes codegen for multiple account ids

### DIFF
--- a/private/model/api/endpoint_arn.go
+++ b/private/model/api/endpoint_arn.go
@@ -76,11 +76,15 @@ const accountIDWithARNShapeTmplDef = `
 {{ range $_, $name := $.MemberNames -}}
 	{{ $elem := index $.MemberRefs $name -}}
 	{{ if $elem.AccountIDMemberWithARN -}}
-		// updateAccountID returns a pointer to a modified copy of input, 
+		{{ $FunctionName := $name }}
+		{{ if eq $name "AccountId" }}
+  		{{ $FunctionName = "AccountID" }}
+		{{ end }}
+		// update{{ $FunctionName }} returns a pointer to a modified copy of input,
 		// if account id is not provided, we update the account id in modified input
 		// if account id is provided, but doesn't match with the one in ARN, we throw an error
 		// if account id is not updated, we return nil. Note that original input is not modified. 
-		func (s {{ $.ShapeName }}) updateAccountID(accountId string) (interface{}, error) {
+		func (s {{ $.ShapeName }}) update{{ $FunctionName }}(accountId string) (interface{}, error) {
 			if s.{{ $name }} == nil {
 				s.{{ $name }} = aws.String(accountId)
 				return &s, nil


### PR DESCRIPTION
For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.

When a model has multiple elements where `if $elem.AccountIDMemberWithARN ` is true it will create the same function signature for each element

```
func (s {{ $.ShapeName }}) updateAccountID(accountId string) (interface{}, error) {
```

This updates the function signature to take the shape name into account

```
func (s {{ $.ShapeName }}) update{{ $name }}(accountId string) (interface{}, error) {
```