### PR TITLE
remove failing Go versions on macos-latest

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,6 +50,15 @@ jobs:
           - 1.15.x
           - 1.16.x
           - 1.17.x
+        exclude:
+          - os: macos-latest
+            go-version: 1.12.x
+          - os: macos-latest
+            go-version: 1.13.x
+          - os: macos-latest
+            go-version: 1.14.x
+          - os: macos-latest
+            go-version: 1.15.x
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2
@@ -91,6 +100,14 @@ jobs:
             go-version: 1.5.x
           - os: macos-latest
             go-version: 1.6.x
+          - os: macos-latest
+            go-version: 1.7.x
+          - os: macos-latest
+            go-version: 1.8.x
+          - os: macos-latest
+            go-version: 1.9.x
+          - os: macos-latest
+            go-version: 1.10.x
         include:
           - os: windows-latest
             go-version: 1.12.x

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,6 +59,8 @@ jobs:
             go-version: 1.14.x
           - os: macos-latest
             go-version: 1.15.x
+          - os: macos-latest
+            go-version: 1.16.x
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2
@@ -85,7 +87,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         go-version:
           - 1.5.x
           - 1.6.x
@@ -95,19 +97,6 @@ jobs:
           - 1.10.x
           - 1.11.x
           - 1.12.x
-        exclude:
-          - os: macos-latest
-            go-version: 1.5.x
-          - os: macos-latest
-            go-version: 1.6.x
-          - os: macos-latest
-            go-version: 1.7.x
-          - os: macos-latest
-            go-version: 1.8.x
-          - os: macos-latest
-            go-version: 1.9.x
-          - os: macos-latest
-            go-version: 1.10.x
         include:
           - os: windows-latest
             go-version: 1.12.x


### PR DESCRIPTION
Excluding Go versions which appear to fail when run on macos-latest.

Exclude <= 1.10 on macos-latest for without module support because of:
https://github.com/golang/go/wiki/MacOS12BSDThreadRegisterIssue

Excluding 1.11-1.16 on macos-latest for same reasons listed on https://github.com/aws/aws-sdk-go-v2/pull/1971/
