### PR TITLE
fix misleading timestamp value from tests and lint issues

### DIFF
--- a/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
@@ -21,13 +21,13 @@ const credsRespTmpl = `{
   "SecretAccessKey" : "secret",
   "Token" : "token",
   "Expiration" : "%s",
-  "LastUpdated" : "2009-11-23T0:00:00Z"
+  "LastUpdated" : "2009-11-23T00:00:00Z"
 }`
 
 const credsFailRespTmpl = `{
   "Code": "ErrorCode",
   "Message": "ErrorMsg",
-  "LastUpdated": "2009-11-23T0:00:00Z"
+  "LastUpdated": "2009-11-23T00:00:00Z"
 }`
 
 func initTestServer(expireOn string, failAssume bool) *httptest.Server {

--- a/aws/session/credentials_test.go
+++ b/aws/session/credentials_test.go
@@ -410,7 +410,7 @@ const ecsResponse = `{
 	  "SecretAccessKey" : "ecs-secret-key",
 	  "Token" : "token",
 	  "Expiration" : "2100-01-01T00:00:00Z",
-	  "LastUpdated" : "2009-11-23T0:00:00Z"
+	  "LastUpdated" : "2009-11-23T00:00:00Z"
 	}`
 
 const ec2MetadataResponse = `{
@@ -420,7 +420,7 @@ const ec2MetadataResponse = `{
 	  "SecretAccessKey" : "%s",
 	  "Token" : "token",
 	  "Expiration" : "2100-01-01T00:00:00Z",
-	  "LastUpdated" : "2009-11-23T0:00:00Z"
+	  "LastUpdated" : "2009-11-23T00:00:00Z"
 	}`
 
 const assumeRoleRespMsg = `

--- a/private/protocol/jsonrpc/unmarshal_error.go
+++ b/private/protocol/jsonrpc/unmarshal_error.go
@@ -22,7 +22,7 @@ const (
 // UnmarshalTypedError provides unmarshaling errors API response errors
 // for both typed and untyped errors.
 type UnmarshalTypedError struct {
-	exceptions map[string]func(protocol.ResponseMetadata) error
+	exceptions      map[string]func(protocol.ResponseMetadata) error
 	queryExceptions map[string]func(protocol.ResponseMetadata, string) error
 }
 
@@ -30,11 +30,13 @@ type UnmarshalTypedError struct {
 // set of exception names to the error unmarshalers
 func NewUnmarshalTypedError(exceptions map[string]func(protocol.ResponseMetadata) error) *UnmarshalTypedError {
 	return &UnmarshalTypedError{
-		exceptions: exceptions,
+		exceptions:      exceptions,
 		queryExceptions: map[string]func(protocol.ResponseMetadata, string) error{},
 	}
 }
 
+// NewUnmarshalTypedErrorWithOptions works similar to NewUnmarshalTypedError applying options to the UnmarshalTypedError
+// before returning it
 func NewUnmarshalTypedErrorWithOptions(exceptions map[string]func(protocol.ResponseMetadata) error, optFns ...func(*UnmarshalTypedError)) *UnmarshalTypedError {
 	unmarshaledError := NewUnmarshalTypedError(exceptions)
 	for _, fn := range optFns {
@@ -43,6 +45,11 @@ func NewUnmarshalTypedErrorWithOptions(exceptions map[string]func(protocol.Respo
 	return unmarshaledError
 }
 
+// WithQueryCompatibility is a helper function to construct a functional option for use with NewUnmarshalTypedErrorWithOptions.
+// The queryExceptions given act as an override for unmarshalling errors when query compatible error codes are found.
+// See also [awsQueryCompatible trait]
+//
+// [awsQueryCompatible trait]: https://smithy.io/2.0/aws/protocols/aws-query-protocol.html#aws-protocols-awsquerycompatible-trait
 func WithQueryCompatibility(queryExceptions map[string]func(protocol.ResponseMetadata, string) error) func(*UnmarshalTypedError) {
 	return func(typedError *UnmarshalTypedError) {
 		typedError.queryExceptions = queryExceptions

--- a/service/s3/statusok_error_test.go
+++ b/service/s3/statusok_error_test.go
@@ -30,7 +30,7 @@ var lastModifiedTime = time.Date(2009, 11, 23, 0, 0, 0, 0, time.UTC)
 func TestCopyObjectNoError(t *testing.T) {
 	const successMsg = `
 <?xml version="1.0" encoding="UTF-8"?>
-<CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2009-11-23T0:00:00Z</LastModified><ETag>&quot;1da64c7f13d1e8dbeaea40b905fd586c&quot;</ETag></CopyObjectResult>`
+<CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2009-11-23T00:00:00Z</LastModified><ETag>&quot;1da64c7f13d1e8dbeaea40b905fd586c&quot;</ETag></CopyObjectResult>`
 
 	var responseBodyClosed bool
 	res, err := newCopyTestSvc(successMsg, &responseBodyClosed).CopyObject(&s3.CopyObjectInput{
@@ -80,7 +80,7 @@ func TestCopyObjectError(t *testing.T) {
 func TestUploadPartCopySuccess(t *testing.T) {
 	const successMsg = `
 <?xml version="1.0" encoding="UTF-8"?>
-<UploadPartCopyResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2009-11-23T0:00:00Z</LastModified><ETag>&quot;1da64c7f13d1e8dbeaea40b905fd586c&quot;</ETag></UploadPartCopyResult>`
+<UploadPartCopyResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2009-11-23T00:00:00Z</LastModified><ETag>&quot;1da64c7f13d1e8dbeaea40b905fd586c&quot;</ETag></UploadPartCopyResult>`
 
 	var responseBodyClosed bool
 	res, err := newCopyTestSvc(successMsg, &responseBodyClosed).UploadPartCopy(&s3.UploadPartCopyInput{


### PR DESCRIPTION
Removes timestamp with single digit hour code to avoid confusion. Also fixes lint issues (`make lint` was failing from query compatible work apparently).

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
