### PR TITLE
Fix expect header value to '100-continue'

### DIFF
--- a/service/s3/platform_handlers_go1.6.go
+++ b/service/s3/platform_handlers_go1.6.go
@@ -25,5 +25,5 @@ func add100Continue(r *request.Request) {
 		return
 	}
 
-	r.HTTPRequest.Header.Set("Expect", "100-Continue")
+	r.HTTPRequest.Header.Set("Expect", "100-continue")
 }

--- a/service/s3/platform_handlers_go1.6_test.go
+++ b/service/s3/platform_handlers_go1.6_test.go
@@ -25,7 +25,7 @@ func TestAdd100Continue_Added(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
-	if e, a := "100-Continue", r.HTTPRequest.Header.Get("Expect"); e != a {
+	if e, a := "100-continue", r.HTTPRequest.Header.Get("Expect"); e != a {
 		t.Errorf("expected %s, but received %s", e, a)
 	}
 }


### PR DESCRIPTION
ref: https://www.rfc-editor.org/rfc/rfc9110.html#name-expect
<img width="889" alt="image" src="https://user-images.githubusercontent.com/48707349/218244960-fa2ec66b-86e8-4044-8b88-dddc376a66c6.png">

Expect header value should be "100-continue" not "100-Continue"