### PR TITLE
add go 1.20 support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go-version:
-          - 1.18.x
           - 1.19.x
+          - 1.20.x
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2
@@ -50,6 +50,7 @@ jobs:
           - 1.15.x
           - 1.16.x
           - 1.17.x
+          - 1.18.x
         exclude:
           - os: macos-latest
             go-version: 1.12.x


### PR DESCRIPTION
Update CI to cover latest two Go versions to 1.19 and 1.20
