### PR TITLE
Use request body error message for unknown errors missing a message header

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+
+- `private/protocol`: Use request body error message for unknown errors missing a message header

--- a/private/protocol/restjson/unmarshal_error.go
+++ b/private/protocol/restjson/unmarshal_error.go
@@ -45,7 +45,7 @@ func (u *UnmarshalTypedError) UnmarshalError(
 	msg := resp.Header.Get(errorMessageHeader)
 
 	body := resp.Body
-	if len(code) == 0 {
+	if len(code) == 0 || len(msg) == 0 {
 		// If unable to get code from HTTP headers have to parse JSON message
 		// to determine what kind of exception this will be.
 		var buf bytes.Buffer
@@ -57,7 +57,9 @@ func (u *UnmarshalTypedError) UnmarshalError(
 		}
 
 		body = ioutil.NopCloser(&buf)
-		code = jsonErr.Code
+		if len(code) == 0 {
+			code = jsonErr.Code
+		}
 		msg = jsonErr.Message
 	}
 

--- a/private/protocol/restjson/unmarshal_error_test.go
+++ b/private/protocol/restjson/unmarshal_error_test.go
@@ -161,6 +161,32 @@ func TestUnmarshalTypedError(t *testing.T) {
 				respMeta.RequestID,
 			),
 		},
+		"unknown code header only": {
+			Response: &http.Response{
+				Header: http.Header{
+					errorTypeHeader: []string{"UnknownError"},
+				},
+				Body: ioutil.NopCloser(strings.NewReader(unknownErrJSON)),
+			},
+			Expect: awserr.NewRequestFailure(
+				awserr.New("UnknownError", "error message", nil),
+				respMeta.StatusCode,
+				respMeta.RequestID,
+			),
+		},
+		"unknown message header only": {
+			Response: &http.Response{
+				Header: http.Header{
+					errorMessageHeader: []string{"overwritten error message"},
+				},
+				Body: ioutil.NopCloser(strings.NewReader(unknownErrJSON)),
+			},
+			Expect: awserr.NewRequestFailure(
+				awserr.New("UnknownError", "error message", nil),
+				respMeta.StatusCode,
+				respMeta.RequestID,
+			),
+		},
 		"code from header": {
 			Response: &http.Response{
 				Header: http.Header{


### PR DESCRIPTION
Closes #4733 

This fix will handle cases when an unknown error response includes a code header, but not a message header. Rather than returning an empty message (the current behavior) the message parsed from the JSON body is returned.

Here is a trivial example of a lambda `ValidationException` before and after the change:

Before:
```
ValidationException:
        status code: 400, request id: 455ba702-2c14-42e4-993f-f091b2e956e2
```

After:
```
ValidationException: 1 validation error detected: Value '2000' at 'timeout' failed to satisfy constraint: Member must have value less than or equal to 900
        status code: 400, request id: 60e3a922-3eec-4fb3-b3fe-83c8e2bca1ed
```


Also adds a pair of unit tests to cover "unknown" response cases with partial headers (ie. code without message and vice-versa):

```console
$ go test -count=1 ./private/protocol/restjson/...
ok      github.com/aws/aws-sdk-go/private/protocol/restjson     4.008s
```