### PR TITLE
feat: add flag to disable IMDSv1 fallback

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,4 +2,6 @@
 
 ### SDK Enhancements
 
+* `aws/ec2metadata`: Added an option to disable fallback to IMDSv1. Use `aws.WithEC2MetadataDisableFallback` to enable.
+
 ### SDK Bugs

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,7 @@
 
 ### SDK Enhancements
 
-* `aws/ec2metadata`: Added an option to disable fallback to IMDSv1. Use `aws.WithEC2MetadataDisableFallback` to enable.
+* `aws/ec2metadata`: Added an option to disable fallback to IMDSv1. 
+  * When set the SDK will no longer fallback to IMDSv1 when fetching a token fails. Use `aws.WithEC2MetadataDisableFallback` to enable.
 
 ### SDK Bugs

--- a/aws/config.go
+++ b/aws/config.go
@@ -194,7 +194,9 @@ type Config struct {
 
 	// Set this to `true` to disable EC2Metadata client from falling back to IMDSv1.
 	// By default, EC2 role credentials will fall back to IMDSv1 as needed for backwards compatibility.
-	// You can disable this behavior by explicitly disabling fallback.
+	// You can disable this behavior by explicitly setting this flag to `true`. When set, the EC2Metadata
+	// client will return any errors encountered from attempting to fetch a token instead of silently
+	// using the insecure data flow of IMDSv1.
 	//
 	// Example:
 	//    sess := session.Must(session.NewSession(aws.NewConfig()
@@ -202,6 +204,9 @@ type Config struct {
 	//
 	//    svc := s3.New(sess)
 	//
+	// See [configuring IMDS] for more information.
+	//
+	// [configuring IMDS]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
 	EC2MetadataDisableFallback *bool
 
 	// Instructs the endpoint to be generated for a service client to

--- a/aws/config.go
+++ b/aws/config.go
@@ -449,9 +449,9 @@ func (c *Config) WithEC2MetadataDisableTimeoutOverride(enable bool) *Config {
 	return c
 }
 
-// WithEC2MetadataDisableFallback sets a config EC2MetadataEnableFallback value
+// WithEC2MetadataEnableFallback sets a config EC2MetadataEnableFallback value
 // returning a Config pointer for chaining.
-func (c *Config) WithEC2MetadataDisableFallback(v bool) *Config {
+func (c *Config) WithEC2MetadataEnableFallback(v bool) *Config {
 	c.EC2MetadataEnableFallback = &v
 	return c
 }

--- a/aws/config.go
+++ b/aws/config.go
@@ -20,16 +20,16 @@ type RequestRetryer interface{}
 // A Config provides service configuration for service clients. By default,
 // all clients will use the defaults.DefaultConfig structure.
 //
-//     // Create Session with MaxRetries configuration to be shared by multiple
-//     // service clients.
-//     sess := session.Must(session.NewSession(&aws.Config{
-//         MaxRetries: aws.Int(3),
-//     }))
+//	// Create Session with MaxRetries configuration to be shared by multiple
+//	// service clients.
+//	sess := session.Must(session.NewSession(&aws.Config{
+//	    MaxRetries: aws.Int(3),
+//	}))
 //
-//     // Create S3 service client with a specific Region.
-//     svc := s3.New(sess, &aws.Config{
-//         Region: aws.String("us-west-2"),
-//     })
+//	// Create S3 service client with a specific Region.
+//	svc := s3.New(sess, &aws.Config{
+//	    Region: aws.String("us-west-2"),
+//	})
 type Config struct {
 	// Enables verbose error printing of all credential chain errors.
 	// Should be used when wanting to see all errors while attempting to
@@ -192,6 +192,18 @@ type Config struct {
 	//
 	EC2MetadataDisableTimeoutOverride *bool
 
+	// Set this to `true` to disable EC2Metadata client from falling back to IMDSv1.
+	// By default, EC2 role credentials will fall back to IMDSv1 as needed for backwards compatibility.
+	// You can disable this behavior by explicitly disabling fallback.
+	//
+	// Example:
+	//    sess := session.Must(session.NewSession(aws.NewConfig()
+	//       .WithEC2MetadataDisableFallback(true)))
+	//
+	//    svc := s3.New(sess)
+	//
+	EC2MetadataDisableFallback *bool
+
 	// Instructs the endpoint to be generated for a service client to
 	// be the dual stack endpoint. The dual stack endpoint will support
 	// both IPv4 and IPv6 addressing.
@@ -283,16 +295,16 @@ type Config struct {
 // NewConfig returns a new Config pointer that can be chained with builder
 // methods to set multiple configuration values inline without using pointers.
 //
-//     // Create Session with MaxRetries configuration to be shared by multiple
-//     // service clients.
-//     sess := session.Must(session.NewSession(aws.NewConfig().
-//         WithMaxRetries(3),
-//     ))
+//	// Create Session with MaxRetries configuration to be shared by multiple
+//	// service clients.
+//	sess := session.Must(session.NewSession(aws.NewConfig().
+//	    WithMaxRetries(3),
+//	))
 //
-//     // Create S3 service client with a specific Region.
-//     svc := s3.New(sess, aws.NewConfig().
-//         WithRegion("us-west-2"),
-//     )
+//	// Create S3 service client with a specific Region.
+//	svc := s3.New(sess, aws.NewConfig().
+//	    WithRegion("us-west-2"),
+//	)
 func NewConfig() *Config {
 	return &Config{}
 }
@@ -429,6 +441,13 @@ func (c *Config) WithUseDualStack(enable bool) *Config {
 // returning a Config pointer for chaining.
 func (c *Config) WithEC2MetadataDisableTimeoutOverride(enable bool) *Config {
 	c.EC2MetadataDisableTimeoutOverride = &enable
+	return c
+}
+
+// WithEC2MetadataDisableFallback sets a config EC2MetadataDisableFallback value
+// returning a Config pointer for chaining.
+func (c *Config) WithEC2MetadataDisableFallback(v bool) *Config {
+	c.EC2MetadataDisableFallback = &v
 	return c
 }
 
@@ -574,6 +593,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.EC2MetadataDisableTimeoutOverride != nil {
 		dst.EC2MetadataDisableTimeoutOverride = other.EC2MetadataDisableTimeoutOverride
+	}
+
+	if other.EC2MetadataDisableFallback != nil {
+		dst.EC2MetadataDisableFallback = other.EC2MetadataDisableFallback
 	}
 
 	if other.SleepDelay != nil {

--- a/aws/config.go
+++ b/aws/config.go
@@ -192,22 +192,22 @@ type Config struct {
 	//
 	EC2MetadataDisableTimeoutOverride *bool
 
-	// Set this to `true` to disable EC2Metadata client from falling back to IMDSv1.
+	// Set this to `false` to disable EC2Metadata client from falling back to IMDSv1.
 	// By default, EC2 role credentials will fall back to IMDSv1 as needed for backwards compatibility.
-	// You can disable this behavior by explicitly setting this flag to `true`. When set, the EC2Metadata
+	// You can disable this behavior by explicitly setting this flag to `false`. When false, the EC2Metadata
 	// client will return any errors encountered from attempting to fetch a token instead of silently
 	// using the insecure data flow of IMDSv1.
 	//
 	// Example:
 	//    sess := session.Must(session.NewSession(aws.NewConfig()
-	//       .WithEC2MetadataDisableFallback(true)))
+	//       .WithEC2MetadataEnableFallback(false)))
 	//
 	//    svc := s3.New(sess)
 	//
 	// See [configuring IMDS] for more information.
 	//
 	// [configuring IMDS]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
-	EC2MetadataDisableFallback *bool
+	EC2MetadataEnableFallback *bool
 
 	// Instructs the endpoint to be generated for a service client to
 	// be the dual stack endpoint. The dual stack endpoint will support
@@ -449,10 +449,10 @@ func (c *Config) WithEC2MetadataDisableTimeoutOverride(enable bool) *Config {
 	return c
 }
 
-// WithEC2MetadataDisableFallback sets a config EC2MetadataDisableFallback value
+// WithEC2MetadataDisableFallback sets a config EC2MetadataEnableFallback value
 // returning a Config pointer for chaining.
 func (c *Config) WithEC2MetadataDisableFallback(v bool) *Config {
-	c.EC2MetadataDisableFallback = &v
+	c.EC2MetadataEnableFallback = &v
 	return c
 }
 
@@ -600,8 +600,8 @@ func mergeInConfig(dst *Config, other *Config) {
 		dst.EC2MetadataDisableTimeoutOverride = other.EC2MetadataDisableTimeoutOverride
 	}
 
-	if other.EC2MetadataDisableFallback != nil {
-		dst.EC2MetadataDisableFallback = other.EC2MetadataDisableFallback
+	if other.EC2MetadataEnableFallback != nil {
+		dst.EC2MetadataEnableFallback = other.EC2MetadataEnableFallback
 	}
 
 	if other.SleepDelay != nil {

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -249,7 +249,7 @@ func TestGetMetadata(t *testing.T) {
 		expectedData                string
 		expectedError               string
 		expectedOperationsAttempted []string
-		disableImdsFallback         *bool
+		enableImdsFallback          *bool
 	}{
 		"Insecure server success case": {
 			NewServer: func(t *testing.T, tokens []string) *httptest.Server {
@@ -347,7 +347,7 @@ func TestGetMetadata(t *testing.T) {
 			expectedError: "failed to get IMDS token and fallback is disabled",
 			// 2 attempts + 2 retries per/attempt
 			expectedOperationsAttempted: []string{"GetToken", "GetToken", "GetToken", "GetToken", "GetToken", "GetToken"},
-			disableImdsFallback:         aws.Bool(true),
+			enableImdsFallback:          aws.Bool(false),
 		},
 	}
 
@@ -360,8 +360,8 @@ func TestGetMetadata(t *testing.T) {
 			op := &operationListProvider{}
 
 			c := ec2metadata.New(unit.Session, &aws.Config{
-				Endpoint:                   aws.String(server.URL),
-				EC2MetadataDisableFallback: x.disableImdsFallback,
+				Endpoint:                  aws.String(server.URL),
+				EC2MetadataEnableFallback: x.enableImdsFallback,
 			})
 
 			c.Handlers.CompleteAttempt.PushBack(op.addToOperationPerformedList)

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -262,7 +262,7 @@ func TestGetMetadata(t *testing.T) {
 				return newTestServer(t, testType, Ts)
 			},
 			expectedData:                "IMDSProfileForGoSDK",
-			expectedOperationsAttempted: []string{"GetToken", "GetMetadata", "GetToken", "GetMetadata"},
+			expectedOperationsAttempted: []string{"GetToken", "GetMetadata", "GetMetadata"},
 		},
 		"Secure server success case": {
 			tokens: []string{"firstToken", "secondToken", "thirdToken"},
@@ -332,7 +332,7 @@ func TestGetMetadata(t *testing.T) {
 				return newTestServer(t, testType, Ts)
 			},
 			expectedData:                "IMDSProfileForGoSDK",
-			expectedOperationsAttempted: []string{"GetToken", "GetMetadata", "GetToken", "GetMetadata"},
+			expectedOperationsAttempted: []string{"GetToken", "GetMetadata", "GetMetadata"},
 		},
 		"No fallback to IMDSv1": {
 			NewServer: func(t *testing.T, tokens []string) *httptest.Server {
@@ -1014,7 +1014,7 @@ func TestExhaustiveRetryToFetchToken(t *testing.T) {
 	}
 
 	resp, err = c.GetMetadata("/some/path")
-	expectedOperationsPerformed := []string{"GetToken", "GetMetadata", "GetToken", "GetMetadata", "GetToken", "GetMetadata", "GetToken", "GetMetadata"}
+	expectedOperationsPerformed := []string{"GetToken", "GetMetadata", "GetMetadata", "GetMetadata", "GetMetadata"}
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -262,7 +262,7 @@ func TestGetMetadata(t *testing.T) {
 				return newTestServer(t, testType, Ts)
 			},
 			expectedData:                "IMDSProfileForGoSDK",
-			expectedOperationsAttempted: []string{"GetToken", "GetMetadata", "GetMetadata"},
+			expectedOperationsAttempted: []string{"GetToken", "GetMetadata", "GetToken", "GetMetadata"},
 		},
 		"Secure server success case": {
 			tokens: []string{"firstToken", "secondToken", "thirdToken"},
@@ -332,7 +332,7 @@ func TestGetMetadata(t *testing.T) {
 				return newTestServer(t, testType, Ts)
 			},
 			expectedData:                "IMDSProfileForGoSDK",
-			expectedOperationsAttempted: []string{"GetToken", "GetMetadata", "GetMetadata"},
+			expectedOperationsAttempted: []string{"GetToken", "GetMetadata", "GetToken", "GetMetadata"},
 		},
 		"No fallback to IMDSv1": {
 			NewServer: func(t *testing.T, tokens []string) *httptest.Server {
@@ -1014,7 +1014,7 @@ func TestExhaustiveRetryToFetchToken(t *testing.T) {
 	}
 
 	resp, err = c.GetMetadata("/some/path")
-	expectedOperationsPerformed := []string{"GetToken", "GetMetadata", "GetMetadata", "GetMetadata", "GetMetadata"}
+	expectedOperationsPerformed := []string{"GetToken", "GetMetadata", "GetToken", "GetMetadata", "GetToken", "GetMetadata", "GetToken", "GetMetadata"}
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -1143,7 +1143,7 @@ func TestRequestTimeOut(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	expectedOperationsPerformed = []string{"GetToken", "GetMetadata", "GetMetadata"}
+	expectedOperationsPerformed = []string{"GetToken", "GetMetadata", "GetToken", "GetMetadata"}
 	if e, a := expectedOperationsPerformed, op.operationsPerformed; !reflect.DeepEqual(e, a) {
 		t.Fatalf("expect %v operations, got %v", e, a)
 	}

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -72,8 +72,9 @@ const (
 	NotFoundRequestTestType
 	InvalidTokenRequestTestType
 	ServerErrorForTokenTestType
-	pageNotFoundForTokenTestType
-	pageNotFoundWith401TestType
+	PageNotFoundForTokenTestType
+	PageNotFoundWith401TestType
+	ThrottleErrorForTokenNoFallbackTestType
 )
 
 type testServer struct {
@@ -126,11 +127,14 @@ func newTestServer(t *testing.T, testType testType, testServer *testServer) *htt
 	case ServerErrorForTokenTestType:
 		mux.HandleFunc("/latest/api/token", getTokenRequiredParams(t, testServer.serverErrorGetTokenHandler))
 		mux.HandleFunc("/", testServer.insecureGetLatestHandler)
-	case pageNotFoundForTokenTestType:
+	case PageNotFoundForTokenTestType:
 		mux.HandleFunc("/latest/api/token", getTokenRequiredParams(t, testServer.pageNotFoundGetTokenHandler))
 		mux.HandleFunc("/", testServer.insecureGetLatestHandler)
-	case pageNotFoundWith401TestType:
+	case PageNotFoundWith401TestType:
 		mux.HandleFunc("/latest/api/token", getTokenRequiredParams(t, testServer.pageNotFoundGetTokenHandler))
+		mux.HandleFunc("/", testServer.unauthorizedGetLatestHandler)
+	case ThrottleErrorForTokenNoFallbackTestType:
+		mux.HandleFunc("/latest/api/token", getTokenRequiredParams(t, testServer.throtleErrorGetTokenHandler))
 		mux.HandleFunc("/", testServer.unauthorizedGetLatestHandler)
 
 	}
@@ -213,6 +217,10 @@ func (s *testServer) unauthorizedGetLatestHandler(w http.ResponseWriter, r *http
 	http.Error(w, "", 401)
 }
 
+func (s *testServer) throtleErrorGetTokenHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "", 429)
+}
+
 func (opListProvider *operationListProvider) addToOperationPerformedList(r *request.Request) {
 	opListProvider.operationsPerformed = append(opListProvider.operationsPerformed, r.Operation.Name)
 }
@@ -241,6 +249,7 @@ func TestGetMetadata(t *testing.T) {
 		expectedData                string
 		expectedError               string
 		expectedOperationsAttempted []string
+		disableImdsFallback         *bool
 	}{
 		"Insecure server success case": {
 			NewServer: func(t *testing.T, tokens []string) *httptest.Server {
@@ -325,6 +334,21 @@ func TestGetMetadata(t *testing.T) {
 			expectedData:                "IMDSProfileForGoSDK",
 			expectedOperationsAttempted: []string{"GetToken", "GetMetadata", "GetMetadata"},
 		},
+		"No fallback to IMDSv1": {
+			NewServer: func(t *testing.T, tokens []string) *httptest.Server {
+				testType := ThrottleErrorForTokenNoFallbackTestType
+				Ts := &testServer{
+					t:      t,
+					tokens: []string{},
+					data:   "IMDSProfileForGoSDK",
+				}
+				return newTestServer(t, testType, Ts)
+			},
+			expectedError: "failed to get IMDS token and fallback is disabled",
+			// 2 attempts + 2 retries per/attempt
+			expectedOperationsAttempted: []string{"GetToken", "GetToken", "GetToken", "GetToken", "GetToken", "GetToken"},
+			disableImdsFallback:         aws.Bool(true),
+		},
 	}
 
 	for name, x := range cases {
@@ -336,8 +360,10 @@ func TestGetMetadata(t *testing.T) {
 			op := &operationListProvider{}
 
 			c := ec2metadata.New(unit.Session, &aws.Config{
-				Endpoint: aws.String(server.URL),
+				Endpoint:                   aws.String(server.URL),
+				EC2MetadataDisableFallback: x.disableImdsFallback,
 			})
+
 			c.Handlers.CompleteAttempt.PushBack(op.addToOperationPerformedList)
 
 			tokenCounter := -1
@@ -953,7 +979,7 @@ func TestExhaustiveRetryToFetchToken(t *testing.T) {
 		data:   "IMDSProfileForSDKGo",
 	}
 
-	server := newTestServer(t, pageNotFoundForTokenTestType, ts)
+	server := newTestServer(t, PageNotFoundForTokenTestType, ts)
 	defer server.Close()
 
 	op := &operationListProvider{}
@@ -1007,7 +1033,7 @@ func TestExhaustiveRetryWith401(t *testing.T) {
 		data:   "IMDSProfileForSDKGo",
 	}
 
-	server := newTestServer(t, pageNotFoundWith401TestType, ts)
+	server := newTestServer(t, PageNotFoundWith401TestType, ts)
 	defer server.Close()
 
 	op := &operationListProvider{}

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -344,7 +344,7 @@ func TestGetMetadata(t *testing.T) {
 				}
 				return newTestServer(t, testType, Ts)
 			},
-			expectedError: "failed to get IMDS token and fallback is disabled",
+			expectedError: "failed to get IMDSv2 token and fallback to IMDSv1 is disabled",
 			// 2 attempts + 2 retries per/attempt
 			expectedOperationsAttempted: []string{"GetToken", "GetToken", "GetToken", "GetToken", "GetToken", "GetToken"},
 			enableImdsFallback:          aws.Bool(false),

--- a/aws/ec2metadata/service.go
+++ b/aws/ec2metadata/service.go
@@ -57,13 +57,13 @@ type EC2Metadata struct {
 // New creates a new instance of the EC2Metadata client with a session.
 // This client is safe to use across multiple goroutines.
 //
-//
 // Example:
-//     // Create a EC2Metadata client from just a session.
-//     svc := ec2metadata.New(mySession)
 //
-//     // Create a EC2Metadata client with additional configuration
-//     svc := ec2metadata.New(mySession, aws.NewConfig().WithLogLevel(aws.LogDebugHTTPBody))
+//	// Create a EC2Metadata client from just a session.
+//	svc := ec2metadata.New(mySession)
+//
+//	// Create a EC2Metadata client with additional configuration
+//	svc := ec2metadata.New(mySession, aws.NewConfig().WithLogLevel(aws.LogDebugHTTPBody))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *EC2Metadata {
 	c := p.ClientConfig(ServiceName, cfgs...)
 	return NewClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion)

--- a/aws/ec2metadata/token_provider.go
+++ b/aws/ec2metadata/token_provider.go
@@ -1,6 +1,7 @@
 package ec2metadata
 
 import (
+	"fmt"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -64,6 +65,7 @@ func (t *tokenProvider) fetchTokenHandler(r *request.Request) {
 			switch requestFailureError.StatusCode() {
 			case http.StatusForbidden, http.StatusNotFound, http.StatusMethodNotAllowed:
 				atomic.StoreUint32(&t.disabled, 1)
+				t.client.Config.Logger.Log(fmt.Sprintf("WARN: failed to get session token, falling back to IMDSv1: %v", requestFailureError))
 			case http.StatusBadRequest:
 				r.Error = requestFailureError
 			}

--- a/aws/ec2metadata/token_provider.go
+++ b/aws/ec2metadata/token_provider.go
@@ -56,7 +56,7 @@ func (t *tokenProvider) fetchTokenHandler(r *request.Request) {
 	if err != nil {
 		// only attempt fallback to insecure data flow if IMDSv1 is enabled
 		if !t.fallbackEnabled() {
-			r.Error = awserr.New("EC2MetadataError", "failed to get IMDS token and fallback is disabled", err)
+			r.Error = awserr.New("EC2MetadataError", "failed to get IMDSv2 token and fallback to IMDSv1 is disabled", err)
 			return
 		}
 


### PR DESCRIPTION
* Adds a flag to config to disable IMDSv1 fallback. When enabled the `EC2Metadata` client will return an error when fetching a token from IMDS fails instead of falling back to the insecure data flow of IMDSv1
    * I did confirm (and tests cover this) that fetching a token is retried

v2 PR: https://github.com/aws/aws-sdk-go-v2/pull/2048