### PR TITLE
chore(ci): Upgrade workflows to non-deprecated runtimes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,12 +20,12 @@ jobs:
           - 1.20.x
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -64,12 +64,12 @@ jobs:
             go-version: 1.16.x
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -109,12 +109,12 @@ jobs:
         echo "${{ github.workspace }}/go/bin" >> $GITHUB_PATH
 
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
         path: go/src/github.com/aws/aws-sdk-go


### PR DESCRIPTION
Hi! 👋🏻

The `go` Github Actions in the repo is using deprecated runtimes for its workflows. I've upgraded the deprecated actions to versions that uses non-deprecated runtimes.

Note that `setup-go@v4` will try to enable caching unless the `cache` input is explicitly set to `false`. I'll be more than happy to make it false if wanted.

Open to feedback if there are any other changes wanted done regarding Github Actions 😄