### PR TITLE
Fix typo in AssumeRoleTokenProvider description

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -224,7 +224,7 @@ type Options struct {
 	// from stdin for the MFA token code.
 	//
 	// This field is only used if the shared configuration is enabled, and
-	// the config enables assume role wit MFA via the mfa_serial field.
+	// the config enables assume role with MFA via the mfa_serial field.
 	AssumeRoleTokenProvider func() (string, error)
 
 	// When the SDK's shared config is configured to assume a role this option


### PR DESCRIPTION
Just fixing a typo in `AssumeRoleTokenProvider` parameter description.
