### PR TITLE
Include SHA256 header when signing requests to OpenSearch Service Serverless (aoss)

### DIFF
--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -695,7 +695,8 @@ func (ctx *signingCtx) buildBodyDigest() error {
 		includeSHA256Header := ctx.unsignedPayload ||
 			ctx.ServiceName == "s3" ||
 			ctx.ServiceName == "s3-object-lambda" ||
-			ctx.ServiceName == "glacier"
+			ctx.ServiceName == "glacier" ||
+			ctx.ServiceName == "aoss" // OpenSearch Server Serverless
 
 		s3Presign := ctx.isPresign &&
 			(ctx.ServiceName == "s3" ||

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -230,6 +230,16 @@ func TestSignBodyGlacier(t *testing.T) {
 	}
 }
 
+func TestSignBodyOpensearchServerless(t *testing.T) {
+	req, body := buildRequest("aoss", "us-east-1", "hello")
+	signer := buildSigner()
+	signer.Sign(req, body, "aoss", "us-east-1", time.Now())
+	hash := req.Header.Get("X-Amz-Content-Sha256")
+	if e, a := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", hash; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
 func TestPresign_SignedPayload(t *testing.T) {
 	req, body := buildRequest("glacier", "us-east-1", "hello")
 	signer := buildSigner()


### PR DESCRIPTION
Pretty simple little fix. As per https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-clients.html#serverless-signing:

> The x-amz-content-sha256 header is required for all AWS Signature Version 4 requests. It provides a hash of the request payload. If there's a request payload, set the value to its Secure Hash Algorithm (SHA) cryptographic hash (SHA256). If there's no request payload, set the value to e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, which is the hash of an empty string.

This code change ensures that header is added. It also adds a test to verify functionality.