### PR TITLE
Update Route53Resolver Rule - TargetIps description

### DIFF
--- a/service/route53resolver/api.go
+++ b/service/route53resolver/api.go
@@ -15531,7 +15531,7 @@ type ResolverRule struct {
 
 	// An array that contains the IP addresses and ports that an outbound endpoint
 	// forwards DNS queries to. Typically, these are the IP addresses of DNS resolvers
-	// on your network. Specify either IPv4 or IPv6 addresses but but not both in the same rule.
+	// on your network. Specify either IPv4 or IPv6 addresses but not both in the same rule.
 	TargetIps []*TargetAddress `min:"1" type:"list"`
 }
 

--- a/service/route53resolver/api.go
+++ b/service/route53resolver/api.go
@@ -15531,7 +15531,7 @@ type ResolverRule struct {
 
 	// An array that contains the IP addresses and ports that an outbound endpoint
 	// forwards DNS queries to. Typically, these are the IP addresses of DNS resolvers
-	// on your network. Specify IPv4 addresses. IPv6 is not supported.
+	// on your network. Specify either IPv4 or IPv6 addresses but but not both in the same rule.
 	TargetIps []*TargetAddress `min:"1" type:"list"`
 }
 


### PR DESCRIPTION
Route53 Resolver rules now support IPv6.
The implementation is already done but the description of the TargetIps hasn't been updated.

Reference: https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_CreateResolverRule.html#Route53Resolver-route53resolver_CreateResolverRule-request-TargetIps
