### PR TITLE
fix: resolve credentials last such that other environment config is respected

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+
+* `aws/session`: Fix `AWS_USE_FIPS_ENDPOINT` not being inferred on resolved credentials.
+  * Defer resolving default credentials chain until after other config is resolved.

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -174,7 +174,6 @@ const (
 
 // Options provides the means to control how a Session is created and what
 // configuration values will be loaded.
-//
 type Options struct {
 	// Provides config values for the SDK to use when creating service clients
 	// and making API requests to services. Any value set in with this field
@@ -322,24 +321,24 @@ type Options struct {
 // credentials file. Enabling the Shared Config will also allow the Session
 // to be built with retrieving credentials with AssumeRole set in the config.
 //
-//     // Equivalent to session.New
-//     sess := session.Must(session.NewSessionWithOptions(session.Options{}))
+//	// Equivalent to session.New
+//	sess := session.Must(session.NewSessionWithOptions(session.Options{}))
 //
-//     // Specify profile to load for the session's config
-//     sess := session.Must(session.NewSessionWithOptions(session.Options{
-//          Profile: "profile_name",
-//     }))
+//	// Specify profile to load for the session's config
+//	sess := session.Must(session.NewSessionWithOptions(session.Options{
+//	     Profile: "profile_name",
+//	}))
 //
-//     // Specify profile for config and region for requests
-//     sess := session.Must(session.NewSessionWithOptions(session.Options{
-//          Config: aws.Config{Region: aws.String("us-east-1")},
-//          Profile: "profile_name",
-//     }))
+//	// Specify profile for config and region for requests
+//	sess := session.Must(session.NewSessionWithOptions(session.Options{
+//	     Config: aws.Config{Region: aws.String("us-east-1")},
+//	     Profile: "profile_name",
+//	}))
 //
-//     // Force enable Shared Config support
-//     sess := session.Must(session.NewSessionWithOptions(session.Options{
-//         SharedConfigState: session.SharedConfigEnable,
-//     }))
+//	// Force enable Shared Config support
+//	sess := session.Must(session.NewSessionWithOptions(session.Options{
+//	    SharedConfigState: session.SharedConfigEnable,
+//	}))
 func NewSessionWithOptions(opts Options) (*Session, error) {
 	var envCfg envConfig
 	var err error
@@ -375,7 +374,7 @@ func NewSessionWithOptions(opts Options) (*Session, error) {
 // This helper is intended to be used in variable initialization to load the
 // Session and configuration at startup. Such as:
 //
-//     var sess = session.Must(session.NewSession())
+//	var sess = session.Must(session.NewSession())
 func Must(sess *Session, err error) *Session {
 	if err != nil {
 		panic(err)
@@ -780,16 +779,6 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config,
 		cfg.EndpointResolver = wrapEC2IMDSEndpoint(cfg.EndpointResolver, ec2IMDSEndpoint, endpointMode)
 	}
 
-	// Configure credentials if not already set by the user when creating the
-	// Session.
-	if cfg.Credentials == credentials.AnonymousCredentials && userCfg.Credentials == nil {
-		creds, err := resolveCredentials(cfg, envCfg, sharedCfg, handlers, sessOpts)
-		if err != nil {
-			return err
-		}
-		cfg.Credentials = creds
-	}
-
 	cfg.S3UseARNRegion = userCfg.S3UseARNRegion
 	if cfg.S3UseARNRegion == nil {
 		cfg.S3UseARNRegion = &envCfg.S3UseARNRegion
@@ -810,6 +799,17 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config,
 			cfg.UseFIPSEndpoint = v
 			break
 		}
+	}
+
+	// Configure credentials if not already set by the user when creating the Session.
+	// Credentials are resolved last such that all _resolved_ config values are propagated to credential providers.
+	// ticket: P83606045
+	if cfg.Credentials == credentials.AnonymousCredentials && userCfg.Credentials == nil {
+		creds, err := resolveCredentials(cfg, envCfg, sharedCfg, handlers, sessOpts)
+		if err != nil {
+			return err
+		}
+		cfg.Credentials = creds
 	}
 
 	return nil
@@ -845,8 +845,8 @@ func initHandlers(s *Session) {
 // and handlers. If any additional configs are provided they will be merged
 // on top of the Session's copied config.
 //
-//     // Create a copy of the current Session, configured for the us-west-2 region.
-//     sess.Copy(&aws.Config{Region: aws.String("us-west-2")})
+//	// Create a copy of the current Session, configured for the us-west-2 region.
+//	sess.Copy(&aws.Config{Region: aws.String("us-west-2")})
 func (s *Session) Copy(cfgs ...*aws.Config) *Session {
 	newSession := &Session{
 		Config:   s.Config.Copy(cfgs...),


### PR DESCRIPTION
Move credentials resolution after other config values are resolved from the current environment. Notably `AWS_USE_FIPS_ENDPOINT` and `AWS_USE_DUALSTACK_ENDPOINT` were being resolved after the credentials chain was configured. This results in credentials that use STS or other AWS service endpoints to not respect those settings. 

internal: `P83606045`
