### PR TITLE
Adds missing changelog entry for a past release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1194,6 +1194,9 @@ Release v1.44.143 (2022-11-21)
 Release v1.44.142 (2022-11-18)
 ===
 
+### Notes
+* Removes old model file for ssm sap and uses the new model file to regenerate client
+
 Release v1.44.141 (2022-11-18)
 ===
 


### PR DESCRIPTION
Creates a change log entry that explains changes done on a previous release. specifically [Ssm sap rename](https://github.com/aws/aws-sdk-go/commit/b18be4c13c6dbd9c53660012dbf7d52c919f4ce4). addressed [issues/4631](https://github.com/aws/aws-sdk-go/issues/4631)

This change removed model files from `models/apis/ssmsap` as they are now being placed in `models/apis/ssm-sap` due to a update in naming for the service. This functionally changes nothing and this is reflected by the changelog one 1.44.141 

```
service/ssm-sap: Updates service API, documentation, paginators, and examples
```

That release actually contained incorrect artifacts and `1.44.142` updated them correctly.