### PR TITLE
Loosen Operation Existence during Model Loading

### DIFF
--- a/private/model/api/pagination.go
+++ b/private/model/api/pagination.go
@@ -58,6 +58,9 @@ func (p *paginationDefinitions) setup() error {
 		if e.InputTokens == nil || e.OutputTokens == nil {
 			continue
 		}
+		if _, ok := p.Operations[n]; !ok {
+			continue
+		}
 		paginator := e
 
 		switch t := paginator.InputTokens.(type) {
@@ -83,11 +86,7 @@ func (p *paginationDefinitions) setup() error {
 			paginator.OutputTokens = toks
 		}
 
-		if o, ok := p.Operations[n]; ok {
-			o.Paginator = &paginator
-		} else {
-			return fmt.Errorf("unknown operation for paginator, %s", n)
-		}
+		p.Operations[n].Paginator = &paginator
 	}
 
 	return nil

--- a/private/model/api/smoke.go
+++ b/private/model/api/smoke.go
@@ -173,6 +173,7 @@ func (a *API) APISmokeTestsGoCode() string {
 var smokeTestTmpl = template.Must(template.New(`smokeTestTmpl`).Parse(`
 {{- range $i, $testCase := $.TestCases }}
 	{{- $op := index $.API.Operations $testCase.OpName }}
+	{{- if $op }}
 	func TestInteg_{{ printf "%02d" $i }}_{{ $op.ExportedName }}(t *testing.T) {
 		ctx, cancelFn := context.WithTimeout(context.Background(), 5 *time.Second)
 		defer cancelFn()
@@ -206,5 +207,6 @@ var smokeTestTmpl = template.Must(template.New(`smokeTestTmpl`).Parse(`
 			}
 		{{- end }}
 	}
+	{{- end }}
 {{- end }}
 `))

--- a/private/model/api/waiters.go
+++ b/private/model/api/waiters.go
@@ -98,8 +98,7 @@ func (p *waiterDefinitions) setup() error {
 		e.OperationName = p.ExportableName(e.OperationName)
 		e.Operation = p.API.Operations[e.OperationName]
 		if e.Operation == nil {
-			return fmt.Errorf("unknown operation %s for waiter %s",
-				e.OperationName, n)
+			continue
 		}
 		p.API.Waiters = append(p.API.Waiters, e)
 	}


### PR DESCRIPTION
For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

N/A.

---

If there is an existing bug or feature this PR is answers please reference it here.

N/A.

---

`aws-sdk-go` doesn't support document types, so they are removed from the API JSON models upstream (and anything that references it, i.e. structures and even operations). 

Paginators do not have the same upstream removal process, so there could be "orphaned" operations. This change loosens restrictions when loading paginators, waiters, and smoke tests when an operation cannot be found in the API JSON model.

Loosen operation existence during model loading so generation won't fail when operations don't exist in the model:

- loosen operation existence for pagination
- loosen operation existence for waiters
- loosen operation existence for smoke tests

