### PR TITLE
Backfill IoT signing name

### DIFF
--- a/service/iot/customizations.go
+++ b/service/iot/customizations.go
@@ -1,0 +1,11 @@
+package iot
+
+import (
+	"github.com/aws/aws-sdk-go/aws/client"
+)
+
+func init() {
+	initClient = func(c *client.Client) {
+		c.ClientInfo.SigningName = ServiceName
+	}
+}

--- a/service/iot/customizations_test.go
+++ b/service/iot/customizations_test.go
@@ -1,0 +1,37 @@
+package iot_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/aws/aws-sdk-go/service/iot"
+)
+
+func TestBackfillIotSigningName(t *testing.T) {
+	svc := iot.New(unit.Session)
+	if svc.SigningName != iot.ServiceName {
+		t.Errorf("Expected backfilled signing name `" + iot.ServiceName + "`, but found: `" + svc.SigningName + "`")
+	}
+}
+
+func TestBackfillIotSigningNameAuthorizationHeader(t *testing.T) {
+	svc := iot.New(unit.Session)
+
+	// Arbitrarily use ListAuthorizers since it doesn't require any input
+	req, _ := svc.ListAuthorizersRequest(&iot.ListAuthorizersInput{})
+	req.Sign()
+	authorizationHeader := req.HTTPRequest.Header.Get("Authorization")
+	if authorizationHeader == "" {
+		t.Errorf("Expected `Authorization` header to be present")
+	}
+
+	r := regexp.MustCompile(
+		`^AWS4-HMAC-SHA256 ` +
+			`Credential=AKID/[[:digit:]]{8}/mock-region/iot/aws4_request, ` +
+			`SignedHeaders=host;x-amz-date;x-amz-security-token, ` +
+			`Signature=[[:xdigit:]]{64}$`)
+	if !r.MatchString(authorizationHeader) {
+		t.Errorf("Expect regex %v to match, but found: %v", r.String(), authorizationHeader)
+	}
+}


### PR DESCRIPTION
For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

N/A.

If there is an existing bug or feature this PR is answers please reference it here.

AWS IoT requires `iot` as the signing name for some APIs rather than `iot` or `execute-api`.

This commit adds a customization to `service/iot` to set the client signing name to `iot`.