### PR TITLE
Wrap debug.Stack() in string()

### DIFF
--- a/private/model/cli/gen-api/main.go
+++ b/private/model/cli/gen-api/main.go
@@ -162,7 +162,7 @@ func writeServiceFiles(g *generateInfo, pkgDir string) {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Fprintf(os.Stderr, "Error generating %s\n%s\n%s\n",
-				pkgDir, r, debug.Stack())
+				    pkgDir, r, string(debug.Stack()))
 			os.Exit(1)
 		}
 	}()


### PR DESCRIPTION
This is being flagged by Snyk as a security issue. In other places in the code, debug.Stack() is wrapped in string(). Just adding that here.

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
