### PR TITLE
fix s3 requests sent to outpost arn missing x-amz-content-sha256 header

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+
+* `service/s3`: Populate X-Amz-Content-Sha256 header when using s3 outpost arn
+  * Using an outpost ARN results in a different signing name from the resolved endpoint. This signing name was not included in the signer logic to indicate the `X-Amz-Content-Sha256` header should be added to the request which is required by S3.

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -3,7 +3,7 @@
 // Provides request signing for request that need to be signed with
 // AWS V4 Signatures.
 //
-// Standalone Signer
+// # Standalone Signer
 //
 // Generally using the signer outside of the SDK should not require any additional
 // logic when using Go v1.5 or higher. The signer does this by taking advantage
@@ -14,10 +14,10 @@
 // The signer will first check the URL.Opaque field, and use its value if set.
 // The signer does require the URL.Opaque field to be set in the form of:
 //
-//     "//<hostname>/<path>"
+//	"//<hostname>/<path>"
 //
-//     // e.g.
-//     "//example.com/some/path"
+//	// e.g.
+//	"//example.com/some/path"
 //
 // The leading "//" and hostname are required or the URL.Opaque escaping will
 // not work correctly.
@@ -695,7 +695,8 @@ func (ctx *signingCtx) buildBodyDigest() error {
 		includeSHA256Header := ctx.unsignedPayload ||
 			ctx.ServiceName == "s3" ||
 			ctx.ServiceName == "s3-object-lambda" ||
-			ctx.ServiceName == "glacier"
+			ctx.ServiceName == "glacier" ||
+			ctx.ServiceName == "s3-outposts"
 
 		s3Presign := ctx.isPresign &&
 			(ctx.ServiceName == "s3" ||


### PR DESCRIPTION
Example code of testing an outpost endpoint. NOTE: You don't actually have to have an outpost endpoint setup, just plugin your own account and a dummy value for the access point (e.g. `my-test-access-point`). 

```go
package main

import (
    "github.com/aws/aws-sdk-go/aws"
    "github.com/aws/aws-sdk-go/aws/session"
    "github.com/aws/aws-sdk-go/service/s3"
    "fmt"
)

func main() {
    sess, err := session.NewSession(&aws.Config{
        Region: aws.String("us-east-1"),
        LogLevel: aws.LogLevel(aws.LogDebugWithHTTPBody),
   },)

    svc := s3.New(sess)
    bucket := "arn:aws:s3-outposts:us-east-1:<account>:outpost/ec2/accesspoint/<my-access-point>"
    resp, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
    fmt.Printf(" response %v error %v \n", resp, err)
}
```

output contains
```
Missing required header for this request: x-amz-content-sha256
```

The resolved endpoint is an outpost ARN which [customizes](https://github.com/aws/aws-sdk-go/blob/36e99e2d8b7f9efaa27e9665760788b3169e24bb/service/s3/endpoint_builder.go#L178) the signing name to be `s3-outposts` instead of `s3`. Requests to S3 must include the `x-amz-content-sha256` header but the the [v4 signer does not ](https://github.com/aws/aws-sdk-go/blob/main/aws/signer/v4/v4.go#L695-L698)special case `s3-outposts` to include the header.

This change does affect the actual `s3outpost` service requests as it shares the same signing name. I've tested that requests with and without the header have the same responses and that it's valid and safe to send this for s3outposts as well.

Go v2 doesn't have this issue since middleware is registered on the operation to add this particular header for S3 requests.