### PR TITLE
Expose ProcessProviderOptions in session's CredentialsProviderOptions

### DIFF
--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -138,7 +138,11 @@ func resolveCredsFromProfile(cfg *aws.Config,
 
 	case len(sharedCfg.CredentialProcess) != 0:
 		// Get credentials from CredentialProcess
-		creds = processcreds.NewCredentials(sharedCfg.CredentialProcess, sessOpts.CredentialsProviderOptions.ProcessProviderOptions)
+		var optFns []func(*processcreds.ProcessProvider)
+		if sessOpts.CredentialsProviderOptions != nil && sessOpts.CredentialsProviderOptions.ProcessProviderOptions != nil {
+			optFns = append(optFns, sessOpts.CredentialsProviderOptions.ProcessProviderOptions)
+		}
+		creds = processcreds.NewCredentials(sharedCfg.CredentialProcess, optFns...)
 
 	default:
 		// Fallback to default credentials provider, include mock errors for

--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -23,6 +23,10 @@ type CredentialsProviderOptions struct {
 	// WebIdentityRoleProviderOptions configures a WebIdentityRoleProvider,
 	// such as setting its ExpiryWindow.
 	WebIdentityRoleProviderOptions func(*stscreds.WebIdentityRoleProvider)
+
+	// ProcessProviderOptions configures a ProcessProvider,
+	// such as setting its Timeout.
+	ProcessProviderOptions func(*processcreds.ProcessProvider)
 }
 
 func resolveCredentials(cfg *aws.Config,
@@ -134,7 +138,7 @@ func resolveCredsFromProfile(cfg *aws.Config,
 
 	case len(sharedCfg.CredentialProcess) != 0:
 		// Get credentials from CredentialProcess
-		creds = processcreds.NewCredentials(sharedCfg.CredentialProcess)
+		creds = processcreds.NewCredentials(sharedCfg.CredentialProcess, sessOpts.CredentialsProviderOptions.ProcessProviderOptions)
 
 	default:
 		// Fallback to default credentials provider, include mock errors for


### PR DESCRIPTION
This change exposes the options for the ProcessProvider in the session's CredentialsProviderOptions. This allows users to configure the timeout for a ProcessProvider.