### PR TITLE
Fix typo in v4.go: "many" should be "may"

### DIFF
--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -8,7 +8,7 @@
 // Generally using the signer outside of the SDK should not require any additional
 // logic when using Go v1.5 or higher. The signer does this by taking advantage
 // of the URL.EscapedPath method. If your request URI requires additional escaping
-// you many need to use the URL.Opaque to define what the raw URI should be sent
+// you may need to use the URL.Opaque to define what the raw URI should be sent
 // to the service as.
 //
 // The signer will first check the URL.Opaque field, and use its value if set.


### PR DESCRIPTION
Just fixing a typo.
