### PR TITLE
prevent unused time import in event streams

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `codegen`: Prevent unused imports from being generated for event streams.
+  * Potentially-unused `"time"` import was causing vet failures on generated code.

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -101,6 +101,7 @@ func (c *RESTJSONService) EmptyStreamWithContext(ctx aws.Context, input *EmptySt
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // EmptyStreamEventStream provides the event stream handling for the EmptyStream.
 //
@@ -326,6 +327,7 @@ func (c *RESTJSONService) GetEventStreamWithContext(ctx aws.Context, input *GetE
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // GetEventStreamEventStream provides the event stream handling for the GetEventStream.
 //

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -101,6 +101,7 @@ func (c *RESTXMLService) EmptyStreamWithContext(ctx aws.Context, input *EmptyStr
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // EmptyStreamEventStream provides the event stream handling for the EmptyStream.
 //
@@ -326,6 +327,7 @@ func (c *RESTXMLService) GetEventStreamWithContext(ctx aws.Context, input *GetEv
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // GetEventStreamEventStream provides the event stream handling for the GetEventStream.
 //

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -103,6 +103,7 @@ func (c *RPCService) EmptyStreamWithContext(ctx aws.Context, input *EmptyStreamI
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // EmptyStreamEventStream provides the event stream handling for the EmptyStream.
 //
@@ -371,6 +372,7 @@ func (c *RPCService) GetEventStreamWithContext(ctx aws.Context, input *GetEventS
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // GetEventStreamEventStream provides the event stream handling for the GetEventStream.
 //

--- a/private/model/api/eventstream_tmpl.go
+++ b/private/model/api/eventstream_tmpl.go
@@ -22,8 +22,14 @@ func renderEventStreamAPI(w io.Writer, op *Operation) error {
 	op.API.AddSDKImport("private/protocol/eventstream")
 	op.API.AddSDKImport("private/protocol/eventstream/eventstreamapi")
 
+	// usages of these imports are conditional - generate a compile-only
+	// reference to avoid potential unused imports:
+	//  - awserr is only used for input streams or json protocols
+	//  - time is only used for input streams or if an event payload has a
+	//    timestamp field
 	w.Write([]byte(`
 var _ awserr.Error
+var _ time.Time
 `))
 
 	return eventStreamAPITmpl.Execute(w, op)

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -3427,6 +3427,7 @@ func (c *Kinesis) SubscribeToShardWithContext(ctx aws.Context, input *SubscribeT
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // SubscribeToShardEventStream provides the event stream handling for the SubscribeToShard.
 //

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -3737,6 +3737,7 @@ func (c *Lambda) InvokeWithResponseStreamWithContext(ctx aws.Context, input *Inv
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // InvokeWithResponseStreamEventStream provides the event stream handling for the InvokeWithResponseStream.
 //

--- a/service/lexruntimev2/api.go
+++ b/service/lexruntimev2/api.go
@@ -723,6 +723,7 @@ func (c *LexRuntimeV2) StartConversationWithContext(ctx aws.Context, input *Star
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // StartConversationEventStream provides the event stream handling for the StartConversation.
 //

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -10709,6 +10709,7 @@ func (c *S3) SelectObjectContentWithContext(ctx aws.Context, input *SelectObject
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // SelectObjectContentEventStream provides the event stream handling for the SelectObjectContent.
 //

--- a/service/transcribestreamingservice/api.go
+++ b/service/transcribestreamingservice/api.go
@@ -165,6 +165,7 @@ func (c *TranscribeStreamingService) StartCallAnalyticsStreamTranscriptionWithCo
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // StartCallAnalyticsStreamTranscriptionEventStream provides the event stream handling for the StartCallAnalyticsStreamTranscription.
 //
@@ -557,6 +558,7 @@ func (c *TranscribeStreamingService) StartMedicalStreamTranscriptionWithContext(
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // StartMedicalStreamTranscriptionEventStream provides the event stream handling for the StartMedicalStreamTranscription.
 //
@@ -947,6 +949,7 @@ func (c *TranscribeStreamingService) StartStreamTranscriptionWithContext(ctx aws
 }
 
 var _ awserr.Error
+var _ time.Time
 
 // StartStreamTranscriptionEventStream provides the event stream handling for the StartStreamTranscription.
 //


### PR DESCRIPTION
Event stream codegen blindly imports `"time"`, but doesn't actually use it unless one of the following is true:
* there's a stream with input
* a payload or header used in event streaming has a timestamp field

This patch adds a compile-time reference to prevent `vet` from failing on the unused import (as we've done with `"awserr"` whose usage is also conditional in event streams).