### PR TITLE
service/lexruntimev2: fix dropped error

### DIFF
--- a/service/lexruntimev2/eventstream_test.go
+++ b/service/lexruntimev2/eventstream_test.go
@@ -942,6 +942,9 @@ func TestStartConversation_Write(t *testing.T) {
 			BiDirectional: true,
 		},
 		true)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 	defer cleanupFn()
 
 	svc := New(sess)
@@ -1040,6 +1043,9 @@ func TestStartConversation_ReadWrite(t *testing.T) {
 			BiDirectional: true,
 		},
 		true)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 	defer cleanupFn()
 
 	svc := New(sess)


### PR DESCRIPTION
This fixes two dropped test `err` variables in `service/lexruntimev2`.
