### PR TITLE
Reduce memory allocations when computing a tree hash

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `service/glacier`: Improve efficiency of tree hash algorithm
+  * Refactor tree hashing to reduce allocations.
 
 ### SDK Bugs


### PR DESCRIPTION
Hello. I've decided to rework **ComputeTreeHash** function because it makes lots of memory allocations. 
Benchmark I used:
```
func BenchmarkComputeTreeHash(b *testing.B) {
	var hashes [][]byte
	for i := 0; i < 1024; i++ {
		h := sha256.Sum256([]byte("test"))
		hashes = append(hashes, h[:])
	}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = glacier.ComputeTreeHash(hashes)
	}
	b.ReportAllocs()
}
```
Benchcmp result:
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkComputeTreeHash-10     128886        88221         -31.55%

benchmark                       old allocs     new allocs     delta
BenchmarkComputeTreeHash-10     3124           1              -99.97%

benchmark                       old bytes     new bytes     delta
BenchmarkComputeTreeHash-10     179808        32768         -81.78%
```