### PR TITLE
Remove depricated package github.com/pkg/errors

### DIFF
--- a/example/aws/credentials/plugincreds/plugin/plugin.go
+++ b/example/aws/credentials/plugincreds/plugin/plugin.go
@@ -5,9 +5,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 // Example plugin that will retrieve credentials from a JSON file that the
@@ -41,7 +40,7 @@ type provider struct {
 func (p *provider) Retrieve() (key, secret, token string, err error) {
 	f, err := os.Open(p.Filename)
 	if err != nil {
-		return "", "", "", errors.Wrapf(err, "failed to open credentials file, %q", p.Filename)
+		return "", "", "", fmt.Errorf("failed to open credentials file, %q: %w", p.Filename, err)
 	}
 	decoder := json.NewDecoder(f)
 
@@ -50,7 +49,7 @@ func (p *provider) Retrieve() (key, secret, token string, err error) {
 	}{}
 
 	if err := decoder.Decode(&creds); err != nil {
-		return "", "", "", errors.Wrap(err, "failed to decode credentials file")
+		return "", "", "", fmt.Errorf("failed to decode credentials file: %w", err)
 	}
 
 	p.loaded = true

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/jmespath/go-jmespath v0.4.0
-	github.com/pkg/errors v0.9.1
 	golang.org/x/net v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
repo github.com/pkg/errors has been archived since Dec 2021.
Go starting with version 1.13, there is now a standard way of replacing the errors.Wrap functions.

The included change should produce exactly the same error.

https://go.dev/blog/go1.13-errors is a good reference