### PR TITLE
Fix deprecated function documentation

### DIFF
--- a/service/s3/s3crypto/aes_cbc_content_cipher.go
+++ b/service/s3/s3crypto/aes_cbc_content_cipher.go
@@ -17,7 +17,7 @@ type cbcContentCipherBuilder struct {
 // AESCBCContentCipherBuilder returns a new encryption only AES/CBC mode structure using the provided padder. The provided cipher data generator
 // will be used to provide keys for content encryption.
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func AESCBCContentCipherBuilder(generator CipherDataGenerator, padder Padder) ContentCipherBuilder {
 	return cbcContentCipherBuilder{generator: generator, padder: padder}
 }
@@ -31,7 +31,7 @@ func AESCBCContentCipherBuilder(generator CipherDataGenerator, padder Padder) Co
 //		panic(err) // handle error
 //	}
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func RegisterAESCBCContentCipher(registry *CryptoRegistry, padder Padder) error {
 	if registry == nil {
 		return errNilCryptoRegistry

--- a/service/s3/s3crypto/aes_gcm_content_cipher.go
+++ b/service/s3/s3crypto/aes_gcm_content_cipher.go
@@ -19,7 +19,7 @@ const (
 // will be fully loaded into memory before encryption or decryption can occur. Caution must be taken to avoid memory
 // allocation failures.
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func AESGCMContentCipherBuilder(generator CipherDataGenerator) ContentCipherBuilder {
 	return gcmContentCipherBuilder{generator}
 }

--- a/service/s3/s3crypto/decryption_client.go
+++ b/service/s3/s3crypto/decryption_client.go
@@ -25,7 +25,7 @@ type CEKEntry func(CipherData) (ContentCipher, error)
 //   - AES/GCM
 //   - AES/CBC
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 type DecryptionClient struct {
 	S3Client s3iface.S3API
 	// LoadStrategy is used to load the metadata either from the metadata of the object
@@ -48,7 +48,7 @@ type DecryptionClient struct {
 //		// Custom client options here
 //	}))
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func NewDecryptionClient(prov client.ConfigProvider, options ...func(*DecryptionClient)) *DecryptionClient {
 	s3client := s3.New(prov)
 
@@ -95,14 +95,14 @@ func NewDecryptionClient(prov client.ConfigProvider, options ...func(*Decryption
 //		})
 //		err := req.Send()
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func (c *DecryptionClient) GetObjectRequest(input *s3.GetObjectInput) (*request.Request, *s3.GetObjectOutput) {
 	return getObjectRequest(c.getClientOptions(), input)
 }
 
 // GetObject is a wrapper for GetObjectRequest
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func (c *DecryptionClient) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	return getObject(c.getClientOptions(), input)
 }
@@ -115,7 +115,7 @@ func (c *DecryptionClient) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOut
 // cause a panic. Use the Context to add deadlining, timeouts, etc. In the future
 // this may create sub-contexts for individual underlying requests.
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func (c *DecryptionClient) GetObjectWithContext(ctx aws.Context, input *s3.GetObjectInput, opts ...request.Option) (*s3.GetObjectOutput, error) {
 	return getObjectWithContext(c.getClientOptions(), ctx, input, opts...)
 }

--- a/service/s3/s3crypto/encryption_client.go
+++ b/service/s3/s3crypto/encryption_client.go
@@ -18,7 +18,7 @@ const DefaultMinFileSize = 1024 * 512 * 5
 // AES GCM will load all data into memory. However, the rest of the content algorithms
 // do not load the entire contents into memory.
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 type EncryptionClient struct {
 	S3Client             s3iface.S3API
 	ContentCipherBuilder ContentCipherBuilder
@@ -56,7 +56,7 @@ func validateV1EncryptionClientConstruction(c *EncryptionClient) error {
 //		handler := s3crypto.NewKMSKeyGenerator(kms.New(sess), cmkID)
 //		svc := s3crypto.NewEncryptionClient(sess, s3crypto.AESGCMContentCipherBuilder(handler))
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func NewEncryptionClient(prov client.ConfigProvider, builder ContentCipherBuilder, options ...func(*EncryptionClient)) *EncryptionClient {
 	s3client := s3.New(prov)
 
@@ -91,7 +91,7 @@ func NewEncryptionClient(prov client.ConfigProvider, builder ContentCipherBuilde
 //	})
 //	err := req.Send()
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func (c *EncryptionClient) PutObjectRequest(input *s3.PutObjectInput) (*request.Request, *s3.PutObjectOutput) {
 	req, out := putObjectRequest(c.getClientOptions(), input)
 	if err := validateV1EncryptionClientConstruction(c); err != nil {
@@ -114,7 +114,7 @@ func setReqError(err error) func(*request.Request) {
 
 // PutObject is a wrapper for PutObjectRequest
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func (c *EncryptionClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
 	if err := validateV1EncryptionClientConstruction(c); err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func (c *EncryptionClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOut
 // this may create sub-contexts for individual underlying requests.
 // PutObject is a wrapper for PutObjectRequest
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func (c *EncryptionClient) PutObjectWithContext(ctx aws.Context, input *s3.PutObjectInput, opts ...request.Option) (*s3.PutObjectOutput, error) {
 	if err := validateV1EncryptionClientConstruction(c); err != nil {
 		return nil, err

--- a/service/s3/s3crypto/envelope.go
+++ b/service/s3/s3crypto/envelope.go
@@ -39,7 +39,7 @@ type Envelope struct {
 	CEKAlg  string `json:"x-amz-cek-alg"`
 	TagLen  string `json:"x-amz-tag-len"`
 
-	// deprecated: This MD5 hash is no longer populated
+	// Deprecated: This MD5 hash is no longer populated
 	UnencryptedMD5 string `json:"-"`
 
 	UnencryptedContentLen string `json:"x-amz-unencrypted-content-length"`

--- a/service/s3/s3crypto/kms_key_handler.go
+++ b/service/s3/s3crypto/kms_key_handler.go
@@ -33,7 +33,7 @@ type kmsKeyHandler struct {
 //	matdesc := s3crypto.MaterialDescription{}
 //	handler := s3crypto.NewKMSKeyGenerator(kms.New(sess), cmkID)
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func NewKMSKeyGenerator(kmsClient kmsiface.KMSAPI, cmkID string) CipherDataGenerator {
 	return NewKMSKeyGeneratorWithMatDesc(kmsClient, cmkID, MaterialDescription{})
 }
@@ -67,7 +67,7 @@ func newKMSKeyHandler(client kmsiface.KMSAPI, cmkID string, matdesc MaterialDesc
 //	matdesc := s3crypto.MaterialDescription{}
 //	handler := s3crypto.NewKMSKeyGeneratorWithMatDesc(kms.New(sess), cmkID, matdesc)
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func NewKMSKeyGeneratorWithMatDesc(kmsClient kmsiface.KMSAPI, cmkID string, matdesc MaterialDescription) CipherDataGenerator {
 	return newKMSKeyHandler(kmsClient, cmkID, matdesc)
 }
@@ -84,7 +84,7 @@ func NewKMSKeyGeneratorWithMatDesc(kmsClient kmsiface.KMSAPI, cmkID string, matd
 //		svc.WrapRegistry[s3crypto.KMSWrap] = decryptHandler
 //	}))
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func NewKMSWrapEntry(kmsClient kmsiface.KMSAPI) WrapEntry {
 	kp := newKMSWrapEntry(kmsClient)
 	return kp.decryptHandler
@@ -101,7 +101,7 @@ func NewKMSWrapEntry(kmsClient kmsiface.KMSAPI) WrapEntry {
 //		panic(err) // handle error
 //	}
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func RegisterKMSWrapWithCMK(registry *CryptoRegistry, client kmsiface.KMSAPI, cmkID string) error {
 	if registry == nil {
 		return errNilCryptoRegistry
@@ -120,7 +120,7 @@ func RegisterKMSWrapWithCMK(registry *CryptoRegistry, client kmsiface.KMSAPI, cm
 //		panic(err) // handle error
 //	}
 //
-// deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
+// Deprecated: This feature is in maintenance mode, no new updates will be released. Please see https://docs.aws.amazon.com/general/latest/gr/aws_sdk_cryptography.html for more information.
 func RegisterKMSWrapWithAnyCMK(registry *CryptoRegistry, client kmsiface.KMSAPI) error {
 	if registry == nil {
 		return errNilCryptoRegistry


### PR DESCRIPTION
Documentation for deprecated functions on pkg.go.dev is case-sensitive. 

Examples
- Working: https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.46.6/aws/awsutil#StringValue
- Broken: https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.46.6/service/s3/s3crypto#EncryptionClient

