### PR TITLE
Fix changelog pending format

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
-"x-amz-expected-bucket-owner" header was added to the list of headers that need to be presigned
+* `aws/signer`: Add bucket owner header to presigned list.
+  * Add x-amz-expected-bucket-owner header to the list of headers that need to be presigned.
 
 ### SDK Bugs

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
-* `aws/signer`: Add bucket owner header to presigned list.
+* `aws/signer/v4`: Add bucket owner header to presigned list.
   * Add x-amz-expected-bucket-owner header to the list of headers that need to be presigned.
 
 ### SDK Bugs


### PR DESCRIPTION
https://github.com/aws/aws-sdk-go/pull/5062/ had an incorrect changelog pending format. 

This PR fixes it.