### PR TITLE
Use SharedCredentialsProvider instead of StaticProvider for shared credentials

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/session`: SDK should now trigger a credential refresh for shared config files if we receive an expired token exception.
+  * This change updates the SDK to use a `SharedCredentialProvider` instead of a `StaticProvider` so that the credentials file will be loaded again whenever we mark the credential as expired. If you're using the default `AfterRetryHandler`, credentials should be reloaded automatically whenever we receive an `ExpiredToken`, `ExpiredTokenException`, or `RequestExpired` error.

--- a/aws/session/credentials_test.go
+++ b/aws/session/credentials_test.go
@@ -633,7 +633,7 @@ func TestSessionAssumeRole_DisableSharedConfig(t *testing.T) {
 	if e, a := "assume_role_w_creds_secret", creds.SecretAccessKey; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := "SharedConfigCredentials", creds.ProviderName; !strings.Contains(a, e) {
+	if e, a := "SharedCredentialsProvider", creds.ProviderName; !strings.Contains(a, e) {
 		t.Errorf("expect %v, to be in %v", e, a)
 	}
 }

--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -238,7 +238,7 @@ func TestNewSessionWithOptions_OverrideProfile(t *testing.T) {
 	if v := creds.SessionToken; len(v) != 0 {
 		t.Errorf("expect empty, got %v", v)
 	}
-	if e, a := "SharedConfigCredentials", creds.ProviderName; !strings.Contains(a, e) {
+	if e, a := "SharedCredentialsProvider", creds.ProviderName; !strings.Contains(a, e) {
 		t.Errorf("expect %v, to be in %v", e, a)
 	}
 }
@@ -275,7 +275,7 @@ func TestNewSessionWithOptions_OverrideSharedConfigEnable(t *testing.T) {
 	if v := creds.SessionToken; len(v) != 0 {
 		t.Errorf("expect empty, got %v", v)
 	}
-	if e, a := "SharedConfigCredentials", creds.ProviderName; !strings.Contains(a, e) {
+	if e, a := "SharedCredentialsProvider", creds.ProviderName; !strings.Contains(a, e) {
 		t.Errorf("expect %v, to be in %v", e, a)
 	}
 }
@@ -312,7 +312,7 @@ func TestNewSessionWithOptions_OverrideSharedConfigDisable(t *testing.T) {
 	if v := creds.SessionToken; len(v) != 0 {
 		t.Errorf("expect empty, got %v", v)
 	}
-	if e, a := "SharedConfigCredentials", creds.ProviderName; !strings.Contains(a, e) {
+	if e, a := "SharedCredentialsProvider", creds.ProviderName; !strings.Contains(a, e) {
 		t.Errorf("expect %v, to be in %v", e, a)
 	}
 }
@@ -349,7 +349,7 @@ func TestNewSessionWithOptions_OverrideSharedConfigFiles(t *testing.T) {
 	if v := creds.SessionToken; len(v) != 0 {
 		t.Errorf("expect empty, got %v", v)
 	}
-	if e, a := "SharedConfigCredentials", creds.ProviderName; !strings.Contains(a, e) {
+	if e, a := "SharedCredentialsProvider", creds.ProviderName; !strings.Contains(a, e) {
 		t.Errorf("expect %v, to be in %v", e, a)
 	}
 }
@@ -372,7 +372,7 @@ func TestNewSessionWithOptions_Overrides(t *testing.T) {
 			OutCreds: credentials.Value{
 				AccessKeyID:     "full_profile_akid",
 				SecretAccessKey: "full_profile_secret",
-				ProviderName:    "SharedConfigCredentials",
+				ProviderName:    "SharedCredentialsProvider",
 			},
 		},
 		"env creds with env profile": {
@@ -405,7 +405,7 @@ func TestNewSessionWithOptions_Overrides(t *testing.T) {
 			OutCreds: credentials.Value{
 				AccessKeyID:     "full_profile_akid",
 				SecretAccessKey: "full_profile_secret",
-				ProviderName:    "SharedConfigCredentials",
+				ProviderName:    "SharedCredentialsProvider",
 			},
 		},
 		"cfg and cred file with opt profile": {
@@ -420,7 +420,7 @@ func TestNewSessionWithOptions_Overrides(t *testing.T) {
 			OutCreds: credentials.Value{
 				AccessKeyID:     "shared_config_akid",
 				SecretAccessKey: "shared_config_secret",
-				ProviderName:    "SharedConfigCredentials",
+				ProviderName:    "SharedCredentialsProvider",
 			},
 		},
 	}

--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -378,10 +378,12 @@ func (cfg *sharedConfig) setFromIniFiles(profiles map[string]struct{}, profile s
 // example if a config file only includes aws_access_key_id but no
 // aws_secret_access_key the aws_access_key_id will be ignored.
 func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile, exOpts bool) error {
-	section, ok := file.IniData.GetSection(profile)
+	sectionName := profile
+	section, ok := file.IniData.GetSection(sectionName)
 	if !ok {
 		// Fallback to to alternate profile name: profile <name>
-		section, ok = file.IniData.GetSection(fmt.Sprintf("profile %s", profile))
+		sectionName = fmt.Sprintf("profile %s", profile)
+		section, ok = file.IniData.GetSection(sectionName)
 		if !ok {
 			return SharedConfigProfileNotExistsError{Profile: profile, Err: nil}
 		}
@@ -458,7 +460,7 @@ func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile, e
 		AccessKeyID:     section.String(accessKeyIDKey),
 		SecretAccessKey: section.String(secretAccessKey),
 		SessionToken:    section.String(sessionTokenKey),
-		ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", file.Filename),
+		ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=%s", file.Filename, sectionName),
 	}
 	if creds.HasKeys() {
 		cfg.Creds = creds

--- a/aws/session/shared_config_test.go
+++ b/aws/session/shared_config_test.go
@@ -52,7 +52,7 @@ func TestLoadSharedConfig(t *testing.T) {
 				Creds: credentials.Value{
 					AccessKeyID:     "shared_config_akid",
 					SecretAccessKey: "shared_config_secret",
-					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=config_file_load_order", testConfigFilename),
 				},
 			},
 		},
@@ -65,7 +65,7 @@ func TestLoadSharedConfig(t *testing.T) {
 				Creds: credentials.Value{
 					AccessKeyID:     "shared_config_other_akid",
 					SecretAccessKey: "shared_config_other_secret",
-					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigOtherFilename),
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=config_file_load_order", testConfigOtherFilename),
 				},
 			},
 		},
@@ -81,7 +81,7 @@ func TestLoadSharedConfig(t *testing.T) {
 					Creds: credentials.Value{
 						AccessKeyID:     "complete_creds_akid",
 						SecretAccessKey: "complete_creds_secret",
-						ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+						ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=complete_creds", testConfigFilename),
 					},
 				},
 			},
@@ -113,7 +113,7 @@ func TestLoadSharedConfig(t *testing.T) {
 					Creds: credentials.Value{
 						AccessKeyID:     "assume_role_w_creds_akid",
 						SecretAccessKey: "assume_role_w_creds_secret",
-						ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+						ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=assume_role_w_creds", testConfigFilename),
 					},
 				},
 			},
@@ -161,7 +161,7 @@ func TestLoadSharedConfig(t *testing.T) {
 						Creds: credentials.Value{
 							AccessKeyID:     "complete_creds_akid",
 							SecretAccessKey: "complete_creds_secret",
-							ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+							ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=complete_creds", testConfigFilename),
 						},
 					},
 				},
@@ -252,7 +252,7 @@ func TestLoadSharedConfig(t *testing.T) {
 					AccessKeyID:     "sso_and_static_akid",
 					SecretAccessKey: "sso_and_static_secret",
 					SessionToken:    "sso_and_static_token",
-					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=profile sso_and_static", testConfigFilename),
 				},
 				SSOAccountID: "012345678901",
 				SSORegion:    "us-west-2",
@@ -496,7 +496,7 @@ func TestLoadSharedConfigFromFile(t *testing.T) {
 				Creds: credentials.Value{
 					AccessKeyID:     "complete_creds_akid",
 					SecretAccessKey: "complete_creds_secret",
-					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=complete_creds", testConfigFilename),
 				},
 			},
 		},
@@ -507,7 +507,7 @@ func TestLoadSharedConfigFromFile(t *testing.T) {
 					AccessKeyID:     "complete_creds_with_token_akid",
 					SecretAccessKey: "complete_creds_with_token_secret",
 					SessionToken:    "complete_creds_with_token_token",
-					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=complete_creds_with_token", testConfigFilename),
 				},
 			},
 		},
@@ -517,7 +517,7 @@ func TestLoadSharedConfigFromFile(t *testing.T) {
 				Creds: credentials.Value{
 					AccessKeyID:     "full_profile_akid",
 					SecretAccessKey: "full_profile_secret",
-					ProviderName:    fmt.Sprintf("SharedConfigCredentials: %s", testConfigFilename),
+					ProviderName:    fmt.Sprintf("SharedConfigCredentials: filename=%s,section=full_profile", testConfigFilename),
 				},
 				Region: "full_profile_region",
 			},


### PR DESCRIPTION
Previously, we were using the StaticProvider for all credentials resolved
while reading shared config files. There is logic in the AfterRetryHandler that
marks a credential object as expired whenever an expired token exception
occurs. When that happens, the ideal workflow is for the provider to trigger
a credentials refresh by re-reading the profile file, but this is not possible
with the StaticProvider.

This commit addresses that problem by using the SharedCredentialsProvider
instead of the StaticProvider when resolving such credentials. With this
change, the SDK should automatically refreshes the credentials whenever we get
a expired token exception from AWS. This should also implicitly address the
feature requested in https://github.com/aws/aws-sdk-go/issues/1993, but instead of refreshing explicitly, the trigger
here would be an exception from AWS.