### PR TITLE
Add `WithUseFIPSEndpoint` to `aws.Config`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,5 +2,6 @@
 
 ### SDK Enhancements
 * `aws`: Add `WithUseFIPSEndpoint` to `aws.Config`. ([#5078](https://github.com/aws/aws-sdk-go/pull/5078))
+  * `WithUseFIPSEndpoint` can be used to explicitly enable or disable FIPS endpoint variants.
 
 ### SDK Bugs

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws`: Add `WithUseFIPSEndpoint` to `aws.Config`. ([#5078](https://github.com/aws/aws-sdk-go/pull/5078))
 
 ### SDK Bugs

--- a/aws/config.go
+++ b/aws/config.go
@@ -442,6 +442,17 @@ func (c *Config) WithUseDualStack(enable bool) *Config {
 	return c
 }
 
+// WithUseFIPSEndpoint sets a config UseFIPSEndpoint value returning a Config
+// pointer for chaining.
+func (c *Config) WithUseFIPSEndpoint(enable bool) *Config {
+	if enable {
+		c.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	} else {
+		c.UseFIPSEndpoint = endpoints.FIPSEndpointStateDisabled
+	}
+	return c
+}
+
 // WithEC2MetadataDisableTimeoutOverride sets a config EC2MetadataDisableTimeoutOverride value
 // returning a Config pointer for chaining.
 func (c *Config) WithEC2MetadataDisableTimeoutOverride(enable bool) *Config {


### PR DESCRIPTION
The ability to chain `UseFIPSEndpoint` was missing.